### PR TITLE
Fix IROH keepalive recovery after relay pong misses

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxConnection.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxConnection.swift
@@ -347,7 +347,7 @@ public actor IrxConnection {
                 try? await Task.sleep(for: interval)
             }
             guard !Task.isCancelled else { return }
-            let seq = await self.nextPingSeq()
+            let seq = self.nextPingSeq()
             let sentAt = DispatchTime.now()
             let activeLane = lane
             do {
@@ -378,7 +378,7 @@ public actor IrxConnection {
                         "path": self.selectedPathDescription(),
                     ]
                 )
-                await self.notePong()
+                self.notePong()
                 strikes = 0
             } catch {
                 guard !Task.isCancelled else { return }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxConnection.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxConnection.swift
@@ -308,8 +308,10 @@ public actor IrxConnection {
     /// Continuous client-side keepalive on a dedicated lane: one tiny ping
     /// every interval, pong deadline enforced per ping, every exchange
     /// journaled with RTT and the selected path (the soak's relay-attribution
-    /// evidence). A single miss re-pings immediately (journaled as a `miss`,
-    /// not a death: one transient stall must never sever a healthy session);
+    /// evidence). A missed deadline resets the lane before retrying because
+    /// the timed-out receive operation may still own the native stream. A
+    /// single miss re-pings immediately (journaled as a `miss`, not a death:
+    /// one transient stall must never sever a healthy session);
     /// `IrxProtocol.keepaliveStrikeLimit` consecutive misses close with
     /// `keepalive-timeout` and report death so the engine redials at once.
     public func startClientKeepalive(
@@ -320,66 +322,97 @@ public actor IrxConnection {
         guard keepaliveTask == nil else { return }
         let lane = try await openLane(IrxLaneDescriptor(lane: .keepalive))
         keepaliveTask = Task { [journal] in
-            var strikes = 0
-            while !Task.isCancelled {
-                if strikes == 0 {
-                    try? await Task.sleep(for: interval)
+            await self.runClientKeepalive(
+                lane: lane,
+                interval: interval,
+                deadline: deadline,
+                journal: journal,
+                onDeath: onDeath
+            )
+        }
+    }
+
+    private func runClientKeepalive(
+        lane initialLane: IrxLaneStream,
+        interval: Duration,
+        deadline: Duration,
+        journal: IrxJournal,
+        onDeath: @escaping @Sendable () async -> Void
+    ) async {
+        var lane = initialLane
+
+        var strikes = 0
+        while !Task.isCancelled {
+            if strikes == 0 {
+                try? await Task.sleep(for: interval)
+            }
+            guard !Task.isCancelled else { return }
+            let seq = await self.nextPingSeq()
+            let sentAt = DispatchTime.now()
+            let activeLane = lane
+            do {
+                try await activeLane.writer.writeControlFrame(IrxPing(seq: seq, pong: false))
+                let pong = try await withIrxDeadline(deadline, onTimeout: {
+                    await activeLane.reader.stop()
+                }) {
+                    () -> IrxPing? in
+                    while true {
+                        guard
+                            let reply = try await activeLane.reader.readControlFrame(
+                                IrxPing.self)
+                        else { return nil }
+                        if reply.pong, reply.seq == seq { return reply }
+                    }
                 }
+                guard pong != nil else {
+                    throw IrxConnectionError.closed(nil)
+                }
+                let rttMs =
+                    (DispatchTime.now().uptimeNanoseconds
+                        - sentAt.uptimeNanoseconds) / 1_000_000
+                journal.record(
+                    "keepalive", "pong",
+                    [
+                        "seq": String(seq),
+                        "rtt_ms": String(rttMs),
+                        "path": self.selectedPathDescription(),
+                    ]
+                )
+                await self.notePong()
+                strikes = 0
+            } catch {
                 guard !Task.isCancelled else { return }
-                let seq = await self.nextPingSeq()
-                let sentAt = DispatchTime.now()
-                do {
-                    try await lane.writer.writeControlFrame(IrxPing(seq: seq, pong: false))
-                    let pong = try await withIrxDeadline(deadline, onTimeout: {
-                        await lane.reader.stop()
-                    }) {
-                        () -> IrxPing? in
-                        while true {
-                            guard
-                                let reply = try await lane.reader.readControlFrame(
-                                    IrxPing.self)
-                            else { return nil }
-                            if reply.pong, reply.seq == seq { return reply }
-                        }
-                    }
-                    guard pong != nil else {
-                        throw IrxConnectionError.closed(nil)
-                    }
-                    let rttMs =
-                        (DispatchTime.now().uptimeNanoseconds
-                            - sentAt.uptimeNanoseconds) / 1_000_000
+                strikes += 1
+                await activeLane.close()
+                if strikes < IrxProtocol.keepaliveStrikeLimit {
                     journal.record(
-                        "keepalive", "pong",
+                        "keepalive", "miss",
                         [
                             "seq": String(seq),
-                            "rtt_ms": String(rttMs),
+                            "strike": String(strikes),
                             "path": self.selectedPathDescription(),
                         ]
                     )
-                    await self.notePong()
-                    strikes = 0
-                } catch {
-                    guard !Task.isCancelled else { return }
-                    strikes += 1
-                    if strikes < IrxProtocol.keepaliveStrikeLimit {
+                    do {
+                        lane = try await openLane(IrxLaneDescriptor(lane: .keepalive))
+                    } catch {
                         journal.record(
-                            "keepalive", "miss",
-                            [
-                                "seq": String(seq),
-                                "strike": String(strikes),
-                                "path": self.selectedPathDescription(),
-                            ]
+                            "keepalive", "lane-reopen-failed",
+                            ["error": String(describing: error)]
                         )
-                        continue
+                        await self.close(code: .keepaliveTimeout, origin: .transport)
+                        await onDeath()
+                        return
                     }
-                    journal.record(
-                        "keepalive", "timeout",
-                        ["seq": String(seq), "path": self.selectedPathDescription()]
-                    )
-                    await self.close(code: .keepaliveTimeout, origin: .transport)
-                    await onDeath()
-                    return
+                    continue
                 }
+                journal.record(
+                    "keepalive", "timeout",
+                    ["seq": String(seq), "path": self.selectedPathDescription()]
+                )
+                await self.close(code: .keepaliveTimeout, origin: .transport)
+                await onDeath()
+                return
             }
         }
     }

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxLiveQUICTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxLiveQUICTests.swift
@@ -64,6 +64,20 @@ enum IrxLiveTestSupport {
     }
 }
 
+actor IrxKeepaliveDropProbe {
+    private var remainingDrops: Int
+
+    init(remainingDrops: Int) {
+        self.remainingDrops = remainingDrops
+    }
+
+    func shouldDrop() -> Bool {
+        guard remainingDrops > 0 else { return false }
+        remainingDrops -= 1
+        return true
+    }
+}
+
 @Suite("live QUIC", .serialized)
 struct IrxLiveQUICTests {
     @Test("closing a control transport releases its owner without closing the session")
@@ -280,6 +294,7 @@ struct IrxLiveQUICTests {
         let client = try await IrxLiveTestSupport.bindLoopback(
             seed: IrxLiveTestSupport.identitySeed(), remoteBiCredit: 0)
         let registry = IrxServerSessionRegistry(journal: journal)
+        let keepaliveDropProbe = IrxKeepaliveDropProbe(remainingDrops: 1)
 
         // Server: admit every connection, run keepalive responders, register
         // for supersession.
@@ -301,7 +316,12 @@ struct IrxLiveQUICTests {
                 Task {
                     while let lane = await irx.acceptLane() {
                         if lane.descriptor.lane == .keepalive {
-                            _ = irx.respondKeepalive(on: lane)
+                            Task {
+                                if await keepaliveDropProbe.shouldDrop() {
+                                    _ = try? await lane.reader.readControlFrame(IrxPing.self)
+                                }
+                                _ = irx.respondKeepalive(on: lane)
+                            }
                         }
                     }
                 }
@@ -331,6 +351,8 @@ struct IrxLiveQUICTests {
         }
         #expect(await !first.connection.isClosed)
         #expect(journal.counterSnapshot()["pong"] ?? 0 >= 1)
+        #expect(journal.counterSnapshot()["miss"] ?? 0 >= 1)
+        #expect(journal.counterSnapshot()["timeout"] ?? 0 == 0)
 
         // Foreground recovery must not replace a healthy session merely
         // because it is older than the historical 15-second threshold.


### PR DESCRIPTION
A relay-only verification run exposed a lifecycle bug in IROH keepalive recovery. The timeout handler stops the receive stream, then the retry reused that stopped reader, so one delayed relay pong forced the next probe to fail and closed the session.

This change closes the timed-out keepalive lane and opens a fresh lane before retrying. A live QUIC regression test drops one pong and asserts the session remains alive without a timeout.

Verification:
- Fleet Swift package build succeeded.
- Exact `keepaliveAndAutoRedial` test passed.
- Full live QUIC suite reached the new test successfully; an unrelated existing denied-grant test remains flaky.
- Tagged app rebuild succeeded, but local download is currently blocked by a full data volume, so iOS simulator installation is pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791177145&installation_model_id=21920&pr_number=12011&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12011&signature=0f6448d9ead06dd77e4aeb954f8097c1eb23bf1ae02552e8cd2f2c90a55d43a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IROH keepalive recovery so a single delayed relay pong no longer kills the session. Previously the retry after a pong timeout reused the stopped receive stream, forcing the next probe to fail and close the connection. The timed-out lane is now closed and a fresh lane opened before retrying.

- Closes the timed-out keepalive lane and reopens a fresh one before the next probe.
- Adds a live QUIC regression test that drops one pong and asserts the session stays alive without a timeout.

<sup>Written for commit 933362c4782ce2e864e161970bb9fa43887ad6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keepalive recovery by replacing timed-out communication lanes before retrying.
  * Connections now close promptly when a replacement lane cannot be opened.
  * Repeated keepalive failures continue to close the connection at the configured failure limit.

* **Tests**
  * Added coverage for dropped keepalive responses and verified accurate miss and timeout reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->