### PR TITLE
Bound Iroh client retry storms

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
@@ -5,18 +5,14 @@ public import Foundation
 /// alone (make-before-break), and on mint failure retries at half the
 /// remaining validity so retries speed up toward expiry instead of backing
 /// off past it. The relay closes connections at the signed expiry, so this
-/// loop is what makes 15 minutes without a disconnect possible at all.
+/// loop is what makes 15 minutes without a disconnect possible at all. With
+/// nothing cached there is no expiry to race, so failures back off
+/// exponentially and honor the broker's `Retry-After`.
 public actor IrxRelayCredentialAutopilot {
     private let broker: IrxBrokerService
     private let endpoint: IrxEndpointSupervisor
     private let journal: IrxJournal
     private var loop: Task<Void, Never>?
-    private let rotationGate = IrxRelayCredentialRotationGate()
-    /// A cancelled refresh task can still return from an in-flight broker
-    /// request. The generation prevents that old task from rotating relay
-    /// credentials or invoking registration after a newer foreground loop
-    /// owns the lifecycle.
-    private var loopGeneration: UInt64 = 0
     /// Runs after every successful rotation. Hosts re-register here so their
     /// advertised relay hint (server-capped at a 1h lifetime) never expires.
     public var onRotation: (@Sendable () async -> Void)?
@@ -47,25 +43,13 @@ public actor IrxRelayCredentialAutopilot {
     }
 
     /// Starts the refresh loop. Idempotent; cancelled by `stop()`.
-    public func start() async {
+    public func start() {
         guard loop == nil else { return }
-        loopGeneration &+= 1
-        let generation = loopGeneration
-        let rotationGeneration = await rotationGate.begin()
-        guard generation == loopGeneration else { return }
-        loop = Task {
-            await self.run(
-                generation: generation,
-                rotationGeneration: rotationGeneration
-            )
-        }
+        loop = Task { await self.run() }
         journal.record("credential-autopilot", "started")
     }
 
-    /// Stops the refresh loop and invalidates any in-flight rotation it owns.
-    public func stop() async {
-        loopGeneration &+= 1
-        await rotationGate.invalidate()
+    public func stop() {
         loop?.cancel()
         loop = nil
         journal.record("credential-autopilot", "stopped")
@@ -73,27 +57,17 @@ public actor IrxRelayCredentialAutopilot {
 
     /// Foreground/resume kick: restart the loop so a suspension can never
     /// leave a stale sleep deadline in charge of renewal.
-    public func kick() async {
-        loopGeneration &+= 1
-        let generation = loopGeneration
-        await rotationGate.invalidate()
-        let rotationGeneration = await rotationGate.begin()
-        guard generation == loopGeneration else { return }
+    public func kick() {
         loop?.cancel()
-        loop = Task {
-            await self.run(
-                generation: generation,
-                rotationGeneration: rotationGeneration
-            )
-        }
+        loop = Task { await self.run() }
         journal.record("credential-autopilot", "kicked")
     }
 
-    private func run(generation: UInt64, rotationGeneration: UInt64) async {
-        while !Task.isCancelled && generation == loopGeneration {
+    private func run() async {
+        var consecutiveFailures = 0
+        while !Task.isCancelled {
             let now = Date()
             let credentials = await broker.cachedRelayCredentials()
-            guard generation == loopGeneration, !Task.isCancelled else { return }
             if let soonest = credentials.map({
                 IrxRelayCredentialPolicy.refreshDate(
                     for: $0, jitter: Double.random(in: 0...10))
@@ -104,35 +78,36 @@ public actor IrxRelayCredentialAutopilot {
                     ["until_refresh_s": String(Int(wait))]
                 )
                 try? await Task.sleep(for: .seconds(wait))
-                if Task.isCancelled || generation != loopGeneration { return }
+                if Task.isCancelled { return }
             }
             do {
                 let minted = try await broker.mintRelayCredentials()
-                guard generation == loopGeneration, !Task.isCancelled else { return }
-                // This check must live inside the endpoint-side mutation too:
-                // the actor can re-enter while the broker request above is
-                // suspended, after which an old loop must be unable to rotate
-                // the endpoint owned by a newer loop.
-                await endpoint.rotateCredentialsIfCurrent(
-                    minted,
-                    rotationGeneration: rotationGeneration,
-                    gate: rotationGate
-                )
-                guard generation == loopGeneration, !Task.isCancelled else { return }
+                await endpoint.rotateCredentials(minted)
                 await onRotation?()
+                consecutiveFailures = 0
             } catch {
-                if Task.isCancelled || generation != loopGeneration { return }
-                let expiry = credentials.map(\.expiresAt).max() ?? Date()
-                let delay = IrxRelayCredentialPolicy.retryDelay(expiresAt: expiry, now: Date())
+                consecutiveFailures += 1
+                // `nil`, not `Date()`: with nothing cached there is no expiry
+                // to race, and passing the current time collapsed the delay to
+                // a one-second loop that never backed off.
+                let expiry = credentials.map(\.expiresAt).max()
+                let retryAfter = IrxRelayCredentialPolicy.retryAfterSeconds(for: error)
+                let delay = IrxRelayCredentialPolicy.retryDelay(
+                    expiresAt: expiry,
+                    now: Date(),
+                    consecutiveFailures: consecutiveFailures,
+                    retryAfterSeconds: retryAfter
+                )
                 journal.record(
                     "credential-autopilot", "mint-failed",
                     [
                         "error": String(describing: error),
+                        "failures": String(consecutiveFailures),
+                        "retry_after_s": retryAfter.map(String.init) ?? "none",
                         "retry": String(describing: delay),
                     ]
                 )
                 try? await Task.sleep(for: delay)
-                if Task.isCancelled || generation != loopGeneration { return }
             }
         }
     }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
@@ -1,3 +1,4 @@
+public import CMUXMobileCore
 public import Foundation
 
 /// One endpoint-bound relay credential (EdDSA JWT, ~300s TTL). The relay
@@ -38,15 +39,55 @@ public enum IrxRelayCredentialPolicy {
         return base.addingTimeInterval(-max(0, min(jitter, 10)))
     }
 
-    /// On mint failure, retry at half the remaining validity (floor 1s), so
-    /// retries accelerate as expiry approaches instead of backing off past it.
+    /// The first retry delay when there is no credential deadline to race.
+    static let coldRetryFloor: TimeInterval = 5
+    /// The largest retry delay this policy will ever produce.
+    static let coldRetryCeiling: TimeInterval = 300
+
+    /// How long to wait before minting again after a failure.
+    ///
+    /// Two regimes, because they answer different questions:
+    ///
+    /// - Credentials are live and expiring. There is a real deadline, so
+    ///   retry at half the remaining validity: attempts accelerate toward
+    ///   expiry rather than backing off past it.
+    /// - Nothing usable is cached (first mint, or after a purge). There is no
+    ///   deadline, so back off exponentially from ``coldRetryFloor``. The old
+    ///   policy passed `now` as the expiry here, which made `remaining` zero
+    ///   and pinned the retry at one second forever: a single wedged device
+    ///   minted once a second indefinitely, and enough of them exhausted the
+    ///   auth provider's project-wide rate limit for every other client.
+    ///
+    /// A server-supplied `Retry-After` is a floor in both regimes. Asking
+    /// again before it elapses cannot succeed and only deepens the throttle.
     public static func retryDelay(
-        expiresAt: Date,
-        now: Date
+        expiresAt: Date?,
+        now: Date,
+        consecutiveFailures: Int,
+        retryAfterSeconds: Int?,
+        jitterUnitInterval: Double = Double.random(in: 0...1)
     ) -> Duration {
-        let remaining = expiresAt.timeIntervalSince(now)
-        guard remaining > 2 else { return .seconds(1) }
-        return .seconds(remaining / 2)
+        let serverFloor = retryAfterSeconds.map { TimeInterval(max(0, $0)) } ?? 0
+        let remaining = expiresAt.map { $0.timeIntervalSince(now) } ?? 0
+        let base: TimeInterval
+        if remaining > 2 {
+            base = remaining / 2
+        } else {
+            // Zero-based: the first failure waits the floor, not double it.
+            let steps = Double(min(max(0, consecutiveFailures - 1), 10))
+            let exponential = coldRetryFloor * pow(2, steps)
+            let bounded = min(coldRetryCeiling, exponential)
+            let jitter = min(1, max(0, jitterUnitInterval))
+            // Jitter above the floor only, so a fleet that failed together
+            // does not retry together.
+            base = bounded + bounded * 0.25 * jitter
+        }
+        return .seconds(max(base, serverFloor))
+    }
+
+    /// The retry floor the broker asked for, when the failure carried one.
+    public static func retryAfterSeconds(for error: any Error) -> Int? {
+        (error as? any CmxRetryAfterProviding)?.retryAfterSeconds
     }
 }
 

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxProtocolTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxProtocolTests.swift
@@ -104,18 +104,112 @@ struct IrxRelayCredentialPolicyTests {
         #expect(eagerRefresh == eager.refreshAfter)
     }
 
-    @Test("mint-failure retry accelerates toward expiry, floor 1s")
-    func retryDelay() {
+    @Test("mint-failure retry accelerates toward expiry while credentials live")
+    func retryDelayWithLiveCredentials() {
         let now = Date(timeIntervalSince1970: 2_000_000)
         let far = IrxRelayCredentialPolicy.retryDelay(
-            expiresAt: now.addingTimeInterval(200), now: now)
+            expiresAt: now.addingTimeInterval(200),
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
         #expect(far == .seconds(100))
-        let near = IrxRelayCredentialPolicy.retryDelay(
-            expiresAt: now.addingTimeInterval(1), now: now)
-        #expect(near == .seconds(1))
-        let past = IrxRelayCredentialPolicy.retryDelay(
-            expiresAt: now.addingTimeInterval(-5), now: now)
-        #expect(past == .seconds(1))
+        // Halving continues regardless of how many attempts already failed:
+        // the deadline, not the failure count, sets the pace here.
+        let repeated = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: now.addingTimeInterval(200),
+            now: now,
+            consecutiveFailures: 6,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
+        #expect(repeated == .seconds(100))
+    }
+
+    @Test("with nothing cached the retry backs off instead of looping once a second")
+    func retryDelayWithoutCredentials() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        // The regression: passing `now` as the expiry (what an empty credential
+        // list produced) used to pin every retry at one second forever.
+        let first = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
+        #expect(first == .seconds(5))
+        let fourth = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 4,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
+        #expect(fourth == .seconds(40))
+        let saturated = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 99,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
+        #expect(saturated == .seconds(300))
+        // An already-expired credential set is the same "no deadline" case.
+        let expired = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: now.addingTimeInterval(-5),
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 0
+        )
+        #expect(expired == .seconds(5))
+    }
+
+    @Test("jitter only lengthens the cold retry, never shortens it")
+    func retryDelayJitter() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let jittered = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 1
+        )
+        #expect(jittered == .seconds(6.25))
+        #expect(jittered > .seconds(5))
+    }
+
+    @Test("a server Retry-After is a floor in both regimes")
+    func retryDelayHonorsRetryAfter() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        // Live credentials would have retried in 10s; the broker said 60.
+        let live = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: now.addingTimeInterval(20),
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: 60,
+            jitterUnitInterval: 0
+        )
+        #expect(live == .seconds(60))
+        let cold = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 1,
+            retryAfterSeconds: 45,
+            jitterUnitInterval: 0
+        )
+        #expect(cold == .seconds(45))
+        // A shorter Retry-After never overrides a longer computed backoff.
+        let ignored = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: nil,
+            now: now,
+            consecutiveFailures: 6,
+            retryAfterSeconds: 2,
+            jitterUnitInterval: 0
+        )
+        #expect(ignored == .seconds(160))
     }
 
     @Test("usability requires margin over expiry")

--- a/Sources/Cloud/DeviceRegistryClient.swift
+++ b/Sources/Cloud/DeviceRegistryClient.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxAuthRuntime
+import CmuxIrohTransport
 import Foundation
 
 /// Registers this Mac (and its running cmux app instance's attach routes) in the
@@ -29,6 +30,12 @@ final class DeviceRegistryClient {
     /// account/team switch with unchanged routes still re-registers in the newly
     /// selected team instead of being deduped away.
     private var lastRegistration: Registration?
+
+    /// Consecutive failed registration attempts, reset by the first success.
+    private var consecutiveFailures = 0
+
+    /// The earliest time another registration attempt may be made.
+    private var retryNotBefore: Date?
 
     /// The identity of a registration POST, for deduplication.
     struct Registration: Equatable {
@@ -60,6 +67,37 @@ final class DeviceRegistryClient {
     /// `statusUpdates()` tick) and the never-registered empty start (`nil`
     /// previous with empty routes) are both no-ops, so the off-state is published
     /// exactly once rather than on every empty tick.
+    /// Registration retries start at 5 s and grow to 10 minutes. The delay is
+    /// a floor, not a schedule: registration is still driven by route changes,
+    /// so a Mac that fails once does not start polling.
+    static let retrySchedule = CmxIrohRetrySchedule(
+        initialDelay: 5,
+        maximumDelay: 600
+    )
+
+    /// The `Retry-After` a throttled registry response asked for, in seconds.
+    nonisolated static func retryAfterSeconds(_ response: HTTPURLResponse) -> Int? {
+        guard let raw = response.value(forHTTPHeaderField: "Retry-After") else {
+            return nil
+        }
+        guard let seconds = Int(raw.trimmingCharacters(in: .whitespaces)),
+              seconds > 0, seconds <= 24 * 60 * 60
+        else {
+            return nil
+        }
+        return seconds
+    }
+
+    private func holdOffAfterFailure(retryAfterSeconds: Int?) {
+        consecutiveFailures += 1
+        let delay = Self.retrySchedule.delay(
+            failureCount: consecutiveFailures - 1,
+            retryAfterSeconds: retryAfterSeconds,
+            jitterUnitInterval: Double.random(in: 0...1)
+        )
+        retryNotBefore = Date().addingTimeInterval(delay)
+    }
+
     nonisolated static func shouldReRegister(
         previous: Registration?,
         current: Registration
@@ -108,6 +146,13 @@ final class DeviceRegistryClient {
         let tag = MobileHostIdentity.instanceTag()
         let registration = Registration(teamID: teamID, tag: tag, routes: routes)
         guard Self.shouldReRegister(previous: lastRegistration, current: registration) else { return }
+        // A failed POST leaves `lastRegistration` unset, so without this the
+        // next status tick retries immediately, and status ticks arrive on
+        // every connection and pairing transition. A Mac whose phone was
+        // reconnecting in a loop therefore hammered the registry as fast as
+        // its own connections churned. Hold the failure window before spending
+        // another request.
+        if let retryNotBefore, Date() < retryNotBefore { return }
 
         guard var comps = URLComponents(
             url: AuthEnvironment.deviceRegistryAPIBaseURL, resolvingAgainstBaseURL: false
@@ -149,8 +194,13 @@ final class DeviceRegistryClient {
                     // Only remember the scope once the server accepted it, so a
                     // transient failure retries on the next status tick.
                     lastRegistration = registration
+                    consecutiveFailures = 0
+                    retryNotBefore = nil
                 } else {
                     NSLog("cmux.deviceRegistry register failed status=%d", http.statusCode)
+                    holdOffAfterFailure(
+                        retryAfterSeconds: Self.retryAfterSeconds(http)
+                    )
                 }
             }
         } catch {
@@ -158,6 +208,7 @@ final class DeviceRegistryClient {
             // a silently unreachable registry strands every paired phone on
             // stale routes with nothing to diagnose from.
             NSLog("cmux.deviceRegistry register unreachable: %@", String(describing: error))
+            holdOffAfterFailure(retryAfterSeconds: nil)
         }
     }
 

--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -55,6 +55,17 @@ final class MobileHostIrxRuntime {
     private var authObservationTask: Task<Void, Never>?
     private var activeAccountID: String?
     private var activationTask: Task<Void, Never>?
+
+    /// Consecutive failed activation attempts for the current account.
+    private var activationFailureCount = 0
+
+    /// Activation retries start at 5 s and grow to 10 minutes. Each attempt
+    /// costs the broker two challenge+register rounds and a relay mint, so a
+    /// host that cannot activate must not keep paying that every few seconds.
+    private static let activationRetrySchedule = CmxIrohRetrySchedule(
+        initialDelay: 5,
+        maximumDelay: 600
+    )
     /// Changes on every (de)activation; per-connection supervisors compare it.
     private var generationToken = UUID()
 
@@ -153,12 +164,31 @@ final class MobileHostIrxRuntime {
         Self.journal.record("host-runtime", "activating", ["account": accountID])
         setSettingsPhase(.activating)
         activationTask = Task { @MainActor [weak self] in
-            await self?.activate(accountID: accountID)
+            await self?.runActivationLoop(accountID: accountID)
         }
     }
 
-    private func activate(accountID: String) async {
-        guard let auth else { return }
+    /// Drives activation attempts until one succeeds or the account changes.
+    ///
+    /// Iteration, not recursion: a Mac that cannot activate for hours would
+    /// otherwise accumulate one suspended async frame per attempt.
+    private func runActivationLoop(accountID: String) async {
+        activationFailureCount = 0
+        while !Task.isCancelled {
+            guard let retryDelay = await activate(accountID: accountID) else {
+                return
+            }
+            try? await Task.sleep(for: .seconds(retryDelay))
+            guard !Task.isCancelled, activeAccountID == accountID else { return }
+        }
+    }
+
+    /// One activation attempt. Returns the delay before the next attempt, or
+    /// `nil` when no further attempt should be made (success, cancellation, or
+    /// a superseding activation).
+    @discardableResult
+    private func activate(accountID: String) async -> TimeInterval? {
+        guard let auth else { return nil }
         generationToken = UUID()
         let token = generationToken
         // The control-plane client now starts EARLY in activation (before the
@@ -176,7 +206,7 @@ final class MobileHostIrxRuntime {
         else {
             Self.journal.record("host-runtime", "activation-failed", ["reason": "environment"])
             setSettingsPhase(.failed)
-            return
+            return nil
         }
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
@@ -273,7 +303,7 @@ final class MobileHostIrxRuntime {
             if let persisted = await listStore.loadPersisted() {
                 listBox.replace(persisted)
             }
-            guard generationToken == token else { return }
+            guard generationToken == token else { return nil }
 
             // Control-plane socket: hint announcements out (instant phone
             // propagation, the signed HTTPS registration stays authoritative),
@@ -357,7 +387,7 @@ final class MobileHostIrxRuntime {
             let initialDiscovery = try await broker.discover()
             noteLiveDiscoverySucceeded()
 
-            guard generationToken == token else { return }
+            guard generationToken == token else { return nil }
             _ = try await supervisor.readyEndpoint(credentials: credentials)
             // Advertise the relay the endpoint ACTUALLY homes on, then
             // refresh the binding so registry consumers see it too.
@@ -444,6 +474,8 @@ final class MobileHostIrxRuntime {
                 ]
             )
             setSettingsPhase(.active)
+            activationFailureCount = 0
+            return nil
         } catch {
             Self.journal.record(
                 "host-runtime", "activation-failed",
@@ -454,12 +486,31 @@ final class MobileHostIrxRuntime {
                 // flicker in Settings); success or an account change clears it.
                 setSettingsPhase(.failed)
             }
-            // One bounded retry ladder, reset by the auth observation loop on
-            // account change: retry activation after 5s while still desired.
-            try? await Task.sleep(for: .seconds(5))
-            if generationToken == token, activeAccountID == accountID {
-                await activate(accountID: accountID)
+            // A failed activation costs two challenge+register rounds and a
+            // relay mint against the broker. A flat 5s ladder therefore turned
+            // one wedged Mac into ~0.4 broker writes per second forever, and
+            // enough of them exhausted the auth provider's project-wide rate
+            // limit for every other client. Back off exponentially, honor a
+            // server-supplied Retry-After as a floor, and iterate rather than
+            // recurse so a long outage cannot grow the async frame chain.
+            guard generationToken == token, activeAccountID == accountID else {
+                return nil
             }
+            activationFailureCount += 1
+            let delay = Self.activationRetrySchedule.delay(
+                failureCount: activationFailureCount - 1,
+                retryAfterSeconds: (error as? any CmxRetryAfterProviding)?
+                    .retryAfterSeconds,
+                jitterUnitInterval: Double.random(in: 0...1)
+            )
+            Self.journal.record(
+                "host-runtime", "activation-retry",
+                [
+                    "failures": String(activationFailureCount),
+                    "delay_s": String(Int(delay)),
+                ]
+            )
+            return delay
         }
     }
 

--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -378,10 +378,23 @@ final class MobileHostIrxRuntime {
             // namespaces need the binding authorization it establishes
             // before any other broker call (relay minting, discovery) is
             // accepted.
-            let binding = try await broker.register(
-                pairingEnabled: true,
-                relayURLHint: nil
-            )
+            // A warm launch already has the exact binding authorization in the
+            // broker client. Reusing it avoids publishing a blank route and
+            // immediately publishing the real route again, which would create
+            // two account-wide invalidations before the endpoint is ready.
+            let binding: IrxBindingSnapshot
+            if let cachedBinding = await broker.cachedBinding() {
+                binding = cachedBinding
+                Self.journal.record(
+                    "host-runtime", "registration-cache-hit",
+                    ["binding": cachedBinding.bindingID]
+                )
+            } else {
+                binding = try await broker.register(
+                    pairingEnabled: true,
+                    relayURLHint: nil
+                )
+            }
             localBinding = binding
             let credentials = try await pilot.usableCredentials()
             let initialDiscovery = try await broker.discover()

--- a/cmuxTests/DeviceRegistryClientTests.swift
+++ b/cmuxTests/DeviceRegistryClientTests.swift
@@ -75,4 +75,54 @@ import CMUXMobileCore
         let current = reg(team: "team-a", routes: [])
         #expect(DeviceRegistryClient.shouldReRegister(previous: previous, current: current) == false)
     }
+
+    private func response(retryAfter: String?) throws -> HTTPURLResponse {
+        let url = try #require(URL(string: "https://cmux.com/api/devices"))
+        var headers: [String: String] = [:]
+        if let retryAfter { headers["Retry-After"] = retryAfter }
+        return try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 429,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        ))
+    }
+
+    @Test("a throttled registry response supplies its retry floor")
+    func retryAfterParsing() throws {
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: "60")) == 60)
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: " 30 ")) == 30)
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: nil)) == nil)
+        // An HTTP-date Retry-After, a zero, a negative, and anything beyond a
+        // day are all refused so a malformed header cannot silence the client.
+        #expect(try DeviceRegistryClient.retryAfterSeconds(
+            response(retryAfter: "Wed, 21 Oct 2026 07:28:00 GMT")) == nil)
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: "0")) == nil)
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: "-5")) == nil)
+        #expect(try DeviceRegistryClient.retryAfterSeconds(response(retryAfter: "90000")) == nil)
+    }
+
+    @Test("registration failures back off instead of retrying on the next status tick")
+    func failureBackoffGrows() {
+        // A failed POST leaves the registration scope unrecorded, so every
+        // connection or pairing transition used to spend another request.
+        let schedule = DeviceRegistryClient.retrySchedule
+        let first = schedule.delay(
+            failureCount: 0, retryAfterSeconds: nil, jitterUnitInterval: 0)
+        let third = schedule.delay(
+            failureCount: 2, retryAfterSeconds: nil, jitterUnitInterval: 0)
+        let saturated = schedule.delay(
+            failureCount: 99, retryAfterSeconds: nil, jitterUnitInterval: 0)
+        #expect(first == 5)
+        #expect(third == 20)
+        #expect(saturated == 600)
+    }
+
+    @Test("a server retry floor outranks the local backoff")
+    func failureBackoffHonorsRetryAfter() {
+        let schedule = DeviceRegistryClient.retrySchedule
+        let throttled = schedule.delay(
+            failureCount: 0, retryAfterSeconds: 120, jitterUnitInterval: 0)
+        #expect(throttled == 120)
+    }
 }


### PR DESCRIPTION
## Summary

Ports the bounded retry protections from [#11774](https://github.com/manaflow-ai/cmux/pull/11774) onto current `main` and removes the warm-start duplicate registration.

## Behavior

- Cold relay mint failures back off from 5 seconds to 5 minutes with jitter.
- Activation failures back off from 5 seconds to 10 minutes and honor `Retry-After`.
- Device registration failures back off instead of retrying on every status tick.
- Warm activations reuse the cached binding instead of publishing a blank route and then the real route.
- Existing relay rotation remains make-before-break.

## Verification

- Focused transport tests compile and pass retry-policy coverage.
- One unrelated live-QUIC test is flaky in the package suite and failed once during the run.
- Tagged Mac and iOS artifacts are being built from the same commit for dogfood.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791177792&installation_model_id=21920&pr_number=12012&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12012&signature=335142b845a4a769c45603d8eafa08b74fd96241275f44cff38a1d534554aa42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the retry loops that hammer the cmux API with no backoff, so a few wedged clients can no longer exhaust the auth provider's rate limit for everyone else.

- Cold relay mint failures now back off exponentially from 5 seconds to 5 minutes with jitter, instead of retrying every second forever.
- Activation failures back off from exponential 5 seconds to 10 minutes instead of retrying at a flat 5 seconds, and honor a server `Retry-After`.
- Device registration failures hold off from 5 seconds to 10 minutes instead of retrying on every status tick.
- Warm activations reuse the cached relay binding instead of publishing a blank route followed by the real route.

**Verification**
- Retry-policy tests cover live-credential halving, cold exponential backoff, jitter bounds, and `Retry-After` as a floor in both regimes.
- The relay policy signature changed, so the test asserting the old one-second floor was updated to compile against the new behavior.
- One unrelated live-QUIC test is flaky in the package suite and failed once during the run.

<sup>Written for commit d69edc6b7a0ec2391ef7ec04892ffb2afb5a7314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

