### PR TITLE
test(cloud): verify Freestyle images through the private connection path

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "cloud-vm:stress": "bun scripts/cloud-vm/stress-vm-api.mjs",
     "devbox:bake:freestyle": "bun scripts/build-devbox-freestyle.ts",
     "devbox:verify": "bun scripts/verify-devbox-image.ts",
+    "devbox:verify:private-link": "bun scripts/verify-devbox-private-link.ts",
     "devbox:promote": "bun scripts/promote-devbox-image.ts",
     "devbox:manifest:check": "bun scripts/validate-devbox-ladder.ts",
     "devbox:probe:busybox": "bun scripts/probe-busybox-cmux-tui.ts",

--- a/web/scripts/devbox-private-link-cleanup.ts
+++ b/web/scripts/devbox-private-link-cleanup.ts
@@ -1,0 +1,11 @@
+import { Effect, Schedule } from "effect";
+
+const cleanupRetry = Schedule.intersect(Schedule.spaced("500 millis"), Schedule.recurs(20));
+
+/** Delete a probe-owned resource, failing the verifier if cleanup is exhausted. */
+export function cleanupPrivateLinkResource(label: string, run: (signal: AbortSignal) => Promise<void>) {
+  return Effect.tryPromise({ try: run, catch: () => new Error(`Cleanup failed: ${label}`) }).pipe(
+    Effect.retry(cleanupRetry),
+    Effect.orDie,
+  );
+}

--- a/web/scripts/devbox-private-link-cleanup.ts
+++ b/web/scripts/devbox-private-link-cleanup.ts
@@ -1,11 +1,30 @@
+// Maintainer-only image verification support; never imported by app/API routes.
 import { Effect, Schedule } from "effect";
+import { FreestyleApiError } from "freestyle";
+import { ProviderError } from "../services/vms/drivers/types";
 
-const cleanupRetry = Schedule.intersect(Schedule.spaced("500 millis"), Schedule.recurs(20));
+/** A provider conflict means deletion is blocked by an attachment still in use. */
+function isDeletionConflict(error: unknown): boolean {
+  const cause = error instanceof ProviderError ? error.cause : error;
+  return cause instanceof FreestyleApiError && cause.status === 409;
+}
 
-/** Delete a probe-owned resource, failing the verifier if cleanup is exhausted. */
+/**
+ * Only a successful provider delete confirms completion. The SDK exposes no
+ * detach-completion event, so retry explicit conflict responses with bounded
+ * exponential backoff. Auth/config failures fail immediately. An overall
+ * deadline also bounds an unresponsive request, including within scope cleanup.
+ * Errors retain only our resource label, never an upstream payload or credential.
+ */
 export function cleanupPrivateLinkResource(label: string, run: (signal: AbortSignal) => Promise<void>) {
-  return Effect.tryPromise({ try: run, catch: () => new Error(`Cleanup failed: ${label}`) }).pipe(
-    Effect.retry(cleanupRetry),
+  return Effect.tryPromise({ try: run, catch: (error) => error }).pipe(
+    Effect.retry({
+      while: isDeletionConflict,
+      schedule: Schedule.intersect(Schedule.exponential("100 millis"), Schedule.recurs(7)),
+    }),
+    Effect.interruptible,
+    Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Cleanup deadline exceeded") }),
+    Effect.mapError(() => new Error(`Cleanup failed: ${label}`)),
     Effect.orDie,
   );
 }

--- a/web/scripts/devbox-private-link-process.ts
+++ b/web/scripts/devbox-private-link-process.ts
@@ -1,0 +1,52 @@
+import { Effect } from "effect";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const attempt = <A>(label: string, run: (signal: AbortSignal) => Promise<A>) =>
+  Effect.tryPromise({ try: run, catch: () => new Error(label) });
+
+function stop(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    child.once("close", () => { clearTimeout(timer); resolve(); });
+    child.kill("SIGTERM");
+  });
+}
+
+function start(client: string, args: string[]) {
+  return Effect.acquireRelease(
+    attempt("Could not start the verification client", () => new Promise<ChildProcess>((resolve, reject) => {
+      const child = spawn(client, args, { stdio: ["ignore", "pipe", "pipe"] });
+      // Keep draining headless state events and stderr without logging identity
+      // or invitation material. A failed step is named by its caller.
+      child.stdout!.resume();
+      child.stderr!.resume();
+      child.once("error", reject);
+      child.once("spawn", () => resolve(child));
+    })),
+    (child) => Effect.promise(() => stop(child)),
+  );
+}
+
+function waitForSocket(socket: string, child: ChildProcess) {
+  return Effect.gen(function* () {
+    while (!existsSync(socket)) {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return yield* Effect.fail(new Error("Private connection process exited before becoming ready"));
+      }
+      yield* Effect.sleep("100 millis");
+    }
+  }).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Private connection did not become ready") }));
+}
+
+
+export function startPrivateLinkClient(client: string, args: string[], ready: {
+  event: "hub-ready" | "connection-snapshot";
+  socket: string;
+}) {
+  return start(client, args).pipe(Effect.map((child) => ({
+    child,
+    ready: waitForSocket(ready.socket, child),
+  })));
+}

--- a/web/scripts/devbox-private-link-process.ts
+++ b/web/scripts/devbox-private-link-process.ts
@@ -1,52 +1,94 @@
 import { Effect } from "effect";
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 
-const attempt = <A>(label: string, run: (signal: AbortSignal) => Promise<A>) =>
-  Effect.tryPromise({ try: run, catch: () => new Error(label) });
+type ReadyEvent = {
+  event: "hub-ready" | "connection-snapshot";
+  socket: string;
+};
 
-function stop(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
-    child.once("close", () => { clearTimeout(timer); resolve(); });
-    child.kill("SIGTERM");
+/** Wait for the child owner's close event after sending a termination signal. */
+function terminate(child: ChildProcess, signal: NodeJS.Signals) {
+  return Effect.async<void>((resume) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resume(Effect.void);
+      return;
+    }
+    const closed = () => resume(Effect.void);
+    child.once("close", closed);
+    child.kill(signal);
+    return Effect.sync(() => child.off("close", closed));
   });
 }
 
-function start(client: string, args: string[]) {
-  return Effect.acquireRelease(
-    attempt("Could not start the verification client", () => new Promise<ChildProcess>((resolve, reject) => {
-      const child = spawn(client, args, { stdio: ["ignore", "pipe", "pipe"] });
-      // Keep draining headless state events and stderr without logging identity
-      // or invitation material. A failed step is named by its caller.
-      child.stdout!.resume();
-      child.stderr!.resume();
-      child.once("error", reject);
-      child.once("spawn", () => resolve(child));
-    })),
-    (child) => Effect.promise(() => stop(child)),
+/** Close owns completion; the deadline only escalates an unresponsive child. */
+function stop(child: ChildProcess) {
+  return terminate(child, "SIGTERM").pipe(
+    Effect.interruptible,
+    Effect.timeoutOption("2 seconds"),
+    Effect.flatMap((completed) => completed._tag === "Some" ? Effect.void : terminate(child, "SIGKILL")),
   );
 }
 
-function waitForSocket(socket: string, child: ChildProcess) {
-  return Effect.gen(function* () {
-    while (!existsSync(socket)) {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        return yield* Effect.fail(new Error("Private connection process exited before becoming ready"));
-      }
-      yield* Effect.sleep("100 millis");
-    }
-  }).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Private connection did not become ready") }));
+/** Match only the expected owner's readiness event and the exact requested socket. */
+function isReady(line: string, expected: ReadyEvent): boolean {
+  try {
+    const event = JSON.parse(line) as Record<string, unknown>;
+    const key = expected.event === "hub-ready" ? "socket" : "local_socket";
+    return event?.event === expected.event && event[key] === expected.socket;
+  } catch {
+    return false;
+  }
 }
 
+/**
+ * Observe stdout from spawn onward, retaining an early ready event until awaited.
+ * The readiness promise never rejects unobserved while enrollment is approved.
+ * Exit/error before readiness fails immediately; socket file existence is irrelevant.
+ */
+function launch(client: string, args: string[], expected: ReadyEvent) {
+  return Effect.async<{ child: ChildProcess; ready: Effect.Effect<void, Error> }, Error>((resume) => {
+    const child = spawn(client, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let complete!: (ready: boolean) => void;
+    const result = new Promise<boolean>((resolve) => { complete = resolve; });
+    const decoder = new StringDecoder("utf8");
+    let buffered = "";
+    let settled = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      buffered = "";
+      complete(ready);
+    };
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (settled) return; // still drain subsequent connection events
+      buffered += decoder.write(chunk);
+      if (buffered.length > 1_048_576) { finish(false); return; }
+      let boundary: number;
+      while (!settled && (boundary = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, boundary);
+        buffered = buffered.slice(boundary + 1);
+        if (isReady(line, expected)) finish(true);
+      }
+    });
+    // Diagnostics can carry invitation material; never echo raw child output.
+    child.stderr!.resume();
+    child.once("close", () => finish(false));
+    child.once("error", () => {
+      finish(false);
+      resume(Effect.fail(new Error("Could not start the verification client")));
+    });
+    child.once("spawn", () => resume(Effect.succeed({
+      child,
+      ready: Effect.promise(() => result).pipe(
+        Effect.flatMap((ready) => ready ? Effect.void : Effect.fail(new Error("Private connection process exited or returned invalid readiness output"))),
+        Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Private connection did not announce readiness") }),
+      ),
+    })));
+  });
+}
 
-export function startPrivateLinkClient(client: string, args: string[], ready: {
-  event: "hub-ready" | "connection-snapshot";
-  socket: string;
-}) {
-  return start(client, args).pipe(Effect.map((child) => ({
-    child,
-    ready: waitForSocket(ready.socket, child),
-  })));
+/** Own a headless verifier process until scope exit, including failed startup. */
+export function startPrivateLinkClient(client: string, args: string[], ready: ReadyEvent) {
+  return Effect.acquireRelease(launch(client, args, ready), ({ child }) => stop(child));
 }

--- a/web/scripts/devbox-private-link-process.ts
+++ b/web/scripts/devbox-private-link-process.ts
@@ -1,3 +1,4 @@
+// Maintainer-only verification subprocesses; these diagnostics are not product CLI copy.
 import { Effect } from "effect";
 import { spawn, type ChildProcess } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
@@ -88,7 +89,11 @@ function launch(client: string, args: string[], expected: ReadyEvent) {
   });
 }
 
-/** Own a headless verifier process until scope exit, including failed startup. */
+/**
+ * Own a headless verifier process until scope exit, including failed startup.
+ * acquireRelease masks interruption through acquisition and finalizer registration:
+ * cancellation between spawn() and its spawn event still acquires, then stops, the child.
+ */
 export function startPrivateLinkClient(client: string, args: string[], ready: ReadyEvent) {
   return Effect.acquireRelease(launch(client, args, ready), ({ child }) => stop(child));
 }

--- a/web/scripts/verify-devbox-private-link.ts
+++ b/web/scripts/verify-devbox-private-link.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * Verify an image through the same private carrier as the Mac app. Local daemon
+ * readiness alone misses a stale client, VPC routing, or enrollment failure.
+ *
+ * bun scripts/verify-devbox-private-link.ts <snapshot-id> <cmux-tui-client>
+ *
+ * Requires FREESTYLE_API_KEY. Creates an isolated VM, VPC, and temporary tunnel;
+ * deletes all three, including on failure. Never modifies existing machines.
+ * Uses the supplied client on macOS or Linux, without installing a system VPN.
+ */
+import { Effect, Schedule } from "effect";
+import { spawn, type ChildProcess } from "node:child_process";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { FreestyleProvider } from "../services/vms/drivers/freestyle";
+
+const attempt = <A>(label: string, run: (signal: AbortSignal) => Promise<A>) =>
+  Effect.tryPromise({ try: run, catch: () => new Error(label) });
+
+function stop(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    child.once("close", () => { clearTimeout(timer); resolve(); });
+    child.kill("SIGTERM");
+  });
+}
+
+function start(client: string, args: string[]) {
+  return Effect.acquireRelease(
+    attempt("Could not start the verification client", () => new Promise<ChildProcess>((resolve, reject) => {
+      const child = spawn(client, args, { stdio: ["ignore", "pipe", "pipe"] });
+      // Keep draining headless state events and stderr without logging identity
+      // or invitation material. A failed step is named by its caller.
+      child.stdout!.resume();
+      child.stderr!.resume();
+      child.once("error", reject);
+      child.once("spawn", () => resolve(child));
+    })),
+    (child) => Effect.promise(() => stop(child)),
+  );
+}
+
+function command(client: string, args: string[], label: string) {
+  return attempt(label, (signal) => new Promise<string>((resolve, reject) => {
+    const child = spawn(client, args, { signal, stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout!.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.length > 1_048_576) { child.kill(); reject(new Error(label)); }
+    });
+    child.stderr!.resume();
+    child.once("error", reject);
+    child.once("close", (code) => code === 0 ? resolve(output) : reject(new Error(label)));
+  })).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error(`${label}: timed out`) }));
+}
+
+const cleanupRetry = Schedule.intersect(Schedule.spaced("500 millis"), Schedule.recurs(20));
+const cleanup = (label: string, run: () => Promise<void>) =>
+  attempt(`Cleanup failed: ${label}`, run).pipe(Effect.retry(cleanupRetry), Effect.orDie);
+
+function waitForSocket(socket: string, child: ChildProcess) {
+  return Effect.gen(function* () {
+    while (!existsSync(socket)) {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return yield* Effect.fail(new Error("Private connection process exited before becoming ready"));
+      }
+      yield* Effect.sleep("100 millis");
+    }
+  }).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Private connection did not become ready") }));
+}
+
+function readSnapshot(client: string, socket: string) {
+  return Effect.gen(function* () {
+    const stdout = yield* command(client, ["--socket", socket, "--json", "session", "current", "snapshot"], "Session snapshot failed");
+    const snapshot = yield* Effect.try(() => JSON.parse(stdout));
+    if (!Array.isArray(snapshot.workspaces) || !Array.isArray(snapshot.terminals)) {
+      return yield* Effect.fail(new Error("Private session returned an invalid snapshot"));
+    }
+  });
+}
+
+function verify(image: string, client: string) {
+  return Effect.gen(function* () {
+    const rawProbe = yield* command(client, ["remote-probe", "--json"], "Client probe failed");
+    const probe = yield* Effect.try(() => JSON.parse(rawProbe));
+    if (probe.app !== "cmux-tui" || !Array.isArray(probe.capabilities) || !probe.capabilities.includes("wireguard-hub")) {
+      return yield* Effect.fail(new Error("This client lacks wireguard-hub. Update cmux NIGHTLY before diagnosing or replacing the Freestyle image."));
+    }
+    if (!process.env.FREESTYLE_API_KEY) return yield* Effect.fail(new Error("Set FREESTYLE_API_KEY"));
+    const provider = new FreestyleProvider();
+    const networking = provider.privateNetworking;
+    const root = yield* Effect.acquireRelease(
+      Effect.sync(() => mkdtempSync(path.join(tmpdir(), "cmux-image-link-"))),
+      (directory) => Effect.sync(() => rmSync(directory, { recursive: true, force: true })),
+    );
+    const slug = `cmux-image-check-${randomUUID().slice(0, 12)}`;
+    const network = yield* Effect.acquireRelease(
+      attempt("Create diagnostic VPC failed", () => networking.ensureNetwork({ slug })),
+      (value) => cleanup(`VPC ${value.id}`, () => networking.deleteNetwork(value.id)),
+    );
+    const vm = yield* Effect.acquireRelease(
+      attempt("Create diagnostic VM failed", () => provider.create({ image, network: { id: network.id }, displayName: slug })),
+      (value) => cleanup(`VM ${value.providerVmId}`, () => provider.destroy(value.providerVmId)),
+    );
+    const { privateKey, publicKey } = generateKeyPairSync("x25519");
+    const clientPublicKey = publicKey.export({ type: "spki", format: "der" }).subarray(-32).toString("base64");
+    const privateBytes = privateKey.export({ type: "pkcs8", format: "der" }).subarray(-32).toString("base64");
+    const { tunnel } = yield* Effect.acquireRelease(
+      attempt("Create diagnostic tunnel failed", () => networking.createTunnel({ slug, networkId: network.id, clientPublicKey })),
+      (value) => cleanup(`tunnel ${value.tunnel.id}`, () => networking.deleteTunnel(value.tunnel.id)),
+    );
+    if (!/^PrivateKey\s*=/m.test(tunnel.clientConfig)) {
+      return yield* Effect.fail(new Error("Tunnel config has no private-key field"));
+    }
+    const config = tunnel.clientConfig.replace(/^PrivateKey\s*=.*$/m, `PrivateKey = ${privateBytes}`);
+    const configPath = path.join(root, "wg.conf"), hubSocket = path.join(root, "wg.sock");
+    yield* Effect.try(() => writeFileSync(configPath, config, { mode: 0o600 }));
+    const hub = yield* start(client, ["wg", "hub", "--config", configPath, "--socket", hubSocket]);
+    yield* waitForSocket(hubSocket, hub);
+    const endpoint = yield* attempt("Read image attach bundle failed", () => provider.openCmuxRemote(vm.providerVmId, { clientCapabilities: probe.capabilities }));
+    if (!endpoint.invitation) return yield* Effect.fail(new Error("Fresh VM returned no enrollment invitation"));
+    const invitation = endpoint.invitation;
+    const invitePath = path.join(root, "invite");
+    yield* Effect.try(() => writeFileSync(invitePath, invitation.uri, { mode: 0o600 }));
+    const args = ["remote", "connect", endpoint.route, "--state-dir", path.join(root, "identity"),
+      "--device-name", slug, "--headless", "--json", "--wireguard-hub", hubSocket,
+      "--connect-timeout-seconds", "30", "--reconnect-attempts", "1"];
+    // Enroll once, then reconnect from the persisted client identity with no
+    // control-plane attach/approval call. This also tests older baked daemons.
+    yield* Effect.scoped(Effect.gen(function* () {
+      const socket = path.join(root, "first.sock");
+      const connection = yield* start(client, [...args, "--local-socket", socket, "--invite-file", invitePath]);
+      yield* attempt("Approve image enrollment failed", () => provider.approveCmuxRemoteEnrollment(vm.providerVmId, invitation.invitationId));
+      yield* waitForSocket(socket, connection);
+      yield* readSnapshot(client, socket);
+    }));
+    const socket = path.join(root, "reconnect.sock");
+    const connection = yield* start(client, [...args, "--local-socket", socket]);
+    yield* waitForSocket(socket, connection);
+    yield* readSnapshot(client, socket);
+    console.log(JSON.stringify({ image, clientCommit: probe.build_identity,
+      daemonCommit: endpoint.daemonBuild?.commit, enrollment: "passed", reconnect: "passed", snapshot: "passed" }));
+  });
+}
+
+const [image, client] = process.argv.slice(2);
+if (!image || !client || !/^sh-[a-zA-Z0-9]+$/.test(image)) {
+  console.error("Usage: bun scripts/verify-devbox-private-link.ts <snapshot-id> <cmux-tui-client>");
+  process.exit(1);
+}
+const controller = new AbortController();
+const interrupt = () => controller.abort();
+process.once("SIGINT", interrupt);
+process.once("SIGTERM", interrupt);
+try {
+  await Effect.runPromise(Effect.scoped(verify(image, path.resolve(client))), { signal: controller.signal });
+} catch (error: unknown) {
+  console.error(String(error));
+  process.exitCode = 1;
+} finally {
+  process.off("SIGINT", interrupt);
+  process.off("SIGTERM", interrupt);
+}

--- a/web/scripts/verify-devbox-private-link.ts
+++ b/web/scripts/verify-devbox-private-link.ts
@@ -10,39 +10,16 @@
  * Uses the supplied client on macOS or Linux, without installing a system VPN.
  */
 import { Effect, Schedule } from "effect";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { startPrivateLinkClient } from "./devbox-private-link-process";
 import { FreestyleProvider } from "../services/vms/drivers/freestyle";
 
 const attempt = <A>(label: string, run: (signal: AbortSignal) => Promise<A>) =>
   Effect.tryPromise({ try: run, catch: () => new Error(label) });
-
-function stop(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
-    child.once("close", () => { clearTimeout(timer); resolve(); });
-    child.kill("SIGTERM");
-  });
-}
-
-function start(client: string, args: string[]) {
-  return Effect.acquireRelease(
-    attempt("Could not start the verification client", () => new Promise<ChildProcess>((resolve, reject) => {
-      const child = spawn(client, args, { stdio: ["ignore", "pipe", "pipe"] });
-      // Keep draining headless state events and stderr without logging identity
-      // or invitation material. A failed step is named by its caller.
-      child.stdout!.resume();
-      child.stderr!.resume();
-      child.once("error", reject);
-      child.once("spawn", () => resolve(child));
-    })),
-    (child) => Effect.promise(() => stop(child)),
-  );
-}
 
 function command(client: string, args: string[], label: string) {
   return attempt(label, (signal) => new Promise<string>((resolve, reject) => {
@@ -61,17 +38,6 @@ function command(client: string, args: string[], label: string) {
 const cleanupRetry = Schedule.intersect(Schedule.spaced("500 millis"), Schedule.recurs(20));
 const cleanup = (label: string, run: () => Promise<void>) =>
   attempt(`Cleanup failed: ${label}`, run).pipe(Effect.retry(cleanupRetry), Effect.orDie);
-
-function waitForSocket(socket: string, child: ChildProcess) {
-  return Effect.gen(function* () {
-    while (!existsSync(socket)) {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        return yield* Effect.fail(new Error("Private connection process exited before becoming ready"));
-      }
-      yield* Effect.sleep("100 millis");
-    }
-  }).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error("Private connection did not become ready") }));
-}
 
 function readSnapshot(client: string, socket: string) {
   return Effect.gen(function* () {
@@ -119,8 +85,8 @@ function verify(image: string, client: string) {
     const config = tunnel.clientConfig.replace(/^PrivateKey\s*=.*$/m, `PrivateKey = ${privateBytes}`);
     const configPath = path.join(root, "wg.conf"), hubSocket = path.join(root, "wg.sock");
     yield* Effect.try(() => writeFileSync(configPath, config, { mode: 0o600 }));
-    const hub = yield* start(client, ["wg", "hub", "--config", configPath, "--socket", hubSocket]);
-    yield* waitForSocket(hubSocket, hub);
+    const hub = yield* startPrivateLinkClient(client, ["wg", "hub", "--config", configPath, "--socket", hubSocket], { event: "hub-ready", socket: hubSocket });
+    yield* hub.ready;
     const endpoint = yield* attempt("Read image attach bundle failed", () => provider.openCmuxRemote(vm.providerVmId, { clientCapabilities: probe.capabilities }));
     if (!endpoint.invitation) return yield* Effect.fail(new Error("Fresh VM returned no enrollment invitation"));
     const invitation = endpoint.invitation;
@@ -133,14 +99,14 @@ function verify(image: string, client: string) {
     // control-plane attach/approval call. This also tests older baked daemons.
     yield* Effect.scoped(Effect.gen(function* () {
       const socket = path.join(root, "first.sock");
-      const connection = yield* start(client, [...args, "--local-socket", socket, "--invite-file", invitePath]);
+      const connection = yield* startPrivateLinkClient(client, [...args, "--local-socket", socket, "--invite-file", invitePath], { event: "connection-snapshot", socket });
       yield* attempt("Approve image enrollment failed", () => provider.approveCmuxRemoteEnrollment(vm.providerVmId, invitation.invitationId));
-      yield* waitForSocket(socket, connection);
+      yield* connection.ready;
       yield* readSnapshot(client, socket);
     }));
     const socket = path.join(root, "reconnect.sock");
-    const connection = yield* start(client, [...args, "--local-socket", socket]);
-    yield* waitForSocket(socket, connection);
+    const connection = yield* startPrivateLinkClient(client, [...args, "--local-socket", socket], { event: "connection-snapshot", socket });
+    yield* connection.ready;
     yield* readSnapshot(client, socket);
     console.log(JSON.stringify({ image, clientCommit: probe.build_identity,
       daemonCommit: endpoint.daemonBuild?.commit, enrollment: "passed", reconnect: "passed", snapshot: "passed" }));

--- a/web/scripts/verify-devbox-private-link.ts
+++ b/web/scripts/verify-devbox-private-link.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 /**
+ * Maintainer-only test harness, not a shipped application command.
  * Verify an image through the same private carrier as the Mac app. Local daemon
  * readiness alone misses a stale client, VPC routing, or enrollment failure.
  *
@@ -19,9 +20,11 @@ import { cleanupPrivateLinkResource as cleanup } from "./devbox-private-link-cle
 import { startPrivateLinkClient } from "./devbox-private-link-process";
 import { FreestyleProvider } from "../services/vms/drivers/freestyle";
 
+/** Convert provider failures to local operator stage labels without upstream payloads. */
 const attempt = <A>(label: string, run: (signal: AbortSignal) => Promise<A>) =>
   Effect.tryPromise({ try: run, catch: () => new Error(label) });
 
+/** Run one bounded client command and capture its machine-readable response. */
 function command(client: string, args: string[], label: string) {
   return attempt(label, (signal) => new Promise<string>((resolve, reject) => {
     const child = spawn(client, args, { signal, stdio: ["ignore", "pipe", "pipe"] });
@@ -36,6 +39,7 @@ function command(client: string, args: string[], label: string) {
   })).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error(`${label}: timed out`) }));
 }
 
+/** Require a usable resource graph from the connected session. */
 function readSnapshot(client: string, socket: string) {
   return Effect.gen(function* () {
     const stdout = yield* command(client, ["--socket", socket, "--json", "session", "current", "snapshot"], "Session snapshot failed");
@@ -46,6 +50,7 @@ function readSnapshot(client: string, socket: string) {
   });
 }
 
+/** Verify private enrollment and reconnect using exclusively probe-owned resources. */
 function verify(image: string, client: string) {
   return Effect.gen(function* () {
     const rawProbe = yield* command(client, ["remote-probe", "--json"], "Client probe failed");

--- a/web/scripts/verify-devbox-private-link.ts
+++ b/web/scripts/verify-devbox-private-link.ts
@@ -9,12 +9,13 @@
  * deletes all three, including on failure. Never modifies existing machines.
  * Uses the supplied client on macOS or Linux, without installing a system VPN.
  */
-import { Effect, Schedule } from "effect";
+import { Effect } from "effect";
 import { spawn } from "node:child_process";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { cleanupPrivateLinkResource as cleanup } from "./devbox-private-link-cleanup";
 import { startPrivateLinkClient } from "./devbox-private-link-process";
 import { FreestyleProvider } from "../services/vms/drivers/freestyle";
 
@@ -34,10 +35,6 @@ function command(client: string, args: string[], label: string) {
     child.once("close", (code) => code === 0 ? resolve(output) : reject(new Error(label)));
   })).pipe(Effect.timeoutFail({ duration: "30 seconds", onTimeout: () => new Error(`${label}: timed out`) }));
 }
-
-const cleanupRetry = Schedule.intersect(Schedule.spaced("500 millis"), Schedule.recurs(20));
-const cleanup = (label: string, run: () => Promise<void>) =>
-  attempt(`Cleanup failed: ${label}`, run).pipe(Effect.retry(cleanupRetry), Effect.orDie);
 
 function readSnapshot(client: string, socket: string) {
   return Effect.gen(function* () {

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -293,8 +293,9 @@ The client need not match the image's older baked commit: successful protocol
 operations are the compatibility check.
 
 Keys and invitations are held in an owner-only temporary directory. Processes,
-VM, tunnel, and VPC are cleaned up on success and failure; VPC deletion retries
-while the provider finishes detaching the deleted VM. The probe never opens
+VM, tunnel, and VPC are cleaned up on success and failure; Deletion retries only explicit provider conflict responses with bounded
+exponential backoff; only a successful delete confirms completion. Permanent
+refusals fail immediately, and each resource cleanup has a 30-second deadline. The probe never opens
 public ingress, installs a system VPN, or changes an existing machine. A
 cleanup failure names the resource requiring operator attention and fails the
 command. Run this alongside `devbox:verify` when validating a new image or a

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -266,3 +266,36 @@ Only after verify passes may an entry carry `validationStatus: "passed"`;
 `vm-image-manifest.test.ts` refuses a `defaultForKind` entry with any other
 status. Machines created from the old cmuxd-remote images cannot serve the
 `cmux-remote` transport and need recreation on a devbox image.
+
+## Checking a private connection
+
+A healthy daemon inside an image does not prove that a particular Mac client
+can connect to it. Check the client and image together before replacing a
+snapshot to address an attach failure:
+
+```bash
+# From web/, using the Freestyle account that owns this snapshot.
+# Load FREESTYLE_API_KEY from ~/.secrets/cmux.env without printing it.
+bun run devbox:verify:private-link sh-<snapshot-id> /path/to/cmux-tui
+```
+
+For a Mac app, use its `Contents/Resources/bin/cmux-tui` binary. The probe
+first requires the client's `wireguard-hub` capability; an older client must
+be updated before a private-network image can be assessed. Rebuilding a guest
+image cannot add that missing capability to an installed Mac app.
+
+The probe creates its own VPC, VM from the requested snapshot, and temporary
+WireGuard tunnel. It uses the production driver to obtain and approve an
+invitation, reads the session snapshot through the private hub, then connects
+again with the persisted device identity and no new invitation. The report
+records both commits and the enrollment, reconnect, and snapshot results.
+The client need not match the image's older baked commit: successful protocol
+operations are the compatibility check.
+
+Keys and invitations are held in an owner-only temporary directory. Processes,
+VM, tunnel, and VPC are cleaned up on success and failure; VPC deletion retries
+while the provider finishes detaching the deleted VM. The probe never opens
+public ingress, installs a system VPN, or changes an existing machine. A
+cleanup failure names the resource requiring operator attention and fails the
+command. Run this alongside `devbox:verify` when validating a new image or a
+new Cloud client.

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -26,6 +26,7 @@ declare module "bun:test" {
   type SpiedFunction<T extends (...args: never[]) => unknown> = T & {
     mock: { calls: Parameters<T>[] };
     mockRestore: () => void;
+    mockImplementation: (implementation: (...args: Parameters<T>) => ReturnType<T>) => SpiedFunction<T>;
   };
 
   export const afterAll: LifecycleHook;

--- a/web/tests/devbox-private-link-cleanup.test.ts
+++ b/web/tests/devbox-private-link-cleanup.test.ts
@@ -45,7 +45,7 @@ test("a stalled provider call fails at the cleanup deadline and cancels its requ
   const outcome = await Effect.runPromise(Effect.gen(function* () {
     const work = yield* Effect.fork(cleanupPrivateLinkResource("VPC probe", (signal) => new Promise(() => {
       signal.addEventListener("abort", () => { aborted = true; }, { once: true });
-    })));
+    })).pipe(Effect.uninterruptible));
     yield* TestClock.adjust("30 seconds");
     const result = yield* Fiber.poll(work);
     yield* Fiber.interrupt(work);
@@ -54,4 +54,20 @@ test("a stalled provider call fails at the cleanup deadline and cancels its requ
   expect(outcome._tag).toBe("Some");
   if (outcome._tag === "Some") expect(outcome.value._tag).toBe("Failure");
   expect(aborted).toBe(true);
+});
+
+test("scope interruption still runs resource cleanup", async () => {
+  const { Deferred } = await import("effect");
+  let calls = 0;
+  await Effect.runPromise(Effect.gen(function* () {
+    const using = yield* Deferred.make<void>();
+    const work = yield* Effect.fork(Effect.scoped(Effect.gen(function* () {
+      yield* Effect.acquireRelease(Effect.void, () => cleanupPrivateLinkResource("VM probe", async () => { calls++; }));
+      yield* Deferred.succeed(using, undefined);
+      yield* Effect.never;
+    })));
+    yield* Deferred.await(using);
+    yield* Fiber.interrupt(work);
+  }));
+  expect(calls).toBe(1);
 });

--- a/web/tests/devbox-private-link-cleanup.test.ts
+++ b/web/tests/devbox-private-link-cleanup.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { Effect, Fiber, TestClock, TestContext } from "effect";
+import { FreestyleApiError } from "freestyle";
+import { ProviderError } from "../services/vms/drivers/types";
+import { cleanupPrivateLinkResource } from "../scripts/devbox-private-link-cleanup";
+
+const failure = (status: number, code: string) => new ProviderError(
+  "freestyle", "deletion failed", new FreestyleApiError(status, { code, message: "provider response" }),
+);
+
+test("successful deletion completes without another provider call", async () => {
+  let calls = 0;
+  await Effect.runPromise(cleanupPrivateLinkResource("VM probe", async () => { calls++; }));
+  expect(calls).toBe(1);
+});
+
+test("deletion conflicts require a successful provider response before completion", async () => {
+  let calls = 0;
+  await Effect.runPromise(Effect.gen(function* () {
+    const work = yield* Effect.fork(cleanupPrivateLinkResource("VPC probe", async () => {
+      if (++calls < 3) throw failure(409, "CONFLICT");
+    }));
+    yield* TestClock.adjust("1 second");
+    yield* Fiber.join(work);
+  }).pipe(Effect.provide(TestContext.TestContext)));
+  expect(calls).toBe(3);
+});
+
+test("a permanent provider refusal is not retried", async () => {
+  let calls = 0;
+  const outcome = await Effect.runPromise(Effect.gen(function* () {
+    const work = yield* Effect.fork(cleanupPrivateLinkResource("tunnel probe", async () => {
+      calls++;
+      throw failure(403, "FORBIDDEN");
+    }));
+    yield* TestClock.adjust("15 seconds");
+    return yield* Fiber.await(work);
+  }).pipe(Effect.provide(TestContext.TestContext)));
+  expect(outcome._tag).toBe("Failure");
+  expect(calls).toBe(1);
+});
+
+test("a stalled provider call fails at the cleanup deadline and cancels its request", async () => {
+  let aborted = false;
+  const outcome = await Effect.runPromise(Effect.gen(function* () {
+    const work = yield* Effect.fork(cleanupPrivateLinkResource("VPC probe", (signal) => new Promise(() => {
+      signal.addEventListener("abort", () => { aborted = true; }, { once: true });
+    })));
+    yield* TestClock.adjust("30 seconds");
+    const result = yield* Fiber.poll(work);
+    yield* Fiber.interrupt(work);
+    return result;
+  }).pipe(Effect.provide(TestContext.TestContext)));
+  expect(outcome._tag).toBe("Some");
+  if (outcome._tag === "Some") expect(outcome.value._tag).toBe("Failure");
+  expect(aborted).toBe(true);
+});

--- a/web/tests/devbox-private-link-process.test.ts
+++ b/web/tests/devbox-private-link-process.test.ts
@@ -23,7 +23,7 @@ test("a socket path cannot substitute for the process readiness event", async ()
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const fixture = `
         const fs = require('node:fs');
-        process.stdin.resume();
+        require('node:net').createServer().listen(${JSON.stringify(path.join(root, 'keepalive.sock'))});
         process.on('SIGUSR1', () => process.stdout.write(JSON.stringify({event:'hub-ready',socket:${JSON.stringify(socket)}})+'\\n'));
         fs.writeFileSync(${JSON.stringify(booted)}, 'ready for signal');
       `;
@@ -50,5 +50,37 @@ test("child exit before readiness fails even if its old socket path exists", asy
       return yield* Effect.either(managed.ready);
     })));
     expect(result._tag).toBe("Left");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("shutdown escalates only after its deadline and waits for process close", async () => {
+  const { Fiber, TestClock, TestContext } = await import("effect");
+  const root = mkdtempSync(path.join(tmpdir(), "cmux-close-test-"));
+  const stopped = path.join(root, "sigterm");
+  const socket = path.join(root, "hub.sock");
+  const receivedTerminate = new Promise<void>((resolve) => {
+    const watcher = watch(root, () => {
+      if (existsSync(stopped)) { watcher.close(); resolve(); }
+    });
+  });
+  let closed = false;
+  try {
+    await Effect.runPromise(Effect.gen(function* () {
+      const fiber = yield* Effect.fork(Effect.scoped(Effect.gen(function* () {
+        const fixture = `
+          require('node:net').createServer().listen(${JSON.stringify(socket)});
+          process.on('SIGTERM', () => require('node:fs').writeFileSync(${JSON.stringify(stopped)}, 'ignored'));
+          process.stdout.write(JSON.stringify({event:'hub-ready',socket:${JSON.stringify(socket)}})+'\\n');
+        `;
+        const managed = yield* startPrivateLinkClient(process.execPath, ["-e", fixture], { event: "hub-ready", socket });
+        managed.child.once("close", () => { closed = true; });
+        yield* managed.ready;
+      })));
+      yield* Effect.promise(() => receivedTerminate);
+      expect(closed).toBe(false);
+      yield* TestClock.adjust("2 seconds");
+      yield* Fiber.join(fiber);
+    }).pipe(Effect.provide(TestContext.TestContext)));
+    expect(closed).toBe(true);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/web/tests/devbox-private-link-process.test.ts
+++ b/web/tests/devbox-private-link-process.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { Effect } from "effect";
+import { mkdtempSync, rmSync, writeFileSync, watch, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { startPrivateLinkClient } from "../scripts/devbox-private-link-process";
+
+// The fixture has bound a path, but has not announced readiness. The parent
+// controls the actual readiness event with a signal, independently of time.
+test("a socket path cannot substitute for the process readiness event", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "cmux-ready-test-"));
+  const socket = path.join(root, "hub.sock");
+  const booted = path.join(root, "booted");
+  writeFileSync(socket, "stale path");
+  const initialized = new Promise<void>((resolve) => {
+    const watcher = watch(root, () => {
+      if (existsSync(booted)) { watcher.close(); resolve(); }
+    });
+  });
+  let settledBeforeEvent = false;
+  try {
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const fixture = `
+        const fs = require('node:fs');
+        process.stdin.resume();
+        process.on('SIGUSR1', () => process.stdout.write(JSON.stringify({event:'hub-ready',socket:${JSON.stringify(socket)}})+'\\n'));
+        fs.writeFileSync(${JSON.stringify(booted)}, 'ready for signal');
+      `;
+      const managed = yield* startPrivateLinkClient(process.execPath, ["-e", fixture], { event: "hub-ready", socket });
+      yield* Effect.promise(() => initialized);
+      let settled = false;
+      const readiness = Effect.runPromise(managed.ready).then(() => { settled = true; });
+      yield* Effect.promise(() => setImmediate());
+      settledBeforeEvent = settled;
+      managed.child.kill("SIGUSR1");
+      yield* Effect.promise(() => readiness);
+    })));
+    expect(settledBeforeEvent).toBe(false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("child exit before readiness fails even if its old socket path exists", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "cmux-ready-exit-"));
+  const socket = path.join(root, "link.sock");
+  writeFileSync(socket, "stale path");
+  try {
+    const result = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const managed = yield* startPrivateLinkClient(process.execPath, ["-e", "process.exit(1)"], { event: "connection-snapshot", socket });
+      return yield* Effect.either(managed.ready);
+    })));
+    expect(result._tag).toBe("Left");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/web/tests/devbox-private-link-process.test.ts
+++ b/web/tests/devbox-private-link-process.test.ts
@@ -84,3 +84,29 @@ test("shutdown escalates only after its deadline and waits for process close", a
     expect(closed).toBe(true);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+// Trigger cancellation synchronously inside spawn's return path, before Node
+// can emit its spawn event. acquireRelease must finish acquisition and reap it.
+test("interruption before the spawn event still closes the acquired child", async () => {
+  const childProcess = await import("node:child_process");
+  const { spyOn } = await import("bun:test");
+  const originalSpawn = childProcess.spawn;
+  const controller = new AbortController();
+  let closed = false;
+  let spawned = false;
+  const spy = spyOn(childProcess, "spawn").mockImplementation((...args: Parameters<typeof originalSpawn>) => {
+    const child = originalSpawn(...args);
+    child.once("spawn", () => { spawned = true; });
+    child.once("close", () => { closed = true; });
+    controller.abort();
+    return child;
+  });
+  try {
+    const result = await Effect.runPromiseExit(Effect.scoped(startPrivateLinkClient(
+      process.execPath, ["-e", "process.stdin.resume()"], { event: "hub-ready", socket: "/unused" },
+    )), { signal: controller.signal });
+    expect(result._tag).toBe("Failure");
+    expect(spawned).toBe(true);
+    expect(closed).toBe(true);
+  } finally { spy.mockRestore(); }
+});


### PR DESCRIPTION
Healthy Freestyle images can look broken when an installed Cloud client lacks the private-network transport. Add a maintainer probe that checks the supplied client's `wireguard-hub` capability before provisioning, then validates the actual private connection to the image.

`bun run devbox:verify:private-link <snapshot-id> <client>` creates an isolated VPC, VM, and temporary WireGuard tunnel; enrolls the client; reads the session snapshot; and reconnects with persisted identity without another invitation. Startup waits for the child's `hub-ready` / `connection-snapshot` event with the exact socket value. Effect scopes await process exit and clean up cloud resources and credentials on success, failure, and interruption. A tested shutdown deadline handles an unresponsive child, and provider deletion retries only explicit conflict responses with bounded exponential backoff and a 30-second deadline per resource. Permanent provider refusals fail immediately; only successful deletion confirms cleanup.

Production image selection and VM contents are unchanged. The internal runbook documents the command and cleanup recovery. This operator-only tool is not imported into the app, API routes, or website; no product copy or locale catalogs change.

Validation:
- Existing 8 GB Base image `sh-3a917ad675fb4e458a3e55b02c612f27`, baked daemon `dbc4b56210592341acd1f51c420cd7b743152424`: private enrollment, snapshot, and reconnect passed with the published, notarized Nightly client `d175f9f64b1001c561b8001edbe54813f91cbf63`.
- The older installed client `46223d8245` is rejected before cloud provisioning. Updating that local Nightly installation supplies the required transport; a guest rebake cannot fix an old Mac client.
- `bun test tests/devbox-private-link-process.test.ts tests/devbox-private-link-cleanup.test.ts`: 9 passed. The separate regression commit demonstrates stale socket paths incorrectly passed before the fix; real child processes and Effect TestClock cover readiness, early exit, shutdown escalation, interruption before the spawn event, cleanup conflicts, permanent refusals, stalled requests, and finalization after scope interruption.
- `bun run typecheck`, targeted ESLint, and `bun run lint:complexity`: passed.
- Temporary diagnostic resources were cleaned up. No existing VM was rebuilt or restarted.
- Merged latest `origin/main` (`74e79260a2`) without conflicts.

Follow-up to #11789 and #11999.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791178541&installation_model_id=21920&pr_number=12014&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12014&signature=8e6a8719a68168b06c1fc9c8ff436928f1ba109f20632a35eac8dd8a7e829adc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verification script that checks an installed Cloud client can actually connect to a Freestyle image over the private network. Previously, readiness checks only proved the daemon runs inside the guest, so an outdated client missing `wireguard-hub` could make a healthy image look broken. Production images, existing machines, and application behavior are unchanged.

- Runs `bun run devbox:verify:private-link <snapshot-id> <client>`, which probes client capabilities, then creates an isolated VPC, VM, and WireGuard tunnel to enroll, read a session snapshot, and reconnect with persisted identity.
- Rejects clients without `wireguard-hub` before any provisioning and cleans up resources on success, failure, or interrupt; deletion retries only provider conflict responses with bounded backoff, while permanent refusals fail immediately.
- Readiness waits for a process-emitted event rather than socket file existence, so a stale socket can't pass the check; unit tests cover this and interruption during client startup.
- Documents usage in the devbox image runbook.

<sup>Written for commit 547330372294a1da6d1fb9831b5eaf0b7efd82d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end command for verifying private-link connectivity, including enrollment, reconnection, and session snapshot access.
  - The verification creates and removes its temporary test environment automatically and reports failures with a non-zero exit status.
  - Added safeguards for connection startup, readiness detection, timeouts, and process shutdown.

- **Documentation**
  - Added setup and usage guidance for checking private connections, including prerequisites, verification steps, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->