### PR TITLE
Use native Cloud VM size picker

### DIFF
--- a/Sources/Cloud/NewMachineSheet.swift
+++ b/Sources/Cloud/NewMachineSheet.swift
@@ -21,7 +21,7 @@ struct NewMachineSheet: View {
             buttons
         }
         .padding(24)
-        .frame(width: 520)
+        .frame(width: 500)
         .accessibilityIdentifier("NewMachineSheet")
     }
 
@@ -59,90 +59,45 @@ struct NewMachineSheet: View {
                 .foregroundStyle(.secondary)
             }
 
-            LazyVGrid(
-                columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
-                spacing: 8
-            ) {
-                ForEach(model.memoryOptions, id: \.self) { memoryMb in
-                    if let size = MachineSizeOption(memoryMb: memoryMb) {
-                        sizeOption(size)
+            if let selectedSize = model.selectedSize {
+                Picker(selection: $model.memoryMb) {
+                    ForEach(model.memoryOptions, id: \.self) { memoryMb in
+                        if let size = MachineSizeOption(memoryMb: memoryMb) {
+                            Text(size.menuTitle).tag(memoryMb)
+                        }
                     }
+                } label: {
+                    Text(selectedSize.menuTitle)
                 }
-            }
-        }
-        .padding(14)
-        .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.09), lineWidth: 1)
-        )
-        .accessibilityIdentifier("NewMachineSheet.sizeSection")
-    }
+                .pickerStyle(.menu)
+                .accessibilityIdentifier("NewMachineSheet.size")
+                .accessibilityLabel(String(localized: "machines.new.size.accessibilityLabel", defaultValue: "RAM size"))
+                .accessibilityValue(selectedSize.menuTitle)
 
-    private func sizeOption(_ size: MachineSizeOption) -> some View {
-        let isSelected = model.memoryMb == size.memoryMb
-        return Button {
-            model.memoryMb = size.memoryMb
-        } label: {
-            HStack(alignment: .center, spacing: 10) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(size.title)
-                        .cmuxFont(size: 13, weight: .semibold)
-                    Text(size.detail)
-                        .cmuxFont(size: 11)
-                        .foregroundStyle(isSelected ? Color.primary.opacity(0.78) : Color.secondary)
-                }
-                Spacer(minLength: 4)
-                if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Color.accentColor)
-                }
+                Text(selectedSize.detail)
+                    .cmuxFont(size: 11)
+                    .foregroundStyle(.secondary)
             }
-            .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
-            .padding(.horizontal, 11)
-            .padding(.vertical, 8)
-            .background(
-                isSelected ? Color.accentColor.opacity(0.14) : Color.primary.opacity(0.035),
-                in: RoundedRectangle(cornerRadius: 9, style: .continuous)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .strokeBorder(
-                        isSelected ? Color.accentColor.opacity(0.76) : Color.primary.opacity(0.12),
-                        lineWidth: isSelected ? 1.5 : 1
-                    )
-            )
         }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("NewMachineSheet.size.\(size.memoryMb)")
-        .accessibilityLabel(size.menuTitle)
-        .accessibilityAddTraits(isSelected ? AccessibilityTraits.isSelected : [])
+        .accessibilityIdentifier("NewMachineSheet.sizeSection")
     }
 
     @ViewBuilder
     private var planSection: some View {
         if model.planMeterText != nil || model.freeAccessNoteText != nil {
-            HStack(alignment: .top, spacing: 9) {
-                Image(systemName: "chart.bar.fill")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 16, height: 16)
-                VStack(alignment: .leading, spacing: 3) {
-                    if let meter = model.planMeterText {
-                        Text(meter)
-                            .cmuxFont(size: 11, weight: .medium)
-                            .foregroundStyle(.secondary)
-                    }
-                    if let note = model.freeAccessNoteText {
-                        Text(note)
-                            .cmuxFont(size: 11)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+            VStack(alignment: .leading, spacing: 3) {
+                if let meter = model.planMeterText {
+                    Text(meter)
+                        .cmuxFont(size: 11, weight: .medium)
+                        .foregroundStyle(.secondary)
+                }
+                if let note = model.freeAccessNoteText {
+                    Text(note)
+                        .cmuxFont(size: 11)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .padding(.vertical, 2)
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityIdentifier("NewMachineSheet.plan")
         }
@@ -208,3 +163,193 @@ struct NewMachineSheet: View {
     }
 
 }
+
+#if DEBUG
+/// Plain SwiftUI alternatives for reviewing the size control without a web mockup.
+/// These views are preview-only. The sheet uses the first variation: the native menu.
+private struct NewMachinePickerVariationsPreview: View {
+    @State private var selectedMemoryMb = 8192
+
+    private static let sizes = [4096, 8192, 16384, 24576, 32768, 65536]
+        .compactMap { MachineSizeOption(memoryMb: $0) }
+
+    private var selectedSize: MachineSizeOption {
+        MachineSizeOption(memoryMb: selectedMemoryMb) ?? Self.sizes[1]
+    }
+
+    private var selectedIndex: Int {
+        Self.sizes.firstIndex(where: { $0.memoryMb == selectedMemoryMb }) ?? 0
+    }
+
+    private var selectedIndexBinding: Binding<Int> {
+        Binding(
+            get: { selectedIndex },
+            set: { selectedMemoryMb = Self.sizes[$0].memoryMb }
+        )
+    }
+
+    private var selectedIndexDoubleBinding: Binding<Double> {
+        Binding(
+            get: { Double(selectedIndex) },
+            set: {
+                let index = min(max(Int($0.rounded()), 0), Self.sizes.count - 1)
+                selectedMemoryMb = Self.sizes[index].memoryMb
+            }
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(String(localized: "machines.new.size.label", defaultValue: "Machine size"))
+                    .font(.headline)
+                Text(String(
+                    localized: "machines.new.size.help",
+                    defaultValue: "Choose the memory and disk profile for this machine."
+                ))
+                .foregroundStyle(.secondary)
+
+                variation(1) {
+                    Picker(selection: $selectedMemoryMb) {
+                        sizeOptions
+                    } label: {
+                        Text(selectedSize.menuTitle)
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                variation(2) {
+                    Picker(selection: $selectedMemoryMb) {
+                        sizeOptions
+                    } label: {
+                        Text(selectedSize.menuTitle)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                variation(3) {
+                    Picker(selection: $selectedMemoryMb) {
+                        sizeOptions
+                    } label: {
+                        Text(selectedSize.menuTitle)
+                    }
+                    .pickerStyle(.radioGroup)
+                }
+
+                variation(4) {
+                    Stepper(value: selectedIndexBinding, in: 0...(Self.sizes.count - 1)) {
+                        Text(selectedSize.menuTitle)
+                    }
+                }
+
+                variation(5) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(selectedSize.menuTitle)
+                        Slider(value: selectedIndexDoubleBinding, in: 0...Double(Self.sizes.count - 1), step: 1)
+                    }
+                }
+
+                variation(6) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Self.sizes, id: \.memoryMb) { size in
+                            Button {
+                                selectedMemoryMb = size.memoryMb
+                            } label: {
+                                HStack {
+                                    Text(size.menuTitle)
+                                    Spacer()
+                                    if size.memoryMb == selectedMemoryMb {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                variation(7) {
+                    DisclosureGroup(selectedSize.menuTitle) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(Self.sizes, id: \.memoryMb) { size in
+                                Button(size.menuTitle) {
+                                    selectedMemoryMb = size.memoryMb
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+
+                variation(8) {
+                    Menu {
+                        ForEach(Self.sizes, id: \.memoryMb) { size in
+                            Button(size.menuTitle) {
+                                selectedMemoryMb = size.memoryMb
+                            }
+                        }
+                    } label: {
+                        Text(selectedSize.menuTitle)
+                    }
+                }
+
+                variation(9) {
+                    Picker(selection: $selectedMemoryMb) {
+                        sizeOptions
+                    } label: {
+                        Text(selectedSize.menuTitle)
+                    }
+                }
+
+                variation(10) {
+                    HStack(spacing: 8) {
+                        Button {
+                            selectedMemoryMb = Self.sizes[max(selectedIndex - 1, 0)].memoryMb
+                        } label: {
+                            Image(systemName: "minus")
+                        }
+                        .buttonStyle(.bordered)
+                        Text(selectedSize.menuTitle)
+                        Button {
+                            selectedMemoryMb = Self.sizes[min(selectedIndex + 1, Self.sizes.count - 1)].memoryMb
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+            .padding()
+        }
+        .frame(width: 620, height: 820)
+    }
+
+    @ViewBuilder
+    private var sizeOptions: some View {
+        ForEach(Self.sizes, id: \.memoryMb) { size in
+            Text(size.menuTitle).tag(size.memoryMb)
+        }
+    }
+
+    @ViewBuilder
+    private func variation<Content: View>(
+        _ number: Int,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(format: "%02d", number))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            content()
+            Divider()
+        }
+    }
+}
+
+private struct NewMachinePickerVariationsPreview_Previews: PreviewProvider {
+    static var previews: some View {
+        NewMachinePickerVariationsPreview()
+    }
+}
+#endif

--- a/Sources/Cloud/NewMachineSheet.swift
+++ b/Sources/Cloud/NewMachineSheet.swift
@@ -70,13 +70,10 @@ struct NewMachineSheet: View {
                     Text(selectedSize.menuTitle)
                 }
                 .pickerStyle(.menu)
+                .labelsHidden()
                 .accessibilityIdentifier("NewMachineSheet.size")
                 .accessibilityLabel(String(localized: "machines.new.size.accessibilityLabel", defaultValue: "RAM size"))
                 .accessibilityValue(selectedSize.menuTitle)
-
-                Text(selectedSize.detail)
-                    .cmuxFont(size: 11)
-                    .foregroundStyle(.secondary)
             }
         }
         .accessibilityIdentifier("NewMachineSheet.sizeSection")
@@ -169,8 +166,9 @@ struct NewMachineSheet: View {
 /// These views are preview-only. The sheet uses the first variation: the native menu.
 private struct NewMachinePickerVariationsPreview: View {
     @State private var selectedMemoryMb = 8192
+    var viewportHeight: CGFloat = 820
 
-    private static let sizes = [4096, 8192, 16384, 24576, 32768, 65536]
+    private static let sizes = NewMachineModel.memoryOptionsMb
         .compactMap { MachineSizeOption(memoryMb: $0) }
 
     private var selectedSize: MachineSizeOption {
@@ -216,15 +214,19 @@ private struct NewMachinePickerVariationsPreview: View {
                         Text(selectedSize.menuTitle)
                     }
                     .pickerStyle(.menu)
+                    .labelsHidden()
                 }
 
                 variation(2) {
                     Picker(selection: $selectedMemoryMb) {
-                        sizeOptions
+                        ForEach(Self.sizes, id: \.memoryMb) { size in
+                            Text(size.title).tag(size.memoryMb)
+                        }
                     } label: {
                         Text(selectedSize.menuTitle)
                     }
                     .pickerStyle(.segmented)
+                    .labelsHidden()
                 }
 
                 variation(3) {
@@ -234,6 +236,7 @@ private struct NewMachinePickerVariationsPreview: View {
                         Text(selectedSize.menuTitle)
                     }
                     .pickerStyle(.radioGroup)
+                    .labelsHidden()
                 }
 
                 variation(4) {
@@ -298,7 +301,7 @@ private struct NewMachinePickerVariationsPreview: View {
                     Picker(selection: $selectedMemoryMb) {
                         sizeOptions
                     } label: {
-                        Text(selectedSize.menuTitle)
+                        Text(String(localized: "machines.new.size.label", defaultValue: "Machine size"))
                     }
                 }
 
@@ -320,9 +323,10 @@ private struct NewMachinePickerVariationsPreview: View {
                     }
                 }
             }
+            .frame(width: 588, alignment: .leading)
             .padding()
         }
-        .frame(width: 620, height: 820)
+        .frame(width: 620, height: viewportHeight)
     }
 
     @ViewBuilder

--- a/Sources/Cloud/NewMachineSheet.swift
+++ b/Sources/Cloud/NewMachineSheet.swift
@@ -21,118 +21,56 @@ struct NewMachineSheet: View {
             buttons
         }
         .padding(24)
-        .frame(width: 500)
+        .frame(width: 520)
         .accessibilityIdentifier("NewMachineSheet")
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: model.isBaseSetup ? "externaldrive.fill" : "cpu")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 32, height: 32)
-                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(model.isBaseSetup
-                    ? String(localized: "machines.new.title.base", defaultValue: "Set Up Base")
-                    : String(localized: "machines.new.title", defaultValue: "New Machine"))
-                    .cmuxFont(size: 16, weight: .semibold)
-                Text(model.isBaseSetup
-                    ? String(
-                        localized: "machines.new.subtitle.base",
-                        defaultValue: "Base is your persistent cloud machine. Opening it later reuses this same machine; reset Base to start over."
-                    )
-                    : String(
-                        localized: "machines.new.subtitle",
-                        defaultValue: "A cloud computer with devtools and coding agents preinstalled. It keeps its home directory between sessions."
-                    ))
-                    .cmuxFont(size: 12)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+        VStack(alignment: .leading, spacing: 5) {
+            Text(model.isBaseSetup
+                ? String(localized: "machines.new.title.base", defaultValue: "Set Up Base")
+                : String(localized: "machines.new.title", defaultValue: "New Machine"))
+                .cmuxFont(size: 19, weight: .semibold)
+            Text(model.isBaseSetup
+                ? String(
+                    localized: "machines.new.subtitle.base",
+                    defaultValue: "Base is your persistent cloud machine. Opening it later reuses this same machine; reset Base to start over."
+                )
+                : String(
+                    localized: "machines.new.subtitle",
+                    defaultValue: "A cloud computer with devtools and coding agents preinstalled. It keeps its home directory between sessions."
+                ))
+                .cmuxFont(size: 12)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
     private var sizeSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(String(localized: "machines.new.size.label", defaultValue: "Machine size"))
-                        .cmuxFont(size: 13, weight: .semibold)
-                    Text(String(
-                        localized: "machines.new.size.help",
-                        defaultValue: "Choose the memory and disk profile for this machine."
-                    ))
-                    .cmuxFont(size: 11)
-                    .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 8)
-                Text(String(localized: "machines.new.size.required", defaultValue: "Required"))
-                    .cmuxFont(size: 10, weight: .medium)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
-                    .background(Color.primary.opacity(0.06), in: Capsule())
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "machines.new.size.label", defaultValue: "Machine size"))
+                    .cmuxFont(size: 13, weight: .semibold)
+                Text(String(
+                    localized: "machines.new.size.help",
+                    defaultValue: "Choose the memory and disk profile for this machine."
+                ))
+                .cmuxFont(size: 11)
+                .foregroundStyle(.secondary)
             }
 
-            if let selectedSize = model.selectedSize {
-                Picker(selection: $model.memoryMb) {
-                    ForEach(model.memoryOptions, id: \.self) { memoryMb in
-                        if let size = MachineSizeOption(memoryMb: memoryMb) {
-                            Text(size.menuTitle).tag(memoryMb)
-                        }
+            LazyVGrid(
+                columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
+                spacing: 8
+            ) {
+                ForEach(model.memoryOptions, id: \.self) { memoryMb in
+                    if let size = MachineSizeOption(memoryMb: memoryMb) {
+                        sizeOption(size)
                     }
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "memorychip")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundStyle(Color.accentColor)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(selectedSize.title)
-                                .cmuxFont(size: 13, weight: .semibold)
-                            Text(selectedSize.detail)
-                                .cmuxFont(size: 11)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer(minLength: 8)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .pickerStyle(.menu)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 11)
-                .padding(.vertical, 9)
-                .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9, style: .continuous)
-                        .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
-                )
-                .accessibilityIdentifier("NewMachineSheet.size")
-                .accessibilityLabel(String(localized: "machines.new.size.accessibilityLabel", defaultValue: "RAM size"))
-                .accessibilityValue(selectedSize.menuTitle)
-            }
-
-            if let selectedSize = model.selectedSize {
-                HStack(spacing: 0) {
-                    resourceMetric(
-                        symbol: "memorychip",
-                        label: String(localized: "machines.new.size.ram", defaultValue: "RAM"),
-                        value: selectedSize.title
-                    )
-                    resourceDivider
-                    resourceMetric(
-                        symbol: "internaldrive",
-                        label: String(localized: "machines.new.size.disk", defaultValue: "Disk"),
-                        value: selectedSize.diskTitle
-                    )
-                }
-                .padding(.horizontal, 4)
-                .accessibilityElement(children: .combine)
-                .accessibilityIdentifier("NewMachineSheet.resources")
             }
         }
-        .padding(13)
+        .padding(14)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -141,28 +79,45 @@ struct NewMachineSheet: View {
         .accessibilityIdentifier("NewMachineSheet.sizeSection")
     }
 
-    private var resourceDivider: some View {
-        Rectangle()
-            .fill(Color.primary.opacity(0.12))
-            .frame(width: 1, height: 26)
-            .padding(.horizontal, 9)
-    }
-
-    private func resourceMetric(symbol: String, label: String, value: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: symbol)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
-                .frame(width: 14)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(label.uppercased())
-                    .cmuxFont(size: 9, weight: .medium)
-                    .foregroundStyle(.tertiary)
-                Text(value)
-                    .cmuxFont(size: 11, weight: .medium, monospacedDigit: true)
+    private func sizeOption(_ size: MachineSizeOption) -> some View {
+        let isSelected = model.memoryMb == size.memoryMb
+        return Button {
+            model.memoryMb = size.memoryMb
+        } label: {
+            HStack(alignment: .center, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(size.title)
+                        .cmuxFont(size: 13, weight: .semibold)
+                    Text(size.detail)
+                        .cmuxFont(size: 11)
+                        .foregroundStyle(isSelected ? Color.primary.opacity(0.78) : Color.secondary)
+                }
+                Spacer(minLength: 4)
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
             }
+            .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(
+                isSelected ? Color.accentColor.opacity(0.14) : Color.primary.opacity(0.035),
+                in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(
+                        isSelected ? Color.accentColor.opacity(0.76) : Color.primary.opacity(0.12),
+                        lineWidth: isSelected ? 1.5 : 1
+                    )
+            )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("NewMachineSheet.size.\(size.memoryMb)")
+        .accessibilityLabel(size.menuTitle)
+        .accessibilityAddTraits(isSelected ? AccessibilityTraits.isSelected : [])
     }
 
     @ViewBuilder
@@ -187,13 +142,8 @@ struct NewMachineSheet: View {
                     }
                 }
             }
-            .padding(10)
+            .padding(.vertical, 2)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
-            )
             .accessibilityIdentifier("NewMachineSheet.plan")
         }
     }


### PR DESCRIPTION
The New Machine sheet repeats the selected RAM and disk values and adds custom boxes, a Required badge, and decorative icons around a single size choice. This change uses a plain native SwiftUI menu with one RAM and disk label. It removes the extra decoration and keeps the plan note as plain text.

Server-provided size filtering, accessibility labels, existing localization keys, and create behavior stay in place. A debug-only SwiftUI preview provides 10 native control variations; the production sheet uses variation 01.

Validation:

- Compiled and rendered the sheet, the version on main, and all 10 preview variations with a standalone SwiftUI/AppKit renderer, using sample plan data and the default font scale.
- Fixed a duplicate picker label and preview overflow found in the native export.
- Swift source parse, localization catalog JSON, and `git diff --check` pass. No new user-facing localization keys were added.

The full tagged app build is still blocked by the local disk guard: 242.4 GiB free against the required 250 GiB floor on the last attempt. The native image export verifies the isolated view; it does not replace full app dogfood before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Simplified the New Machine sheet header with a larger, more prominent title.
  - Streamlined the size selection area by removing the “Required” badge and RAM and disk resource details.
  - Updated the size picker with a simpler text-based presentation.
  - Removed decorative icons and background cards from the size and plan sections for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->