### PR TITLE
iOS: restore native terminal scrolling on screen-anchored hosts

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputTransportSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputTransportSelection.swift
@@ -9,11 +9,17 @@ extension MobileShellComposite {
             || terminalFidelity == "render_grid"
         let supportsTerminalBytes = capabilities.contains("terminal.bytes.v1")
         let supportsVerifiedReplay = capabilities.contains("terminal.render_grid.verified_replay.v1")
-        // Verified render-grid replay is useful for snapshots and alternate
-        // TUI surfaces, but it must not displace the dedicated terminal lane
-        // for the primary surface. Render-grid applies can wait on a replay
-        // fence while a keyboard resize is in flight; raw terminal bytes do
-        // not have that dependency.
+        let supportsScreenAnchor = capabilities.contains("terminal.render_grid.screen_anchor.v1")
+        // Screen-anchored frames maintain the phone's local scrollback and
+        // enable pixel-precise primary-screen scrolling. Hybrid delivery does
+        // not negotiate that anchor, so selecting it here would fall back to
+        // whole-row scrolling and forward every gesture to the Mac.
+        if supportsRenderGrid, supportsScreenAnchor {
+            return .renderGrid
+        }
+        // Hosts without screen anchors keep the dedicated terminal lane:
+        // their render-grid applies can wait on a replay fence while a
+        // keyboard resize is in flight; raw bytes have no such dependency.
         if supportsRenderGrid, supportsTerminalBytes {
             return .hybrid
         }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputTransportSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputTransportSelectionTests.swift
@@ -1,6 +1,71 @@
 import Testing
 @testable import CmuxMobileShell
 
+@Test("screen-anchored hosts retain the transport that supports local pixel scrolling")
+func screenAnchoredHostKeepsLocalScrollTransport() {
+    let capabilities: Set<String> = [
+        "terminal.bytes.v1",
+        "terminal.render_grid.v1",
+        "terminal.render_grid.verified_replay.v1",
+        "terminal.render_grid.screen_anchor.v1"
+    ]
+
+    #expect(
+        MobileShellComposite.resolvedTerminalOutputTransport(
+            capabilities: capabilities,
+            terminalFidelity: nil
+        ) == .renderGrid
+    )
+    #expect(
+        MobileShellComposite.fallbackTerminalOutputTransport(
+            learnedCapabilities: capabilities
+        ) == .renderGrid
+    )
+}
+
+@Test("a screen-anchor capability alone cannot select render-grid transport")
+func screenAnchorRequiresRenderGridTransport() {
+    #expect(
+        MobileShellComposite.resolvedTerminalOutputTransport(
+            capabilities: ["terminal.bytes.v1", "terminal.render_grid.screen_anchor.v1"],
+            terminalFidelity: nil
+        ) == .rawBytes
+    )
+}
+
+@MainActor
+@Test("screen-anchored primary scrolling stays local while TUI wheel input still reaches the Mac")
+func screenAnchoredHostKeepsPrimaryScrollLocal() async throws {
+    let router = LivenessHostRouter()
+    await router.setCapabilities([
+        "events.v1",
+        "terminal.bytes.v1",
+        "terminal.render_grid.v1",
+        "terminal.render_grid.verified_replay.v1",
+        "terminal.render_grid.screen_anchor.v1",
+        "terminal.replay.v1"
+    ])
+    let store = try await makeConnectedStore(
+        router: router,
+        box: TransportBox(),
+        clock: TestClock()
+    )
+    #expect(store.usesVerifiedTerminalReplay)
+    try #require(store.usesScreenAnchoredRenderGrid)
+    #expect(!store.ownsLocalPrimaryScreenScroll(surfaceID: "live-terminal"))
+
+    store.terminalActiveScreenBySurfaceID["live-terminal"] = .primary
+    #expect(store.ownsLocalPrimaryScreenScroll(surfaceID: "live-terminal"))
+    await store.scrollTerminal(surfaceID: "live-terminal", lines: 3, col: 0, row: 0)
+    #expect(store.terminalScrollQueuesBySurfaceID["live-terminal"] == nil)
+    #expect(await router.count(of: "mobile.terminal.scroll") == 0)
+
+    store.terminalActiveScreenBySurfaceID["live-terminal"] = .alternate
+    #expect(!store.ownsLocalPrimaryScreenScroll(surfaceID: "live-terminal"))
+    await store.scrollTerminal(surfaceID: "live-terminal", lines: 3, col: 0, row: 0)
+    #expect(try await pollUntil { await router.count(of: "mobile.terminal.scroll") == 1 })
+}
+
 @Test("a transient status failure retains the dedicated terminal lane")
 func transientStatusFailureRetainsVerifiedTransport() {
     let verifiedCapabilities: Set<String> = [

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -1468,6 +1468,10 @@ private final class WorkspaceListTableDataSource: NSObject, UITableViewDataSourc
     weak var coordinator: WorkspaceListTableCoordinator?
     private let cellProvider: CellProvider
     private(set) var items: [WorkspaceListTableItem] = []
+    /// Row lookup for the batch update path. Live workspace updates can touch
+    /// many visible rows at once, so resolving each item by scanning `items`
+    /// would turn one update into O(changedRows * totalRows) work.
+    private var rowIndexByID: [String: Int] = [:]
 
     init(tableView: UITableView, cellProvider: @escaping CellProvider) {
         self.cellProvider = cellProvider
@@ -1495,7 +1499,7 @@ private final class WorkspaceListTableDataSource: NSObject, UITableViewDataSourc
     }
 
     func indexPath(for item: WorkspaceListTableItem) -> IndexPath? {
-        indexPath(where: { $0 == item })
+        rowIndexByID[item.id].map { IndexPath(row: $0, section: 0) }
     }
 
     func indexPath(
@@ -1506,6 +1510,7 @@ private final class WorkspaceListTableDataSource: NSObject, UITableViewDataSourc
 
     func replaceItems(_ items: [WorkspaceListTableItem], in tableView: UITableView) {
         self.items = items
+        rebuildRowIndex()
         tableView.reloadData()
     }
 
@@ -1523,11 +1528,20 @@ private final class WorkspaceListTableDataSource: NSObject, UITableViewDataSourc
         let removed = items.remove(at: sourceIndexPath.row)
         let destination = min(destinationIndexPath.row, items.count)
         items.insert(replacement ?? removed, at: destination)
+        rebuildRowIndex()
         tableView.performBatchUpdates {
             tableView.moveRow(
                 at: sourceIndexPath,
                 to: IndexPath(row: destination, section: 0)
             )
+        }
+    }
+
+    private func rebuildRowIndex() {
+        rowIndexByID.removeAll(keepingCapacity: true)
+        rowIndexByID.reserveCapacity(items.count)
+        for (index, item) in items.enumerated() {
+            rowIndexByID[item.id] = index
         }
     }
 


### PR DESCRIPTION
Internal build `1.0.4 (20260905040136)` changed screen-anchored hosts from render-grid delivery to hybrid delivery in https://github.com/manaflow-ai/cmux/pull/11977. That disabled the phone-owned, pixel-precise scroll path and sent primary-screen gestures through whole-row scrolling plus Mac scroll requests.

Prefer render-grid delivery when the host supports screen anchors, restoring independent local terminal history and smooth pixel scrolling. Hosts without screen anchors retain hybrid delivery. Alternate-screen apps still receive wheel input on the Mac. Also maintain a stable-ID row index for workspace updates, removing repeated full-table scans during live agent updates.

The new regression tests fail before the transport fix and pass after it. They cover initial and fallback selection, incomplete capabilities, local primary scrolling, and forwarded alternate-screen input. The prior workspace-only diagnosis did not explain the terminal regression; this change addresses the transport boundary in the reported build.

Validation: 3 fleet Swift package regression tests passed after confirming failure before the fix; 9 related output, replay, and scroll-delivery tests passed; `git diff --check` passed. Tagged Mac `scrfix` build and optimized iOS Debug archive/export succeeded from `db7e0e95844`. The isolated simulator app matched the changed source hashes, but the available fleet Mac had no GUI launchd domain, so a paired real-drag recording could not be completed. The signed iPhone app is queued while the device is unreachable.

Apple HIG reference: [Scroll views](https://developer.apple.com/design/human-interface-guidelines/scroll-views). No new gesture behavior or visual styling is introduced.
