### PR TITLE
fix(sidebar): order panels without reading a single tab title

### DIFF
--- a/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/ExternalTreeNode+SpatialOrder.swift
+++ b/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/ExternalTreeNode+SpatialOrder.swift
@@ -23,6 +23,31 @@ extension ExternalTreeNode {
         paneTabs: [String: [UUID]],
         fallbackPanelIds: [UUID]
     ) -> [UUID] {
+        PaneSpatialOrder.orderedPanelIds(
+            orderedPaneIds: orderedPaneIds,
+            paneTabs: paneTabs,
+            fallbackPanelIds: fallbackPanelIds
+        )
+    }
+}
+
+/// Ordering that needs pane order but not the rest of a tree snapshot.
+///
+/// `BonsplitController.allPaneIds` walks first-then-second the same way
+/// `ExternalTreeNode.orderedPaneIds` does, so a caller holding pane ids
+/// already has the order and does not need to build a snapshot to get it.
+/// That matters because a snapshot reads every tab's title, and a caller
+/// running inside a SwiftUI update is then invalidated by every title change
+/// in the window.
+public enum PaneSpatialOrder {
+    /// Panel ids in on-screen spatial order: panes in the given order, tabs
+    /// within each pane in tab order, then any panels missing from the panes
+    /// in the caller-provided stable fallback order.
+    public static func orderedPanelIds(
+        orderedPaneIds: [String],
+        paneTabs: [String: [UUID]],
+        fallbackPanelIds: [UUID]
+    ) -> [UUID] {
         var ordered: [UUID] = []
         var seen: Set<UUID> = []
 

--- a/Packages/macOS/CmuxPanes/Tests/CmuxPanesTests/SpatialOrderTests.swift
+++ b/Packages/macOS/CmuxPanes/Tests/CmuxPanesTests/SpatialOrderTests.swift
@@ -39,6 +39,43 @@ import Bonsplit
         #expect(result == [p1, p2, p3, orphan])
     }
 
+    /// The tree method is the pane-id method with the ids read off the tree.
+    /// Callers that already hold pane ids skip the snapshot, so the two have
+    /// to agree or skipping it changes the sidebar order.
+    @Test func orderedPanelIdsIsTheSameThroughEitherEntryPoint() {
+        let p1 = UUID(), p2 = UUID(), p3 = UUID(), orphan = UUID()
+        let tree = ExternalTreeNode.split(ExternalSplitNode(
+            id: "s1", orientation: "horizontal", dividerPosition: 0.5,
+            first: pane("a"),
+            second: .split(ExternalSplitNode(
+                id: "s2", orientation: "vertical", dividerPosition: 0.5,
+                first: pane("b"), second: pane("c")
+            ))
+        ))
+        let paneTabs = ["a": [p1, p2], "b": [p3, p1], "c": []]
+        let fallback = [orphan, p2]
+
+        #expect(
+            PaneSpatialOrder.orderedPanelIds(
+                orderedPaneIds: tree.orderedPaneIds,
+                paneTabs: paneTabs,
+                fallbackPanelIds: fallback
+            ) == tree.orderedPanelIds(paneTabs: paneTabs, fallbackPanelIds: fallback)
+        )
+    }
+
+    /// A pane id with no entry in `paneTabs` contributes nothing rather than
+    /// stopping the walk, which is what an empty pane looks like.
+    @Test func panesMissingFromPaneTabsAreSkipped() {
+        let p1 = UUID(), p2 = UUID()
+        let result = PaneSpatialOrder.orderedPanelIds(
+            orderedPaneIds: ["a", "missing", "b"],
+            paneTabs: ["a": [p1], "b": [p2]],
+            fallbackPanelIds: []
+        )
+        #expect(result == [p1, p2])
+    }
+
     @Test func paneCycleNavigatorWrapsForwardAndBackward() {
         let panes = [paneId(1), paneId(2), paneId(3)]
         let navigator = PaneCycleNavigator()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1,5 +1,6 @@
 import CmuxAppKitSupportUI
 import CmuxFoundation
+import CmuxPanes
 import Foundation
 import CmuxCore
 import CmuxRemoteDaemon
@@ -6397,21 +6398,32 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         recomputeListeningPorts()
     }
 
+    /// Panel ids in on-screen order.
+    ///
+    /// Ids only, all the way down. The version this replaced asked for `Tab`
+    /// values and a `treeSnapshot()`, and both read every tab's title:
+    /// `Tab.init(from:)` copies all fourteen `TabItem` properties, and the
+    /// snapshot puts a title in every `ExternalTab`. Sidebar views call this
+    /// from inside their bodies, so an animating tab title invalidated them
+    /// about twenty times a second for an ordering that never looked at a
+    /// title. `allPaneIds` walks the tree first-then-second exactly as
+    /// `ExternalTreeNode.orderedPaneIds` does, so the snapshot was not buying
+    /// the order either.
     func sidebarOrderedPanelIds() -> [UUID] {
+        let orderedPaneIds = bonsplitController.allPaneIds
         let paneTabs: [String: [UUID]] = Dictionary(
-            uniqueKeysWithValues: bonsplitController.allPaneIds.map { paneId in
+            uniqueKeysWithValues: orderedPaneIds.map { paneId in
                 let panelIds = bonsplitController
-                    .tabs(inPane: paneId)
-                    .compactMap { panelIdFromSurfaceId($0.id) }
+                    .tabIds(inPane: paneId)
+                    .compactMap { panelIdFromSurfaceId($0) }
                 return (paneId.id.uuidString, panelIds)
             }
         )
 
-        let fallbackPanelIds = panels.keys.sorted { $0.uuidString < $1.uuidString }
-        let tree = bonsplitController.treeSnapshot()
-        return tree.orderedPanelIds(
+        return PaneSpatialOrder.orderedPanelIds(
+            orderedPaneIds: orderedPaneIds.map { $0.id.uuidString },
             paneTabs: paneTabs,
-            fallbackPanelIds: fallbackPanelIds
+            fallbackPanelIds: panels.keys.sorted { $0.uuidString < $1.uuidString }
         )
     }
 


### PR DESCRIPTION
**Status:** updated onto `main` (`78f4c82504`) as merge commit `25a2e642a5`. Still a draft: it calls `bonsplitController.tabIds(inPane:)`, which lands in manaflow-ai/bonsplit#233 and is not in the pinned submodule yet. Nothing else in the diff needs that PR.

**Reviewer's guide**
- Read `Sources/Workspace.swift` (`sidebarOrderedPanelIds`) and the new `PaneSpatialOrder` enum; the tree method delegates to it, so there is one implementation.
- Tests: `Packages/macOS/CmuxPanes/Tests/CmuxPanesTests/SpatialOrderTests.swift`.
- Skip the pbxproj line.

---

> **Draft: blocked on manaflow-ai/bonsplit#233.** This calls `bonsplitController.tabIds(inPane:)`, which does not exist in the bonsplit commit currently pinned here. It will not compile until that PR merges and the submodule pointer moves. Opening it now so the cmux-side change is reviewable alongside it. The pointer bump is deliberately not in this diff.

## Summary

`sidebarOrderedPanelIds()` reads every tab's title to produce a list of ids.

It asks bonsplit for `tabs(inPane:)` and builds a `treeSnapshot()`. Both read titles: `Tab.init(from:)` copies all fourteen `TabItem` properties, and the snapshot puts a title in every `ExternalTab`. Sidebar views call this from inside their bodies, so an animating tab title invalidates them for an ordering that never looks at a title.

`allPaneIds` already walks the tree first-then-second, exactly as `ExternalTreeNode.orderedPaneIds` does, so the snapshot was not buying the pane order either.

## Change

The call site asks for `tabIds(inPane:)` and never mentions a tab. The ordering moves out of the `ExternalTreeNode` extension into `PaneSpatialOrder`, which takes pane ids directly; the tree method delegates to it, so there is still one implementation and one set of tests.

## Measurement

From a 20.7s `sample` of a running cmux, main thread:

| Frame | Time |
|---|---|
| `sidebarOrderedPanelIds` path | 142.4 ms |
| `VerticalTabsSidebar` body | 1058.6 ms (21.4%) |

After, in a 16013-sample run with tab titles updating, `sidebarOrderedPanelIds` costs 8 samples (0.05%) and `treeSnapshot` does not appear on the main thread at all.

Two caveats on those numbers, since they are not a clean A/B. The before and after traces are from different sessions under different load, so treat the 142.4 ms against 8 samples as a direction rather than a ratio. The `VerticalTabsSidebar` figure is the whole body, which this change only partly accounts for; the rest is #5832.

## Related

- manaflow-ai/bonsplit#233 adds the method this depends on.
- #12009, #10856, #10351, #10349, #10353 are the other idle-work fixes from the same profiles.
- #5832 covers the remaining `VerticalTabsSidebar` body cost.

---

https://claude.ai/code/session_01Bj791kgph6Xk9CJf9c41Db
