### PR TITLE
test(cloud): verify WebSocket path before snapshots

### DIFF
--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -91,6 +91,7 @@ import {
   devboxGhosttyDebSha256,
   devboxGhosttyDebUrl,
   devboxParkDaemonCommand,
+  cmuxTuiWebsocketSmokeCommand,
   emitBakeResult,
   hasFlag,
   manifestEntrySkeleton,
@@ -438,6 +439,9 @@ try {
     "cmux-tui-daemon-up",
     `for i in $(seq 1 30); do env HOME=/root /root/.cmux/bin/cmux-tui server status --session ${CMUX_TUI_SESSION} >/dev/null 2>&1 && grep -qi ':0539 ' /proc/net/tcp6 && break; sleep 1; done && env HOME=/root /root/.cmux/bin/cmux-tui server status --session ${CMUX_TUI_SESSION} && grep -qi ':0539 ' /proc/net/tcp6 && test "$(cat /etc/cmux/daemon-instance-id)" = "$(${instanceIdCommand})" && echo daemon-up-bound-to-builder`,
   );
+  // Wait after the daemon first reports ready, then exercise the real
+  // WebSocket/Noise/RPC/PTY path before this machine can become a snapshot.
+  await step("cmux-tui-websocket-smoke", `sleep 30 && ${cmuxTuiWebsocketSmokeCommand()}`);
   // Park it (devboxParkDaemonCommand): the supervisor stops the daemon while
   // the machine's id equals the recorded bake id, its identity and session
   // state are wiped, and a clone (different id) starts fresh within one tick.

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -31,7 +31,7 @@ import {
   type VmImageSize,
   type VmImageSizeName,
 } from "../services/vms/images/sizes";
-import { argValue, devboxParkDaemonCommand, hasFlag } from "./devbox-image-common";
+import { argValue, cmuxTuiWebsocketSmokeCommand, devboxParkDaemonCommand, hasFlag } from "./devbox-image-common";
 
 const apiKey = process.env.FREESTYLE_API_KEY;
 const stackToken = process.env.FREESTYLE_STACK_ACCESS_TOKEN;
@@ -153,6 +153,9 @@ for (const name of sizes) {
         const m = await measure(vm);
         throw new Error(`${name}: resize did not take: ${fits(m, size)} (${JSON.stringify(m)})`);
       }
+      await sleep(30_000);
+      const websocket = await sh(vm, cmuxTuiWebsocketSmokeCommand(), 300_000);
+      if (websocket.code !== 0) throw new Error(`${name}: WebSocket smoke failed before snapshot: ${websocket.out.slice(-1000)}`);
       // A resized clone runs a live daemon bound to its own instance id; park
       // it so the derived snapshot, like the master, carries no identity.
       const parked = await sh(vm, devboxParkDaemonCommand(), 120_000);
@@ -170,6 +173,7 @@ for (const name of sizes) {
   const check = await fs.vms.create({ snapshotId: imageId, displayName: `${slugPrefix} verify ${name}`, firewall: FIREWALL });
   let measured: Awaited<ReturnType<typeof measure>>;
   try {
+    await sleep(30_000);
     measured = await measure(check.vm);
     const problem = fits(measured, size);
     if (problem) throw new Error(`${name}: derived snapshot ${imageId} boots wrong: ${problem}`);
@@ -182,6 +186,8 @@ for (const name of sizes) {
       if (daemon.code !== 0) await sleep(1000);
     }
     if (daemon.code !== 0) throw new Error(`${name}: cmux-tui daemon did not come up on the derived snapshot ${imageId}: ${daemon.out.slice(-300)}`);
+    const websocket = await sh(check.vm, cmuxTuiWebsocketSmokeCommand(), 300_000);
+    if (websocket.code !== 0) throw new Error(`${name}: WebSocket smoke failed after snapshot boot: ${websocket.out.slice(-1000)}`);
   } finally {
     await check.vm.delete().catch(() => {});
   }

--- a/web/scripts/devbox-image-common.ts
+++ b/web/scripts/devbox-image-common.ts
@@ -15,6 +15,7 @@
  */
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -59,6 +60,105 @@ export const devboxTerminfoCheckCommand = [
 /** Compile the checked-in overlay before any per-TERM cache is seeded. */
 export const devboxTerminfoInstallCommand =
   `test -s /etc/cmux/terminfo.src && tic -x -o /etc/terminfo /etc/cmux/terminfo.src && chmod -R a+rX /etc/terminfo && ${devboxTerminfoCheckCommand}`;
+
+/**
+ * Proves the baked daemon's direct-WebSocket path, not only its TCP listener.
+ * The client runs inside the guest, so this also works when the operator's
+ * Mac has no IPv6 route or VPC tunnel. It enrolls a temporary device,
+ * performs authenticated RPC, creates a PTY, takes a terminal snapshot,
+ * reconnects, and confirms that the marker survives. Cleanup revokes the
+ * temporary device and removes the workspace before a snapshot can capture
+ * test state.
+ */
+export function cmuxTuiWebsocketSmokeCommand(
+  session = "cloud",
+  binary = "/root/.cmux/bin/cmux-tui",
+): string {
+  const shell = `#!/usr/bin/env bash
+set -euo pipefail
+export HOME=/root
+BIN=${binary}
+SESSION=${session}
+ROOT=/tmp/cmux-tui-websocket-smoke
+ROUTE='ws://[::1]:1337/v1/link'
+MARKER="CMUX_WS_SMOKE_${session}_$$"
+CONNECT_PID=""
+INVITATION_ID=""
+DEVICE_FINGERPRINT=""
+WORKSPACE_ID=""
+PROCESS_ID=""
+rm -rf "$ROOT"
+mkdir -m 700 -p "$ROOT/state"
+rpc() {
+  "$BIN" remote rpc "$ROUTE" --state-dir "$ROOT/state" --lanes single --connect-timeout-seconds 45 --reconnect-attempts 1 --request "$1"
+}
+cleanup() {
+  if [ -n "$CONNECT_PID" ]; then
+    kill "$CONNECT_PID" 2>/dev/null || true
+    wait "$CONNECT_PID" 2>/dev/null || true
+  fi
+  if [ -n "$PROCESS_ID" ]; then
+    KILL_REQUEST="$(jq -nc --arg process "$PROCESS_ID" '{type:"signal-process",process:$process,signal:"kill"}')"
+    rpc "$KILL_REQUEST" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$WORKSPACE_ID" ]; then
+    CLOSE_REQUEST="$(jq -nc --arg workspace "$WORKSPACE_ID" '{type:"close-workspace",workspace:$workspace}')"
+    rpc "$CLOSE_REQUEST" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$DEVICE_FINGERPRINT" ]; then
+    "$BIN" remote enroll revoke "$DEVICE_FINGERPRINT" --session "$SESSION" --json >/dev/null 2>&1 || true
+  fi
+  if [ -n "$INVITATION_ID" ]; then
+    "$BIN" remote enroll deny "$INVITATION_ID" --session "$SESSION" --json >/dev/null 2>&1 || true
+  fi
+  rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+"$BIN" remote enroll create --session "$SESSION" --ttl 300 --advertise "$ROUTE" --json >"$ROOT/create.json"
+jq -r '.. | strings | select(startswith("cmux://enroll/"))' "$ROOT/create.json" | head -1 >"$ROOT/invitation"
+test -s "$ROOT/invitation"
+chmod 600 "$ROOT/invitation"
+("$BIN" remote connect --invite-file "$ROOT/invitation" --device-name "snapshot-websocket-smoke" --state-dir "$ROOT/state" --session "$SESSION" --headless --json --lanes single --connect-timeout-seconds 60 --reconnect-attempts 2 >"$ROOT/connect.out" 2>"$ROOT/connect.err") &
+CONNECT_PID=$!
+for attempt in $(seq 1 90); do
+  PENDING="$("$BIN" remote enroll pending --session "$SESSION" --json 2>/dev/null || true)"
+  INVITATION_ID="$(printf '%s' "$PENDING" | jq -r 'if type == "array" then (.[0].invitation_id // empty) else (.pending[0].invitation_id // .invitations[0].invitation_id // empty) end' 2>/dev/null || true)"
+  DEVICE_FINGERPRINT="$(printf '%s' "$PENDING" | jq -r 'if type == "array" then (.[0].device_fingerprint // empty) else (.pending[0].device_fingerprint // .invitations[0].device_fingerprint // empty) end' 2>/dev/null || true)"
+  if [ -n "$INVITATION_ID" ]; then break; fi
+  sleep 1
+done
+test -n "$INVITATION_ID"
+"$BIN" remote enroll approve "$INVITATION_ID" --session "$SESSION" --json >/dev/null
+sleep 2
+kill "$CONNECT_PID" 2>/dev/null || true
+wait "$CONNECT_PID" 2>/dev/null || true
+CONNECT_PID=""
+
+CAPABILITIES="$(rpc '{"type":"capabilities"}')"
+echo "$CAPABILITIES" | jq -e '.type == "capabilities"' >/dev/null
+WORKSPACE="$(rpc '{"type":"open-workspace","root":"/tmp"}')"
+WORKSPACE_ID="$(echo "$WORKSPACE" | jq -r '.id // .result.Ok.id')"
+test -n "$WORKSPACE_ID" && test "$WORKSPACE_ID" != "null"
+SPAWN_REQUEST="$(jq -nc --arg workspace "$WORKSPACE_ID" --arg marker "$MARKER" '{type:"spawn-process",workspace:$workspace,argv:["bash","-lc",("printf "+$marker+"; sleep 60")],cwd:null,env:{},io:{type:"pty",cols:120,rows:40,term:"xterm-256color",eof:"control-d"},lifetime:"detached"}')"
+SPAWN="$(rpc "$SPAWN_REQUEST")"
+PROCESS_ID="$(echo "$SPAWN" | jq -r '.process // .result.Ok.process')"
+test -n "$PROCESS_ID" && test "$PROCESS_ID" != "null"
+sleep 2
+SNAPSHOT_REQUEST="$(jq -nc --arg process "$PROCESS_ID" '{type:"snapshot-process-terminal",process:$process}')"
+FIRST="$(rpc "$SNAPSHOT_REQUEST")"
+echo "$FIRST" | jq -e --arg marker "$MARKER" 'tostring | contains($marker)' >/dev/null
+FIRST_SEQUENCE="$(echo "$FIRST" | jq -r '.snapshot.through_sequence // .result.Ok.snapshot.through_sequence')"
+test "$FIRST_SEQUENCE" -ge 1
+SECOND="$(rpc "$SNAPSHOT_REQUEST")"
+echo "$SECOND" | jq -e --arg marker "$MARKER" 'tostring | contains($marker)' >/dev/null
+SECOND_SEQUENCE="$(echo "$SECOND" | jq -r '.snapshot.through_sequence // .result.Ok.snapshot.through_sequence')"
+test "$SECOND_SEQUENCE" -ge "$FIRST_SEQUENCE"
+echo "websocket-smoke-ok marker=$MARKER through_sequence=$FIRST_SEQUENCE->$SECOND_SEQUENCE"
+`;
+  const encoded = Buffer.from(shell, "utf8").toString("base64");
+  return `printf %s ${encoded} | base64 -d >/tmp/cmux-tui-websocket-smoke.sh && chmod 700 /tmp/cmux-tui-websocket-smoke.sh && bash /tmp/cmux-tui-websocket-smoke.sh`;
+}
 
 /**
  * The desktop layer (ported from the retired Blaxel cmux-devbox image): an

--- a/web/scripts/verify-devbox-image.ts
+++ b/web/scripts/verify-devbox-image.ts
@@ -34,6 +34,7 @@ import {
   devboxAgentPins,
   devboxDir,
   devboxTerminfoCheckCommand,
+  cmuxTuiWebsocketSmokeCommand,
   sha256File,
 } from "./devbox-image-common";
 import {
@@ -123,6 +124,7 @@ const DAEMON_CHECKS: readonly string[] = [
   // The static model-plane env is baked; a shell with no boot env sources it.
   `test -s /etc/cmux/model-plane.env && grep -q "^export OPENAI_BASE_URL='https://" /etc/cmux/model-plane.env && ! grep -q crt_ /etc/cmux/model-plane.env && env -i HOME=/tmp/mp-verify bash -c '. /etc/cmux/agent-config.sh; printf %s "$OPENAI_BASE_URL"' | grep -q '^https://' && rm -rf /tmp/mp-verify && echo model-plane-env-baked`,
   "systemctl is-active cmux-tui-daemon >/dev/null && echo systemd-supervisor-active",
+  cmuxTuiWebsocketSmokeCommand(),
 ];
 
 // The desktop layer (Freestyle bakes; /etc/cmux/image-stamp says "desktop"),
@@ -305,6 +307,7 @@ if (provider === "freestyle") {
     const exec = execFor(vm);
     const daemonMs = await waitForBakedDaemon("freestyle", exec);
     console.log(`baked daemon answered ${daemonMs} ms after the first probe (${Date.now() - t0} ms after create)`);
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
     // The baked binary must be the pin the bake resolved and recorded in
     // /etc/cmux/cmux-tui-pin (that is the image's contract; the manifest entry
     // carries the same commit). The live files.cmux.com pin moves with every
@@ -331,6 +334,7 @@ if (provider === "freestyle") {
     try {
       const exec2 = execFor(second.vm);
       await waitForBakedDaemon("freestyle", exec2);
+      await new Promise((resolve) => setTimeout(resolve, 30_000));
       const digest = `cat ${REMOTE_IDENTITY} ${MACHINE_SECRETS} | sha256sum | cut -c1-64`;
       const [a, b] = await Promise.all([exec(digest, 30_000), exec2(digest, 30_000)]);
       const digestA = a.output.trim();


### PR DESCRIPTION
## Problem
Snapshot creation checked that `cmux-tui` was listening, but it did not prove the authenticated WebSocket, Noise, RPC, and PTY path worked before saving an image.

## Change
- Add an in-guest WebSocket smoke command that enrolls a temporary device, performs authenticated RPC, opens a workspace, spawns a PTY, takes two terminal snapshots, checks marker retention and sequence progress, and cleans up all temporary state.
- Run it after the daemon settles during master image creation.
- Run it before saving every derived size and again after every derived snapshot boots.
- Keep the 30-second settle wait in the creation and verification gates.

## Validation
- Passed ESLint for all four changed scripts.
- Passed `bun run lint:complexity`.
- Passed the smoke check on all six sizes (`sm`, `md`, `lg`, `lgx`, `xl`, `2xl`) after a 30-second settle.
- Passed an end-to-end `md` derivation with the creation-time gate; the temporary snapshot was deleted afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791254983&installation_model_id=21920&pr_number=12025&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12025&signature=c7a7efb1480659ff45228876f9f5e6f511174934ec073665dbb906fcd206a988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies the full authenticated WebSocket path before any master or derived devbox snapshot is saved. Previously only the TCP listener was checked; the smoke now runs inside the guest and exercises enrollment, authenticated RPC, PTY spawn, and terminal snapshots.

- Runs after a 30-second settle during master image creation, before saving each derived size, and again after each derived snapshot boots.
- Cleans up the temporary device, workspace, and process so no test state leaks into a snapshot.

<sup>Written for commit eb06fb14225c931c6034339a2f8c0681748a645f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated checks to verify reliable WebSocket connectivity after development environments are built, resized, restored, and started.
  * Expanded validation of authenticated remote sessions, workspace creation, terminal processes, and terminal output.
  * Added stabilization time before verification to reduce failures caused by services still starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->