### PR TITLE
Keep notification search at the bottom after workspace return

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchNavigationStack.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchNavigationStack.swift
@@ -1,0 +1,63 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// Keeps one search host alive across scope changes and workspace pushes.
+/// Search presentation ends before navigation and returns to the native bottom
+/// control, without recreating the field from a destination's disappearance.
+struct MobilePrimarySearchNavigationStack<Root: View, Destination: View>: View {
+    @Binding var path: [MobileWorkspacePreview.ID]
+    @Binding var selection: MobilePrimaryTab
+    @Bindable var searchCoordinator: MobilePrimarySearchCoordinator
+    @ViewBuilder let root: () -> Root
+    @ViewBuilder let destination: (MobileWorkspacePreview.ID) -> Destination
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            root()
+                .modifier(MobilePrimarySearchLifecycleModifier(
+                    scope: searchCoordinator.scope,
+                    update: searchCoordinator.updateLifecycle
+                ))
+                .navigationDestination(for: MobileWorkspacePreview.ID.self, destination: destination)
+        }
+        .searchable(text: searchText, isPresented: searchPresentation, prompt: prompt)
+        .onSubmit(of: .search) {
+            selection = searchCoordinator.commitSubmit()
+        }
+        .toolbarVisibility(path.isEmpty ? .automatic : .hidden, for: .tabBar)
+    }
+
+    private var searchPresentation: Binding<Bool> {
+        Binding(
+            get: { searchCoordinator.isPresented },
+            set: { presented in
+                searchCoordinator.setPresentation(presented)
+            }
+        )
+    }
+
+    private var searchText: Binding<String> {
+        let scope = searchCoordinator.scope
+        let generation = searchCoordinator.activationGeneration
+        return Binding(
+            get: { searchCoordinator.nativeSearchText(for: scope) },
+            set: { text in
+                searchCoordinator.updateNativeSearchText(
+                    text, for: scope, activationGeneration: generation
+                )
+            }
+        )
+    }
+
+    private var prompt: Text {
+        switch searchCoordinator.scope {
+        case .workspaces:
+            Text(L10n.string("mobile.workspaces.search.placeholder", defaultValue: "Search workspaces"))
+        case .notifications:
+            Text(L10n.string("mobile.notificationFeed.search.placeholder", defaultValue: "Search notifications"))
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -8,8 +8,7 @@ import SwiftUI
 struct MobilePrimaryTabScaffold<
     Workspaces: View,
     Notifications: View,
-    WorkspaceSearch: View,
-    NotificationSearch: View
+    Search: View
 >: View {
     @Binding var selection: MobilePrimaryTab
     @Bindable var searchCoordinator: MobilePrimarySearchCoordinator
@@ -17,8 +16,7 @@ struct MobilePrimaryTabScaffold<
     let taskComposerAction: (() -> Void)?
     let workspaces: Workspaces
     let notifications: Notifications
-    let workspaceSearch: WorkspaceSearch
-    let notificationSearch: NotificationSearch
+    let search: Search
 
     init(
         selection: Binding<MobilePrimaryTab>,
@@ -27,8 +25,7 @@ struct MobilePrimaryTabScaffold<
         taskComposerAction: (() -> Void)? = nil,
         @ViewBuilder workspaces: () -> Workspaces,
         @ViewBuilder notifications: () -> Notifications,
-        @ViewBuilder workspaceSearch: () -> WorkspaceSearch,
-        @ViewBuilder notificationSearch: () -> NotificationSearch
+        @ViewBuilder search: () -> Search
     ) {
         _selection = selection
         self.searchCoordinator = searchCoordinator
@@ -36,8 +33,7 @@ struct MobilePrimaryTabScaffold<
         self.taskComposerAction = taskComposerAction
         self.workspaces = workspaces()
         self.notifications = notifications()
-        self.workspaceSearch = workspaceSearch()
-        self.notificationSearch = notificationSearch()
+        self.search = search()
     }
 
     var body: some View {
@@ -47,19 +43,8 @@ struct MobilePrimaryTabScaffold<
                     primaryTabs
 
                     Tab(value: MobilePrimaryTab.search, role: .search) {
-                        // Scoped to the search tab's content: a TabView-level
-                        // searchable is inherited by every tab's navigation bar,
-                        // which rendered a second, top search field on the
-                        // workspaces and notifications tabs.
-                        searchDestination
-                            .searchable(
-                                text: activeSearchText,
-                                isPresented: searchPresentation,
-                                prompt: activeSearchPrompt
-                            )
-                            .onSubmit(of: .search) {
-                                selection = searchCoordinator.commitSubmit()
-                            }
+                        search
+                            .environment(\.mobilePrimarySearchDestination, true)
                     }
                     .accessibilityIdentifier("MobilePrimaryTabSearch")
                 }
@@ -122,73 +107,6 @@ struct MobilePrimaryTabScaffold<
                 selection = newValue
             }
         )
-    }
-
-    private var searchPresentation: Binding<Bool> {
-        Binding(
-            get: { searchCoordinator.isPresented },
-            set: { presented in
-                searchCoordinator.setPresentation(presented)
-            }
-        )
-    }
-
-    @ViewBuilder
-    private var searchDestination: some View {
-        switch searchCoordinator.scope {
-        case .workspaces:
-            workspaceSearch
-                .modifier(MobilePrimarySearchLifecycleModifier(
-                    scope: .workspaces,
-                    update: updateSearchLifecycle
-                ))
-                .environment(\.mobilePrimarySearchDestination, true)
-        case .notifications:
-            notificationSearch
-                .modifier(MobilePrimarySearchLifecycleModifier(
-                    scope: .notifications,
-                    update: updateSearchLifecycle
-                ))
-                .environment(\.mobilePrimarySearchDestination, true)
-        }
-    }
-
-    private var activeSearchText: Binding<String> {
-        let scope = searchCoordinator.scope
-        let activationGeneration = searchCoordinator.activationGeneration
-        return Binding(
-            get: { searchCoordinator.nativeSearchText(for: scope) },
-            set: { value in
-                searchCoordinator.updateNativeSearchText(
-                    value,
-                    for: scope,
-                    activationGeneration: activationGeneration
-                )
-            }
-        )
-    }
-
-    private var activeSearchPrompt: Text {
-        switch searchCoordinator.scope {
-        case .workspaces:
-            Text(
-                L10n.string(
-                    "mobile.workspaces.search.placeholder",
-                    defaultValue: "Search workspaces"
-                )
-            )
-        case .notifications:
-            Text(
-                L10n.string(
-                    "mobile.notificationFeed.search.placeholder",
-                    defaultValue: "Search notifications"
-                )
-            )
-        }
-    }
-
-    private func updateSearchLifecycle(scope: MobilePrimarySearchScope, isSearching: Bool) {
-        searchCoordinator.updateLifecycle(scope: scope, isSearching: isSearching)
     }
 
     @TabContentBuilder<MobilePrimaryTab>

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
@@ -16,6 +16,7 @@ public struct NotificationFeedPreviewView: View {
     @State private var items: [MobileNotificationFeedItem]
     @State private var projection = NotificationFeedProjection()
     @State private var notificationRoute: NotificationWorkspaceRoute?
+    @State private var restoreSearchOnPop = false
     @State private var pendingSearchNotificationNavigationID: MobileWorkspacePreview.ID?
     @State private var macSelection: WorkspaceMacSelection = .all
 
@@ -76,9 +77,18 @@ public struct NotificationFeedPreviewView: View {
                                     defaultValue: "Workspace"
                                 )
                         )
-                        .toolbarVisibility(.hidden, for: .tabBar)
+                        .onDisappear {
+                            guard restoreSearchOnPop else { return }
+                            restoreSearchOnPop = false
+                            guard selectedTab == .search, notificationRoute == nil else { return }
+                            primarySearchCoordinator.setPresentation(true)
+                        }
                     }
                 }
+                .toolbarVisibility(
+                    notificationRoute == nil ? .automatic : .hidden,
+                    for: .tabBar
+                )
             }
             .background {
                 NotificationFeedSearchProjectionSync(
@@ -91,6 +101,11 @@ public struct NotificationFeedPreviewView: View {
         .onChange(of: primarySearchCoordinator.isPresented) { _, isPresented in
             guard !isPresented else { return }
             consumePendingSearchNavigation(for: selectedTab)
+        }
+        .onChange(of: selectedTab) { oldValue, newValue in
+            if oldValue == .search, newValue != .search {
+                restoreSearchOnPop = false
+            }
         }
         .onChange(of: items, initial: true) { _, items in
             projection.update(items: items, referenceDate: referenceDate)
@@ -140,6 +155,8 @@ public struct NotificationFeedPreviewView: View {
             open: { item in
                 let workspaceID = MobileWorkspacePreview.ID(rawValue: item.remoteWorkspaceID)
                 if selectedTab == .search {
+                    primarySearchCoordinator.deactivateCurrentSearch()
+                    restoreSearchOnPop = true
                     notificationRoute = NotificationWorkspaceRoute(id: workspaceID)
                 } else if primarySearchCoordinator.isPresented {
                     pendingSearchNotificationNavigationID = workspaceID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
@@ -16,7 +16,7 @@ public struct NotificationFeedPreviewView: View {
     @State private var items: [MobileNotificationFeedItem]
     @State private var projection = NotificationFeedProjection()
     @State private var notificationRoute: NotificationWorkspaceRoute?
-    @State private var restoreSearchOnPop = false
+    @State private var searchNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var pendingSearchNotificationNavigationID: MobileWorkspacePreview.ID?
     @State private var macSelection: WorkspaceMacSelection = .all
 
@@ -46,7 +46,9 @@ public struct NotificationFeedPreviewView: View {
                 searchCoordinator: primarySearchCoordinator,
                 notificationUnreadCount: items.lazy.filter { !$0.isRead }.count
             ) {
-                NotificationFeedPreviewWorkspacesView()
+                NavigationStack {
+                    NotificationFeedPreviewWorkspacesView()
+                }
             } notifications: {
                 NavigationStack {
                     ScrollViewReader { proxy in
@@ -59,36 +61,28 @@ public struct NotificationFeedPreviewView: View {
                 .onChange(of: pendingSearchNotificationNavigationID) { _, _ in
                     consumePendingSearchNavigation(for: .notifications)
                 }
-            } workspaceSearch: {
-                NotificationFeedPreviewWorkspacesView()
-            } notificationSearch: {
-                NavigationStack {
-                    NotificationFeedView(
-                        status: .ready,
-                        projection: projection,
-                        refreshesOnAppear: false,
-                        actions: actions
-                    )
-                    .navigationDestination(isPresented: notificationRouteIsPresented) {
-                        NotificationFeedPreviewWorkspaceDestination(
-                            workspaceName: notificationRoute.map { workspaceName(for: $0.id) }
-                                ?? L10n.string(
-                                    "mobile.notificationFeed.workspaceFallback",
-                                    defaultValue: "Workspace"
-                                )
+            } search: {
+                MobilePrimarySearchNavigationStack(
+                    path: $searchNavigationPath,
+                    selection: $selectedTab,
+                    searchCoordinator: primarySearchCoordinator
+                ) {
+                    switch primarySearchCoordinator.scope {
+                    case .workspaces:
+                        NotificationFeedPreviewWorkspacesView()
+                    case .notifications:
+                        NotificationFeedView(
+                            status: .ready,
+                            projection: projection,
+                            refreshesOnAppear: false,
+                            actions: actions
                         )
-                        .onDisappear {
-                            guard restoreSearchOnPop else { return }
-                            restoreSearchOnPop = false
-                            guard selectedTab == .search, notificationRoute == nil else { return }
-                            primarySearchCoordinator.setPresentation(true)
-                        }
                     }
+                } destination: { workspaceID in
+                    NotificationFeedPreviewWorkspaceDestination(
+                        workspaceName: workspaceName(for: workspaceID)
+                    )
                 }
-                .toolbarVisibility(
-                    notificationRoute == nil ? .automatic : .hidden,
-                    for: .tabBar
-                )
             }
             .background {
                 NotificationFeedSearchProjectionSync(
@@ -104,7 +98,7 @@ public struct NotificationFeedPreviewView: View {
         }
         .onChange(of: selectedTab) { oldValue, newValue in
             if oldValue == .search, newValue != .search {
-                restoreSearchOnPop = false
+                searchNavigationPath = []
             }
         }
         .onChange(of: items, initial: true) { _, items in
@@ -156,8 +150,7 @@ public struct NotificationFeedPreviewView: View {
                 let workspaceID = MobileWorkspacePreview.ID(rawValue: item.remoteWorkspaceID)
                 if selectedTab == .search {
                     primarySearchCoordinator.deactivateCurrentSearch()
-                    restoreSearchOnPop = true
-                    notificationRoute = NotificationWorkspaceRoute(id: workspaceID)
+                    searchNavigationPath = [workspaceID]
                 } else if primarySearchCoordinator.isPresented {
                     pendingSearchNotificationNavigationID = workspaceID
                     transitionPrimaryTab(to: .notifications)
@@ -540,13 +533,11 @@ private func makeNotificationFeedPreviewStressItems(
 
 private struct NotificationFeedPreviewWorkspacesView: View {
     var body: some View {
-        NavigationStack {
-            ContentUnavailableView(
-                L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"),
-                systemImage: "rectangle.stack"
-            )
-            .navigationTitle(L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"))
-        }
+        ContentUnavailableView(
+            L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"),
+            systemImage: "rectangle.stack"
+        )
+        .navigationTitle(L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"))
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -789,22 +789,26 @@ public struct WorkspaceListLayoutPreviewView: View {
                     } notifications: {
                         Text("Notification feed fixture")
                             .foregroundStyle(.secondary)
-                    } workspaceSearch: {
-                        NavigationStack(path: $searchFixturePath) {
-                            MobilePrimaryWorkspaceSearchContentHost(
-                                searchCoordinator: primarySearchCoordinator
-                            ) { searchText in
-                                workspaceListFixture(searchText: searchText)
+                    } search: {
+                        MobilePrimarySearchNavigationStack(
+                            path: $searchFixturePath,
+                            selection: $selectedPrimaryTab,
+                            searchCoordinator: primarySearchCoordinator
+                        ) {
+                            switch primarySearchCoordinator.scope {
+                            case .workspaces:
+                                MobilePrimaryWorkspaceSearchContentHost(
+                                    searchCoordinator: primarySearchCoordinator
+                                ) { searchText in
+                                    workspaceListFixture(searchText: searchText)
+                                }
+                            case .notifications:
+                                Text("Notification feed fixture")
+                                    .foregroundStyle(.secondary)
                             }
-                            // Mirrors the shell: a tapped search result pushes
-                            // inside the search tab with the system back button.
-                            .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
-                                fixtureWorkspaceDetail(for: workspaceID)
-                            }
+                        } destination: { workspaceID in
+                            fixtureWorkspaceDetail(for: workspaceID)
                         }
-                    } notificationSearch: {
-                        Text("Notification feed fixture")
-                            .foregroundStyle(.secondary)
                     }
                 } else {
                     workspaceListStack

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -254,6 +254,7 @@ struct WorkspaceShellView: View {
     // instead of stranding the user on a deactivated search tab whose selected
     // (tinted) search control suggests a search is still in progress.
     @State private var searchSelectionReturnsToWorkspaces = false
+    @State private var restoreNotificationSearchOnPop = false
     @State private var rootToolbarMachineSnapshots: WorkspaceMachineSnapshots?
     @State private var rootToolbarPendingSelection: WorkspaceMacSelection?
     @State private var rootToolbarSelectionTask: Task<Void, Never>?
@@ -373,6 +374,7 @@ struct WorkspaceShellView: View {
                     notificationSearchNavigationPath = []
                     workspaceSearchNavigationPath = []
                     searchSelectionReturnsToWorkspaces = false
+                    restoreNotificationSearchOnPop = false
                 }
             }
             .onChange(of: visibleSimulatorWorkspaceID) { previousWorkspaceID, workspaceID in
@@ -574,7 +576,21 @@ struct WorkspaceShellView: View {
                     canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
                 )
                 .toolbarVisibility(.hidden, for: .tabBar)
+                .onDisappear {
+                    guard restoreNotificationSearchOnPop else { return }
+                    restoreNotificationSearchOnPop = false
+                    guard selectedPrimaryTab == .search,
+                          notificationSearchNavigationPath.isEmpty else { return }
+                    primarySearchCoordinator.setPresentation(true)
+                }
             }
+            // Make the tab bar available before the popped destination
+            // disappears. This gives the restored search field its normal
+            // bottom placement.
+            .toolbarVisibility(
+                notificationSearchNavigationPath.isEmpty ? .automatic : .hidden,
+                for: .tabBar
+            )
         }
     }
 
@@ -1488,6 +1504,8 @@ struct WorkspaceShellView: View {
                 selectedTab: selectedPrimaryTab
             ) {
             case .mountedNotificationSearch:
+                primarySearchCoordinator.deactivateCurrentSearch()
+                restoreNotificationSearchOnPop = true
                 if notificationSearchNavigationPath.last != workspaceID {
                     notificationSearchNavigationPath = [workspaceID]
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -254,7 +254,6 @@ struct WorkspaceShellView: View {
     // instead of stranding the user on a deactivated search tab whose selected
     // (tinted) search control suggests a search is still in progress.
     @State private var searchSelectionReturnsToWorkspaces = false
-    @State private var restoreNotificationSearchOnPop = false
     @State private var rootToolbarMachineSnapshots: WorkspaceMachineSnapshots?
     @State private var rootToolbarPendingSelection: WorkspaceMacSelection?
     @State private var rootToolbarSelectionTask: Task<Void, Never>?
@@ -374,7 +373,6 @@ struct WorkspaceShellView: View {
                     notificationSearchNavigationPath = []
                     workspaceSearchNavigationPath = []
                     searchSelectionReturnsToWorkspaces = false
-                    restoreNotificationSearchOnPop = false
                 }
             }
             .onChange(of: visibleSimulatorWorkspaceID) { previousWorkspaceID, workspaceID in
@@ -465,12 +463,8 @@ struct WorkspaceShellView: View {
             .onChange(of: pendingPrimarySearchNotificationNavigationID) { _, _ in
                 consumePendingPrimarySearchNavigation(for: .notifications)
             }
-        } workspaceSearch: {
-            workspaceSearchTabContent(
-                canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
-            )
-        } notificationSearch: {
-            notificationSearchTabContent(presentation: presentation)
+        } search: {
+            primarySearchTabContent(presentation: presentation)
         }
     }
     #endif
@@ -491,42 +485,59 @@ struct WorkspaceShellView: View {
     }
     #endif
 
-    private func workspaceSearchTabContent(canCreateWorkspaceForSelection: Bool) -> some View {
+    private var primarySearchNavigationPath: Binding<[MobileWorkspacePreview.ID]> {
+        primarySearchCoordinator.scope == .workspaces
+            ? $workspaceSearchNavigationPath
+            : $notificationSearchNavigationPath
+    }
+
+    private func primarySearchTabContent(
+        presentation: WorkspaceShellRenderPresentation
+    ) -> some View {
         workspaceActionToastOverlay {
-            NavigationStack(path: $workspaceSearchNavigationPath) {
-                MobilePrimaryWorkspaceSearchContentHost(
-                    searchCoordinator: primarySearchCoordinator
-                ) { searchText in
-                    workspaceList(
-                        navigationStyle: .push,
-                        searchText: searchText,
-                        canCreateWorkspaceForSelection: canCreateWorkspaceForSelection,
-                        showsNavigationToolbar: true,
-                        selectWorkspaceAction: selectWorkspaceFromSearch,
-                        createWorkspaceAction: createWorkspaceFromSearch,
-                        createWorkspaceInGroupAction: createWorkspaceInGroupFromSearchClosure,
-                        createWorkspaceGroupAction: createWorkspaceGroupFromSearchClosure
-                    )
+            MobilePrimarySearchNavigationStack(
+                path: primarySearchNavigationPath,
+                selection: $selectedPrimaryTab,
+                searchCoordinator: primarySearchCoordinator
+            ) {
+                Group {
+                    switch primarySearchCoordinator.scope {
+                    case .workspaces:
+                        MobilePrimaryWorkspaceSearchContentHost(
+                            searchCoordinator: primarySearchCoordinator
+                        ) { searchText in
+                            workspaceList(
+                                navigationStyle: .push,
+                                searchText: searchText,
+                                canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection,
+                                showsNavigationToolbar: true,
+                                selectWorkspaceAction: selectWorkspaceFromSearch,
+                                createWorkspaceAction: createWorkspaceFromSearch,
+                                createWorkspaceInGroupAction: createWorkspaceInGroupFromSearchClosure,
+                                createWorkspaceGroupAction: createWorkspaceGroupFromSearchClosure
+                            )
+                        }
+                    case .notifications:
+                        NotificationFeedStoreView(
+                            store: store,
+                            items: presentation.notificationFeedItems,
+                            status: presentation.notificationFeedStatus,
+                            projection: notificationFeedProjection,
+                            selectedMacDeviceIDs: presentation.selectedNotificationFeedMacDeviceIDs
+                        )
+                    }
                 }
                 .toolbar {
-                    if workspaceSearchNavigationPath.isEmpty {
+                    if primarySearchNavigationPath.wrappedValue.isEmpty {
                         rootToolbarContent
                     }
                 }
-                // Selecting a search result opens the workspace inside the
-                // search tab's own stack, exactly like notification search.
-                // Transitioning to the Workspaces tab and pushing on its stack
-                // from here raced the search-field dismissal and could record
-                // the push without performing it, stranding the list with no
-                // tab bar (the "stuck after selecting from search" bug).
-                .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
-                    workspaceDestination(
-                        for: workspaceID,
-                        createWorkspace: createWorkspaceInCompactStack,
-                        canCreateWorkspaceForSelection: canCreateWorkspaceForSelection
-                    )
-                    .toolbarVisibility(.hidden, for: .tabBar)
-                }
+            } destination: { workspaceID in
+                workspaceDestination(
+                    for: workspaceID,
+                    createWorkspace: createWorkspaceInCompactStack,
+                    canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
+                )
             }
         }
     }
@@ -549,50 +560,6 @@ struct WorkspaceShellView: View {
                 .padding(.bottom, 12)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
                 .accessibilityIdentifier("MobileWorkspaceActionToast")
-            }
-        }
-    }
-
-    private func notificationSearchTabContent(
-        presentation: WorkspaceShellRenderPresentation
-    ) -> some View {
-        NavigationStack(path: $notificationSearchNavigationPath) {
-            NotificationFeedStoreView(
-                store: store,
-                items: presentation.notificationFeedItems,
-                status: presentation.notificationFeedStatus,
-                projection: notificationFeedProjection,
-                selectedMacDeviceIDs: presentation.selectedNotificationFeedMacDeviceIDs
-            )
-            .toolbar {
-                if notificationSearchNavigationPath.isEmpty {
-                    rootToolbarContent
-                }
-            }
-                .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
-                    workspaceDestination(
-                        for: workspaceID,
-                        createWorkspace: createWorkspaceInCompactStack,
-                        canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
-                    )
-                    .toolbarVisibility(.hidden, for: .tabBar)
-            }
-            // Keep the tab bar hidden only while the detail route is active so
-            // the restored search control returns to its bottom placement.
-            .toolbarVisibility(
-                notificationSearchNavigationPath.isEmpty ? .automatic : .hidden,
-                for: .tabBar
-            )
-            .onChange(of: notificationSearchNavigationPath) { oldPath, newPath in
-                guard !oldPath.isEmpty,
-                      newPath.isEmpty,
-                      restoreNotificationSearchOnPop else { return }
-                restoreNotificationSearchOnPop = false
-                guard selectedPrimaryTab == .search else { return }
-                // Back is the authoritative transition out of the detail
-                // route. Restore the native search session from that state
-                // change instead of relying on a destination lifecycle callback.
-                primarySearchCoordinator.setPresentation(true)
             }
         }
     }
@@ -1508,7 +1475,6 @@ struct WorkspaceShellView: View {
             ) {
             case .mountedNotificationSearch:
                 primarySearchCoordinator.deactivateCurrentSearch()
-                restoreNotificationSearchOnPop = true
                 if notificationSearchNavigationPath.last != workspaceID {
                     notificationSearchNavigationPath = [workspaceID]
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -569,28 +569,31 @@ struct WorkspaceShellView: View {
                     rootToolbarContent
                 }
             }
-            .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
-                workspaceDestination(
-                    for: workspaceID,
-                    createWorkspace: createWorkspaceInCompactStack,
-                    canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
-                )
-                .toolbarVisibility(.hidden, for: .tabBar)
-                .onDisappear {
-                    guard restoreNotificationSearchOnPop else { return }
-                    restoreNotificationSearchOnPop = false
-                    guard selectedPrimaryTab == .search,
-                          notificationSearchNavigationPath.isEmpty else { return }
-                    primarySearchCoordinator.setPresentation(true)
-                }
+                .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
+                    workspaceDestination(
+                        for: workspaceID,
+                        createWorkspace: createWorkspaceInCompactStack,
+                        canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
+                    )
+                    .toolbarVisibility(.hidden, for: .tabBar)
             }
-            // Make the tab bar available before the popped destination
-            // disappears. This gives the restored search field its normal
-            // bottom placement.
+            // Keep the tab bar hidden only while the detail route is active so
+            // the restored search control returns to its bottom placement.
             .toolbarVisibility(
                 notificationSearchNavigationPath.isEmpty ? .automatic : .hidden,
                 for: .tabBar
             )
+            .onChange(of: notificationSearchNavigationPath) { oldPath, newPath in
+                guard !oldPath.isEmpty,
+                      newPath.isEmpty,
+                      restoreNotificationSearchOnPop else { return }
+                restoreNotificationSearchOnPop = false
+                guard selectedPrimaryTab == .search else { return }
+                // Back is the authoritative transition out of the detail
+                // route. Restore the native search session from that state
+                // change instead of relying on a destination lifecycle callback.
+                primarySearchCoordinator.setPresentation(true)
+            }
         }
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3953,11 +3953,62 @@ final class cmuxUITests: XCTestCase {
         let systemBack = app.navigationBars.buttons.firstMatch
         XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
         systemBack.tap()
-        XCTAssertTrue(searchField.waitForHittable(timeout: 3))
+        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
         XCTAssertEqual(searchField.value as? String, "Tests passed")
-        XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
+        XCTAssertTrue(waitForNotHittable(matchingRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(nonmatchingRow, timeout: 3))
         XCTAssertGreaterThan(searchField.frame.midY, app.frame.midY)
+    }
+
+    @MainActor
+    func testNotificationSearchStaysAtBottomAfterOpeningWorkspaceAndReturningTwice() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The bottom search control requires iOS 26.")
+        }
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_NOTIFICATION_FEED_PREVIEW": "1",
+        ])
+        defer { app.terminate() }
+        let feed = app.descendants(matching: .any)["MobileNotificationFeed"]
+        XCTAssertTrue(feed.waitForExistence(timeout: 8))
+        let searchButton = app.tabBars.buttons["Search"]
+        XCTAssertTrue(waitForHittable(searchButton, timeout: 3))
+        tap(searchButton, in: app)
+        let searchField = app.searchFields["Search notifications"]
+        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
+        searchField.typeText("Tests passed")
+        let matchingRow = app.descendants(matching: .any)["MobileNotificationFeedRow-macbook-tests-passed"]
+        XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
+        let initialFrame = searchField.frame
+        XCTAssertGreaterThan(initialFrame.midY, app.frame.midY)
+
+        func capture(_ name: String) {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = name
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+            let hierarchy = XCTAttachment(string: app.debugDescription)
+            hierarchy.name = name + "-hierarchy"
+            hierarchy.lifetime = .keepAlways
+            add(hierarchy)
+        }
+        capture("notification-search-before-open")
+        for cycle in 1...2 {
+            matchingRow.tap()
+            let detail = app.descendants(matching: .any)["MobileNotificationFeedPreviewWorkspaceDestination"]
+            XCTAssertTrue(detail.waitForExistence(timeout: 5))
+            capture("notification-search-workspace-\(cycle)")
+            let back = app.navigationBars.buttons.firstMatch
+            XCTAssertTrue(waitForHittable(back, timeout: 3))
+            back.tap()
+            XCTAssertTrue(waitForHittable(searchField, timeout: 5))
+            capture("notification-search-after-back-\(cycle)")
+            XCTAssertEqual(searchField.value as? String, "Tests passed")
+            XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
+            XCTAssertGreaterThan(searchField.frame.midY, app.frame.midY)
+            XCTAssertEqual(searchField.frame.minY, initialFrame.minY, accuracy: 4)
+            XCTAssertEqual(searchField.frame.height, initialFrame.height, accuracy: 4)
+        }
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3951,7 +3951,7 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Release"].waitForExistence(timeout: 3))
 
         let systemBack = app.navigationBars.buttons.firstMatch
-        XCTAssertTrue(systemBack.waitForHittable(timeout: 3))
+        XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
         systemBack.tap()
         XCTAssertTrue(searchField.waitForHittable(timeout: 3))
         XCTAssertEqual(searchField.value as? String, "Tests passed")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3801,7 +3801,9 @@ final class cmuxUITests: XCTestCase {
         let mainRow = app.descendants(matching: .any)["MobileWorkspaceRow-workspace-main"]
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
-        tap(docsRow, in: app)
+        // Tap the result with search still active. The generic tap helper
+        // submits the keyboard's Search action first, which changes tabs.
+        docsRow.tap()
 
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
         XCTAssertTrue(workspaceDetail.waitForExistence(timeout: 3))
@@ -3906,13 +3908,13 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(feed.waitForExistence(timeout: 8))
 
         let matchingRow = app.descendants(matching: .any)[
-            "MobileNotificationFeedRow-macbook-tests-passed"
+            "MobileNotificationFeedRow-macbook-legacy-tests-passed"
         ]
         let nonmatchingRow = app.descendants(matching: .any)[
-            "MobileNotificationFeedRow-studio-codex-approval"
+            "MobileNotificationFeedRow-studio-legacy-codex-approval"
         ]
         let readRow = app.descendants(matching: .any)[
-            "MobileNotificationFeedRow-studio-localization-complete"
+            "MobileNotificationFeedRow-studio-legacy-localization-complete"
         ]
         XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
         XCTAssertTrue(waitForHittable(nonmatchingRow, timeout: 3))
@@ -3953,6 +3955,9 @@ final class cmuxUITests: XCTestCase {
         let systemBack = app.navigationBars.buttons.firstMatch
         XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
         systemBack.tap()
+        XCTAssertTrue(waitForHittable(searchButton, timeout: 3))
+        XCTAssertGreaterThan(searchButton.frame.midY, app.frame.midY)
+        tap(searchButton, in: app)
         XCTAssertTrue(waitForHittable(searchField, timeout: 3))
         XCTAssertEqual(searchField.value as? String, "Tests passed")
         XCTAssertTrue(waitForNotHittable(matchingRow, timeout: 3))
@@ -3962,6 +3967,16 @@ final class cmuxUITests: XCTestCase {
 
     @MainActor
     func testNotificationSearchStaysAtBottomAfterOpeningWorkspaceAndReturningTwice() throws {
+        try verifyNotificationSearchReturn(switchFromWorkspaceSearch: false)
+    }
+
+    @MainActor
+    func testNotificationSearchStaysAtBottomAfterSwitchingFromWorkspaceSearch() throws {
+        try verifyNotificationSearchReturn(switchFromWorkspaceSearch: true)
+    }
+
+    @MainActor
+    private func verifyNotificationSearchReturn(switchFromWorkspaceSearch: Bool) throws {
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("The bottom search control requires iOS 26.")
         }
@@ -3973,11 +3988,20 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(feed.waitForExistence(timeout: 8))
         let searchButton = app.tabBars.buttons["Search"]
         XCTAssertTrue(waitForHittable(searchButton, timeout: 3))
+        if switchFromWorkspaceSearch {
+            tap(app.tabBars.buttons["Workspaces"], in: app)
+            tap(searchButton, in: app)
+            let workspaceField = app.searchFields["Search workspaces"]
+            XCTAssertTrue(waitForHittable(workspaceField, timeout: 3))
+            XCTAssertGreaterThan(workspaceField.frame.midY, app.frame.midY)
+            app.buttons["Close"].tap()
+            tap(app.tabBars.buttons["Notifications"], in: app)
+        }
         tap(searchButton, in: app)
         let searchField = app.searchFields["Search notifications"]
         XCTAssertTrue(waitForHittable(searchField, timeout: 3))
         searchField.typeText("Tests passed")
-        let matchingRow = app.descendants(matching: .any)["MobileNotificationFeedRow-macbook-tests-passed"]
+        let matchingRow = app.descendants(matching: .any)["MobileNotificationFeedRow-macbook-legacy-tests-passed"]
         XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
         let initialFrame = searchField.frame
         XCTAssertGreaterThan(initialFrame.midY, app.frame.midY)
@@ -4001,10 +4025,19 @@ final class cmuxUITests: XCTestCase {
             let back = app.navigationBars.buttons.firstMatch
             XCTAssertTrue(waitForHittable(back, timeout: 3))
             back.tap()
-            XCTAssertTrue(waitForHittable(searchField, timeout: 5))
+            XCTAssertTrue(waitForHittable(searchButton, timeout: 5))
             capture("notification-search-after-back-\(cycle)")
-            XCTAssertEqual(searchField.value as? String, "Tests passed")
+            XCTAssertGreaterThan(searchButton.frame.midY, app.frame.midY)
+            XCTAssertFalse(app.navigationBars.buttons["Search"].exists,
+                "Returning must not add a second Search control to the top toolbar")
+            if searchField.exists && searchField.isHittable {
+                XCTAssertGreaterThan(searchField.frame.midY, app.frame.midY)
+            }
             XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
+            tap(searchButton, in: app)
+            XCTAssertTrue(waitForHittable(searchField, timeout: 5))
+            capture("notification-search-reopened-\(cycle)")
+            XCTAssertEqual(searchField.value as? String, "Tests passed")
             XCTAssertGreaterThan(searchField.frame.midY, app.frame.midY)
             XCTAssertEqual(searchField.frame.minY, initialFrame.minY, accuracy: 4)
             XCTAssertEqual(searchField.frame.height, initialFrame.height, accuracy: 4)

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3949,6 +3949,15 @@ final class cmuxUITests: XCTestCase {
         ]
         XCTAssertTrue(workspaceDestination.waitForExistence(timeout: 3))
         XCTAssertTrue(app.navigationBars["Release"].waitForExistence(timeout: 3))
+
+        let systemBack = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(systemBack.waitForHittable(timeout: 3))
+        systemBack.tap()
+        XCTAssertTrue(searchField.waitForHittable(timeout: 3))
+        XCTAssertEqual(searchField.value as? String, "Tests passed")
+        XCTAssertTrue(waitForHittable(matchingRow, timeout: 3))
+        XCTAssertTrue(waitForNotHittable(nonmatchingRow, timeout: 3))
+        XCTAssertGreaterThan(searchField.frame.midY, app.frame.midY)
     }
 
     @MainActor


### PR DESCRIPTION
Opening a notification search result and going Back could move search into the top navigation bar. Keep one search navigation host mounted across both scopes, commit the query before pushing, and let Back restore the native bottom Search control. Tapping Search reopens the saved query at the same bottom position. Remove the automatic re-presentation callbacks and separate per-scope search stacks.

The notification fixture shares the production feed, tab scaffold, and search navigation host. Regression coverage checks two consecutive open/Back/reopen cycles, switching from workspace search, no duplicate top Search button, query retention, unread filtering, and existing workspace search navigation. The workspace test now taps its result directly; its generic tap helper previously submitted search before selecting the row.

Validation: four focused XCUITests passed on an isolated fleet iPhone 17 Pro Max simulator (iOS 26.3.1). The previous implementation failed with the search field at y=92. The final native Search button returns at y=904, and the reopened field matches its original frame (y=555, height=48). Recorded the run and inspected transition frames and both return screenshots. Mac and iOS builds completed from `8d15d13d4dc` with tag `nsrch`. The signed phone update is queued for automatic installation and launch on Aziz, which is unreachable. Physical-device verification remains pending.
