### PR TITLE
sidebar: Strip inline Markdown from notification previews

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarMarkdownRenderer.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarMarkdownRenderer.swift
@@ -15,6 +15,11 @@ public struct SidebarMarkdownRenderer {
         self.markdown = markdown
     }
 
+    /// Inline Markdown as plain text, preserving whitespace and falling back to the source on parse failure.
+    public var plainText: String {
+        workspaceDescription.map { String($0.characters) } ?? markdown
+    }
+
     /// The markdown rendered into an `AttributedString`, interpreting only
     /// inline syntax and preserving whitespace. `nil` when it cannot be parsed.
     public var workspaceDescription: AttributedString? {

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarMarkdownRendererTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarMarkdownRendererTests.swift
@@ -1,0 +1,24 @@
+import CmuxFoundation
+import Testing
+
+@Suite
+struct SidebarMarkdownRendererTests {
+    @Test(arguments: [
+        ("**Pi finished.**", "Pi finished."),
+        ("*Italic* and **bold**", "Italic and bold"),
+        ("Run `swift test`", "Run swift test"),
+        ("Read [the results](https://example.com)", "Read the results"),
+        ("**Done**\n\n*All checks passed*", "Done\n\nAll checks passed"),
+        ("  **Done**\t next  ", "  Done\t next  "),
+        ("**完成 🎉**", "完成 🎉"),
+        (#"\*\*literal\*\*"#, "**literal**"),
+        ("`**literal**`", "**literal**"),
+        ("CMUX_NOTIFICATION_BODY and src/my_file.swift", "CMUX_NOTIFICATION_BODY and src/my_file.swift"),
+        ("**unfinished", "**unfinished"),
+        ("", ""),
+    ])
+    func plainTextPreservesContentWithoutInlineFormatting(content: (String, String)) {
+        let (markdown, expected) = content
+        #expect(SidebarMarkdownRenderer(markdown: markdown).plainText == expected)
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15711,7 +15711,12 @@ struct TabItemView: View, Equatable {
         let effectiveSubtitle = latestNotificationSubtitle ?? conversationMessageSubtitle
         let subtitleLineLimit = latestNotificationSubtitle == nil ? 2 : settings.notificationMessageLineLimit
         // Bound notification payloads before shaping so pathological text stays cheap in lazy, Equatable rows.
-        let displayedSubtitle = effectiveSubtitle?.sidebarBoundedDisplayString(maxDisplayedLines: subtitleLineLimit, maxDisplayedCharacters: 4096)
+        let displayedSubtitle = effectiveSubtitle.map { subtitle in
+            let display = subtitle.sidebarBoundedDisplayString(maxDisplayedLines: subtitleLineLimit, maxDisplayedCharacters: 4096)
+            return latestNotificationSubtitle == nil
+                ? display
+                : SidebarMarkdownRenderer(markdown: display).plainText
+        }
         let detailVisibility = visibleAuxiliaryDetails
         let titleLineLimit = settings.wrapsWorkspaceTitles ? Self.maxWrappedTitleLines : 1
         let displayedTitle = workspaceSnapshot.title.sidebarBoundedDisplayString(

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -547,10 +547,13 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         subtitleView.isHidden = effectiveSubtitle == nil
         if let effectiveSubtitle {
             subtitleView.maximumNumberOfLines = subtitleLineLimit
-            subtitleView.stringValue = effectiveSubtitle.sidebarBoundedDisplayString(
+            let display = effectiveSubtitle.sidebarBoundedDisplayString(
                 maxDisplayedLines: subtitleLineLimit,
                 maxDisplayedCharacters: 4096
             )
+            subtitleView.stringValue = model.latestNotificationText == nil
+                ? display
+                : SidebarMarkdownRenderer(markdown: display).plainText
             subtitleView.font = .systemFont(ofSize: model.scaled(10))
             subtitleView.textColor = palette.secondary(0.8)
         }

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -244,6 +244,25 @@ struct SidebarAppKitRowCellTests {
         return cell
     }
 
+    @Test(arguments: [false, true], [
+        ("**Pi finished.**", "Pi finished."),
+        ("Run `swift test` and read [the results](https://example.com).", "Run swift test and read the results."),
+        ("**Done**\n*All checks passed*", "Done\nAll checks passed"),
+    ])
+    func notificationPreviewDisplaysPlainText(isActive: Bool, content: (String, String)) throws {
+        let (markdown, expected) = content
+        var model = Self.makeModel(isActive: isActive)
+        model.latestNotificationText = markdown
+        let cell = Self.configuredCell(model: model)
+        let subtitle = try #require(Self.descendants(of: cell)
+            .compactMap { $0 as? SidebarRowTextView }
+            .first { !$0.isHidden && $0.stringValue == expected })
+
+        #expect(Self.accessibilityLinks(in: subtitle).isEmpty)
+        #expect(subtitle.maximumNumberOfLines == model.settings.notificationMessageLineLimit)
+        #expect(cell.currentModelForMeasurement?.latestNotificationText == markdown)
+    }
+
     fileprivate static func descendants(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
     }


### PR DESCRIPTION
> [!NOTE]
> AI-generated description.

## Summary

- Show inline Markdown as plain text in notification previews in both the AppKit and legacy SwiftUI workspace sidebars. For example, `**Pi finished.**` displays as `Pi finished.` using the existing `SidebarMarkdownRenderer`, without a new parser or dependency.
- Keep the existing input bounds, whitespace, conversation-message fallback, and non-clickable preview behavior. Stored notifications, API payloads, desktop banners, and block-level Markdown are unchanged.

Related: #2144 strips desktop notification text; #5429 adds rich notification panels but leaves sidebar preview formatting intact. Neither fixes this sidebar display path.

## Testing

- `swift test --package-path Packages/macOS/CmuxFoundation`: **309 tests passed**, including 12 new inline-formatting cases covering emphasis, code, links, whitespace, Unicode, escaping, identifiers, and incomplete syntax.
- Added six AppKit row cases covering selected/unselected rows, displayed text, inactive links, line limits, and preservation of the raw notification snapshot. These are in a separate test-only commit; the app-target tests have not been run locally.
- `swiftc -parse` passed for the changed app/test files; `scripts/lint-pbxproj-test-wiring.sh`, `scripts/check-package-resolved-policy.py`, and `git diff --check` passed.
- `./scripts/reload.sh --tag kate-sidebar-markdown --no-global-cli-links` is blocked by missing Zig. App-target compilation and visual verification remain pending.
- Localization audit: both changed sidebar surfaces display existing agent-supplied text; no new user-facing strings or catalog keys.

## Demo Video

Not captured: the tagged app build is blocked by the missing build prerequisite above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (package tests only)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no configuration or documented API changes)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

---

### Human Notes

Draft pending app-target tests and a tagged sidebar UI check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791271064&installation_model_id=21920&pr_number=12030&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12030&signature=60941f0d52a61be53968eeed41c42483afb85df303daf66b4361aaf0f1b195fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips inline Markdown from notification previews in the AppKit and legacy SwiftUI workspace sidebars, so `**Pi finished.**` displays as `Pi finished.` instead of raw Markdown syntax. Stored notifications, API payloads, desktop banners, and block-level Markdown are unchanged.

**Scope**
- Applies only to notification-driven previews; conversation-message fallback subtitles keep existing formatting.
- Existing input bounds, whitespace handling, and non-clickable preview behavior are preserved.

**Testing**
- Added 12 inline-formatting cases and 6 AppKit row cases; package suite passes 309 tests.
- App-target compilation and visual verification are pending because the tagged build requires Zig.

<sup>Written for commit 73cc757d03dea2a5ee7d7d45b4e29c3abb5b00dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification previews now display readable plain text instead of Markdown formatting.
  * Notification preview line limits and accessibility behavior are preserved.
  * Conversation subtitles continue displaying their existing formatting.

* **Tests**
  * Added coverage for Markdown removal, whitespace preservation, non-ASCII text, empty content, line limits, and accessibility links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->