### PR TITLE
fix(cloud): stop the snapshot parser trapping on every non-empty snapshot

### DIFF
--- a/Sources/Surfaces/CmuxTuiSnapshotParser.swift
+++ b/Sources/Surfaces/CmuxTuiSnapshotParser.swift
@@ -397,7 +397,11 @@ struct CmuxTuiSnapshotParser: Sendable {
     private static func orderedSnapshotRows(
         _ rows: [[String: Any]],
         focusedFirst: Bool = false
-    ) -> [(element: [String: Any], offset: Int)] {
+    ) -> [(offset: Int, element: [String: Any])] {
+        // `enumerated()` yields `(offset:, element:)`. Returning that array through a
+        // tuple type with the labels reordered compiles into a runtime element cast
+        // that fails for every non-empty array (a SIGTRAP the moment a machine reports
+        // a workspace), so the return type keeps the sequence's own label order.
         rows.enumerated().sorted { left, right in
             if focusedFirst {
                 let leftFocused = (left.element["focused"] as? Bool) == true

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -2019,3 +2019,81 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(legacy.placements.first?.remoteWorkspaceID == "ws_api")
     }
 }
+
+/// Regression coverage for the snapshot row ordering helper. In
+/// 0.64.22-nightly.3400956733901 the app trapped (EXC_BREAKPOINT in
+/// `orderedSnapshotRows`) the first time a machine reported any workspace,
+/// screen, pane, or tab: the helper returned `enumerated().sorted` through a
+/// tuple type with reordered labels, which Swift compiles into a runtime array
+/// cast that fails for every non-empty array. Empty snapshots never reach the
+/// cast, so the crash only appeared once a machine actually connected.
+@Suite struct CmuxTuiSnapshotRowOrderingRegressionTests {
+    static let machine = SurfaceMachineID.cloud("gentle-ochre-dingo")
+
+    @Test func workspacesFromANonEmptySnapshotSurviveAndFollowTheirIndexes() {
+        let snapshot: [String: Any] = [
+            "workspaces": [
+                ["id": "ws_second", "name": "second", "index": 1, "focused": false],
+                ["id": "ws_first", "name": "first", "index": 0, "focused": true],
+                ["id": "ws_legacy", "name": "legacy"],
+            ],
+        ]
+        let workspaces = CmuxTuiSnapshotParser.workspaces(fromSnapshot: snapshot)
+        #expect(
+            workspaces.map(\.id) == ["ws_first", "ws_second", "ws_legacy"],
+            "explicit indexes win; a row without one keeps its transport order after them"
+        )
+        #expect(workspaces.map(\.index) == [0, 1, 2])
+        #expect(workspaces.first?.focused == true)
+    }
+
+    @Test func terminalProjectionTargetFromANonEmptySnapshotPrefersFocusedRowsThenIndexes() throws {
+        let snapshot: [String: Any] = [
+            "workspaces": [
+                ["id": "ws_bg", "index": 0, "focused": false],
+                ["id": "ws_fg", "index": 1, "focused": true],
+            ],
+            "screens": [
+                ["id": "screen_bg", "workspace_id": "ws_bg", "focused": true],
+                ["id": "screen_fg_2", "workspace_id": "ws_fg", "index": 1],
+                ["id": "screen_fg_1", "workspace_id": "ws_fg", "index": 0],
+            ],
+            "panes": [
+                ["id": "pane_fg_1", "screen_id": "screen_fg_1"],
+                ["id": "pane_bg", "screen_id": "screen_bg"],
+            ],
+            "tabs": [
+                ["id": "tab_1", "pane_id": "pane_fg_1", "content_kind": "terminal", "content_id": "term_1"],
+            ],
+            "terminals": [
+                ["id": "term_1", "tab_id": "tab_1", "title": "shell", "lifecycle": "running"],
+            ],
+            "browsers": [],
+            "agents": [],
+        ]
+        let target = try #require(CmuxTuiSnapshotParser.terminalProjectionTarget(from: snapshot))
+        #expect(target.workspaceID == "ws_fg", "the focused workspace wins over a lower index")
+        #expect(target.screenID == "screen_fg_1", "within it, the lowest explicit index wins")
+        #expect(target.paneID == "pane_fg_1")
+        #expect(target.index == 1, "the new tab lands after the pane's existing tab")
+    }
+
+    @Test func terminalsFromANonEmptySnapshotOrderTheirViewsByTabIndex() throws {
+        let snapshot: [String: Any] = [
+            "workspaces": [["id": "ws_main", "name": "main", "focused": true]],
+            "screens": [["id": "screen_1", "workspace_id": "ws_main"]],
+            "panes": [["id": "pane_1", "screen_id": "screen_1"]],
+            "tabs": [
+                ["id": "tab_b", "pane_id": "pane_1", "index": 1, "content_kind": "terminal", "content_id": "term_b"],
+                ["id": "tab_a", "pane_id": "pane_1", "index": 0, "content_kind": "terminal", "content_id": "term_a"],
+            ],
+            "terminals": [
+                ["id": "term_b", "tab_id": "tab_b", "title": "b", "lifecycle": "running"],
+                ["id": "term_a", "tab_id": "tab_a", "title": "a", "lifecycle": "running"],
+            ],
+        ]
+        let resources = CmuxTuiSnapshotParser.terminals(fromSnapshot: snapshot, machine: Self.machine)
+        #expect(resources.map { $0.id.key } == ["term_a", "term_b"], "tab index, not transport order, decides the view order")
+        #expect(resources.compactMap { $0.remoteViews?.first?.index } == [0, 1])
+    }
+}


### PR DESCRIPTION
## What broke

`cmux NIGHTLY` 0.64.22-nightly.3400956733901 crashed three launches in a row on 2026-09-06 (pids 80728, 64295, 79413; `EXC_BREAKPOINT` on the main thread, all three with the same frames). Each crash landed the moment a Cloud machine finished connecting and sent its first cmux-tui state snapshot, about 30 seconds after launch once the tunnel was healthy.

## Root cause

`CmuxTuiSnapshotParser.orderedSnapshotRows` (added in bdf914a09e) returns `rows.enumerated().sorted { … }` from a function declared to return `[(element: [String: Any], offset: Int)]`. `EnumeratedSequence` yields `(offset:, element:)`, so the labels are reordered. Swift accepts that with only a deprecation warning and compiles it into a runtime array element cast, and that cast fails for every non-empty array:

```
Could not cast value of type '(offset: Swift.Int, element: Swift.Dictionary<Swift.String, Any>)'
                     to '(element: Swift.Dictionary<Swift.String, Any>, offset: Swift.Int)'
```

Under `-O` that is a bare `brk #1`, which is exactly the trap in the crash reports (disassembly of the shipped binary shows `sorted` followed by the cast, with the empty-array path returning normally). Empty snapshots never reach the cast, which is why the app looked fine until a machine actually reported a workspace.

A standalone `swiftc -O` program with the same conversion reproduces the SIGTRAP; changing the return type to the sequence's own label order runs clean.

## Fix

Keep `(offset:, element:)` as the return type. Every caller reads `.element` and `.offset` by name, so nothing else changes.

## Tests

Two commits so the Commits tab shows the test failing first:

1. `test(cloud)`: three Swift Testing cases in `CmuxTuiSurfaceProviderTests.swift` drive `workspaces(fromSnapshot:)`, `terminalProjectionTarget(from:)`, and `terminals(fromSnapshot:machine:)` with non-empty, indexed rows. They trap without the fix and pin the ordering semantics (explicit index over transport order, focused-first for the projection target).
2. `fix(cloud)`: the return type change.

No user-facing strings changed, so no localization audit was needed. Local disk on the dev Mac is full, so the app was not rebuilt here; the reproduction is the standalone compiler program plus the shipped binary's disassembly, and CI runs the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gpMLNXsCY4bmCvkHEavBe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791275318&installation_model_id=21920&pr_number=12034&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12034&signature=1e0751b6110df62b69ec40a422cf63e751f98115b7d4ccca33ca8bcb029daace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the snapshot parser crashing on every non-empty snapshot by aligning the return type with the `enumerated()` sequence's tuple labels. The crash occurred when a machine connected and reported a workspace; empty snapshots were unaffected.

Adds regression tests covering workspace, terminal projection target, and terminal ordering from non-empty snapshots.

<sup>Written for commit 6ab129337ca42e1682c46b1b82a8fa29248fa774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed crashes when processing non-empty terminal snapshots.
  - Corrected snapshot row ordering for workspaces and terminal views, including focused workspaces and rows without explicit indexes.

- **Tests**
  - Added regression coverage for snapshot ordering and terminal projection selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->