### PR TITLE
Fix cloud snapshot ordering runtime trap

### DIFF
--- a/Sources/Surfaces/CmuxTuiSnapshotParser.swift
+++ b/Sources/Surfaces/CmuxTuiSnapshotParser.swift
@@ -398,7 +398,14 @@ struct CmuxTuiSnapshotParser: Sendable {
         _ rows: [[String: Any]],
         focusedFirst: Bool = false
     ) -> [(element: [String: Any], offset: Int)] {
-        rows.enumerated().sorted { left, right in
+        // `enumerated()` produces `(offset:element:)`, while this helper's
+        // public shape is `(element:offset:)`. Swift can implicitly relabel
+        // the tuple at compile time, but the generated cast traps at runtime
+        // for every non-empty result. Relabel each element before sorting so
+        // the returned array already has the declared tuple shape.
+        rows.enumerated().map { entry in
+            (element: entry.element, offset: entry.offset)
+        }.sorted { left, right in
             if focusedFirst {
                 let leftFocused = (left.element["focused"] as? Bool) == true
                 let rightFocused = (right.element["focused"] as? Bool) == true


### PR DESCRIPTION
## Problem

Cloud snapshot ordering trapped at runtime whenever the daemon returned a non-empty row collection. `enumerated()` produces `(offset:element:)`, but `orderedSnapshotRows` declared `(element:offset:)`; Swift accepted the implicit relabeling with a deprecation warning and emitted a runtime tuple cast.

## Fix

Explicitly relabel each enumerated tuple before sorting, eliminating the runtime cast while preserving focused/index/transport ordering.

## Validation

- Reproduced the crash with a minimal Swift program using the old implementation.
- Verified the corrected implementation with non-empty input.
- `git diff --check` passes.
- Existing `CmuxTuiSurfaceProviderTests` coverage exercises non-empty ordered snapshot rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791277207&installation_model_id=21920&pr_number=12038&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12038&signature=9439825500a2413339ffe04da7d9c5e0ea06577c3ab7be6a96497a5f1d901339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime trap in cloud snapshot ordering when the daemon returns non-empty rows. Previously, `enumerated()` produced `(offset:element:)` tuples but the helper expected `(element:offset:)`, and Swift's implicit relabeling caused a runtime tuple cast trap. Now each tuple is explicitly relabeled before sorting, preserving focused/index/transport ordering.

<sup>Written for commit f81b8cd21d328d23b8faa3cd6bc8859b2d9b5786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a runtime crash that could occur when processing non-empty terminal snapshot results.
  * Snapshot rows are now sorted reliably while preserving their expected positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->