### PR TITLE
fix(ci): retry transient R2 errors when publishing nightly appcasts

### DIFF
--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -8,6 +8,7 @@ import hmac
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -104,6 +105,44 @@ def _build_signed_request(
     return urllib.request.Request(url, data=request_body, headers=request_headers, method=method)
 
 
+# R2 answers a healthy request with an occasional 5xx (an instant InternalError
+# took two nightly publishes down on 2026-09-06). Those and dropped connections
+# are retried with backoff; every other HTTP error is final.
+RETRYABLE_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _retry_settings() -> tuple[int, float]:
+    attempts = int(os.environ.get("CMUX_R2_UPLOAD_MAX_ATTEMPTS", "5"))
+    delay = float(os.environ.get("CMUX_R2_UPLOAD_RETRY_DELAY_SECONDS", "1"))
+    return max(1, attempts), max(0.0, delay)
+
+
+def _open_with_retries(request: urllib.request.Request, *, timeout: float, what: str):
+    """urlopen that retries R2's transient answers; the last failure propagates."""
+
+    attempts, delay = _retry_settings()
+    for attempt in range(1, attempts + 1):
+        try:
+            return urllib.request.urlopen(request, timeout=timeout)
+        except urllib.error.HTTPError as error:
+            if error.code not in RETRYABLE_HTTP_STATUSES or attempt == attempts:
+                raise
+            error.close()
+            reason = f"HTTP {error.code} {error.reason}"
+        except urllib.error.URLError as error:
+            if attempt == attempts:
+                raise
+            reason = str(error.reason)
+        except (TimeoutError, OSError) as error:
+            if attempt == attempts:
+                raise
+            reason = str(error)
+        sys.stderr.write(f"R2 {what} attempt {attempt}/{attempts} failed: {reason}; retrying in {delay:g}s\n")
+        time.sleep(delay)
+        delay = min(delay * 2, 16.0)
+    raise AssertionError("unreachable: every attempt either returned or raised")
+
+
 def _read_existing_object(
     args: argparse.Namespace,
     *,
@@ -114,7 +153,7 @@ def _read_existing_object(
 
     head = _build_signed_request(args, b"", amz_date, method="HEAD")
     try:
-        with urllib.request.urlopen(head, timeout=30) as response:
+        with _open_with_retries(head, timeout=30, what="HEAD") as response:
             response.read()
     except urllib.error.HTTPError as error:
         if error.code == 404:
@@ -122,7 +161,7 @@ def _read_existing_object(
         raise
 
     get = _build_signed_request(args, b"", amz_date, method="GET")
-    with urllib.request.urlopen(get, timeout=120) as response:
+    with _open_with_retries(get, timeout=120, what="GET") as response:
         existing = response.read()
     actual_digest = hashlib.sha256(existing).hexdigest()
     if actual_digest != expected_digest:
@@ -192,7 +231,7 @@ def main() -> int:
             amz_date,
             extra_headers={"if-none-match": "*"} if args.write_once else None,
         )
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with _open_with_retries(request, timeout=30, what="upload") as response:
             response.read()
             print(f"Uploaded {args.file} to s3://{args.bucket}/{args.key} ({response.status})")
             return 0

--- a/tests/fixtures/fake_r2_server.py
+++ b/tests/fixtures/fake_r2_server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""A stand-in for the Cloudflare R2 S3 endpoint used by the uploader tests.
+
+Answers PutObject with the same InternalError body R2 returned on 2026-09-06
+for the first ``--fail-first`` requests (or every request with
+``--always-fail``), then with 200. Writes its port to ``<state-dir>/port`` and
+the running PUT count to ``<state-dir>/put-count`` so a shell test can drive
+and inspect it without any network access.
+"""
+from __future__ import annotations
+
+import argparse
+import http.server
+import pathlib
+import threading
+
+INTERNAL_ERROR = (
+    b'<?xml version="1.0" encoding="UTF-8"?><Error><Code>InternalError</Code>'
+    b"<Message>We encountered an internal error. Please try again.</Message></Error>"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fake R2 endpoint for upload-r2-object.py tests.")
+    parser.add_argument("--state-dir", required=True, help="Directory for the port and put-count files")
+    parser.add_argument("--fail-first", type=int, default=0, help="Answer this many PUTs with HTTP 500 first")
+    parser.add_argument("--always-fail", action="store_true", help="Answer every PUT with HTTP 500")
+    args = parser.parse_args()
+
+    state = pathlib.Path(args.state_dir)
+    state.mkdir(parents=True, exist_ok=True)
+    lock = threading.Lock()
+    puts = {"count": 0}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_args: object) -> None:  # keep the test output readable
+            pass
+
+        def do_PUT(self) -> None:
+            length = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(length)
+            with lock:
+                puts["count"] += 1
+                count = puts["count"]
+                (state / "put-count").write_text(str(count))
+            if args.always_fail or count <= args.fail_first:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/xml")
+                self.send_header("Content-Length", str(len(INTERNAL_ERROR)))
+                self.end_headers()
+                self.wfile.write(INTERNAL_ERROR)
+                return
+            self.send_response(200)
+            self.send_header("ETag", '"fake-etag"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_HEAD(self) -> None:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        do_GET = do_HEAD
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    (state / "port").write_text(str(server.server_address[1]))
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_r2_upload_python.sh
+++ b/tests/test_ci_r2_upload_python.sh
@@ -3,7 +3,48 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+FAKE_R2_PID=""
+stop_fake_r2() {
+  if [ -n "${FAKE_R2_PID:-}" ]; then
+    kill "$FAKE_R2_PID" 2>/dev/null || true
+    wait "$FAKE_R2_PID" 2>/dev/null || true
+    FAKE_R2_PID=""
+  fi
+}
+trap 'stop_fake_r2; rm -rf "$TMP_DIR"' EXIT
+
+# Starts tests/fixtures/fake_r2_server.py and waits for its port file.
+start_fake_r2() {
+  local state="$1"
+  shift
+  mkdir -p "$state"
+  python3 "$ROOT_DIR/tests/fixtures/fake_r2_server.py" --state-dir "$state" "$@" &
+  FAKE_R2_PID=$!
+  for _ in $(seq 1 200); do
+    [ -s "$state/port" ] && return 0
+    sleep 0.05
+  done
+  echo "FAIL: fake R2 server did not start" >&2
+  exit 1
+}
+
+upload_to_fake_r2() {
+  local port="$1"
+  local out="$2"
+  local err="$3"
+  shift 3
+  AWS_ACCESS_KEY_ID=AKIDEXAMPLE \
+  AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY \
+  AWS_DEFAULT_REGION=auto \
+  CMUX_R2_UPLOAD_RETRY_DELAY_SECONDS=0 \
+  "$@" \
+  python3 "$ROOT_DIR/scripts/ci/upload-r2-object.py" \
+    --file "$TMP_DIR/appcast.xml" \
+    --endpoint-url "http://127.0.0.1:$port" \
+    --bucket cmux-binaries \
+    --key nightly/appcast.xml \
+    --cache-control "no-cache, no-store, must-revalidate" >"$out" 2>"$err"
+}
 
 printf '<rss>ok</rss>' >"$TMP_DIR/appcast.xml"
 
@@ -55,3 +96,57 @@ if ! grep -Fq "scripts/ci/upload-r2-object.py" "$ROOT_DIR/.github/workflows/rele
 fi
 
 echo "PASS: Python R2 uploader signs appcast uploads without awscli"
+
+# On 2026-09-06 R2 answered the first appcast PutObject with an instant
+# HTTP 500 InternalError twice, 49 minutes apart, and each time the whole
+# nightly publish died after the DMGs were already on the GitHub release.
+# One transient 5xx must be retried, not fatal.
+STATE="$TMP_DIR/transient"
+start_fake_r2 "$STATE" --fail-first 2
+PORT="$(cat "$STATE/port")"
+set +e
+upload_to_fake_r2 "$PORT" "$TMP_DIR/transient.out" "$TMP_DIR/transient.err" env
+rc=$?
+set -e
+stop_fake_r2
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: uploader gave up on a transient R2 InternalError (exit $rc)" >&2
+  cat "$TMP_DIR/transient.err" >&2
+  exit 1
+fi
+PUTS="$(cat "$STATE/put-count")"
+if [ "$PUTS" != "3" ]; then
+  echo "FAIL: expected 3 PUT attempts (two InternalErrors, then success), saw $PUTS" >&2
+  exit 1
+fi
+if ! grep -q "Uploaded" "$TMP_DIR/transient.out"; then
+  echo "FAIL: the successful retry was not reported" >&2
+  exit 1
+fi
+
+# A persistent outage still fails, after a bounded number of attempts, with
+# R2's own error body in the output so the workflow log says what happened.
+STATE="$TMP_DIR/persistent"
+start_fake_r2 "$STATE" --always-fail
+PORT="$(cat "$STATE/port")"
+set +e
+upload_to_fake_r2 "$PORT" "$TMP_DIR/persistent.out" "$TMP_DIR/persistent.err" env CMUX_R2_UPLOAD_MAX_ATTEMPTS=3
+rc=$?
+set -e
+stop_fake_r2
+if [ "$rc" -eq 0 ]; then
+  echo "FAIL: uploader must fail when R2 keeps returning InternalError" >&2
+  exit 1
+fi
+PUTS="$(cat "$STATE/put-count")"
+if [ "$PUTS" != "3" ]; then
+  echo "FAIL: expected exactly 3 bounded attempts, saw $PUTS" >&2
+  exit 1
+fi
+if ! grep -q "InternalError" "$TMP_DIR/persistent.err"; then
+  echo "FAIL: R2's error body must be surfaced on the final failure" >&2
+  cat "$TMP_DIR/persistent.err" >&2
+  exit 1
+fi
+echo "PASS: Python R2 uploader retries transient InternalError and bounds a persistent one"
+


### PR DESCRIPTION
## What broke

Two Nightly publishes failed today at the same step, `Upload nightly appcasts to R2`:

- run 34020074283 (c0eed85efb) at 08:14Z
- run 34022099394 (c49e5af397, the Cloud snapshot crash fix) at 09:03Z

Both got an instant answer from Cloudflare R2 on the very first PutObject (`nightly/appcast-arm64.xml`):

```
R2 upload failed: HTTP 500 Internal Server Error
<Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message></Error>
```

Nothing on our side changed: the uploader and the workflow step are identical to the run that succeeded at 04:16Z, and Cloudflare's status page lists R2 as operational. The build, signing, notarization, and GitHub release publish all completed, so the DMGs and deltas are on the `nightly` release, but the appcasts on files.cmux.com still point at 3400956733901 and the nightly tag did not move. `scripts/ci/upload-r2-object.py` treats every HTTP error as final, so one bad R2 answer sinks the whole publish.

## Fix

Retry 5xx, 429, and dropped connections up to five times with doubling backoff (1s, 2s, 4s, 8s). Every other HTTP error stays final, and the final failure still prints R2's response body. Two env overrides (`CMUX_R2_UPLOAD_MAX_ATTEMPTS`, `CMUX_R2_UPLOAD_RETRY_DELAY_SECONDS`) exist for tests.

## Tests

Two commits so the Commits tab shows red then green:

1. `test(ci)`: `tests/fixtures/fake_r2_server.py` is a local endpoint that replays R2's exact InternalError. `tests/test_ci_r2_upload_python.sh` now asserts the uploader survives two transient 500s (three PUTs, success reported), still fails after a bounded three attempts when the outage persists, and surfaces the error body. Fails on main: `uploader gave up on a transient R2 InternalError (exit 1)`.
2. `fix(ci)`: the retry. The test passes locally; CI runs it in `workflow-guard-tests`.

No user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gpMLNXsCY4bmCvkHEavBe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791277936&installation_model_id=21920&pr_number=12040&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12040&signature=b39d895ca2f54344a150b018d1526c2591a58c0ab8d6e5ab929320d63038fdd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient R2 errors in the nightly appcast uploader so a single 5xx from Cloudflare no longer fails the whole publish.

Retries 5xx, 429, and dropped connections up to five times with doubling backoff; other HTTP errors stay final and the final failure still prints R2's response body. `CMUX_R2_UPLOAD_MAX_ATTEMPTS` and `CMUX_R2_UPLOAD_RETRY_DELAY_SECONDS` override the defaults for tests.

**Tests**
- Adds a fake R2 endpoint that replays the exact InternalError and asserts the uploader survives two transient 500s, then fails after a bounded three attempts on a persistent outage.

<sup>Written for commit 0ab1787f40e2f68f18f859fadd02f8a551719c45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upload reliability by retrying transient storage failures, including rate limits, server errors, timeouts, and connection issues.
  - Uses bounded retries with exponential backoff while preserving final errors for non-retryable failures.

- **Tests**
  - Added coverage for successful recovery after temporary failures.
  - Added coverage confirming persistent failures stop after a limited number of attempts and retain the service error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->