### PR TITLE
Cloud attach: trust the private network, drop cmux-tui device enrollment

### DIFF
--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -345,7 +345,10 @@ extension CMUXCLI {
         let trustedCarrier = (info["trusted_carrier"] as? Bool) ?? false
         if known == nil {
             guard trustedCarrier else {
-                throw CLIError(message: "The Cloud machine's daemon is not serving the trusted listener yet. Retry in a moment.")
+                throw CLIError(message: String(
+                    localized: "cli.vm.tui.trustedListenerPending",
+                    defaultValue: "The Cloud machine is still preparing remote access. Try again shortly."
+                ))
             }
             // Later opens reuse the private route with no control-plane call.
             Self.saveVMTuiDevice(vmId: vmId, deviceFingerprint: Self.carrierDeviceMarker)

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -18,8 +18,9 @@ extension CMUXCLI {
         let vmId: String
         let route: String
         let session: String
-        let invitationUri: String?
-        let invitationId: String?
+        /// Dial the machine's trusted-carrier listener (`--carrier`); false presents
+        /// the device key this Mac enrolled with before trusted listeners.
+        let carrier: Bool
         let clientPath: String
         let stateDir: String
         let deviceName: String
@@ -65,9 +66,9 @@ extension CMUXCLI {
         Open the FULL cmux-tui client for a machine (its own workspaces, panes and
         tabs) in a pane. `cmux vm shell <id>` and every other open give you a plain
         terminal on the machine instead; use this when you want the client itself.
-        The pane runs the local cmux-tui client against the machine's authenticated
-        link; the first attach from this Mac enrolls the device (approved by cmux),
-        later attaches reconnect with the stored device key.
+        The pane runs the local cmux-tui client against the machine's daemon over
+        the owner's private network; the network is the admission, so no device
+        enrollment or approval happens.
 
         The client binary is found via CMUX_TUI_CLIENT, then ~/.cmux/bin/cmux, then
         `cmux-tui` on PATH. Install one with:
@@ -90,6 +91,11 @@ extension CMUXCLI {
             .appendingPathComponent(".cmuxterm", isDirectory: true)
             .appendingPathComponent("vm-tui-devices.json", isDirectory: false)
     }
+
+    /// Stored in place of a device fingerprint for a machine reached over its
+    /// trusted-carrier listener: the next open dials `--carrier` again with no
+    /// control-plane call. Mirrors `CloudTuiClientPaths.carrierDeviceMarker`.
+    static let carrierDeviceMarker = "carrier"
 
     static func loadVMTuiDevices(from url: URL? = nil) -> [String: VMTuiDeviceRecord] {
         let storeURL = url ?? vmTuiDevicesStoreURL()
@@ -228,7 +234,8 @@ extension CMUXCLI {
         /// a desktop split opens beside it.
         let terminalSurfaceId: String?
         let session: String
-        let enrolling: Bool
+        /// The pane dials the trusted-carrier listener; false means the stored device key.
+        let trustedCarrier: Bool
         /// The machine-side terminal the pane shows (`term_…`) and its cmux-tui
         /// workspace (`ws_…`); nil for `vm tui`, whose pane is the whole client.
         let terminalId: String?
@@ -281,7 +288,7 @@ extension CMUXCLI {
                 "vm_id": vmId,
                 "workspace_id": opened.workspaceId,
                 "session": opened.session,
-                "enrolling": opened.enrolling,
+                "trusted_carrier": opened.trustedCarrier,
             ]))
             return
         }
@@ -289,8 +296,8 @@ extension CMUXCLI {
             "cli.vm.tui.opened",
             defaultValue: "Opened cmux-tui for %1$@ (%2$@)"
         )
-        let mode = opened.enrolling
-            ? CMUXDiffViewerLocalization.string("cli.vm.tui.mode.enrolling", defaultValue: "enrolling this Mac")
+        let mode = opened.trustedCarrier
+            ? CMUXDiffViewerLocalization.string("cli.vm.tui.mode.carrier", defaultValue: "private network trust")
             : CMUXDiffViewerLocalization.string("cli.vm.tui.mode.enrolled", defaultValue: "device already enrolled")
         print(String(format: template, vmId, mode))
     }
@@ -333,9 +340,16 @@ extension CMUXCLI {
             try Self.checkCmuxTuiCompatibility(client: clientProbe, daemon: info["daemon_build"] as? [String: Any])
         }
         let session = (info["session"] as? String) ?? "cloud"
-        let invitation = info["invitation"] as? [String: Any]
-        let invitationUri = invitation?["uri"] as? String
-        let invitationId = invitation?["invitation_id"] as? String
+        // A known machine dials as it did before (carrier marker or stored key); a
+        // new one must serve the trusted listener, which the app has just proven.
+        let trustedCarrier = (info["trusted_carrier"] as? Bool) ?? false
+        if known == nil {
+            guard trustedCarrier else {
+                throw CLIError(message: "The Cloud machine's daemon is not serving the trusted listener yet. Retry in a moment.")
+            }
+            // Later opens reuse the private route with no control-plane call.
+            Self.saveVMTuiDevice(vmId: vmId, deviceFingerprint: Self.carrierDeviceMarker)
+        }
         let networkAddresses: [String: String]? = {
             guard let raw = info["network_addresses"] as? [String: Any] else { return nil }
             let values = raw.compactMapValues { $0 as? String }
@@ -350,8 +364,7 @@ extension CMUXCLI {
                 vmId: vmId,
                 route: route,
                 session: session,
-                invitationUri: invitationUri,
-                invitationId: invitationId,
+                carrier: trustedCarrier,
                 clientPath: clientPath,
                 stateDir: stateDir.path,
                 deviceName: Self.vmTuiDeviceName(),
@@ -502,7 +515,7 @@ extension CMUXCLI {
             windowId: windowId,
             terminalSurfaceId: paneSurfaceId,
             session: session,
-            enrolling: invitationUri != nil,
+            trustedCarrier: trustedCarrier,
             terminalId: terminalId,
             remoteWorkspaceId: remoteWorkspaceId,
             networkAddresses: networkAddresses
@@ -513,10 +526,10 @@ extension CMUXCLI {
 
     /// The argv the pane hands to the cmux-tui client. Pure, so the exec line can be
     /// checked without a pane.
-    static func vmTuiConnectArguments(config: VMTuiConnectConfig, inviteFilePath: String?) -> [String] {
+    static func vmTuiConnectArguments(config: VMTuiConnectConfig) -> [String] {
         var arguments = ["remote", "connect", config.route, "--device-name", config.deviceName, "--state-dir", config.stateDir]
-        if let inviteFilePath, !inviteFilePath.isEmpty {
-            arguments += ["--invite-file", inviteFilePath]
+        if config.carrier {
+            arguments.append("--carrier")
         }
         if let hubSocket = config.wireguardHubSocket, !hubSocket.isEmpty {
             arguments += ["--wireguard-hub", hubSocket]
@@ -537,124 +550,16 @@ extension CMUXCLI {
         }
         let configURL = URL(fileURLWithPath: configPath)
         let config = try JSONDecoder().decode(VMTuiConnectConfig.self, from: Data(contentsOf: configURL))
-        // The config carries a single-use invitation secret; it has served its purpose.
+        // The config is one-shot; it has served its purpose.
         try? FileManager.default.removeItem(at: configURL)
-
-        var inviteURL: URL?
-        if let uri = config.invitationUri, !uri.isEmpty {
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent("cmux-vm-tui-invite-\(UUID().uuidString.lowercased())")
-            try (uri + "\n").data(using: .utf8)!.write(to: url, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-            inviteURL = url
-        }
 
         cliWriteStderr(String(format: CMUXDiffViewerLocalization.string(
             "cli.vm.tui.connecting",
             defaultValue: "Connecting to %1$@ through cmux-tui…"
         ), config.vmId) + "\n")
 
-        // While the client claims the invitation, approve the pending enrollment through
-        // the app: the control plane minted this invitation for the signed-in user, so
-        // approving the claim is the honest encoding of "already authenticated". The
-        // helper owns the invite file's lifetime and removes it once the claim is
-        // approved or the window closes.
-        if let invitationId = config.invitationId, !invitationId.isEmpty {
-            var approverArguments = ["vm-tui-approve", "--id", config.vmId, "--invitation-id", invitationId]
-            if let inviteURL {
-                approverArguments += ["--invite-file", inviteURL.path]
-            }
-            let executablePath = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
-            do {
-                try Self.spawnDetachedVMTuiApprover(
-                    executablePath: executablePath,
-                    arguments: approverArguments,
-                    socketPath: client.socketPath
-                )
-            } catch {
-                if let inviteURL { try? FileManager.default.removeItem(at: inviteURL) }
-                throw error
-            }
-        }
-
-        let arguments = Self.vmTuiConnectArguments(config: config, inviteFilePath: inviteURL?.path)
+        let arguments = Self.vmTuiConnectArguments(config: config)
         try execInteractiveProgram(launchPath: config.clientPath, arguments: arguments)
-    }
-
-    /// Spawns `cmux vm-tui-approve …` in its own session with stdio on /dev/null, so it
-    /// survives the pane's exec and never touches the tty the client is about to own.
-    static func spawnDetachedVMTuiApprover(executablePath: String, arguments: [String], socketPath: String) throws {
-        var fileActions: posix_spawn_file_actions_t?
-        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
-            throw CLIError(message: "vm-tui-connect: couldn't prepare the enrollment approver (file actions)")
-        }
-        defer { posix_spawn_file_actions_destroy(&fileActions) }
-        for fd in [STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO] {
-            let status = "/dev/null".withCString { path in
-                posix_spawn_file_actions_addopen(&fileActions, fd, path, fd == STDIN_FILENO ? O_RDONLY : O_WRONLY, 0)
-            }
-            guard status == 0 else {
-                throw CLIError(message: "vm-tui-connect: couldn't detach the enrollment approver from the terminal")
-            }
-        }
-        var attributes: posix_spawnattr_t?
-        guard posix_spawnattr_init(&attributes) == 0 else {
-            throw CLIError(message: "vm-tui-connect: couldn't prepare the enrollment approver (attributes)")
-        }
-        defer { posix_spawnattr_destroy(&attributes) }
-        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT)) == 0 else {
-            throw CLIError(message: "vm-tui-connect: couldn't give the enrollment approver its own session")
-        }
-
-        // Same socket the pane talks to; CMUX_SOCKET (the ambient terminal's socket) must
-        // not win over it, as the CLI's other child spawns also ensure.
-        var environment = ProcessInfo.processInfo.environment
-        environment["CMUX_SOCKET_PATH"] = socketPath
-        environment.removeValue(forKey: "CMUX_SOCKET")
-        let environmentStrings = environment.map { "\($0.key)=\($0.value)" }
-        var argv = ([executablePath] + arguments).map { strdup($0) }
-        var envp = environmentStrings.map { strdup($0) }
-        defer {
-            for item in argv { free(item) }
-            for item in envp { free(item) }
-        }
-        argv.append(nil)
-        envp.append(nil)
-        var pid: pid_t = 0
-        let status = posix_spawn(&pid, executablePath, &fileActions, &attributes, &argv, &envp)
-        guard status == 0 else {
-            throw CLIError(message: "vm-tui-connect: couldn't start the enrollment approver: \(String(cString: strerror(status)))")
-        }
-    }
-
-    // MARK: - cmux vm-tui-approve --id <vm> --invitation-id <id> [--invite-file <path>]  (detached)
-
-    /// Approves a pending cmux-tui enrollment through the app while the pane's client
-    /// claims the invitation. Silent: it owns no terminal. The app makes one request;
-    /// the VM waits for the claim on its local daemon socket. The invite file is deleted
-    /// either way.
-    func runVMTuiApprove(commandArgs: [String], client: SocketClient) throws {
-        let (vmIdOpt, rest0) = parseOption(commandArgs, name: "--id")
-        let (invitationOpt, rest1) = parseOption(rest0, name: "--invitation-id")
-        let (inviteFileOpt, _) = parseOption(rest1, name: "--invite-file")
-        guard let vmId = vmIdOpt, !vmId.isEmpty, let invitationId = invitationOpt, !invitationId.isEmpty else {
-            throw CLIError(message: "Usage: cmux vm-tui-approve --id <vm> --invitation-id <id> [--invite-file <path>]")
-        }
-        defer {
-            if let inviteFileOpt, !inviteFileOpt.isEmpty {
-                try? FileManager.default.removeItem(atPath: inviteFileOpt)
-            }
-        }
-        guard let result = try? client.sendV2(
-            method: "vm.cmux_remote_approve",
-            params: ["id": vmId, "invitation_id": invitationId],
-            responseTimeout: 75
-        ) else { return }
-        if (result["state"] as? String) == "approved",
-           let fingerprint = result["device_fingerprint"] as? String,
-           !fingerprint.isEmpty {
-            Self.saveVMTuiDevice(vmId: vmId, deviceFingerprint: fingerprint)
-        }
     }
 }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7104,8 +7104,6 @@ struct CMUXCLI {
             try runVMPtyAttach(commandArgs: commandArgs, client: client)
         case "vm-tui-connect":
             try runVMTuiConnect(commandArgs: commandArgs, client: client)
-        case "vm-tui-approve":
-            try runVMTuiApprove(commandArgs: commandArgs, client: client)
         case "vm-ssh-attach":
             // Hidden compatibility alias for workspaces created before the split helper was
             // nested under `cmux vm`.
@@ -13299,7 +13297,7 @@ struct CMUXCLI {
             "window_id": opened.windowId ?? NSNull(),
             "transport": "cmux-remote",
             "session": opened.session,
-            "enrolling": opened.enrolling,
+            "trusted_carrier": opened.trustedCarrier,
             "terminal_id": opened.terminalId ?? NSNull(),
             "remote_workspace_id": opened.remoteWorkspaceId ?? NSNull(),
             "surface_id": opened.terminalSurfaceId ?? NSNull(),

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -66914,6 +66914,23 @@
         }
       }
     },
+    "cli.vm.tui.trustedListenerPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Cloud machine is still preparing remote access. Try again shortly."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドマシンはまだリモートアクセスを準備中です。しばらくしてからもう一度お試しください。"
+          }
+        }
+      }
+    },
     "cli.vm.tui.mode.carrier": {
       "extractionState": "manual",
       "localizations": {
@@ -67581,6 +67598,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Помилка SSH (%@): %@"
+          }
+        }
+      }
+    },
+    "cloud.link.trustedListenerPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Cloud machine is still preparing remote access. Try again shortly."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドマシンはまだリモートアクセスを準備中です。しばらくしてからもう一度お試しください。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -66914,6 +66914,23 @@
         }
       }
     },
+    "cli.vm.tui.mode.carrier": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "private network trust"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライベートネットワークの信頼"
+          }
+        }
+      }
+    },
     "cli.vm.tui.mode.enrolled": {
       "extractionState": "manual",
       "localizations": {
@@ -66927,23 +66944,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "このデバイスは登録済みです"
-          }
-        }
-      }
-    },
-    "cli.vm.tui.mode.enrolling": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "enrolling this Mac"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac を登録しています"
           }
         }
       }

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -151,7 +151,6 @@ actor CloudMachineLink {
     private var eventsRecoveryTask: Task<Void, Never>?
     private var eventsStabilityTask: Task<Void, Never>?
     private var eventsRecoveryPhase: EventsRecoveryPhase = .healthy
-    private var inviteFileURL: URL?
     private var stderrTail: [String] = []
     /// Releases this link's claim on the app's WireGuard hub; runs once when the link ends.
     private var releaseHubLease: (@Sendable () async -> Void)?
@@ -180,13 +179,15 @@ actor CloudMachineLink {
 
     /// Spawns the headless client against `route` and waits for its local socket.
     ///
-    /// `wireguardHubSocket` routes the client through the app's WireGuard hub for a
-    /// machine on the private network; `releaseHubLease` is called exactly once when the
-    /// link ends (disconnect, exit, or a failed connect), so the hub can idle out.
+    /// `carrier` dials the machine's trusted listener with no enrollment; false presents
+    /// the stored device key instead. `wireguardHubSocket` routes the client through the
+    /// app's WireGuard hub for a machine on the private network; `releaseHubLease` is
+    /// called exactly once when the link ends (disconnect, exit, or a failed connect), so
+    /// the hub can idle out.
     func connect(
         route: String,
         session: String,
-        invitationURI: String?,
+        carrier: Bool = false,
         timeout: Duration = .seconds(60),
         wireguardHubSocket: String? = nil,
         releaseHubLease: (@Sendable () async -> Void)? = nil
@@ -199,22 +200,13 @@ actor CloudMachineLink {
         eventsCursor = nil
         resetEventsRecovery()
         try paths.ensureStateDir()
-        var inviteFilePath: String?
-        if let invitationURI, !invitationURI.isEmpty {
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent("cmux-cloud-link-invite-\(UUID().uuidString.lowercased())")
-            try (invitationURI + "\n").data(using: .utf8)!.write(to: url, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-            inviteFileURL = url
-            inviteFilePath = url.path
-        }
         let process = Process()
         process.executableURL = clientURL
         process.arguments = CloudTuiCommandLine.linkArguments(
             route: route,
             deviceName: CloudTuiClientPaths.deviceName(),
             stateDir: paths.stateDir.path,
-            inviteFilePath: inviteFilePath,
+            carrier: carrier,
             wireguardHubSocket: wireguardHubSocket
         )
         var environment = ProcessInfo.processInfo.environment
@@ -238,7 +230,6 @@ actor CloudMachineLink {
         } catch {
             state = .error
             lastError = Self.errorText(error)
-            removeInviteFile()
             await releaseHubLeaseOnce()
             throw LinkError.spawnFailed(error.localizedDescription)
         }
@@ -279,7 +270,6 @@ actor CloudMachineLink {
         } catch {
             state = .error
             lastError = Self.errorText(error)
-            removeInviteFile()
             await Self.terminateAndWait(process, exit: processExit)
             if self.process === process {
                 self.process = nil
@@ -306,7 +296,6 @@ actor CloudMachineLink {
         eventsRecoveryPhase = .healthy
         state = .unavailable
         connected = nil
-        removeInviteFile()
         changesContinuation.finish()
         if let eventsProcess, let eventsProcessExit {
             await Self.terminateAndWait(eventsProcess, exit: eventsProcessExit)
@@ -714,7 +703,6 @@ actor CloudMachineLink {
         process = nil
         processExit = nil
         connected = nil
-        removeInviteFile()
         if state != .unavailable {
             state = status == 0 ? .unavailable : .error
             lastError = status == 0 ? nil : LinkError.exited(status: status, output: stderrTail.joined(separator: "\n")).errorDescription
@@ -806,12 +794,6 @@ actor CloudMachineLink {
         return try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
     }
 
-    private func removeInviteFile() {
-        if let inviteFileURL {
-            try? FileManager.default.removeItem(at: inviteFileURL)
-            self.inviteFileURL = nil
-        }
-    }
 }
 
 private enum CloudLinkCommandOutcome: Sendable, Equatable {

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -90,6 +90,14 @@ actor CloudMachineLink {
         let session: String
     }
 
+    /// The first thing the link process tells us: a socket line, stdout closing
+    /// without one, or the connect deadline passing.
+    private enum LinkFirstLine: Sendable {
+        case socket(String)
+        case ended
+        case timedOut
+    }
+
     enum LinkError: Error, LocalizedError {
         case clientMissing
         case spawnFailed(String)
@@ -252,17 +260,28 @@ actor CloudMachineLink {
         }
         let socketPath: String
         do {
-            socketPath = try await withThrowingTaskGroup(of: String?.self) { group in
-                group.addTask { await firstSocket.result }
+            socketPath = try await withThrowingTaskGroup(of: LinkFirstLine.self) { group in
+                group.addTask { (await firstSocket.result).map(LinkFirstLine.socket) ?? .ended }
                 group.addTask {
                     try await Task.sleep(for: timeout)
-                    return nil
+                    return .timedOut
                 }
                 defer { group.cancelAll() }
-                guard let first = try await group.next(), let socket = first else {
+                switch try await group.next() {
+                case .socket(let socket)?:
+                    return socket
+                case .ended?:
+                    // stdout closed before a socket line: the client exited (an older
+                    // client rejecting a flag, a refused dial). Report that exit and its
+                    // stderr, not the deadline it never reached.
+                    await Self.terminateAndWait(process, exit: processExit)
+                    throw LinkError.exited(
+                        status: process.terminationStatus,
+                        output: stderrTail.joined(separator: "\n")
+                    )
+                case .timedOut?, nil:
                     throw LinkError.timedOut
                 }
-                return socket
             }
             guard process.isRunning else {
                 throw LinkError.exited(status: process.terminationStatus, output: stderrTail.joined(separator: "\n"))

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -7,7 +7,7 @@ import Foundation
 /// or the account signs out.
 ///
 /// The private route comes from the machine list. For a device this machine
-/// has not seen, the control plane creates one invitation and approves it.
+/// has not seen, the control plane proves the machine's trusted listener first.
 /// Later links use only the saved device key and private route.
 actor CloudMachineLinkManager {
     struct LinkStatus: Sendable, Equatable {
@@ -53,16 +53,10 @@ actor CloudMachineLinkManager {
     /// A failed link is not retried for this long, so a polling sidebar does not hammer
     /// a machine whose route is broken.
     private let retryBackoff: TimeInterval = 15
-    /// How long a link may take to report its socket when this Mac is already
-    /// enrolled: the daemon accepts the session immediately, so anything slower
-    /// than this is a broken route rather than a slow one.
+    /// How long a link may take to report its socket: the daemon accepts a
+    /// carrier or enrolled session immediately, so anything slower than this is
+    /// a broken route rather than a slow one.
     private let connectTimeout: Duration = .seconds(60)
-    /// The budget for a *first* link to a machine, which must also cover
-    /// enrollment. Enrollment cannot be done up front — the control plane can
-    /// only approve an invitation the client has already claimed. The one
-    /// approval request waits for that claim inside the VM, so the connection
-    /// and approval still share one larger first-use window.
-    private let enrollingConnectTimeout: Duration = .seconds(240)
     /// This Mac's resolved Ghostty default colors ("#rrggbb"), pushed to each machine as
     /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
     /// the local theme. Injected so tests need no Ghostty runtime.
@@ -139,12 +133,17 @@ actor CloudMachineLinkManager {
             let capabilities = Self.clientCapabilities(clientURL: clientURL)
             let knownFingerprint = paths.deviceFingerprint(for: machineID)
             var session = "cmux"
-            var invitation: VMCmuxRemoteEndpoint.Invitation?
-            var client: VMClient?
-            // First use is a control-plane enrollment. Later connections use
-            // only the stored device identity and the private route.
-            if knownFingerprint == nil {
-                client = await MainActor.run { VMClient.shared }
+            // The machine's daemon serves a trusted listener inside the private
+            // network, so a link needs no enrollment: the first use asks the
+            // control plane once (it also brings an older daemon to the trusted
+            // build), later uses dial `--carrier` from the stored marker with no
+            // control-plane call. A real stored fingerprint is a machine this Mac
+            // enrolled with before trusted listeners; it keeps its stored key.
+            let carrier: Bool
+            if let knownFingerprint {
+                carrier = knownFingerprint == CloudTuiClientPaths.carrierDeviceMarker
+            } else {
+                let client = await MainActor.run { VMClient.shared }
                 guard let client else {
                     throw VMClientError.malformedResponse("Cloud VM client is not available (not signed in).")
                 }
@@ -154,19 +153,11 @@ actor CloudMachineLinkManager {
                     clientCapabilities: capabilities
                 )
                 session = endpoint.session
-                invitation = endpoint.invitation
-            }
-            var approval: Task<Void, Error>?
-            if let invitation, let client {
-                approval = Task {
-                    try await self.approveEnrollment(
-                        machineID: machineID,
-                        invitationID: invitation.invitationId,
-                        client: client
-                    )
+                guard endpoint.trustedCarrier else {
+                    throw ManagerError.retryLater("The Cloud machine's daemon is not serving the trusted listener yet.")
                 }
+                carrier = true
             }
-            defer { approval?.cancel() }
             guard capabilities.contains(CloudTuiCommandLine.wireGuardHubCapability) else {
                 throw ManagerError.wireGuardHubUnsupported
             }
@@ -191,18 +182,18 @@ actor CloudMachineLinkManager {
                 try await link.connect(
                     route: privateRoute,
                     session: session,
-                    invitationURI: invitation?.uri,
-                    // Enrollment rides this same window (see enrollingConnectTimeout).
-                    timeout: invitation == nil ? connectTimeout : enrollingConnectTimeout,
+                    carrier: carrier,
+                    timeout: connectTimeout,
                     wireguardHubSocket: claim.ready.socketPath,
                     releaseHubLease: releaseLease
                 )
             }
             do {
-                if let approval {
-                    try await approval.value
+                let connected = try await connect.value
+                if carrier, knownFingerprint == nil {
+                    paths.saveDeviceFingerprint(CloudTuiClientPaths.carrierDeviceMarker, for: machineID)
                 }
-                return try await connect.value
+                return connected
             } catch {
                 connect.cancel()
                 await link.disconnect()
@@ -343,18 +334,6 @@ actor CloudMachineLinkManager {
 
     private func store(link: CloudMachineLink, for machineID: String) {
         links[machineID] = link
-    }
-
-    /// The control plane minted the invitation for this signed-in user. One request
-    /// waits for its claim inside the VM, approves it, and returns the device identity.
-    private func approveEnrollment(machineID: String, invitationID: String, client: VMClient) async throws {
-        let approval = try await client.approveCmuxRemoteEnrollment(id: machineID, invitationId: invitationID)
-        guard approval.state == "approved" else {
-            throw ManagerError.retryLater("The Cloud machine did not approve this Mac.")
-        }
-        if let fingerprint = approval.deviceFingerprint, !fingerprint.isEmpty {
-            paths.saveDeviceFingerprint(fingerprint, for: machineID)
-        }
     }
 
     /// `remote-probe --json` → `capabilities`; the control plane picks the machine host by

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -154,7 +154,10 @@ actor CloudMachineLinkManager {
                 )
                 session = endpoint.session
                 guard endpoint.trustedCarrier else {
-                    throw ManagerError.retryLater("The Cloud machine's daemon is not serving the trusted listener yet.")
+                    throw ManagerError.retryLater(String(
+                        localized: "cloud.link.trustedListenerPending",
+                        defaultValue: "The Cloud machine is still preparing remote access. Try again shortly."
+                    ))
                 }
                 carrier = true
             }

--- a/Sources/Cloud/CloudTuiClientPaths.swift
+++ b/Sources/Cloud/CloudTuiClientPaths.swift
@@ -13,6 +13,13 @@ struct CloudTuiClientPaths: Sendable {
         let updatedAtUnix: Int
     }
 
+    /// Stored in place of a device fingerprint for a machine this Mac reaches over
+    /// the trusted-carrier listener: there is no enrolled device, and the next link
+    /// dials `--carrier` again with no control-plane call. A real fingerprint means
+    /// the Mac enrolled before the machine's daemon served the trusted listener and
+    /// keeps presenting its stored key. Mirrored by the CLI's own store.
+    static let carrierDeviceMarker = "carrier"
+
     let home: URL
 
     init(home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) {

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -6,21 +6,25 @@ import Foundation
 /// `--socket`/`--json`/`--jsonl` as global options, and `attach --terminal <id>` as the
 /// single-terminal renderer (`spec/cli.md` §"attach").
 struct CloudTuiCommandLine: Sendable {
-    /// `remote connect <route> --device-name … --state-dir … --headless --json [--invite-file …]`:
+    /// `remote connect <route> --device-name … --state-dir … --headless --json [--carrier]`:
     /// a headless link whose stdout carries `connection-snapshot` JSON lines with the
     /// local mux socket path (`remote_cli.rs` `connect_with_flags`).
+    /// `--carrier` dials with carrier authentication: the machine's daemon serves a
+    /// trusted listener reachable only inside the owner's private network, so there is
+    /// no device enrollment and no invitation. Without it the client presents its
+    /// stored device key (a machine this Mac enrolled with before trusted listeners).
     /// `--wireguard-hub <socket>` makes the client dial the route through the app's
     /// in-process WireGuard hub (``CloudWireGuardHub``) instead of the OS network stack;
     /// it is added only for routes inside the private Cloud VM network.
-    static func linkArguments(route: String, deviceName: String, stateDir: String, inviteFilePath: String?, wireguardHubSocket: String? = nil) -> [String] {
+    static func linkArguments(route: String, deviceName: String, stateDir: String, carrier: Bool = false, wireguardHubSocket: String? = nil) -> [String] {
         var arguments = [
             "remote", "connect", route,
             "--device-name", deviceName,
             "--state-dir", stateDir,
             "--headless", "--json", "--exit-with-parent",
         ]
-        if let inviteFilePath, !inviteFilePath.isEmpty {
-            arguments += ["--invite-file", inviteFilePath]
+        if carrier {
+            arguments.append("--carrier")
         }
         if let wireguardHubSocket, !wireguardHubSocket.isEmpty {
             arguments += ["--wireguard-hub", wireguardHubSocket]

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -583,11 +583,13 @@ final class MachinesPanelViewModel: ObservableObject {
         refreshTree(force: forceTree)
     }
 
-    /// Samples every machine's CPU/memory/disk. Sleeping machines report
+    /// Samples every desktop machine's CPU/memory/disk. Sleeping machines report
     /// `asleep` without being woken, so polling never costs the user anything.
+    /// Shell-only (`base`) machines serve no stats endpoint (501 on every poll),
+    /// so they are left out rather than asked every cycle.
     func refreshStats() {
         statsTask?.cancel()
-        let ids = machines.map(\.id)
+        let ids = machines.filter(\.isDesktop).map(\.id)
         guard !ids.isEmpty else { return }
         statsTask = Task { [weak self] in
             await withTaskGroup(of: (String, VMStats?).self) { group in

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -633,17 +633,14 @@ struct VMWebSocketDaemonEndpoint {
 /// cmuxd-remote → cmux-tui migration). The route carries the ingress token; the
 /// invitation is present only when this device is not yet enrolled with the daemon.
 struct VMCmuxRemoteEndpoint {
-    struct Invitation {
-        let uri: String
-        let invitationId: String
-        let expiresAtUnix: Int64
-    }
-
     let route: String
     let token: String
     let expiresAtUnix: Int64
     let session: String
-    let invitation: Invitation?
+    /// The machine's daemon serves the trusted-carrier listener: dial `--carrier`,
+    /// no enrollment. False only for a daemon the control plane left on an older
+    /// build because this Mac is already enrolled there.
+    let trustedCarrier: Bool
     /// The machine's private addresses, when the provider returned them. Keep
     /// this metadata on the client boundary so agents and diagnostics can see
     /// the same route state the backend used, without reconstructing it.
@@ -661,12 +658,6 @@ struct VMCmuxRemoteEndpoint {
     }
 
     let daemonBuild: DaemonBuild?
-}
-
-struct VMCmuxRemoteApproval {
-    let approved: Bool
-    let state: String
-    let deviceFingerprint: String?
 }
 
 enum VMAttachEndpoint {
@@ -1482,13 +1473,9 @@ actor VMClient {
             throw VMClientError.malformedResponse("Cloud VM cmux-remote attach response was missing required fields.")
         }
         let expiresAtUnix = (obj["expiresAtUnix"] as? Int64) ?? Int64((obj["expiresAtUnix"] as? Double) ?? 0)
-        var invitation: VMCmuxRemoteEndpoint.Invitation?
-        if let raw = obj["invitation"] as? [String: Any],
-           let uri = raw["uri"] as? String, !uri.isEmpty,
-           let invitationId = raw["invitationId"] as? String, !invitationId.isEmpty {
-            let invitationExpires = (raw["expiresAtUnix"] as? Int64) ?? Int64((raw["expiresAtUnix"] as? Double) ?? 0)
-            invitation = .init(uri: uri, invitationId: invitationId, expiresAtUnix: invitationExpires)
-        }
+        // Absent on a control plane older than the trusted listener: such a
+        // daemon would still expect enrollment, which this build no longer does.
+        let trustedCarrier = (obj["trustedCarrier"] as? Bool) ?? false
         var daemonBuild: VMCmuxRemoteEndpoint.DaemonBuild?
         if let raw = obj["daemonBuild"] as? [String: Any] {
             daemonBuild = .init(
@@ -1513,27 +1500,9 @@ actor VMClient {
             token: token,
             expiresAtUnix: expiresAtUnix,
             session: session,
-            invitation: invitation,
+            trustedCarrier: trustedCarrier,
             networkAddresses: networkAddresses,
             daemonBuild: daemonBuild
-        )
-    }
-
-    func approveCmuxRemoteEnrollment(id: String, invitationId: String) async throws -> VMCmuxRemoteApproval {
-        let encodedID = try pathSegment(id, fieldName: "vm id")
-        let (data, http) = try await request(
-            "POST",
-            path: "/api/vm/\(encodedID)/cmux-remote/approve",
-            jsonBody: ["invitationId": invitationId],
-            timeoutSeconds: 60
-        )
-        try ensureOK(http, data: data)
-        let obj = try decodeJSONObject(data)
-        let state = (obj["state"] as? String) ?? "pending"
-        return VMCmuxRemoteApproval(
-            approved: (obj["approved"] as? Bool) ?? false,
-            state: state,
-            deviceFingerprint: obj["deviceFingerprint"] as? String
         )
     }
 

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -2067,10 +2067,10 @@ actor VMClient {
             }
             if retryTransientServiceUnavailable,
                retriesLeft > 0,
-               let delaySeconds = Self.transientVMRetryDelay(http: http, data: data) {
+               let delay = Self.transientVMRetryDelay(http: http, data: data) {
                 retriesLeft -= 1
                 onRetry()
-                try await Task.sleep(for: .seconds(delaySeconds))
+                try await Task.sleep(for: delay)
                 continue
             }
             if let sessionIdentity {

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -434,19 +434,21 @@ extension TerminalController {
                     throw CloudMachineLinkManager.ManagerError.wireGuardHubUnsupported
                 }
                 var payload: [String: Any]
-                if deviceFingerprint != nil {
+                if let deviceFingerprint {
                     guard let knownRoute = await registry.privateRoute(machineID: vmId) else {
                         throw CloudMachineLinkManager.ManagerError.privateRouteRequired(vmId)
                     }
-                    // The daemon already knows this cmux-tui identity. Reuse
-                    // the private VPC route and local device key without a
-                    // Vercel request or a Freestyle exec.
+                    // This Mac has linked to the machine before: reuse the private
+                    // VPC route without a Vercel request or a Freestyle exec. The
+                    // carrier marker means dial the trusted listener again; a real
+                    // fingerprint means present the stored device key.
                     payload = [
                         "transport": "cmux-remote",
                         "route": knownRoute,
                         "token": "",
                         "expires_at_unix": 0,
                         "session": "cmux",
+                        "trusted_carrier": deviceFingerprint == CloudTuiClientPaths.carrierDeviceMarker,
                     ]
                 } else {
                     let endpoint = try await VMClient.shared.openCmuxRemote(
@@ -460,6 +462,7 @@ extension TerminalController {
                         "token": endpoint.token,
                         "expires_at_unix": endpoint.expiresAtUnix,
                         "session": endpoint.session,
+                        "trusted_carrier": endpoint.trustedCarrier,
                     ]
                     if let build = endpoint.daemonBuild {
                         var raw: [String: Any] = [:]
@@ -467,13 +470,6 @@ extension TerminalController {
                         if let remoteProtocol = build.remoteProtocol { raw["remote_protocol"] = remoteProtocol }
                         if let version = build.version { raw["version"] = version }
                         payload["daemon_build"] = raw
-                    }
-                    if let invitation = endpoint.invitation {
-                        payload["invitation"] = [
-                            "uri": invitation.uri,
-                            "invitation_id": invitation.invitationId,
-                            "expires_at_unix": invitation.expiresAtUnix,
-                        ]
                     }
                     if let addresses = endpoint.networkAddresses {
                         payload["network_addresses"] = [
@@ -503,20 +499,6 @@ extension TerminalController {
                     throw CloudMachineLinkManager.ManagerError.privateRouteRequired(route)
                 }
                 payload["wireguard_hub_socket"] = ready.socketPath
-                return payload
-            }
-        case "vm.cmux_remote_approve":
-            guard let vmId = Self.socketWorkerString(params["id"]), !vmId.isEmpty,
-                  let invitationId = Self.socketWorkerString(params["invitation_id"]) ?? Self.socketWorkerString(params["invitationId"]),
-                  !invitationId.isEmpty else {
-                return v2Error(id: id, code: "invalid_params", message: "vm.cmux_remote_approve requires `id` and `invitation_id`.")
-            }
-            return v2VmCall(id: id) {
-                let approval = try await VMClient.shared.approveCmuxRemoteEnrollment(id: vmId, invitationId: invitationId)
-                var payload: [String: Any] = ["approved": approval.approved, "state": approval.state]
-                if let fingerprint = approval.deviceFingerprint {
-                    payload["device_fingerprint"] = fingerprint
-                }
                 return payload
             }
         case "vm.sessions":

--- a/Sources/Surfaces/CmuxTuiSnapshotParser.swift
+++ b/Sources/Surfaces/CmuxTuiSnapshotParser.swift
@@ -394,10 +394,15 @@ struct CmuxTuiSnapshotParser: Sendable {
     /// order remains the compatibility fallback. An explicit index wins over
     /// an omitted one, and equal explicit indexes use the stable id before the
     /// transport offset as a deterministic tie-break.
+    // The tuple keeps `enumerated()`'s own label order on purpose: returning the
+    // sorted array under relabeled tuple labels compiles to a runtime array cast
+    // that the Swift 6.x runtime shipped with Xcode 26.6 refuses, which aborted
+    // the app on every snapshot publish. Callers read `.element` and `.offset`
+    // by name, so the order is invisible to them.
     private static func orderedSnapshotRows(
         _ rows: [[String: Any]],
         focusedFirst: Bool = false
-    ) -> [(element: [String: Any], offset: Int)] {
+    ) -> [(offset: Int, element: [String: Any])] {
         rows.enumerated().sorted { left, right in
             if focusedFirst {
                 let leftFocused = (left.element["focused"] as? Bool) == true

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3023,7 +3023,6 @@ class TerminalController {
             "vm.open_port",
             "vm.attach_info",
             "vm.cmux_remote_info",
-            "vm.cmux_remote_approve",
             "vm.ssh_info",
             "vm.sessions",
             "vm.session_attach_info",

--- a/cmux-tui/crates/cmux-remote/src/crypto.rs
+++ b/cmux-tui/crates/cmux-remote/src/crypto.rs
@@ -162,12 +162,18 @@ impl VerifiedSshPrincipal {
 /// Server-side evidence established by the transport boundary.
 ///
 /// Network evidence identifies provenance for diagnostics but never
-/// authorizes carrier authentication.
+/// authorizes carrier authentication. `TrustedNetwork` is the one exception:
+/// a listener the operator marked trusted, because the network it is bound to
+/// already admits only authorized peers (a cmux Cloud machine's private VPC,
+/// where every member is the owner's Mac or another of the owner's machines).
+/// The listener, not the daemon, carries that policy, so ssh, relay, and iroh
+/// links on the same daemon still enroll.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InboundAuthEvidence {
     Kernel(VerifiedKernelPeer),
     Ssh(VerifiedSshPrincipal),
     Network(NetworkPeer),
+    TrustedNetwork(NetworkPeer),
 }
 
 impl InboundAuthEvidence {

--- a/cmux-tui/crates/cmux-remote/src/daemon.rs
+++ b/cmux-tui/crates/cmux-remote/src/daemon.rs
@@ -2114,7 +2114,11 @@ mod tests {
             )
             .await
             .unwrap_or_else(|error| panic!("trusted {peer:?} evidence was rejected: {error}"));
-            assert_eq!(grant.device_id, format!("carrier:{}", public_key_fingerprint(&public_key)));
+            assert_eq!(grant.device_id, format!("network:{}", public_key_fingerprint(&public_key)));
+            // The grant stays current without the daemon-wide carrier policy: the
+            // network, not the device list, is what admits and revokes it.
+            assert!(denied.grant_is_current(&grant).await);
+            assert!(denied.device_is_active(&grant.device_id).await);
         }
         assert!(
             ServerAuthenticator::authorize(

--- a/cmux-tui/crates/cmux-remote/src/daemon.rs
+++ b/cmux-tui/crates/cmux-remote/src/daemon.rs
@@ -69,6 +69,13 @@ impl InboundLink {
         Self::new(link, InboundAuthEvidence::Network(peer))
     }
 
+    /// A link from a listener the operator marked trusted (`DirectWebSocketOptions::
+    /// trusted_carrier`): the network admitted the peer, so carrier authentication
+    /// is granted without enrollment.
+    pub fn trusted_network(link: Box<dyn FrameLink>, peer: NetworkPeer) -> Self {
+        Self::new(link, InboundAuthEvidence::TrustedNetwork(peer))
+    }
+
     pub fn evidence(&self) -> &InboundAuthEvidence {
         &self.evidence
     }
@@ -1248,6 +1255,18 @@ async fn close_pending_links(pending: Option<PendingLinks>) {
 struct WebSocketState {
     daemon: Arc<RemoteDaemon>,
     maximum_frame_bytes: usize,
+    trusted_carrier: bool,
+}
+
+/// How a direct WebSocket listener admits links.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DirectWebSocketOptions {
+    /// Bind plaintext off loopback (the carrier is expected to encrypt: WireGuard, TLS proxy).
+    pub allow_insecure_non_loopback: bool,
+    /// Grant carrier authentication to every link: the listener is reachable only
+    /// from a network whose members are all authorized (a cmux Cloud machine's
+    /// private VPC). Enrolled and invitation dials keep working alongside.
+    pub trusted_carrier: bool,
 }
 
 struct LimitedTcpListener {
@@ -1386,6 +1405,22 @@ pub async fn serve_direct_websocket(
     maximum_frame_bytes: usize,
     allow_insecure_non_loopback: bool,
 ) -> Result<DirectWebSocketServer, DaemonError> {
+    serve_direct_websocket_with_options(
+        daemon,
+        address,
+        maximum_frame_bytes,
+        DirectWebSocketOptions { allow_insecure_non_loopback, trusted_carrier: false },
+    )
+    .await
+}
+
+pub async fn serve_direct_websocket_with_options(
+    daemon: Arc<RemoteDaemon>,
+    address: SocketAddr,
+    maximum_frame_bytes: usize,
+    options: DirectWebSocketOptions,
+) -> Result<DirectWebSocketServer, DaemonError> {
+    let DirectWebSocketOptions { allow_insecure_non_loopback, trusted_carrier } = options;
     if !address.ip().is_loopback() && !allow_insecure_non_loopback {
         return Err(DaemonError::Protocol(format!(
             "refusing plaintext remote WebSocket bind {address}; use TLS or explicitly allow it"
@@ -1397,7 +1432,7 @@ pub async fn serve_direct_websocket(
     let local_addr = listener.local_addr().map_err(|error| {
         DaemonError::Protocol(format!("could not read WebSocket address: {error}"))
     })?;
-    let state = WebSocketState { daemon, maximum_frame_bytes };
+    let state = WebSocketState { daemon, maximum_frame_bytes, trusted_carrier };
     let router = Router::new().route("/v1/link", get(upgrade_websocket)).with_state(state);
     let listener = LimitedTcpListener {
         inner: listener,
@@ -1430,7 +1465,11 @@ async fn upgrade_websocket(
             admission.upgraded.store(true, Ordering::Release);
             let link =
                 AxumWebSocketLink::new("direct-websocket", state.maximum_frame_bytes, socket);
-            let inbound = InboundLink::network(Box::new(link), NetworkPeer::Tcp);
+            let inbound = if state.trusted_carrier {
+                InboundLink::trusted_network(Box::new(link), NetworkPeer::Tcp)
+            } else {
+                InboundLink::network(Box::new(link), NetworkPeer::Tcp)
+            };
             let _ = state.daemon.accept(inbound).await;
         })
 }
@@ -2056,6 +2095,37 @@ mod tests {
                 "{carrier} network evidence granted Carrier authentication"
             );
         }
+    }
+
+    /// A listener the operator marked trusted vouches for its peers by itself:
+    /// the grant needs no enrollment and no daemon-wide carrier policy, and it
+    /// still names the client's own key so the connection stays attributable.
+    #[tokio::test]
+    async fn trusted_network_listener_grants_carrier_without_policy_or_enrollment() {
+        let directory = tempdir().unwrap();
+        let denied =
+            AuthDatabase::load_or_create(directory.path(), "trusted-network", false).unwrap();
+        let client = StaticIdentity::generate().unwrap();
+        let public_key = client.public_key();
+        for peer in [NetworkPeer::Tcp, NetworkPeer::Tls] {
+            let grant = ServerAuthenticator::authorize(
+                &*denied,
+                carrier_auth_request(public_key, InboundAuthEvidence::TrustedNetwork(peer)),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("trusted {peer:?} evidence was rejected: {error}"));
+            assert_eq!(grant.device_id, format!("carrier:{}", public_key_fingerprint(&public_key)));
+        }
+        assert!(
+            ServerAuthenticator::authorize(
+                &*denied,
+                carrier_auth_request(public_key, InboundAuthEvidence::Network(NetworkPeer::Tcp)),
+            )
+            .await
+            .is_err(),
+            "an untrusted listener's network evidence granted Carrier authentication"
+        );
+        assert!(denied.pending_enrollments().await.is_empty());
     }
 
     struct FaultEpoch {

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -1385,7 +1385,10 @@ impl AuthDatabase {
         device_id: &str,
         connection_attempt: ConnectionAttemptId,
     ) -> Result<(), IdentityError> {
-        if device_id.starts_with("carrier:") {
+        // Carrier and trusted-network grants have no device record to stamp;
+        // their admission is the transport's, not the device list's.
+        if device_id.starts_with("carrier:") || device_id.starts_with(TRUSTED_NETWORK_DEVICE_PREFIX)
+        {
             return Ok(());
         }
         let now = unix_time()?;

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -1569,6 +1569,21 @@ impl ServerAuthenticator for AuthDatabase {
                     revocation_generation: generation,
                 })
             }
+            // A trusted-network listener vouches for every peer that can reach it;
+            // the grant still names the client's own key so connections stay
+            // attributable and individually disconnectable.
+            AuthKind::Carrier
+                if matches!(&request.inbound, InboundAuthEvidence::TrustedNetwork(_)) =>
+            {
+                Ok(AuthGrant {
+                    device_id: format!(
+                        "carrier:{}",
+                        public_key_fingerprint(&request.device_public_key)
+                    ),
+                    daemon_name: self.daemon_name.clone(),
+                    revocation_generation: *self.revocation_tx.borrow(),
+                })
+            }
             AuthKind::Carrier
                 if self.allow_carrier
                     && matches!(

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -26,6 +26,10 @@ pub const AUTH_STATE_VERSION: u32 = 2;
 const MAX_INVITATION_TTL: Duration = Duration::from_secs(5 * 60);
 const MAX_LIVE_INVITATIONS: usize = 256;
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+/// Device-id prefix of a grant issued by a trusted-network listener. Such a
+/// connection is admitted by the network it arrived on; it is never revoked by
+/// the daemon's device list or its carrier policy, only by leaving the network.
+pub const TRUSTED_NETWORK_DEVICE_PREFIX: &str = "network:";
 const ENROLLMENT_RETRY_GRACE: Duration = Duration::from_secs(60);
 const MAX_INVITATION_RELAY_ROUTES: usize = 2;
 const MAX_RELAY_SLOT_BYTES: usize = 256;
@@ -1152,6 +1156,9 @@ impl AuthDatabase {
     }
 
     pub async fn device_is_active(&self, device_id: &str) -> bool {
+        if device_id.starts_with(TRUSTED_NETWORK_DEVICE_PREFIX) {
+            return true;
+        }
         if device_id.starts_with("carrier:") {
             return self.allow_carrier;
         }
@@ -1167,6 +1174,9 @@ impl AuthDatabase {
     /// published. The generation check closes the race where a revocation can
     /// happen after the Noise handshake but before all physical lanes arrive.
     pub async fn grant_is_current(&self, grant: &AuthGrant) -> bool {
+        if grant.device_id.starts_with(TRUSTED_NETWORK_DEVICE_PREFIX) {
+            return true;
+        }
         if grant.device_id.starts_with("carrier:") {
             return self.allow_carrier;
         }
@@ -1571,13 +1581,15 @@ impl ServerAuthenticator for AuthDatabase {
             }
             // A trusted-network listener vouches for every peer that can reach it;
             // the grant still names the client's own key so connections stay
-            // attributable and individually disconnectable.
+            // attributable and individually disconnectable. The `network:` prefix
+            // keeps it apart from a policy-gated `carrier:` grant: the network's
+            // membership, not `allow_carrier`, is what keeps it current.
             AuthKind::Carrier
                 if matches!(&request.inbound, InboundAuthEvidence::TrustedNetwork(_)) =>
             {
                 Ok(AuthGrant {
                     device_id: format!(
-                        "carrier:{}",
+                        "{TRUSTED_NETWORK_DEVICE_PREFIX}{}",
                         public_key_fingerprint(&request.device_public_key)
                     ),
                     daemon_name: self.daemon_name.clone(),

--- a/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
@@ -250,6 +250,7 @@ fn ensure_size(actual: usize, maximum: usize) -> Result<(), LinkError> {
 pub struct DirectWebSocketProvider {
     maximum: usize,
     dialer: Arc<dyn Dialer>,
+    carrier_auth: bool,
 }
 
 impl DirectWebSocketProvider {
@@ -261,7 +262,21 @@ impl DirectWebSocketProvider {
     /// Dial over a caller-supplied carrier, such as an in-process WireGuard
     /// tunnel. The route, TLS, and upgrade are unchanged.
     pub fn with_dialer(maximum: usize, dialer: Arc<dyn Dialer>) -> Self {
-        Self { maximum, dialer }
+        Self { maximum, dialer, carrier_auth: false }
+    }
+
+    /// Offer carrier authentication on `ws`/`wss` routes: the daemon behind the
+    /// route is expected to serve a trusted-network listener (a cmux Cloud
+    /// machine reached over the owner's private network), so the client dials
+    /// without an enrollment or invitation. A daemon whose listener is not
+    /// trusted rejects the handshake; nothing is weakened on the client side.
+    pub fn with_carrier_auth(mut self, carrier_auth: bool) -> Self {
+        self.carrier_auth = carrier_auth;
+        self
+    }
+
+    pub fn carrier_auth(&self) -> bool {
+        self.carrier_auth
     }
 
     pub fn dialer(&self) -> &Arc<dyn Dialer> {
@@ -280,7 +295,11 @@ impl TransportProvider for DirectWebSocketProvider {
     }
 
     fn supported_client_auth(&self) -> SupportedClientAuthModes {
-        SupportedClientAuthModes::DeviceOnly
+        if self.carrier_auth {
+            SupportedClientAuthModes::DeviceOrCarrier
+        } else {
+            SupportedClientAuthModes::DeviceOnly
+        }
     }
 
     async fn connect(&self, request: ConnectRequest) -> Result<Arc<dyn LinkGroup>, ProviderError> {

--- a/cmux-tui/crates/cmux-remote/tests/direct_ws_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/direct_ws_e2e.rs
@@ -148,7 +148,9 @@ async fn carrier_dial_is_accepted_only_by_a_trusted_listener() {
         .await
         .unwrap();
     let provider = DirectWebSocketProvider::new(65_535).with_carrier_auth(true);
-    let dial = |server: &cmux_remote::daemon::DirectWebSocketServer, session: SessionId| {
+    let dial = |server: &cmux_remote::daemon::DirectWebSocketServer,
+                session: SessionId,
+                reconnect: ReconnectPolicy| {
         let endpoint = Url::parse(&format!("ws://{}/v1/link", server.local_addr())).unwrap();
         let provider = provider.clone();
         async move {
@@ -171,17 +173,20 @@ async fn carrier_dial_is_accepted_only_by_a_trusted_listener() {
                     session,
                     lane_policy: LanePolicy::Isolated,
                     limits: SessionLimits::default(),
-                    reconnect: ReconnectPolicy { maximum_attempts: Some(1), ..Default::default() },
+                    reconnect,
                 },
             )
             .await
         }
     };
 
-    let client = tokio::time::timeout(CONNECT_TIMEOUT, dial(&trusted, SessionId([81; 16])))
-        .await
-        .expect("trusted carrier dial timed out")
-        .expect("trusted listener refused a carrier dial");
+    let client = tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        dial(&trusted, SessionId([81; 16]), ReconnectPolicy::default()),
+    )
+    .await
+    .expect("trusted carrier dial timed out")
+    .expect("trusted listener refused a carrier dial");
     let daemon_client =
         tokio::time::timeout(Duration::from_secs(5), accepted.recv()).await.unwrap().unwrap();
     assert_eq!(client.snapshot().await.state, ConnectionState::Connected);
@@ -193,10 +198,19 @@ async fn carrier_dial_is_accepted_only_by_a_trusted_listener() {
     assert_eq!(daemon_client.receive().await.unwrap().unwrap().payload, b"input".as_slice());
     client.close().await.unwrap();
 
-    tokio::time::timeout(CONNECT_TIMEOUT, dial(&untrusted, SessionId([82; 16])))
-        .await
-        .expect("untrusted carrier dial timed out")
-        .expect_err("untrusted listener accepted a carrier dial");
+    // One attempt is enough to observe the refusal; a retry budget would only
+    // repeat the same rejected handshake.
+    tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        dial(
+            &untrusted,
+            SessionId([82; 16]),
+            ReconnectPolicy { maximum_attempts: Some(1), ..Default::default() },
+        ),
+    )
+    .await
+    .expect("untrusted carrier dial timed out")
+    .expect_err("untrusted listener accepted a carrier dial");
 
     trusted.shutdown().await.unwrap();
     untrusted.shutdown().await.unwrap();

--- a/cmux-tui/crates/cmux-remote/tests/direct_ws_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/direct_ws_e2e.rs
@@ -123,3 +123,81 @@ async fn invitation_enrolls_over_direct_websocket_with_isolated_lanes() {
     client.close().await.unwrap();
     server.shutdown().await.unwrap();
 }
+
+/// A cmux Cloud machine's listener is reachable only from the owner's private
+/// network, so it grants carrier authentication to every link: the client
+/// dials with no enrollment and no invitation. The same dial against a
+/// listener that is not trusted is refused, so the client flag alone weakens
+/// nothing.
+#[tokio::test]
+async fn carrier_dial_is_accepted_only_by_a_trusted_listener() {
+    use cmux_remote::daemon::{DirectWebSocketOptions, serve_direct_websocket_with_options};
+
+    let state = tempdir().unwrap();
+    let auth = AuthDatabase::load_or_create(state.path(), "trusted-listener-test", false).unwrap();
+    let (daemon, mut accepted) = RemoteDaemon::new(auth.clone(), SessionLimits::default());
+    let trusted = serve_direct_websocket_with_options(
+        daemon.clone(),
+        "127.0.0.1:0".parse().unwrap(),
+        65_535,
+        DirectWebSocketOptions { allow_insecure_non_loopback: false, trusted_carrier: true },
+    )
+    .await
+    .unwrap();
+    let untrusted = serve_direct_websocket(daemon, "127.0.0.1:0".parse().unwrap(), 65_535, false)
+        .await
+        .unwrap();
+    let provider = DirectWebSocketProvider::new(65_535).with_carrier_auth(true);
+    let dial = |server: &cmux_remote::daemon::DirectWebSocketServer, session: SessionId| {
+        let endpoint = Url::parse(&format!("ws://{}/v1/link", server.local_addr())).unwrap();
+        let provider = provider.clone();
+        async move {
+            let group = provider
+                .connect(ConnectRequest {
+                    endpoint,
+                    session,
+                    lane_policy: LanePolicy::Isolated,
+                    routing: Default::default(),
+                })
+                .await
+                .unwrap();
+            ClientConnection::connect(
+                group,
+                ClientConnectionConfig {
+                    identity: StaticIdentity::generate().unwrap(),
+                    expected_daemon: None,
+                    auth: ClientAuthMode::Carrier,
+                    device_name: "carrier-client".into(),
+                    session,
+                    lane_policy: LanePolicy::Isolated,
+                    limits: SessionLimits::default(),
+                    reconnect: ReconnectPolicy { maximum_attempts: Some(1), ..Default::default() },
+                },
+            )
+            .await
+        }
+    };
+
+    let client = tokio::time::timeout(CONNECT_TIMEOUT, dial(&trusted, SessionId([81; 16])))
+        .await
+        .expect("trusted carrier dial timed out")
+        .expect("trusted listener refused a carrier dial");
+    let daemon_client =
+        tokio::time::timeout(Duration::from_secs(5), accepted.recv()).await.unwrap().unwrap();
+    assert_eq!(client.snapshot().await.state, ConnectionState::Connected);
+    assert!(auth.pending_enrollments().await.is_empty(), "carrier dial left a pending enrollment");
+    client
+        .send(Lane::Interactive, 1, Bytes::from_static(b"input"), FrameFlags::empty())
+        .await
+        .unwrap();
+    assert_eq!(daemon_client.receive().await.unwrap().unwrap().payload, b"input".as_slice());
+    client.close().await.unwrap();
+
+    tokio::time::timeout(CONNECT_TIMEOUT, dial(&untrusted, SessionId([82; 16])))
+        .await
+        .expect("untrusted carrier dial timed out")
+        .expect_err("untrusted listener accepted a carrier dial");
+
+    trusted.shutdown().await.unwrap();
+    untrusted.shutdown().await.unwrap();
+}

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -1483,12 +1483,15 @@ ROUTES:
   relay+ws:// | relay+wss:// | relay+https:// | relay+do://
 
 IDENTITY AND SESSION:
-  --invite-file PATH|-  --daemon FINGERPRINT
+  --invite-file PATH|-  --daemon FINGERPRINT  --carrier
   --device-name NAME  --session NAME
   --state-dir PATH  --local-socket PATH  --headless [--json]
 
   --invite-file avoids exposing the single-use invitation in process arguments.
   Regular files must be owner-only; - reads one line from stdin.
+  --carrier dials ws routes with carrier authentication (no enrollment, no
+    invitation); only a daemon whose listener is trusted accepts it, such as a
+    cmux Cloud machine reached over the owner's private network.
 
 TRANSPORT:
   --lanes auto|single|isolated  --connect-timeout-seconds N
@@ -2159,12 +2162,15 @@ cmux machine-agent - ローカルの cmux セッションをリモートサー�
   relay+ws:// | relay+wss:// | relay+https:// | relay+do://
 
 ID とセッション:
-  --invite-file パス|-  --daemon フィンガープリント
+  --invite-file パス|-  --daemon フィンガープリント  --carrier
   --device-name 名前  --session 名前
   --state-dir パス  --local-socket パス  --headless [--json]
 
   --invite-file は一回限りの招待をプロセス引数に公開しません。
   通常ファイルは所有者だけが読める必要があります。- は標準入力から 1 行読みます。
+  --carrier は ws ルートをキャリア認証で接続します（登録や招待は不要）。
+    信頼済みリスナーを持つデーモンだけが受け入れます（例: 所有者のプライベート
+    ネットワーク経由で到達する cmux Cloud マシン）。
 
 トランスポート:
   --lanes auto|single|isolated  --connect-timeout-seconds 秒数

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2294,6 +2294,7 @@ fn finish_server_shutdown<W, R>(
 /// `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1` is how a systemd drop-in turns the
 /// trusted listener on for a daemon whose baked launch line predates the flag
 /// (cmux Cloud machines healed in place). Only an exact truthy value counts.
+#[cfg(unix)]
 fn remote_ws_trusted_carrier_from_env() -> bool {
     std::env::var("CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER")
         .map(|value| matches!(value.trim(), "1" | "true" | "yes"))

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -448,6 +448,9 @@ START OPTIONS
   --remote          Run the authenticated remote daemon with this session.
   --remote-ws <addr> Listen for direct remote WebSocket links.
   --remote-ws-insecure-bind  Allow plaintext remote WebSocket off loopback.
+  --remote-ws-trusted-carrier  Grant every remote WebSocket link carrier auth (no
+                    enrollment): only behind a private network whose members are
+                    all authorized. Also CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1.
   --remote-http <addr> Listen for bearer-authenticated workspace HTTP RPC on loopback.
   --remote-state-dir <path>  Override remote identity and runtime state.
   --remote-link-socket <path> Override the local authenticated link socket.
@@ -509,6 +512,7 @@ struct Args {
     remote: bool,
     remote_ws: Option<String>,
     remote_ws_insecure_bind: bool,
+    remote_ws_trusted_carrier: bool,
     remote_http: Option<String>,
     remote_state_dir: Option<PathBuf>,
     remote_link_socket: Option<PathBuf>,
@@ -583,6 +587,7 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
         remote: false,
         remote_ws: None,
         remote_ws_insecure_bind: false,
+        remote_ws_trusted_carrier: false,
         remote_http: None,
         remote_state_dir: None,
         remote_link_socket: None,
@@ -696,6 +701,10 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
             }
             "--remote-ws-insecure-bind" => {
                 out.remote_ws_insecure_bind = true;
+                out.remote = true;
+            }
+            "--remote-ws-trusted-carrier" => {
+                out.remote_ws_trusted_carrier = true;
                 out.remote = true;
             }
             "--remote-http" => {
@@ -1361,6 +1370,7 @@ fn is_cli_invocation(args: &[String]) -> bool {
             | "--ws-insecure-bind"
             | "--remote"
             | "--remote-ws-insecure-bind"
+            | "--remote-ws-trusted-carrier"
             | "--iroh" => index += 1,
             "-h" | "--help" | "help" => return true,
             "attach" => return false,
@@ -2077,6 +2087,8 @@ fn run_server(
                 admin_socket: args.remote_admin_socket,
                 direct_websocket: remote_direct_websocket,
                 allow_insecure_non_loopback: args.remote_ws_insecure_bind,
+                trusted_carrier_websocket: args.remote_ws_trusted_carrier
+                    || remote_ws_trusted_carrier_from_env(),
                 workspace_http: remote_workspace_http,
                 relays: remote_relays,
                 iroh: args.iroh,
@@ -2279,11 +2291,21 @@ fn finish_server_shutdown<W, R>(
     result
 }
 
+/// `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1` is how a systemd drop-in turns the
+/// trusted listener on for a daemon whose baked launch line predates the flag
+/// (cmux Cloud machines healed in place). Only an exact truthy value counts.
+fn remote_ws_trusted_carrier_from_env() -> bool {
+    std::env::var("CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER")
+        .map(|value| matches!(value.trim(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 #[cfg(not(unix))]
 fn reject_unsupported_remote_options(args: &Args) -> anyhow::Result<()> {
     let requested = args.remote
         || args.remote_ws.is_some()
         || args.remote_ws_insecure_bind
+        || args.remote_ws_trusted_carrier
         || args.remote_http.is_some()
         || args.remote_state_dir.is_some()
         || args.remote_link_socket.is_some()

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -1841,8 +1841,13 @@ fn start_wireguard_with_timeout_inner(
         anyhow!(catalog().remote_client.wireguard_config_invalid(&error.to_string()))
     })?;
     let net = match timeout {
+        // The timeout future must be built inside the runtime: `tokio::time::timeout`
+        // registers its sleep with the current reactor at construction, and there is
+        // none on this thread, so building it as `block_on`'s argument panics.
         Some(timeout) => runtime
-            .block_on(tokio::time::timeout(timeout, cmux_wg::WgNet::start_with_new_socket(config)))
+            .block_on(async {
+                tokio::time::timeout(timeout, cmux_wg::WgNet::start_with_new_socket(config)).await
+            })
             .map_err(|_| anyhow!("WireGuard startup timed out after {timeout:?}"))?
             .map_err(|error| {
                 anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string()))

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -3147,6 +3147,29 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn wireguard_hub_start_deadline_is_built_inside_the_runtime() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // `wg hub` runs on a plain thread and hands its runtime to the starter.
+        // The deadline future used to be built as `block_on`'s argument, where no
+        // reactor exists, and every hub start panicked with "there is no reactor
+        // running". A literal endpoint keeps DNS out of the test; the start may
+        // still fail, and any `Result` is the pass condition.
+        let directory = tempfile::tempdir().unwrap();
+        let config = directory.path().join("hub.conf");
+        fs::write(
+            &config,
+            "[Interface]\nPrivateKey = yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk=\nAddress = 100.64.0.1/32\nMTU = 1200\n\n[Peer]\nPublicKey = xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=\nAllowedIPs = 10.0.0.0/24\nEndpoint = 127.0.0.1:1\n",
+        )
+        .unwrap();
+        fs::set_permissions(&config, fs::Permissions::from_mode(0o600)).unwrap();
+        let runtime = tokio_runtime().unwrap();
+        let started = start_wireguard_with_timeout(&runtime, &config, Duration::from_secs(5));
+        drop(started);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn invitation_file_requires_owner_only_permissions() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -1735,11 +1735,8 @@ fn run_wg(args: &[String]) -> anyhow::Result<()> {
     let flags = parse_wg_hub_flags(&args[1..])?;
     let owner = flags.exit_with_parent.then(current_parent_process_id);
     let async_runtime = tokio_runtime()?;
-    let net = start_wireguard_with_timeout(
-        &async_runtime,
-        &flags.config,
-        WIREGUARD_HUB_START_TIMEOUT,
-    )?;
+    let net =
+        start_wireguard_with_timeout(&async_runtime, &flags.config, WIREGUARD_HUB_START_TIMEOUT)?;
     async_runtime.block_on(net.wait_for_handshake(WIREGUARD_HUB_HANDSHAKE_TIMEOUT)).map_err(
         |error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())),
     )?;
@@ -1845,15 +1842,16 @@ fn start_wireguard_with_timeout_inner(
     })?;
     let net = match timeout {
         Some(timeout) => runtime
-            .block_on(tokio::time::timeout(
-                timeout,
-                cmux_wg::WgNet::start_with_new_socket(config),
-            ))
+            .block_on(tokio::time::timeout(timeout, cmux_wg::WgNet::start_with_new_socket(config)))
             .map_err(|_| anyhow!("WireGuard startup timed out after {timeout:?}"))?
-            .map_err(|error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())))?,
-        None => runtime
-            .block_on(cmux_wg::WgNet::start_with_new_socket(config))
-            .map_err(|error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())))?,
+            .map_err(|error| {
+                anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string()))
+            })?,
+        None => {
+            runtime.block_on(cmux_wg::WgNet::start_with_new_socket(config)).map_err(|error| {
+                anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string()))
+            })?
+        }
     };
     Ok(Arc::new(net))
 }

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -3161,7 +3161,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             registry.supported_client_auth("ws").unwrap(),
-            cmux_remote::provider::SupportedClientAuthModes::DeviceOrCarrier
+            SupportedClientAuthModes::DeviceOrCarrier
         );
         let registry = client_provider_registry(
             SshProviderConfig::default(),
@@ -3173,7 +3173,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             registry.supported_client_auth("ws").unwrap(),
-            cmux_remote::provider::SupportedClientAuthModes::DeviceOnly
+            SupportedClientAuthModes::DeviceOnly
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -47,9 +47,9 @@ use crate::remote_runtime::persist_daemon_lifecycle_fence;
 use crate::remote_runtime::{
     ClientRuntimeOptions, DaemonRuntimeOptions, DaemonShutdownStatus, RelayClientOptions,
     ResolvedRouteCandidate, SshBootstrapOptions, acknowledge_failed_shutdown_outcome,
-    acknowledge_legacy_shutdown_state, client_provider_registry_with_carrier,
-    complete_verified_daemon_stop, daemon_paths, inactive_daemon_needs_legacy_acknowledgement,
-    load_runtime_info, load_shutdown_outcome, start_client_runtime, start_daemon_runtime,
+    acknowledge_legacy_shutdown_state, client_provider_registry, complete_verified_daemon_stop,
+    daemon_paths, inactive_daemon_needs_legacy_acknowledgement, load_runtime_info,
+    load_shutdown_outcome, start_client_runtime, start_daemon_runtime,
 };
 use crate::session::{RemoteSession, Session};
 
@@ -676,7 +676,7 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         maximum_frame_bytes: crate::remote_runtime::MAX_CARRIER_FRAME_BYTES,
     };
     let relay_route_names = relay_routes.keys().cloned().collect::<Vec<_>>();
-    let providers = Arc::new(client_provider_registry_with_carrier(
+    let providers = Arc::new(client_provider_registry(
         ssh.clone(),
         relay_routes,
         flags.iroh_path,
@@ -2872,11 +2872,12 @@ mod tests {
 
     fn test_provider_registry() -> Arc<cmux_remote::provider::ProviderRegistry> {
         Arc::new(
-            crate::remote_runtime::client_provider_registry(
+            client_provider_registry(
                 SshProviderConfig::default(),
                 BTreeMap::new(),
                 IrohPathMode::Auto,
                 None,
+                false,
             )
             .unwrap(),
         )
@@ -3150,7 +3151,7 @@ mod tests {
                 .unwrap();
         assert!(carrier.carrier);
         assert_eq!(carrier.route.as_deref(), Some("ws://10.0.0.5:1337/v1/link"));
-        let registry = client_provider_registry_with_carrier(
+        let registry = client_provider_registry(
             SshProviderConfig::default(),
             BTreeMap::new(),
             IrohPathMode::Auto,
@@ -3162,11 +3163,12 @@ mod tests {
             registry.supported_client_auth("ws").unwrap(),
             cmux_remote::provider::SupportedClientAuthModes::DeviceOrCarrier
         );
-        let registry = crate::remote_runtime::client_provider_registry(
+        let registry = client_provider_registry(
             SshProviderConfig::default(),
             BTreeMap::new(),
             IrohPathMode::Auto,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -47,7 +47,8 @@ use crate::remote_runtime::persist_daemon_lifecycle_fence;
 use crate::remote_runtime::{
     ClientRuntimeOptions, DaemonRuntimeOptions, DaemonShutdownStatus, RelayClientOptions,
     ResolvedRouteCandidate, SshBootstrapOptions, acknowledge_failed_shutdown_outcome,
-    acknowledge_legacy_shutdown_state, client_provider_registry, complete_verified_daemon_stop,
+    acknowledge_legacy_shutdown_state, client_provider_registry,
+    client_provider_registry_with_carrier, complete_verified_daemon_stop,
     daemon_paths, inactive_daemon_needs_legacy_acknowledgement, load_runtime_info,
     load_shutdown_outcome, start_client_runtime, start_daemon_runtime,
 };
@@ -214,6 +215,9 @@ struct ConnectFlags {
     iroh_path: IrohPathMode,
     wireguard_config: Option<PathBuf>,
     wireguard_hub: Option<PathBuf>,
+    /// Dial `ws`/`wss` routes with carrier authentication: no enrollment, no
+    /// invitation. Only a daemon serving a trusted-network listener accepts it.
+    carrier: bool,
     /// Internal app ownership fence. The helper exits when its direct parent exits,
     /// including an abort or forced app replacement that cannot run Swift cleanup.
     exit_with_parent: bool,
@@ -274,6 +278,7 @@ fn parse_connect_flags(args: &[String]) -> anyhow::Result<ConnectFlags> {
                 InvitationArg::File(value("--invite-file")?.into()),
             )?,
             "--daemon" => flags.daemon = Some(value("--daemon")?),
+            "--carrier" => flags.carrier = true,
             "--lanes" => {
                 flags.lanes = value("--lanes")?.parse().map_err(|_: String| {
                     anyhow!(
@@ -672,11 +677,12 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         maximum_frame_bytes: crate::remote_runtime::MAX_CARRIER_FRAME_BYTES,
     };
     let relay_route_names = relay_routes.keys().cloned().collect::<Vec<_>>();
-    let providers = Arc::new(client_provider_registry(
+    let providers = Arc::new(client_provider_registry_with_carrier(
         ssh.clone(),
         relay_routes,
         flags.iroh_path,
         direct_dialer,
+        flags.carrier,
     )?);
     let explicit_route = flags.route.take();
     let explicit_route_for_refresh = explicit_route.clone();
@@ -2291,6 +2297,7 @@ fn run_remote_sidecar(args: &[String]) -> anyhow::Result<()> {
             admin_socket: None,
             direct_websocket: None,
             allow_insecure_non_loopback: false,
+            trusted_carrier_websocket: false,
             workspace_http: None,
             relays: Vec::new(),
             iroh: false,
@@ -3133,6 +3140,40 @@ mod tests {
         let error = read_invitation_uri(&fifo).unwrap_err().to_string();
         assert!(started.elapsed() < Duration::from_secs(1));
         assert!(error.contains("regular file"));
+    }
+
+    #[test]
+    fn carrier_flag_is_off_by_default_and_needs_no_value() {
+        let default = parse_connect_flags(&["ws://10.0.0.5:1337/v1/link".into()]).unwrap();
+        assert!(!default.carrier);
+        let carrier =
+            parse_connect_flags(&["ws://10.0.0.5:1337/v1/link".into(), "--carrier".into()])
+                .unwrap();
+        assert!(carrier.carrier);
+        assert_eq!(carrier.route.as_deref(), Some("ws://10.0.0.5:1337/v1/link"));
+        let registry = client_provider_registry_with_carrier(
+            SshProviderConfig::default(),
+            BTreeMap::new(),
+            IrohPathMode::Auto,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            registry.supported_client_auth("ws").unwrap(),
+            cmux_remote::provider::SupportedClientAuthModes::DeviceOrCarrier
+        );
+        let registry = client_provider_registry(
+            SshProviderConfig::default(),
+            BTreeMap::new(),
+            IrohPathMode::Auto,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            registry.supported_client_auth("ws").unwrap(),
+            cmux_remote::provider::SupportedClientAuthModes::DeviceOnly
+        );
     }
 
     #[test]
@@ -4459,6 +4500,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -47,10 +47,9 @@ use crate::remote_runtime::persist_daemon_lifecycle_fence;
 use crate::remote_runtime::{
     ClientRuntimeOptions, DaemonRuntimeOptions, DaemonShutdownStatus, RelayClientOptions,
     ResolvedRouteCandidate, SshBootstrapOptions, acknowledge_failed_shutdown_outcome,
-    acknowledge_legacy_shutdown_state, client_provider_registry,
-    client_provider_registry_with_carrier, complete_verified_daemon_stop,
-    daemon_paths, inactive_daemon_needs_legacy_acknowledgement, load_runtime_info,
-    load_shutdown_outcome, start_client_runtime, start_daemon_runtime,
+    acknowledge_legacy_shutdown_state, client_provider_registry_with_carrier,
+    complete_verified_daemon_stop, daemon_paths, inactive_daemon_needs_legacy_acknowledgement,
+    load_runtime_info, load_shutdown_outcome, start_client_runtime, start_daemon_runtime,
 };
 use crate::session::{RemoteSession, Session};
 
@@ -2873,7 +2872,7 @@ mod tests {
 
     fn test_provider_registry() -> Arc<cmux_remote::provider::ProviderRegistry> {
         Arc::new(
-            client_provider_registry(
+            crate::remote_runtime::client_provider_registry(
                 SshProviderConfig::default(),
                 BTreeMap::new(),
                 IrohPathMode::Auto,
@@ -3163,7 +3162,7 @@ mod tests {
             registry.supported_client_auth("ws").unwrap(),
             cmux_remote::provider::SupportedClientAuthModes::DeviceOrCarrier
         );
-        let registry = client_provider_registry(
+        let registry = crate::remote_runtime::client_provider_registry(
             SshProviderConfig::default(),
             BTreeMap::new(),
             IrohPathMode::Auto,

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -25,7 +25,10 @@ use cmux_remote::connection::{
 use cmux_remote::crypto::{AuthKind, ClientAuthMode, CryptoError, StaticIdentity};
 #[cfg(test)]
 use cmux_remote::daemon::serve_unix;
-use cmux_remote::daemon::{DaemonSessionPolicy, serve_direct_websocket, serve_unix_with_shutdown};
+use cmux_remote::daemon::{
+    DaemonSessionPolicy, DirectWebSocketOptions, serve_direct_websocket_with_options,
+    serve_unix_with_shutdown,
+};
 use cmux_remote::http::serve_workspace_http;
 use cmux_remote::identity::{
     AuthDatabase, IdentityError, PersistedAuthStateSchema, credential_free_route_hint,
@@ -251,6 +254,10 @@ pub struct DaemonRuntimeOptions {
     pub admin_socket: Option<PathBuf>,
     pub direct_websocket: Option<SocketAddr>,
     pub allow_insecure_non_loopback: bool,
+    /// The direct WebSocket listener grants carrier authentication to every link
+    /// (`--remote-ws-trusted-carrier`): only for a listener reachable solely
+    /// from a network whose members are all authorized.
+    pub trusted_carrier_websocket: bool,
     pub workspace_http: Option<SocketAddr>,
     pub relays: Vec<RelayDaemonOptions>,
     pub iroh: bool,
@@ -274,6 +281,7 @@ impl fmt::Debug for DaemonRuntimeOptions {
             .field("admin_socket", &self.admin_socket)
             .field("direct_websocket", &self.direct_websocket)
             .field("allow_insecure_non_loopback", &self.allow_insecure_non_loopback)
+            .field("trusted_carrier_websocket", &self.trusted_carrier_websocket)
             .field("workspace_http", &self.workspace_http)
             .field("relays", &self.relays)
             .field("iroh", &self.iroh)
@@ -446,11 +454,25 @@ pub fn client_provider_registry(
     iroh_path: IrohPathMode,
     direct_dialer: Option<Arc<dyn Dialer>>,
 ) -> Result<cmux_remote::provider::ProviderRegistry, ProviderError> {
+    client_provider_registry_with_carrier(ssh, relay_routes, iroh_path, direct_dialer, false)
+}
+
+/// `direct_carrier_auth` lets `ws`/`wss` routes dial with carrier authentication
+/// (`remote connect --carrier`): the daemon is expected to serve a trusted-network
+/// listener, as cmux Cloud machines do behind the owner's private network.
+pub fn client_provider_registry_with_carrier(
+    ssh: SshProviderConfig,
+    relay_routes: BTreeMap<String, RelayClientOptions>,
+    iroh_path: IrohPathMode,
+    direct_dialer: Option<Arc<dyn Dialer>>,
+    direct_carrier_auth: bool,
+) -> Result<cmux_remote::provider::ProviderRegistry, ProviderError> {
     let mut providers = cmux_remote::provider::ProviderRegistry::default();
     let direct = match direct_dialer {
         Some(dialer) => DirectWebSocketProvider::with_dialer(MAX_CARRIER_FRAME_BYTES, dialer),
         None => DirectWebSocketProvider::new(MAX_CARRIER_FRAME_BYTES),
-    };
+    }
+    .with_carrier_auth(direct_carrier_auth);
     providers.register(Arc::new(direct))?;
     #[cfg(unix)]
     providers.register(Arc::new(UnixProvider::new(MAX_CARRIER_FRAME_BYTES)))?;
@@ -1891,11 +1913,14 @@ async fn run_daemon(
             .await?;
             let websocket = match options.direct_websocket {
                 Some(address) => Some(
-                    serve_direct_websocket(
+                    serve_direct_websocket_with_options(
                         daemon.clone(),
                         address,
                         MAX_CARRIER_FRAME_BYTES,
-                        options.allow_insecure_non_loopback,
+                        DirectWebSocketOptions {
+                            allow_insecure_non_loopback: options.allow_insecure_non_loopback,
+                            trusted_carrier: options.trusted_carrier_websocket,
+                        },
                     )
                     .await?,
                 ),
@@ -3249,6 +3274,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3308,6 +3334,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3345,6 +3372,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3396,6 +3424,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -3447,6 +3476,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3489,6 +3519,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3541,6 +3572,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3588,6 +3620,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -3634,6 +3667,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3679,6 +3713,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3742,6 +3777,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3803,6 +3839,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3846,6 +3883,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -3923,6 +3961,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -3964,6 +4003,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -4001,6 +4041,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -4046,6 +4087,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -4071,6 +4113,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -4119,6 +4162,7 @@ mod tests {
                 admin_socket: Some(directory.path().join("sockets/admin.sock")),
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -4152,6 +4196,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -4263,6 +4308,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -4318,6 +4364,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -4401,6 +4448,7 @@ mod tests {
                     admin_socket: None,
                     direct_websocket: None,
                     allow_insecure_non_loopback: false,
+                    trusted_carrier_websocket: false,
                     workspace_http: None,
                     relays: Vec::new(),
                     iroh: false,
@@ -4604,6 +4652,7 @@ mod tests {
             admin_socket: None,
             direct_websocket: None,
             allow_insecure_non_loopback: false,
+            trusted_carrier_websocket: false,
             workspace_http: None,
             relays: vec![relay_options],
             iroh: false,
@@ -4891,6 +4940,7 @@ mod tests {
                 admin_socket: Some(daemon_root.join("admin.sock")),
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -5926,6 +5976,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,
@@ -5958,6 +6009,7 @@ mod tests {
                 admin_socket: None,
                 direct_websocket: None,
                 allow_insecure_non_loopback: false,
+                trusted_carrier_websocket: false,
                 workspace_http: None,
                 relays: Vec::new(),
                 iroh: false,

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -448,19 +448,10 @@ impl TransportProvider for RoutedRelayProvider {
 /// `direct_dialer` replaces the operating-system TCP dial for `ws`/`wss`
 /// routes: an in-process WireGuard tunnel (`WireGuardDialer`) or a shared hub
 /// (`SocksDialer`). Every other scheme is unaffected.
-pub fn client_provider_registry(
-    ssh: SshProviderConfig,
-    relay_routes: BTreeMap<String, RelayClientOptions>,
-    iroh_path: IrohPathMode,
-    direct_dialer: Option<Arc<dyn Dialer>>,
-) -> Result<cmux_remote::provider::ProviderRegistry, ProviderError> {
-    client_provider_registry_with_carrier(ssh, relay_routes, iroh_path, direct_dialer, false)
-}
-
 /// `direct_carrier_auth` lets `ws`/`wss` routes dial with carrier authentication
 /// (`remote connect --carrier`): the daemon is expected to serve a trusted-network
 /// listener, as cmux Cloud machines do behind the owner's private network.
-pub fn client_provider_registry_with_carrier(
+pub fn client_provider_registry(
     ssh: SshProviderConfig,
     relay_routes: BTreeMap<String, RelayClientOptions>,
     iroh_path: IrohPathMode,
@@ -2926,7 +2917,10 @@ mod tests {
     }
 
     fn test_providers(ssh: SshProviderConfig) -> Arc<cmux_remote::provider::ProviderRegistry> {
-        Arc::new(client_provider_registry(ssh, BTreeMap::new(), IrohPathMode::Auto, None).unwrap())
+        Arc::new(
+            client_provider_registry(ssh, BTreeMap::new(), IrohPathMode::Auto, None, false)
+                .unwrap(),
+        )
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -4987,7 +4981,7 @@ mod tests {
             ..SshProviderConfig::default()
         };
         let providers = Arc::new(
-            client_provider_registry(ssh.clone(), BTreeMap::new(), IrohPathMode::Auto, None)
+            client_provider_registry(ssh.clone(), BTreeMap::new(), IrohPathMode::Auto, None, false)
                 .unwrap(),
         );
         let mut unix_route = Url::parse("unix:///").unwrap();

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -95,7 +95,11 @@ filesystem error text.
 
 Authenticated network operations use `remote connect|ssh|forward|rpc`,
 `remote enroll`, and `remote known-daemons`; they cannot accept local server
-targeting. `remote stop` manages only a replaceable SSH sidecar. A listener
+targeting. `remote connect --carrier` dials a `ws`/`wss` route with carrier
+authentication and no enrollment; only a daemon started with
+`--remote-ws-trusted-carrier` (or `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1`), whose
+listener is reachable solely from a private network of authorized members,
+accepts it. `remote stop` manages only a replaceable SSH sidecar. A listener
 embedded by `server start` stops only through `server stop`, which also stops
 the local owner and its workspaces. `server start` accepts the explicit
 remote-listener flags when the owning process also serves authenticated

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -890,15 +890,17 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
     }
 
     @Test func clientArgvIsExact() {
-        #expect(CloudTuiCommandLine.linkArguments(route: "wss://m.vm.cmux.sh/v1/link?t=1", deviceName: "cmux-mac", stateDir: "/s", inviteFilePath: "/i") ==
-            ["remote", "connect", "wss://m.vm.cmux.sh/v1/link?t=1", "--device-name", "cmux-mac", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent", "--invite-file", "/i"])
-        #expect(CloudTuiCommandLine.linkArguments(route: "r", deviceName: "d", stateDir: "/s", inviteFilePath: nil) ==
+        // A machine's trusted listener is dialed with --carrier: no invite file, no enrollment.
+        #expect(CloudTuiCommandLine.linkArguments(route: "wss://m.vm.cmux.sh/v1/link?t=1", deviceName: "cmux-mac", stateDir: "/s", carrier: true) ==
+            ["remote", "connect", "wss://m.vm.cmux.sh/v1/link?t=1", "--device-name", "cmux-mac", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent", "--carrier"])
+        // A machine this Mac enrolled with before trusted listeners presents its stored key.
+        #expect(CloudTuiCommandLine.linkArguments(route: "r", deviceName: "d", stateDir: "/s") ==
             ["remote", "connect", "r", "--device-name", "d", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent"])
         // A private-network machine dials through the app's WireGuard hub. Both long-lived
         // helper processes must also stop if their app parent exits without cleanup.
-        #expect(CloudTuiCommandLine.linkArguments(route: "ws://[fd00::10]:1337/v1/link", deviceName: "d", stateDir: "/s", inviteFilePath: "/i", wireguardHubSocket: "/h.sock") ==
-            ["remote", "connect", "ws://[fd00::10]:1337/v1/link", "--device-name", "d", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent", "--invite-file", "/i", "--wireguard-hub", "/h.sock"])
-        #expect(CloudTuiCommandLine.linkArguments(route: "r", deviceName: "d", stateDir: "/s", inviteFilePath: nil, wireguardHubSocket: "") ==
+        #expect(CloudTuiCommandLine.linkArguments(route: "ws://[fd00::10]:1337/v1/link", deviceName: "d", stateDir: "/s", carrier: true, wireguardHubSocket: "/h.sock") ==
+            ["remote", "connect", "ws://[fd00::10]:1337/v1/link", "--device-name", "d", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent", "--carrier", "--wireguard-hub", "/h.sock"])
+        #expect(CloudTuiCommandLine.linkArguments(route: "r", deviceName: "d", stateDir: "/s", wireguardHubSocket: "") ==
             ["remote", "connect", "r", "--device-name", "d", "--state-dir", "/s", "--headless", "--json", "--exit-with-parent"])
         #expect(CloudTuiCommandLine.wireGuardHubArguments(configPath: "/w/cmux-app.conf", socketPath: "/w/hub-1.sock") ==
             ["wg", "hub", "--config", "/w/cmux-app.conf", "--socket", "/w/hub-1.sock", "--exit-with-parent"])
@@ -1070,7 +1072,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
             paths: CloudTuiClientPaths(home: root)
         )
         let task = Task {
-            try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main", invitationURI: nil)
+            try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main")
         }
         for _ in 0..<200 where !FileManager.default.fileExists(atPath: pidFile.path) {
             try await Task.sleep(for: .milliseconds(10))
@@ -1115,7 +1117,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
             clientURL: client,
             paths: CloudTuiClientPaths(home: root)
         )
-        _ = try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main", invitationURI: nil)
+        _ = try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main")
         for _ in 0..<200 where !FileManager.default.fileExists(atPath: eventPIDFile.path) {
             try await Task.sleep(for: .milliseconds(10))
         }

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -1112,7 +1112,9 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
             clientURL: client,
             paths: CloudTuiClientPaths(home: root)
         )
-        let started = ContinuousClock.now
+        // The error kind is the whole check: before the fix this path threw
+        // `timedOut` the moment stdout closed, so a wall-clock bound adds nothing
+        // and only measures how fast the host spawns a fresh script.
         do {
             _ = try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main", carrier: true, timeout: .seconds(60))
             Issue.record("a client that exits before its socket line must fail the connect")
@@ -1122,7 +1124,6 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         } catch {
             Issue.record("expected LinkError.exited, got \(error)")
         }
-        #expect(ContinuousClock.now - started < .seconds(10), "an exited client must not wait for the connect deadline")
     }
 
     @Test func disconnectStopsLinkAndEventChildrenBeforeReturning() async throws {

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -1093,6 +1093,38 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(Darwin.kill(pid, 0) == -1 && errno == ESRCH, "the link child must be reaped before connect returns")
     }
 
+    @Test func linkClientExitingBeforeItsSocketLineReportsTheExitNotATimeout() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cloud-connect-exit-\(UUID().uuidString.lowercased())", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let client = root.appendingPathComponent("fake-cmux-tui")
+        // An older bundled client that does not know a flag exits at once with a
+        // usage error and never prints a connection snapshot.
+        try """
+        #!/bin/sh
+        echo 'cmux-tui: unknown option "--carrier"' >&2
+        exit 2
+        """.write(to: client, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: client.path)
+        let link = CloudMachineLink(
+            machineID: "test-machine",
+            clientURL: client,
+            paths: CloudTuiClientPaths(home: root)
+        )
+        let started = ContinuousClock.now
+        do {
+            _ = try await link.connect(route: "ws://10.0.0.1:1337/v1/link", session: "main", carrier: true, timeout: .seconds(60))
+            Issue.record("a client that exits before its socket line must fail the connect")
+        } catch CloudMachineLink.LinkError.exited(let status, let output) {
+            #expect(status == 2)
+            #expect(output.contains("unknown option"), "the client's stderr must reach the error: \(output)")
+        } catch {
+            Issue.record("expected LinkError.exited, got \(error)")
+        }
+        #expect(ContinuousClock.now - started < .seconds(10), "an exited client must not wait for the connect deadline")
+    }
+
     @Test func disconnectStopsLinkAndEventChildrenBeforeReturning() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-cloud-disconnect-\(UUID().uuidString.lowercased())", isDirectory: true)

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -312,7 +312,7 @@ VM subcommands:
 | `vm ssh-info` | Print SSH connection info. |
 | `vm ssh-attach` | Internal attach helper. |
 | `vm exec` | Run a shell command inside a VM. |
-| `vm tui <id>` | Open the FULL cmux-tui client (its own workspaces/panes/tabs) in a pane — every other open gives a plain terminal instead; enrolls this Mac's device on first use (hidden helpers, used only by this command: `vm-tui-connect --config <file>` execs the local cmux-tui client in the pane; `vm-tui-approve --id <vm> --invitation-id <id> [--invite-file <path>]` is the detached process that approves the pending enrollment through the app and removes the invite file). |
+| `vm tui <id>` | Open the FULL cmux-tui client (its own workspaces/panes/tabs) in a pane — every other open gives a plain terminal instead; dials the machine's trusted-carrier listener over the private network, so no device enrollment or approval happens (hidden helper, used only by this command: `vm-tui-connect --config <file>` execs the local cmux-tui client in the pane). |
 | `vm run -- <command...>` | Run a command without naming a machine: reuses an idle machine the router provisioned earlier (persisted in `~/.cmuxterm/vm-run-pool.json`, labeled `agent-pool`), wakes a sleeper, or provisions a fresh one; `--sync` pushes the cwd first, `--pull <remote>` fetches results, and the remote exit code passes through. |
 | `vm push <id> <local> [remote]`, `vm upload` | Copy a local file or directory onto a VM over the exec channel (base64-chunked, SHA-256 verified; directories travel as tarballs). |
 | `vm pull <id> <remote> [local]`, `vm download` | Copy a file or directory from a VM to local disk over the exec channel. |

--- a/docs/cloud-cmux-tui-daemon.md
+++ b/docs/cloud-cmux-tui-daemon.md
@@ -341,35 +341,41 @@ The rejected alternatives are explicit:
 ## Lease/auth integration with the attach-endpoint flow
 
 `POST /api/vm/[id]/attach-endpoint` returns
-`{transport:"cmux-remote", route, token, expiresAtUnix, session, invitation?}`.
+`{transport:"cmux-remote", route, token, expiresAtUnix, session, trustedCarrier}`.
 The route is a direct Freestyle private IPv4 address on port 1337 when available,
 then private IPv6 for machines with a VPC, or the machine's public IPv6 for legacy
 public-network machines.
 The provider route token is recorded as a hash in the lease ledger and is not
-used as daemon session authentication. The cmux-tui Noise handshake and the
-enrolled device key authenticate the session. Private-network machines are
-reachable only when the owner's WireGuard tunnel is active.
+used as daemon session authentication. Private-network machines are reachable
+only when the owner's WireGuard tunnel is active, and that reachability is the
+admission: the daemon's cloud listener runs in trusted-carrier mode
+(`--remote-ws-trusted-carrier`, or `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1` from
+the driver's systemd drop-in), so every link that reaches it is granted carrier
+authentication keyed by the client's own key. There is no device enrollment,
+no invitation, and no approval on the cloud path. The Noise handshake still
+runs for encryption and key binding; only the authorization check changed.
+Every other transport on the same daemon (unix, ssh, relay, iroh) keeps the
+enrollment model, and plain network evidence on an untrusted listener is still
+refused, so the flag is a property of that one listener.
 
 - `route` is a `ws://[address]:1337/v1/link` endpoint. It must never be copied
   into a durable invitation or log. The route posture is read from the VM, so
   changing the private-network feature flag cannot strand an existing VM.
-- `invitation` is present only when this client device is not yet enrolled
-  with this VM's daemon. The endpoint execs `remote enroll create --ttl 300`
-  in the VM and returns the single-use `cmux://enroll/...` URI. The Mac claims
-  it through `remote connect --invite-file`; the control plane approves the
-  matching invitation through `/cmux-remote/approve`. Approval and device
-  enrollment are separate from the short-lived provider lease.
-- After first enrollment the device key lives in the Mac's client state and
-  reattach needs only a fresh route and a valid device key. Revocation removes
-  the control-plane lease row. Freestyle does not yet revoke the daemon device
-  record because the lease ledger does not persist the claimed device id. This
-  is an explicit security follow-up: persist the returned fingerprint/device id
-  per lease, then call `remote enroll revoke <device-id>` for exactly those rows.
-  Never revoke every device on a team VM when one member signs out.
+- `trustedCarrier` is true when the machine's daemon serves the trusted
+  listener; the Mac then dials `remote connect <route> --carrier`. The endpoint
+  brings a daemon from an older bake to the pinned build and restarts it with
+  the drop-in, except under a device that is already enrolled there (the
+  restart would end its sessions); that device keeps dialing with its stored
+  key, and `trustedCarrier` is false for it until the machine is restarted for
+  another reason.
+- Revocation is the private network's: deleting a Mac's WireGuard peer ends
+  every connection from it at once. `POST /cmux-remote/approve` remains as a
+  no-op that answers `approved` for older Mac builds and is deleted once they
+  have rolled.
 
-Per-VM daemon identity plus per-user device keys give cloud attach the same
-model as every other cmux-tui remote (ssh, iroh, relay), which is what makes
-the right-pane drag UX (below) uniform.
+The trusted listener is what gives cloud attach one trust layer: the private
+network. The right-pane drag UX (below) stays uniform because the daemon still
+names every connection by the client's key.
 
 ## macOS integration: manual IO instead of a PTY bridge
 

--- a/docs/cloud-userspace-wireguard.md
+++ b/docs/cloud-userspace-wireguard.md
@@ -40,10 +40,11 @@ The first terminal use creates the terminal peer through `POST /api/vm/tunnel`.
 The completed WireGuard configuration stays on the Mac with mode 0600. Later
 app launches reuse it and make no Freestyle tunnel call.
 
-The first cmux-tui connection to one VM still needs one device invitation. The
-control plane creates and approves that invitation. The invitation is sent
-through the private WireGuard link. Later connections use the saved cmux-tui
-device key and private route, with no connection ticket and no Freestyle call.
+cmux-tui connections need no device invitation and no approval. The VM's
+daemon serves a trusted-carrier listener that is reachable only inside the
+private network, so the Mac dials `remote connect <route> --carrier` and is
+admitted by the network itself. Every connection uses the private route, with
+no connection ticket and no Freestyle call.
 
 ## Browser path
 
@@ -94,12 +95,12 @@ Freestyle calls required by this design are:
 5. Create, delete, start, stop, resize, or inspect a VM when the user requests
    that management operation.
 
-The first cmux-tui device invitation per Mac and VM uses one control-plane
-approval request and one Freestyle VM command. The command waits for the claim
-on the VM's local daemon socket. The Mac does not poll Vercel or Freestyle. This
-flow is not part of normal reconnect traffic. Machine list refresh can use the
-Cloud API, but live workspace, terminal, pane, display, and agent metadata comes
-from cmux-tui through the terminal WireGuard link.
+The first attach to a machine whose daemon predates the trusted listener costs
+one control-plane request that brings the daemon to the pinned build and
+restarts it with the trusted drop-in. Nothing is approved and the Mac does not
+poll Vercel or Freestyle. Machine list refresh can use the Cloud API, but live
+workspace, terminal, pane, display, and agent metadata comes from cmux-tui
+through the terminal WireGuard link.
 
 ## WireGuard implementation
 

--- a/web/app/api/vm/[id]/cmux-remote/approve/route.ts
+++ b/web/app/api/vm/[id]/cmux-remote/approve/route.ts
@@ -9,11 +9,11 @@ import { approveVmCmuxRemoteEnrollment, runVmWorkflow } from "../../../../../../
 import { parseLenientObjectBody } from "../../../../../../services/vms/routeInput";
 
 /**
- * Approves the cmux-tui device enrollment that a prior `attach-endpoint`
- * (`transport: "cmux-remote"`) invited. The control plane is the daemon owner: it
- * minted the invitation for this authenticated user, so approving the pending claim
- * is the honest encoding of "the web tier already authenticated this device". One
- * request waits for the claim inside the VM and then approves it.
+ * Compatibility endpoint. Cloud machines serve a trusted-carrier listener
+ * (reachable only inside the owner's private network), so there is no device
+ * enrollment to approve: the provider answers `approved` without touching the
+ * machine. Older Mac builds call this once after their first connect; the
+ * route stays until every published build has stopped calling it.
  */
 export async function POST(
   request: Request,

--- a/web/scripts/verify-devbox-private-link.ts
+++ b/web/scripts/verify-devbox-private-link.ts
@@ -90,19 +90,15 @@ function verify(image: string, client: string) {
     const hub = yield* startPrivateLinkClient(client, ["wg", "hub", "--config", configPath, "--socket", hubSocket], { event: "hub-ready", socket: hubSocket });
     yield* hub.ready;
     const endpoint = yield* attempt("Read image attach bundle failed", () => provider.openCmuxRemote(vm.providerVmId, { clientCapabilities: probe.capabilities }));
-    if (!endpoint.invitation) return yield* Effect.fail(new Error("Fresh VM returned no enrollment invitation"));
-    const invitation = endpoint.invitation;
-    const invitePath = path.join(root, "invite");
-    yield* Effect.try(() => writeFileSync(invitePath, invitation.uri, { mode: 0o600 }));
-    const args = ["remote", "connect", endpoint.route, "--state-dir", path.join(root, "identity"),
+    if (!endpoint.trustedCarrier) return yield* Effect.fail(new Error("Fresh VM does not serve the trusted-carrier listener"));
+    const args = ["remote", "connect", endpoint.route, "--carrier", "--state-dir", path.join(root, "identity"),
       "--device-name", slug, "--headless", "--json", "--wireguard-hub", hubSocket,
       "--connect-timeout-seconds", "30", "--reconnect-attempts", "1"];
-    // Enroll once, then reconnect from the persisted client identity with no
-    // control-plane attach/approval call. This also tests older baked daemons.
+    // Two carrier dials, no enrollment, no approval, no control-plane call in
+    // between: the private network is the only admission.
     yield* Effect.scoped(Effect.gen(function* () {
       const socket = path.join(root, "first.sock");
-      const connection = yield* startPrivateLinkClient(client, [...args, "--local-socket", socket, "--invite-file", invitePath], { event: "connection-snapshot", socket });
-      yield* attempt("Approve image enrollment failed", () => provider.approveCmuxRemoteEnrollment(vm.providerVmId, invitation.invitationId));
+      const connection = yield* startPrivateLinkClient(client, [...args, "--local-socket", socket], { event: "connection-snapshot", socket });
       yield* connection.ready;
       yield* readSnapshot(client, socket);
     }));
@@ -111,7 +107,7 @@ function verify(image: string, client: string) {
     yield* connection.ready;
     yield* readSnapshot(client, socket);
     console.log(JSON.stringify({ image, clientCommit: probe.build_identity,
-      daemonCommit: endpoint.daemonBuild?.commit, enrollment: "passed", reconnect: "passed", snapshot: "passed" }));
+      daemonCommit: endpoint.daemonBuild?.commit, trustedCarrier: true, reconnect: "passed", snapshot: "passed" }));
   });
 }
 

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -483,12 +483,16 @@ the root layout they are baked around.
 
 `POST /api/vm/[id]/attach-endpoint` with
 `{"transport":"cmux-remote","clientCapabilities":[...]}` returns
-`{route, token, session, daemonBuild?, invitation?}` where `invitation` is a single-use
-`cmux://enroll/…` URI minted only when the caller's device is not enrolled. The client
-connects with `cmux-tui remote connect <route> --invite-file …` through the user-space
-WireGuard hub, then
-`POST /api/vm/[id]/cmux-remote/approve {invitationId}` approves the pending claim (poll
-inside one provider-side wait command until `state` is `approved`). The legacy websocket/SSH attach (`attach-endpoint` without a
+`{route, token, session, trustedCarrier, daemonBuild?}`. The machine's daemon serves a
+trusted-carrier listener: the route is reachable only inside the owner's private network,
+whose members are all the owner's, so the daemon grants every link carrier
+authentication and the client connects with `cmux-tui remote connect <route> --carrier`
+through the user-space WireGuard hub — no device enrollment, no invitation, no approval.
+The endpoint brings a daemon from an older bake to the pinned build and restarts it with
+the trusted drop-in, except under a device that is already enrolled there (its sessions
+would end); that device keeps dialing with its stored key. `POST
+/api/vm/[id]/cmux-remote/approve` remains as a no-op that answers `approved` for older
+Mac builds. The legacy websocket/SSH attach (`attach-endpoint` without a
 transport, `POST /api/vm/[id]/sessions`) answers `409 vm_attach_transport_unsupported` with
 `details.supportedTransports: ["cmux-remote"]`. `cmux vm shell`, `cmux vm new`,
 `cmux vm base open` and the Machines panel all drive this from the Mac.

--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -21,7 +21,15 @@ export function shellQuote(value: string): string {
 export const CMUX_TUI_PORT = 1337;
 export const CMUX_TUI_SESSION = "cloud";
 export const CMUX_TUI_BINARY_PATH = "/root/.cmux/bin/cmux-tui";
-export const CMUX_TUI_INVITATION_TTL_SECONDS = 5 * 60;
+/**
+ * The daemon's cloud listener is reachable only inside the owner's private
+ * network (every member is the owner's Mac or another of the owner's machines),
+ * so it grants carrier authentication to every link: no device enrollment, no
+ * invitation, no approval. The env form is what a systemd drop-in sets on a
+ * machine whose baked launch line predates the flag; the daemon reads either.
+ */
+export const CMUX_TUI_TRUSTED_CARRIER_ENV = "CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER";
+export const CMUX_TUI_TRUSTED_CARRIER_FLAG = "--remote-ws-trusted-carrier";
 export const CMUX_TUI_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
 // A provider can attach the volume after the process starts, but a permanently
 // missing volume must fail through the provider's restart/reconciliation path.
@@ -488,7 +496,7 @@ export function cmuxTuiDaemonCommand(
   layout?: CmuxTuiHomeLayout,
   options?: CmuxTuiDaemonOptions,
 ): string {
-  const args = `server start --session ${CMUX_TUI_SESSION} --remote-ws ${remoteWsBind} --remote-ws-insecure-bind`;
+  const args = `server start --session ${CMUX_TUI_SESSION} --remote-ws ${remoteWsBind} --remote-ws-insecure-bind ${CMUX_TUI_TRUSTED_CARRIER_FLAG}`;
   if (!layout) {
     return `cd /root && env HOME=/root TERM=xterm-256color ${CMUX_TUI_BINARY_PATH} ${args}`;
   }
@@ -560,36 +568,6 @@ export function cmuxTuiDaemonCommand(
   );
 }
 
-/** Enrollment invitations are `cmux://enroll/<base64url JSON>`; the id and expiry inside are what the approve flow needs. */
-export function parseEnrollmentInvitationUri(
-  uri: string,
-  provider: ProviderId = "freestyle",
-): { id: string; expiresAtUnix: number; daemonFingerprint: string | null } {
-  const prefix = "cmux://enroll/";
-  if (!uri.startsWith(prefix)) {
-    throw new ProviderError(provider, "cmux-tui returned an invitation with an unexpected scheme");
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(Buffer.from(uri.slice(prefix.length), "base64url").toString("utf8"));
-  } catch (err) {
-    throw new ProviderError(provider, "cmux-tui returned an undecodable invitation", err);
-  }
-  const record = parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
-  const id = typeof record.id === "string" ? record.id : "";
-  const expiresAtUnix = typeof record.expires_at_unix === "number" ? record.expires_at_unix : 0;
-  if (!id || !expiresAtUnix) {
-    throw new ProviderError(provider, "cmux-tui returned an invitation without an id or expiry");
-  }
-  return {
-    id,
-    expiresAtUnix,
-    daemonFingerprint: typeof record.daemon_fingerprint === "string" ? record.daemon_fingerprint : null,
-  };
-}
-
-export const ENROLLMENT_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
-
 export function parseJsonObject(text: string): Record<string, unknown> {
   try {
     const value = JSON.parse(text.trim());
@@ -646,50 +624,42 @@ export async function cmuxTuiDaemonBuild(
   return { commit, remoteProtocol, version };
 }
 
-export async function mintCmuxTuiInvitation(
-  invoke: CmuxTuiInvoke,
-  provider: ProviderId,
-  vmId: string,
-): Promise<NonNullable<CmuxRemoteEndpoint["invitation"]>> {
-  const created = await invoke(
-    `remote enroll create --session ${CMUX_TUI_SESSION} --ttl ${CMUX_TUI_INVITATION_TTL_SECONDS} --json`,
-  );
-  if (created.exitCode !== 0) {
-    throw new ProviderError(provider, `cmux-tui enrollment invitation in ${vmId} failed: ${created.stderr || created.stdout}`);
-  }
-  const uri = parseJsonObject(created.stdout).uri;
-  if (typeof uri !== "string" || !uri) {
-    throw new ProviderError(provider, `cmux-tui enrollment invitation in ${vmId} returned no uri`);
-  }
-  const parsed = parseEnrollmentInvitationUri(uri, provider);
-  return { uri, invitationId: parsed.id, expiresAtUnix: parsed.expiresAtUnix };
-}
-
-export async function isCmuxTuiDeviceEnrolled(
-  invoke: CmuxTuiInvoke,
-  fingerprint: string,
-): Promise<boolean> {
-  const devices = await invoke(`remote enroll devices --session ${CMUX_TUI_SESSION} --json`).catch(() => null);
-  if (!devices || devices.exitCode !== 0) return false;
-  return parseJsonArray(devices.stdout).some((device) =>
-    device.fingerprint === fingerprint && (device.revoked_at_unix === null || device.revoked_at_unix === undefined)
-  );
-}
-
 /**
- * Everything attach needs from the daemon in ONE guest exec instead of four:
- * an optional readiness gate (exit 3 when it fails, so the caller can run the
- * heal), the daemon build (`remote-probe`), the enrolled devices, and, unless
- * the caller's fingerprint is already among them, a fresh invitation. Each
- * section is fenced by a marker line so the outputs parse independently.
+ * Everything attach needs from the daemon in ONE guest exec: an optional
+ * readiness gate (exit 3 when it fails, so the caller can run the heal), the
+ * daemon build (`remote-probe`), the enrolled devices (so a machine where the
+ * caller is already enrolled is never restarted under it), and whether the
+ * running daemon serves the trusted-carrier listener. Each section is fenced
+ * by a marker line so the outputs parse independently.
  */
 export const CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT = 3;
-const BUNDLE_MARKERS = { probe: "__CMUX_PROBE__", devices: "__CMUX_DEVICES__", invite: "__CMUX_INVITE__", end: "__CMUX_END__" } as const;
+const BUNDLE_MARKERS = { probe: "__CMUX_PROBE__", devices: "__CMUX_DEVICES__", trusted: "__CMUX_TRUSTED__", end: "__CMUX_END__" } as const;
+
+/**
+ * Prints `1` when the daemon process that owns the cloud session serves the
+ * trusted-carrier listener: it was started with the flag or the env, AND its
+ * binary is the pinned build (an older binary ignores both, so the env alone
+ * proves nothing). Anything else prints `0`.
+ */
+export function cmuxTuiTrustedListenerProbe(pinnedSha256?: string): string {
+  if (pinnedSha256 !== undefined && !/^[0-9a-f]{64}$/.test(pinnedSha256)) {
+    throw new Error("pinned sha256 has an unexpected shape");
+  }
+  const binaryMatches = pinnedSha256
+    ? ` && printf '%s  %s\\n' ${shellQuote(pinnedSha256)} "/proc/$p/exe" | sha256sum -c >/dev/null 2>&1`
+    : "";
+  return (
+    "p=$(pgrep -f 'cmux-tui server [s]tart' | head -n1); " +
+    `if [ -n "$p" ] && { tr '\\0' '\\n' < "/proc/$p/environ" 2>/dev/null | grep -qx ${shellQuote(`${CMUX_TUI_TRUSTED_CARRIER_ENV}=1`)} || tr '\\0' '\\n' < "/proc/$p/cmdline" 2>/dev/null | grep -qx -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; }${binaryMatches}; then echo 1; else echo 0; fi`
+  );
+}
 
 export function cmuxTuiAttachBundleCommand(options: {
   readonly readyGate?: string;
   readonly deviceFingerprint?: string;
   readonly binary?: string;
+  /** The manifest's sha256; the trusted probe reports `1` only for a daemon running this build. */
+  readonly pinnedSha256?: string;
 }): string {
   const bin = options.binary ?? CMUX_TUI_BINARY_PATH;
   const run = `env HOME=/root ${bin}`;
@@ -697,13 +667,6 @@ export function cmuxTuiAttachBundleCommand(options: {
   if (fingerprint !== undefined && fingerprint !== "" && !/^[A-Za-z0-9._:=+/-]+$/.test(fingerprint)) {
     throw new Error("device fingerprint has an unexpected shape");
   }
-  // The shell decides only whether to mint; the server re-derives "enrolled"
-  // from the devices JSON and mints separately if the two disagree.
-  const needle = fingerprint ? `"fingerprint":"${fingerprint}"` : "";
-  const mint = `${run} remote enroll create --session ${CMUX_TUI_SESSION} --ttl ${CMUX_TUI_INVITATION_TTL_SECONDS} --json`;
-  const invite = needle
-    ? `case "$D" in *${shellQuote(needle)}*) ;; *) ${mint};; esac`
-    : mint;
   return [
     // Run the readiness probe in a subshell. The Freestyle gate uses `exit` for
     // its success and failure branches; without a subshell those exits terminate
@@ -712,17 +675,19 @@ export function cmuxTuiAttachBundleCommand(options: {
     `echo ${BUNDLE_MARKERS.probe}`,
     `${run} remote-probe --json; echo`,
     `echo ${BUNDLE_MARKERS.devices}`,
-    `D=$(${run} remote enroll devices --session ${CMUX_TUI_SESSION} --json); printf '%s\\n' "$D"`,
-    `echo ${BUNDLE_MARKERS.invite}`,
-    `${invite}; echo`,
+    `${run} remote enroll devices --session ${CMUX_TUI_SESSION} --json; echo`,
+    `echo ${BUNDLE_MARKERS.trusted}`,
+    cmuxTuiTrustedListenerProbe(options.pinnedSha256),
     `echo ${BUNDLE_MARKERS.end}`,
   ].join("; ");
 }
 
 export type CmuxTuiAttachBundle = {
   readonly daemonBuild: CmuxRemoteEndpoint["daemonBuild"] | null;
+  /** The caller's device is on the daemon's enrolled list (only known when a fingerprint was given). */
   readonly enrolled: boolean;
-  readonly invitation: NonNullable<CmuxRemoteEndpoint["invitation"]> | null;
+  /** The running daemon grants carrier authentication on its cloud listener. */
+  readonly trustedCarrier: boolean;
 };
 
 /** Parses the fenced stdout of {@link cmuxTuiAttachBundleCommand}. */
@@ -739,8 +704,8 @@ export function parseCmuxTuiAttachBundle(
     return stdout.slice(start + from.length, end).trim();
   };
   const probeText = section(BUNDLE_MARKERS.probe, BUNDLE_MARKERS.devices);
-  const devicesText = section(BUNDLE_MARKERS.devices, BUNDLE_MARKERS.invite);
-  const inviteText = section(BUNDLE_MARKERS.invite, BUNDLE_MARKERS.end);
+  const devicesText = section(BUNDLE_MARKERS.devices, BUNDLE_MARKERS.trusted);
+  const trustedText = section(BUNDLE_MARKERS.trusted, BUNDLE_MARKERS.end);
   let daemonBuild: CmuxTuiAttachBundle["daemonBuild"] = null;
   try {
     const record = parseJsonObject(probeText);
@@ -761,76 +726,9 @@ export function parseCmuxTuiAttachBundle(
       enrolled = false;
     }
   }
-  let invitation: CmuxTuiAttachBundle["invitation"] = null;
-  if (inviteText) {
-    const uri = parseJsonObject(inviteText).uri;
-    if (typeof uri !== "string" || !uri) {
-      throw new ProviderError(provider, `cmux-tui enrollment invitation in ${vmId} returned no uri`);
-    }
-    const parsed = parseEnrollmentInvitationUri(uri, provider);
-    invitation = { uri, invitationId: parsed.id, expiresAtUnix: parsed.expiresAtUnix };
-  }
-  return { daemonBuild, enrolled, invitation };
-}
-
-export async function approveCmuxTuiEnrollment(
-  invoke: (command: string, timeoutMs: number) => Promise<ExecResult>,
-  provider: ProviderId,
-  vmId: string,
-  invitationId: string,
-): Promise<{ approved: boolean; state: "approved" | "pending"; deviceFingerprint?: string }> {
-  if (!ENROLLMENT_ID_PATTERN.test(invitationId)) {
-    throw new ProviderError(provider, "invitation id has an unexpected shape");
-  }
-  const approved = await invoke(cmuxTuiApproveWaitCommand(invitationId), 40_000);
-  if (approved.exitCode !== 0) {
-    throw new ProviderError(provider, `cmux-tui enrollment approval in ${vmId} failed: ${approved.stderr || approved.stdout}`);
-  }
-  const device = parseJsonObject(approved.stdout);
-  const fingerprint = typeof device.fingerprint === "string" ? device.fingerprint : undefined;
-  return { approved: true, state: "approved", ...(fingerprint ? { deviceFingerprint: fingerprint } : {}) };
-}
-
-/**
- * One guest command waits for the invitation claim on the daemon's local socket,
- * then approves it. The Mac makes one Vercel request and Vercel makes one provider
- * exec request. The bounded local checks do not cross either control plane.
- */
-export function cmuxTuiApproveWaitCommand(
-  invitationId: string,
-  options: {
-    readonly binaryPath?: string;
-    readonly attempts?: number;
-    readonly delaySeconds?: number;
-  } = {},
-): string {
-  if (!ENROLLMENT_ID_PATTERN.test(invitationId)) {
-    throw new Error("invitation id has an unexpected shape");
-  }
-  const attempts = options.attempts ?? 120;
-  const delaySeconds = options.delaySeconds ?? 0.25;
-  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 120) {
-    throw new Error("approval attempts must be an integer from 1 through 120");
-  }
-  if (!Number.isFinite(delaySeconds) || delaySeconds < 0.01 || delaySeconds > 1) {
-    throw new Error("approval delay must be from 0.01 through 1 second");
-  }
-  const binary = shellQuote(options.binaryPath ?? CMUX_TUI_BINARY_PATH);
-  const approve =
-    `env HOME=/root ${binary} remote enroll approve ${shellQuote(invitationId)} ` +
-    `--session ${CMUX_TUI_SESSION} --json`;
-  return `
-cmux_approve_attempt=0
-cmux_approve_output=''
-while [ "$cmux_approve_attempt" -lt ${attempts} ]; do
-  if cmux_approve_output="$(${approve} 2>&1)"; then
-    printf '%s\\n' "$cmux_approve_output"
-    exit 0
-  fi
-  cmux_approve_attempt=$((cmux_approve_attempt + 1))
-  sleep ${delaySeconds}
-done
-printf '%s\\n' "$cmux_approve_output" >&2
-exit 75
-`.trim();
+  // Fail closed: a missing or malformed section means the caller must heal.
+  const trustedCarrier = trustedText.split("\n").pop()?.trim() === "1";
+  void provider;
+  void vmId;
+  return { daemonBuild, enrolled, trustedCarrier };
 }

--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -637,20 +637,17 @@ const BUNDLE_MARKERS = { probe: "__CMUX_PROBE__", devices: "__CMUX_DEVICES__", t
 
 /**
  * Prints `1` when the daemon process that owns the cloud session serves the
- * trusted-carrier listener: it was started with the flag or the env, AND its
- * binary is the pinned build (an older binary ignores both, so the env alone
- * proves nothing). Anything else prints `0`.
+ * trusted-carrier listener: it was started with the flag or the env, AND the
+ * binary it runs knows the flag (its `--help` names it). An older binary
+ * ignores the env, so the env alone proves nothing; asking the running binary
+ * itself also keeps the answer honest while the pinned manifest and the
+ * machine's install disagree. Anything else prints `0`.
  */
-export function cmuxTuiTrustedListenerProbe(pinnedSha256?: string): string {
-  if (pinnedSha256 !== undefined && !/^[0-9a-f]{64}$/.test(pinnedSha256)) {
-    throw new Error("pinned sha256 has an unexpected shape");
-  }
-  const binaryMatches = pinnedSha256
-    ? ` && printf '%s  %s\\n' ${shellQuote(pinnedSha256)} "/proc/$p/exe" | sha256sum -c >/dev/null 2>&1`
-    : "";
+export function cmuxTuiTrustedListenerProbe(): string {
   return (
     "p=$(pgrep -f 'cmux-tui server [s]tart' | head -n1); " +
-    `if [ -n "$p" ] && { tr '\\0' '\\n' < "/proc/$p/environ" 2>/dev/null | grep -qx ${shellQuote(`${CMUX_TUI_TRUSTED_CARRIER_ENV}=1`)} || tr '\\0' '\\n' < "/proc/$p/cmdline" 2>/dev/null | grep -qx -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; }${binaryMatches}; then echo 1; else echo 0; fi`
+    `if [ -n "$p" ] && { tr '\\0' '\\n' < "/proc/$p/environ" 2>/dev/null | grep -qx ${shellQuote(`${CMUX_TUI_TRUSTED_CARRIER_ENV}=1`)} || tr '\\0' '\\n' < "/proc/$p/cmdline" 2>/dev/null | grep -qx -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; }` +
+    ` && "/proc/$p/exe" --help 2>/dev/null | grep -q -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; then echo 1; else echo 0; fi`
   );
 }
 
@@ -658,8 +655,6 @@ export function cmuxTuiAttachBundleCommand(options: {
   readonly readyGate?: string;
   readonly deviceFingerprint?: string;
   readonly binary?: string;
-  /** The manifest's sha256; the trusted probe reports `1` only for a daemon running this build. */
-  readonly pinnedSha256?: string;
 }): string {
   const bin = options.binary ?? CMUX_TUI_BINARY_PATH;
   const run = `env HOME=/root ${bin}`;
@@ -677,7 +672,7 @@ export function cmuxTuiAttachBundleCommand(options: {
     `echo ${BUNDLE_MARKERS.devices}`,
     `${run} remote enroll devices --session ${CMUX_TUI_SESSION} --json; echo`,
     `echo ${BUNDLE_MARKERS.trusted}`,
-    cmuxTuiTrustedListenerProbe(options.pinnedSha256),
+    cmuxTuiTrustedListenerProbe(),
     `echo ${BUNDLE_MARKERS.end}`,
   ].join("; ");
 }

--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -638,16 +638,18 @@ const BUNDLE_MARKERS = { probe: "__CMUX_PROBE__", devices: "__CMUX_DEVICES__", t
 /**
  * Prints `1` when the daemon process that owns the cloud session serves the
  * trusted-carrier listener: it was started with the flag or the env, AND the
- * binary it runs knows the flag (its `--help` names it). An older binary
- * ignores the env, so the env alone proves nothing; asking the running binary
- * itself also keeps the answer honest while the pinned manifest and the
- * machine's install disagree. Anything else prints `0`.
+ * binary it runs parses the flag (`--remote-ws-trusted-carrier --version`
+ * exits 0; an older binary rejects the unknown argument with exit 2 before
+ * it reaches `--version`). An older binary ignores the env, so the env alone
+ * proves nothing; asking the running binary itself also keeps the answer
+ * honest while the pinned manifest and the machine's install disagree.
+ * Anything else prints `0`.
  */
 export function cmuxTuiTrustedListenerProbe(): string {
   return (
     "p=$(pgrep -f 'cmux-tui server [s]tart' | head -n1); " +
     `if [ -n "$p" ] && { tr '\\0' '\\n' < "/proc/$p/environ" 2>/dev/null | grep -qx ${shellQuote(`${CMUX_TUI_TRUSTED_CARRIER_ENV}=1`)} || tr '\\0' '\\n' < "/proc/$p/cmdline" 2>/dev/null | grep -qx -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; }` +
-    ` && "/proc/$p/exe" --help 2>/dev/null | grep -q -- ${shellQuote(CMUX_TUI_TRUSTED_CARRIER_FLAG)}; then echo 1; else echo 0; fi`
+    ` && "/proc/$p/exe" ${CMUX_TUI_TRUSTED_CARRIER_FLAG} --version >/dev/null 2>&1; then echo 1; else echo 0; fi`
   );
 }
 

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -53,14 +53,13 @@ import {
   CMUX_TUI_INSTALL_TIMEOUT_MS,
   CMUX_TUI_PORT,
   CMUX_TUI_SESSION,
-  approveCmuxTuiEnrollment,
+  CMUX_TUI_TRUSTED_CARRIER_ENV,
   CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT,
   cmuxTuiAttachBundleCommand,
   cmuxTuiDaemonBuild,
   cmuxTuiDaemonCommand,
   cmuxTuiInstallCommand,
   cmuxTuiPinCheckCommand,
-  mintCmuxTuiInvitation,
   parseCmuxTuiAttachBundle,
   resolveCmuxTuiSource,
   type CmuxTuiSource,
@@ -684,18 +683,19 @@ const REMOTE_WS_BIND_OVERRIDE =
   "/etc/systemd/system/cmux-tui-daemon.service.d/10-cmux-remote-ws-bind.conf";
 
 /**
- * (Re)start the daemon listening dual-stack. Under systemd (the baked
- * cmux-tui-daemon unit), install a drop-in setting
- * CMUX_TUI_REMOTE_WS_BIND=[::]:1337 — the env cmux-devbox-boot reads — then
- * restart the unit, healing machines from bakes that predate the env default.
- * Without systemd (or the unit), fall back to a direct daemon launch with the
- * dual-stack bind.
+ * (Re)start the daemon listening dual-stack with the trusted-carrier listener.
+ * Under systemd (the baked cmux-tui-daemon unit), install a drop-in setting
+ * CMUX_TUI_REMOTE_WS_BIND=[::]:1337 — the env cmux-devbox-boot reads — and
+ * CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1 — which the daemon itself reads, so a
+ * baked launch line that predates the flag still serves the trusted listener —
+ * then restart the unit. Without systemd (or the unit), fall back to a direct
+ * daemon launch carrying both.
  */
 export function freestyleStartDaemonCommand(): string {
   return [
     "if [ -d /run/systemd/system ] && [ -f /etc/systemd/system/cmux-tui-daemon.service ]; then",
     `mkdir -p ${REMOTE_WS_BIND_OVERRIDE.replace(/\/[^/]+$/, "")};`,
-    `printf '[Service]\\nEnvironment=CMUX_TUI_REMOTE_WS_BIND=${FREESTYLE_REMOTE_WS_BIND}\\n' > ${REMOTE_WS_BIND_OVERRIDE};`,
+    `printf '[Service]\\nEnvironment=CMUX_TUI_REMOTE_WS_BIND=${FREESTYLE_REMOTE_WS_BIND}\\nEnvironment=${CMUX_TUI_TRUSTED_CARRIER_ENV}=1\\n' > ${REMOTE_WS_BIND_OVERRIDE};`,
     "systemctl daemon-reload;",
     "systemctl restart cmux-tui-daemon;",
     "else",
@@ -1323,21 +1323,31 @@ export class FreestyleProvider implements VMProvider {
           const data = persisted ?? await vm.data();
           const route = freestyleCmuxRemoteRoute(data, vmId);
           const fingerprint = options?.deviceFingerprint;
-          const { bundle, healed } = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint);
+          const source = await resolveCmuxTuiSource("freestyle");
+          let { bundle, healed } = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint, source);
+          // A daemon from a bake that predates the trusted listener is brought to
+          // the pinned build and restarted with the drop-in — but never under a
+          // device that is already enrolled there, whose sessions the restart
+          // would end; that device keeps dialing with its stored key.
+          if (!bundle.trustedCarrier && !bundle.enrolled) {
+            healed = true;
+            await this.installTrustedCmuxTui(vm, vmId, source);
+            const retried = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint, source);
+            bundle = retried.bundle;
+          }
           span.setAttribute("cmux.vm.cmux_remote.healed", healed);
+          span.setAttribute("cmux.vm.cmux_remote.trusted", bundle.trustedCarrier);
+          span.setAttribute("cmux.vm.cmux_remote.enrolled", bundle.enrolled);
           span.setAttribute("cmux.vm.network.private", (data.vpcs ?? data.networks ?? []).length > 0);
           span.setAttribute("cmux.vm.route.source", persisted ? "row" : "provider");
-          const invoke = this.cmuxTuiInvoke(vm);
-          const invitation = await this.cmuxRemoteInvitation(bundle, invoke, vmId);
-          span.setAttribute("cmux.vm.cmux_remote.invited", !bundle.enrolled);
           return {
             transport: "cmux-remote" as const,
             route,
             token: `cmux-freestyle-route-${randomBytes(32).toString("hex")}`,
             expiresAtUnix: Math.floor(Date.now() / 1000) + ROUTE_TOKEN_TTL_SECONDS,
             session: CMUX_TUI_SESSION,
+            trustedCarrier: bundle.trustedCarrier,
             ...(bundle.daemonBuild ? { daemonBuild: bundle.daemonBuild } : {}),
-            ...(invitation ? { invitation } : {}),
             ...this.networkAddresses(data),
           };
         } catch (err) {
@@ -1353,17 +1363,19 @@ export class FreestyleProvider implements VMProvider {
     vm: Vm,
     vmId: string,
     fingerprint: string | undefined,
+    source: CmuxTuiSource,
   ) {
+    const bundleOptions = { deviceFingerprint: fingerprint, pinnedSha256: source.sha256 };
     let result = await this.execResult(
       vm,
-      cmuxTuiAttachBundleCommand({ readyGate: freestyleDaemonSettledCommand(), deviceFingerprint: fingerprint }),
+      cmuxTuiAttachBundleCommand({ readyGate: freestyleDaemonSettledCommand(), ...bundleOptions }),
       DAEMON_SETTLE_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS + EXEC_DEFAULT_TIMEOUT_MS,
     );
     let healed = false;
     if (!result || result.exitCode === CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT) {
       healed = true;
       await this.ensureCmuxTuiRunning(vm, vmId);
-      result = await this.execResult(vm, cmuxTuiAttachBundleCommand({ deviceFingerprint: fingerprint }));
+      result = await this.execResult(vm, cmuxTuiAttachBundleCommand(bundleOptions));
     }
     if (!result || result.exitCode !== 0) {
       throw new ProviderError(
@@ -1374,13 +1386,22 @@ export class FreestyleProvider implements VMProvider {
     return { bundle: parseCmuxTuiAttachBundle(result.stdout, "freestyle", vmId, fingerprint), healed };
   }
 
-  private async cmuxRemoteInvitation(
-    bundle: ReturnType<typeof parseCmuxTuiAttachBundle>,
-    invoke: CmuxTuiInvoke,
-    vmId: string,
-  ): Promise<CmuxRemoteEndpoint["invitation"] | undefined> {
-    if (bundle.enrolled || bundle.invitation) return bundle.invitation ?? undefined;
-    return mintCmuxTuiInvitation(invoke, "freestyle", vmId);
+  /**
+   * Bring a machine's daemon to the pinned build and restart it with the
+   * trusted-carrier drop-in. The manifest sha decides the install, not the
+   * bake-time pin file: a bake that predates the trusted listener records a
+   * binary that ignores the env, and only a build that honors it counts.
+   */
+  private async installTrustedCmuxTui(vm: Vm, vmId: string, source: CmuxTuiSource): Promise<void> {
+    const pinned = await this.execResult(vm, cmuxTuiPinCheckCommand(source));
+    if (pinned?.exitCode !== 0) {
+      await this.execOrThrow(vm, vmId, cmuxTuiInstallCommand(source), CMUX_TUI_INSTALL_TIMEOUT_MS)
+        .catch((err: unknown) => {
+          throw new ProviderError("freestyle", `cmux-tui install in ${vmId} failed: ${errorMessage(err)}`);
+        });
+    }
+    await this.execOrThrow(vm, vmId, freestyleStartDaemonCommand(), 60_000);
+    await waitForCmuxTuiReady(this.cmuxTuiInvoke(vm), "freestyle", vmId);
   }
 
   private networkAddresses(data: FreestyleRouteAddresses): Pick<CmuxRemoteEndpoint, "networkAddresses"> {
@@ -1398,29 +1419,14 @@ export class FreestyleProvider implements VMProvider {
     options?: CmuxRemoteApprovalOptions,
   ): Promise<CmuxRemoteApprovalResult> {
     void options;
+    void invitationId;
+    // Compatibility: the trusted listener enrolls nobody, so there is nothing
+    // to approve and nothing to exec. Older Mac builds call this once after
+    // their first connect and only need `approved` back.
     return withVmSpan(
       "cmux.vm.provider.approve_cmux_remote_enrollment",
-      spanAttributes(vmId, "approve_cmux_remote_enrollment"),
-      async () => {
-        try {
-          const vm = this.deps.client().vms.ref(vmId);
-          return await approveCmuxTuiEnrollment(
-            async (command, timeoutMs) =>
-              await this.execResult(vm, command, timeoutMs) ?? {
-                exitCode: 124,
-                stdout: "",
-                stderr: "exec failed",
-              },
-            "freestyle",
-            vmId,
-            invitationId,
-          );
-        } catch (err) {
-          throw err instanceof ProviderError
-            ? err
-            : new ProviderError("freestyle", `approveCmuxRemoteEnrollment(${vmId}) failed`, err);
-        }
-      },
+      spanAttributes(vmId, "approve_cmux_remote_enrollment", { "cmux.vm.cmux_remote.approve_noop": true }),
+      async () => ({ approved: true, state: "approved" as const }),
     );
   }
 

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -1324,7 +1324,7 @@ export class FreestyleProvider implements VMProvider {
           const route = freestyleCmuxRemoteRoute(data, vmId);
           const fingerprint = options?.deviceFingerprint;
           const source = await resolveCmuxTuiSource("freestyle");
-          let { bundle, healed } = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint, source);
+          let { bundle, healed } = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint);
           // A daemon from a bake that predates the trusted listener is brought to
           // the pinned build and restarted with the drop-in — but never under a
           // device that is already enrolled there, whose sessions the restart
@@ -1332,7 +1332,7 @@ export class FreestyleProvider implements VMProvider {
           if (!bundle.trustedCarrier && !bundle.enrolled) {
             healed = true;
             await this.installTrustedCmuxTui(vm, vmId, source);
-            const retried = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint, source);
+            const retried = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint);
             bundle = retried.bundle;
           }
           span.setAttribute("cmux.vm.cmux_remote.healed", healed);
@@ -1363,9 +1363,8 @@ export class FreestyleProvider implements VMProvider {
     vm: Vm,
     vmId: string,
     fingerprint: string | undefined,
-    source: CmuxTuiSource,
   ) {
-    const bundleOptions = { deviceFingerprint: fingerprint, pinnedSha256: source.sha256 };
+    const bundleOptions = { deviceFingerprint: fingerprint };
     let result = await this.execResult(
       vm,
       cmuxTuiAttachBundleCommand({ readyGate: freestyleDaemonSettledCommand(), ...bundleOptions }),

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -691,7 +691,15 @@ const REMOTE_WS_BIND_OVERRIDE =
  * then restart the unit. Without systemd (or the unit), fall back to a direct
  * daemon launch carrying both.
  */
-export function freestyleStartDaemonCommand(): string {
+/**
+ * `replaceExisting` is the trusted-listener heal: a daemon that already runs
+ * without the trusted env must go, or installing the pinned binary changes
+ * nothing for the live process. systemd restarts unconditionally; the
+ * fallback launcher otherwise keeps a running daemon.
+ */
+export function freestyleStartDaemonCommand(options?: { replaceExisting?: boolean }): string {
+  const replace = options?.replaceExisting === true;
+  const fallbackLaunch = `(setsid nohup sh -c '${cmuxTuiDaemonCommand(FREESTYLE_REMOTE_WS_BIND)}' >>/tmp/cmux-tui-daemon.log 2>&1 &)`;
   return [
     "if [ -d /run/systemd/system ] && [ -f /etc/systemd/system/cmux-tui-daemon.service ]; then",
     `mkdir -p ${REMOTE_WS_BIND_OVERRIDE.replace(/\/[^/]+$/, "")};`,
@@ -699,7 +707,9 @@ export function freestyleStartDaemonCommand(): string {
     "systemctl daemon-reload;",
     "systemctl restart cmux-tui-daemon;",
     "else",
-    `pgrep -f 'cmux-tui server [s]tart' >/dev/null 2>&1 || (setsid nohup sh -c '${cmuxTuiDaemonCommand(FREESTYLE_REMOTE_WS_BIND)}' >>/tmp/cmux-tui-daemon.log 2>&1 &);`,
+    replace
+      ? `pkill -f 'cmux-tui server [s]tart' >/dev/null 2>&1; sleep 1; ${fallbackLaunch};`
+      : `pgrep -f 'cmux-tui server [s]tart' >/dev/null 2>&1 || ${fallbackLaunch};`,
     "fi",
   ].join(" ");
 }
@@ -1323,17 +1333,25 @@ export class FreestyleProvider implements VMProvider {
           const data = persisted ?? await vm.data();
           const route = freestyleCmuxRemoteRoute(data, vmId);
           const fingerprint = options?.deviceFingerprint;
-          const source = await resolveCmuxTuiSource("freestyle");
           let { bundle, healed } = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint);
           // A daemon from a bake that predates the trusted listener is brought to
           // the pinned build and restarted with the drop-in — but never under a
           // device that is already enrolled there, whose sessions the restart
-          // would end; that device keeps dialing with its stored key.
+          // would end; that device keeps dialing with its stored key. The
+          // manifest is read only here, so a manifest outage cannot reject an
+          // attach that needs no heal.
           if (!bundle.trustedCarrier && !bundle.enrolled) {
             healed = true;
+            const source = await this.deps.resolveDaemonSource("freestyle");
             await this.installTrustedCmuxTui(vm, vmId, source);
             const retried = await this.loadCmuxRemoteBundle(vm, vmId, fingerprint);
             bundle = retried.bundle;
+            if (!bundle.trustedCarrier) {
+              throw new ProviderError(
+                "freestyle",
+                `cmux-tui daemon in ${vmId} still refuses the trusted listener after the pinned build was installed and restarted`,
+              );
+            }
           }
           span.setAttribute("cmux.vm.cmux_remote.healed", healed);
           span.setAttribute("cmux.vm.cmux_remote.trusted", bundle.trustedCarrier);
@@ -1399,7 +1417,7 @@ export class FreestyleProvider implements VMProvider {
           throw new ProviderError("freestyle", `cmux-tui install in ${vmId} failed: ${errorMessage(err)}`);
         });
     }
-    await this.execOrThrow(vm, vmId, freestyleStartDaemonCommand(), 60_000);
+    await this.execOrThrow(vm, vmId, freestyleStartDaemonCommand({ replaceExisting: true }), 60_000);
     await waitForCmuxTuiReady(this.cmuxTuiInvoke(vm), "freestyle", vmId);
   }
 

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -214,6 +214,15 @@ export type CmuxRemoteEndpoint = {
     remoteProtocol: number | null;
     version: string | null;
   };
+  /**
+   * The daemon's cloud listener grants carrier authentication: the client dials
+   * `remote connect --carrier` with no enrollment and no invitation, because the
+   * route is reachable only inside the owner's private network. False only for
+   * a daemon the provider could not bring to the trusted build, in which case
+   * an already-enrolled device may still dial with its stored key.
+   */
+  trustedCarrier: boolean;
+  /** @deprecated Never returned since the trusted listener; kept so older clients decode. */
   invitation?: {
     /** Single-use `cmux://enroll/...` URI; the client must pass it via `--invite-file`, never argv. */
     uri: string;
@@ -478,7 +487,9 @@ export interface VMProvider {
   // Every cmux Cloud machine runs this daemon; providers that have not been migrated
   // leave this undefined.
   openCmuxRemote?(vmId: string, options?: CmuxRemoteAttachOptions): Promise<CmuxRemoteEndpoint>;
-  // Optional: approve the pending enrollment a previous openCmuxRemote invited.
+  // Optional, compatibility only: the trusted listener needs no approval, so a
+  // provider answers `approved` without touching the machine. Older Mac builds
+  // still call it once after their first connect.
   approveCmuxRemoteEnrollment?(
     vmId: string,
     invitationId: string,

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -285,10 +285,11 @@ be updated before a private-network image can be assessed. Rebuilding a guest
 image cannot add that missing capability to an installed Mac app.
 
 The probe creates its own VPC, VM from the requested snapshot, and temporary
-WireGuard tunnel. It uses the production driver to obtain and approve an
-invitation, reads the session snapshot through the private hub, then connects
-again with the persisted device identity and no new invitation. The report
-records both commits and the enrollment, reconnect, and snapshot results.
+WireGuard tunnel. It uses the production driver to confirm the machine serves
+the trusted-carrier listener, dials it with `--carrier` (no enrollment, no
+approval), reads the session snapshot through the private hub, then connects
+again the same way. The report records both commits and the trusted-listener,
+reconnect, and snapshot results.
 The client need not match the image's older baked commit: successful protocol
 operations are the compatibility check.
 

--- a/web/services/vms/images/devbox/cmux-devbox-boot
+++ b/web/services/vms/images/devbox/cmux-devbox-boot
@@ -102,7 +102,10 @@ while true; do
       fi
       if [ -z "$daemon_pid" ] || ! kill -0 "$daemon_pid" 2>/dev/null; then
         [ -n "$daemon_pid" ] && wait "$daemon_pid" 2>/dev/null
-        (cd /root && exec env HOME=/root TERM=xterm-256color /root/.cmux/bin/cmux-tui server start --session cloud --remote-ws "${CMUX_TUI_REMOTE_WS_BIND:-0.0.0.0:1337}" --remote-ws-insecure-bind) &
+        # --remote-ws-trusted-carrier: the listener is reachable only inside the
+        # owner's private network, whose members are all authorized, so every
+        # link gets carrier authentication with no device enrollment.
+        (cd /root && exec env HOME=/root TERM=xterm-256color /root/.cmux/bin/cmux-tui server start --session cloud --remote-ws "${CMUX_TUI_REMOTE_WS_BIND:-0.0.0.0:1337}" --remote-ws-insecure-bind --remote-ws-trusted-carrier) &
         daemon_pid=$!
       fi
     fi

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -2867,7 +2867,7 @@ export function openVmCmuxRemote(input: {
       tokenHash: hashToken(endpoint.token),
       expiresAt: new Date(endpoint.expiresAtUnix * 1000),
       transport: "cmux-remote",
-      metadata: { session: endpoint.session, invited: !!endpoint.invitation },
+      metadata: { session: endpoint.session, invited: false, trustedCarrier: endpoint.trustedCarrier },
     }).pipe(
       Effect.catchAll((err) => {
         const cleanup = providers.revokeEndpointLeases
@@ -2884,7 +2884,7 @@ export function openVmCmuxRemote(input: {
       eventType: "vm.attach",
       provider: vm.provider,
       imageId: vm.imageId,
-      metadata: { transport: "cmux-remote", invited: !!endpoint.invitation },
+      metadata: { transport: "cmux-remote", invited: false, trustedCarrier: endpoint.trustedCarrier },
     }).pipe(Effect.catchAll(() => Effect.void));
     // Backfill: machines created before address recording learn their private
     // address on first attach, so "Copy IP Address" appears for them too.

--- a/web/tests/freestyle-cloud-shell-repair.test.ts
+++ b/web/tests/freestyle-cloud-shell-repair.test.ts
@@ -31,6 +31,8 @@ describe("Freestyle Cloud VM daemon repair", () => {
     const daemon = cmuxTuiDaemonCommand(`[::]:${CMUX_TUI_PORT}`);
     expect(daemon).toContain("server start --session cloud");
     expect(daemon).toContain(`--remote-ws [::]:${CMUX_TUI_PORT}`);
+    // The cloud listener is reachable only inside the owner's private network.
+    expect(daemon).toContain("--remote-ws-trusted-carrier");
     expect(daemon).toContain(CMUX_TUI_BINARY_PATH);
     expect(daemon).not.toContain("cmuxd-remote");
   });
@@ -63,6 +65,9 @@ describe("Freestyle Cloud VM daemon repair", () => {
     const start = freestyleStartDaemonCommand();
     expect(start).toContain("cmux-tui-daemon.service");
     expect(start).toContain("Environment=CMUX_TUI_REMOTE_WS_BIND=[::]:1337");
+    // Machines healed in place get trusted mode through the same drop-in; the
+    // daemon reads the env, so the baked launch line need not carry the flag.
+    expect(start).toContain("Environment=CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1");
     expect(start).toContain("systemctl daemon-reload");
     expect(start).toContain("systemctl restart cmux-tui-daemon");
     expect(start).toContain("--remote-ws [::]:1337");

--- a/web/tests/freestyle-cloud-shell-repair.test.ts
+++ b/web/tests/freestyle-cloud-shell-repair.test.ts
@@ -72,6 +72,17 @@ describe("Freestyle Cloud VM daemon repair", () => {
     expect(start).toContain("systemctl restart cmux-tui-daemon");
     expect(start).toContain("--remote-ws [::]:1337");
 
+    // The default launcher keeps a daemon that already runs; the trusted-listener
+    // heal must replace it, or installing the pinned binary changes nothing for
+    // the live process and the retried bundle still reports an untrusted daemon.
+    expect(start).toContain("pgrep -f 'cmux-tui server [s]tart' >/dev/null 2>&1 ||");
+    expect(start).not.toContain("pkill");
+    const heal = freestyleStartDaemonCommand({ replaceExisting: true });
+    expect(heal).toContain("systemctl restart cmux-tui-daemon");
+    expect(heal).toContain("pkill -f 'cmux-tui server [s]tart'");
+    expect(heal).not.toContain("pgrep -f 'cmux-tui server [s]tart' >/dev/null 2>&1 ||");
+    expect(heal).toContain("--remote-ws-trusted-carrier");
+
     const pinCheck = cmuxTuiPinCheckCommand(SOURCE);
     expect(pinCheck).toContain(SOURCE.sha256);
     expect(pinCheck).toContain("sha256sum -c");

--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -843,8 +843,9 @@ describe("cmux-tui attach bundle", () => {
     expect(probe).toContain("'CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1'");
     expect(probe).toContain("/proc/$p/cmdline");
     expect(probe).toContain("'--remote-ws-trusted-carrier'");
-    // The running binary answers for itself, so a stale install never reads as trusted.
-    expect(probe).toContain("\"/proc/$p/exe\" --help");
+    // The running binary answers for itself, so a stale install never reads as
+    // trusted: an old parser rejects the flag before it reaches --version.
+    expect(probe).toContain("\"/proc/$p/exe\" --remote-ws-trusted-carrier --version >/dev/null 2>&1");
     expect(probe).not.toContain("sha256sum");
   });
 

--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -832,22 +832,20 @@ describe("cmux-tui attach bundle", () => {
     expect(bundle.enrolled).toBe(true);
   });
 
-  test("rejects a malformed device fingerprint or pin", () => {
+  test("rejects a malformed device fingerprint", () => {
     expect(() => cmuxTuiAttachBundleCommand({ deviceFingerprint: "bad fp; rm -rf /" })).toThrow("unexpected shape");
-    expect(() => cmuxTuiAttachBundleCommand({ pinnedSha256: "nope" })).toThrow("unexpected shape");
   });
 
-  test("the trusted probe requires the env or flag on the live daemon and, when pinned, the pinned binary", () => {
-    const probe = cmuxTuiTrustedListenerProbe("a".repeat(64));
+  test("the trusted probe requires the env or flag on the live daemon and a binary that knows the flag", () => {
+    const probe = cmuxTuiTrustedListenerProbe();
     expect(probe).toContain("pgrep -f 'cmux-tui server [s]tart'");
     expect(probe).toContain("/proc/$p/environ");
     expect(probe).toContain("'CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1'");
     expect(probe).toContain("/proc/$p/cmdline");
     expect(probe).toContain("'--remote-ws-trusted-carrier'");
-    expect(probe).toContain(`'${"a".repeat(64)}'`);
-    expect(probe).toContain("/proc/$p/exe");
-    expect(probe).toContain("sha256sum -c");
-    expect(cmuxTuiTrustedListenerProbe()).not.toContain("sha256sum");
+    // The running binary answers for itself, so a stale install never reads as trusted.
+    expect(probe).toContain("\"/proc/$p/exe\" --help");
+    expect(probe).not.toContain("sha256sum");
   });
 
   test("parses build, enrollment, and the trusted flag from the fenced output; a missing flag is untrusted", () => {

--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -11,9 +11,8 @@ import {
   cmuxTuiManifestUrl,
   cmuxTuiPersistentMountWait,
   parseCmuxTuiManifest,
-  parseEnrollmentInvitationUri,
   cmuxTuiAttachBundleCommand,
-  cmuxTuiApproveWaitCommand,
+  cmuxTuiTrustedListenerProbe,
   parseCmuxTuiAttachBundle,
 } from "../services/vms/drivers/cmuxTuiDaemon";
 
@@ -92,7 +91,7 @@ describe("cmux-tui install and daemon commands", () => {
   test("the daemon serves /v1/link on its own port from the persistent home", () => {
     const command = cmuxTuiDaemonCommand();
     expect(command.startsWith("cd /root && env HOME=/root")).toBe(true);
-    expect(command).toContain("server start --session cloud --remote-ws 0.0.0.0:1337 --remote-ws-insecure-bind");
+    expect(command).toContain("server start --session cloud --remote-ws 0.0.0.0:1337 --remote-ws-insecure-bind --remote-ws-trusted-carrier");
   });
 
   test("with the cloud layout the install lands in the cmux home and hands the bin dir to the user", () => {
@@ -768,80 +767,9 @@ describe("cmux-tui install and daemon commands", () => {
   });
 });
 
-describe("enrollment invitation parsing", () => {
-  test("one provider command waits locally for the claim and approves it", () => {
-    const command = cmuxTuiApproveWaitCommand("inv_abc-123");
-    expect(command).toContain("while [ \"$cmux_approve_attempt\" -lt 120 ]");
-    expect(command).toContain("remote enroll approve 'inv_abc-123' --session cloud --json");
-    expect(command).toContain("sleep 0.25");
-    expect(() => cmuxTuiApproveWaitCommand("bad; rm -rf /")).toThrow(/unexpected shape/);
-  });
-
-  test("the one provider command retries only inside the VM", () => {
-    const root = mkdtempSync(join(tmpdir(), "cmux-approve-wait-"));
-    const binary = join(root, "cmux-tui");
-    const count = join(root, "count");
-    try {
-      writeFileSync(binary, [
-        "#!/bin/sh",
-        "n=$(cat \"$CMUX_APPROVE_COUNT\" 2>/dev/null || printf 0)",
-        "n=$((n + 1))",
-        "printf '%s' \"$n\" > \"$CMUX_APPROVE_COUNT\"",
-        "[ \"$n\" -ge 3 ] || exit 1",
-        "printf '%s\\n' '{\"fingerprint\":\"fp-approved\"}'",
-        "",
-      ].join("\n"));
-      chmodSync(binary, 0o755);
-      const command = cmuxTuiApproveWaitCommand("inv-abc", {
-        binaryPath: binary,
-        attempts: 4,
-        delaySeconds: 0.01,
-      });
-      const result = spawnSync("/bin/sh", ["-c", command], {
-        env: { ...process.env, CMUX_APPROVE_COUNT: count },
-        encoding: "utf8",
-      });
-      expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('{"fingerprint":"fp-approved"}');
-      expect(readFileSync(count, "utf8")).toBe("3");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  test("extracts the id and expiry the approve flow needs", () => {
-    const payload = {
-      version: 1,
-      id: "inv_abc-123",
-      secret: "s3cret",
-      daemon_public_key: "pk",
-      daemon_fingerprint: "fp-daemon",
-      daemon_name: "cloud",
-      expires_at_unix: 1_800_000_000,
-      route_hints: [],
-      relay_access: [],
-      approval_required: true,
-    };
-    const uri = `cmux://enroll/${Buffer.from(JSON.stringify(payload)).toString("base64url")}`;
-    expect(parseEnrollmentInvitationUri(uri)).toEqual({
-      id: "inv_abc-123",
-      expiresAtUnix: 1_800_000_000,
-      daemonFingerprint: "fp-daemon",
-    });
-  });
-
-  test("rejects foreign schemes and malformed payloads", () => {
-    expect(() => parseEnrollmentInvitationUri("https://example.com/enroll")).toThrow(/scheme/);
-    expect(() => parseEnrollmentInvitationUri("cmux://enroll/!!!")).toThrow(/undecodable|id or expiry/);
-    const missing = `cmux://enroll/${Buffer.from(JSON.stringify({ version: 1 })).toString("base64url")}`;
-    expect(() => parseEnrollmentInvitationUri(missing)).toThrow(/id or expiry/);
-  });
-});
-
 describe("cmux-tui attach bundle", () => {
-  const stdoutFor = (probe: string, devices: string, invite: string) =>
-    ["__CMUX_PROBE__", probe, "__CMUX_DEVICES__", devices, "__CMUX_INVITE__", invite, "__CMUX_END__", ""].join("\n");
-  const invitation = `cmux://enroll/${Buffer.from(JSON.stringify({ id: "inv-abc", expires_at_unix: 1900000000 })).toString("base64url")}`;
+  const stdoutFor = (probe: string, devices: string, trusted: string) =>
+    ["__CMUX_PROBE__", probe, "__CMUX_DEVICES__", devices, "__CMUX_TRUSTED__", trusted, "__CMUX_END__", ""].join("\n");
 
   const runBundle = (readyGate: string, deviceFingerprint?: string) => {
     const root = mkdtempSync(join(tmpdir(), "cmux-tui-attach-bundle-"));
@@ -853,7 +781,6 @@ describe("cmux-tui attach bundle", () => {
       "case \"$*\" in",
       `  'remote-probe --json') printf '%s\\n' '{"build_identity":"abc123","remote_protocol":12,"version":"0.13.0"}' ;;`,
       `  'remote enroll devices --session cloud --json') printf '%s\\n' '[{"fingerprint":"fp-1","revoked_at_unix":null}]' ;;`,
-      `  'remote enroll create --session cloud --ttl 300 --json') printf '%s\\n' '${JSON.stringify({ uri: invitation })}' ;;`,
       "  *) exit 64 ;;",
       "esac",
       "",
@@ -876,18 +803,19 @@ describe("cmux-tui attach bundle", () => {
     }
   };
 
-  test("a successful readiness exit continues with the complete attach bundle", () => {
+  test("a successful readiness exit reads build, devices, and the trusted probe; nothing is minted", () => {
     const result = runBundle("exit 0", "fp-new");
     expect(result.status).toBe(0);
     expect(result.calls).toEqual([
       "remote-probe --json",
       "remote enroll devices --session cloud --json",
-      "remote enroll create --session cloud --ttl 300 --json",
     ]);
+    expect(cmuxTuiAttachBundleCommand({})).not.toContain("remote enroll create");
     const bundle = parseCmuxTuiAttachBundle(result.stdout, "freestyle", "vm-1", "fp-new");
     expect(bundle.daemonBuild).toEqual({ commit: "abc123", remoteProtocol: 12, version: "0.13.0" });
     expect(bundle.enrolled).toBe(false);
-    expect(bundle.invitation?.invitationId).toBe("inv-abc");
+    // No cloud daemon runs on the test host, so the probe reports untrusted.
+    expect(bundle.trustedCarrier).toBe(false);
   });
 
   test("a failed readiness exit returns the repair signal without calling the daemon", () => {
@@ -897,28 +825,37 @@ describe("cmux-tui attach bundle", () => {
     expect(result.stdout).toBe("");
   });
 
-  test("an enrolled device passes the readiness exit without minting an invitation", () => {
+  test("an enrolled device is recognized so the heal never restarts under it", () => {
     const result = runBundle("exit 0", "fp-1");
     expect(result.status).toBe(0);
-    expect(result.calls).toEqual([
-      "remote-probe --json",
-      "remote enroll devices --session cloud --json",
-    ]);
     const bundle = parseCmuxTuiAttachBundle(result.stdout, "freestyle", "vm-1", "fp-1");
     expect(bundle.enrolled).toBe(true);
-    expect(bundle.invitation).toBeNull();
   });
 
-  test("rejects a malformed device fingerprint", () => {
+  test("rejects a malformed device fingerprint or pin", () => {
     expect(() => cmuxTuiAttachBundleCommand({ deviceFingerprint: "bad fp; rm -rf /" })).toThrow("unexpected shape");
+    expect(() => cmuxTuiAttachBundleCommand({ pinnedSha256: "nope" })).toThrow("unexpected shape");
   });
 
-  test("parses build, enrollment, and invitation from the fenced output", () => {
+  test("the trusted probe requires the env or flag on the live daemon and, when pinned, the pinned binary", () => {
+    const probe = cmuxTuiTrustedListenerProbe("a".repeat(64));
+    expect(probe).toContain("pgrep -f 'cmux-tui server [s]tart'");
+    expect(probe).toContain("/proc/$p/environ");
+    expect(probe).toContain("'CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1'");
+    expect(probe).toContain("/proc/$p/cmdline");
+    expect(probe).toContain("'--remote-ws-trusted-carrier'");
+    expect(probe).toContain(`'${"a".repeat(64)}'`);
+    expect(probe).toContain("/proc/$p/exe");
+    expect(probe).toContain("sha256sum -c");
+    expect(cmuxTuiTrustedListenerProbe()).not.toContain("sha256sum");
+  });
+
+  test("parses build, enrollment, and the trusted flag from the fenced output; a missing flag is untrusted", () => {
     const parsed = parseCmuxTuiAttachBundle(
       stdoutFor(
         JSON.stringify({ build_identity: "abc123", remote_protocol: 12, version: "0.13.0" }),
         JSON.stringify([{ fingerprint: "fp-2", revoked_at_unix: null }]),
-        JSON.stringify({ uri: invitation }),
+        "1",
       ),
       "freestyle",
       "vm-1",
@@ -926,22 +863,23 @@ describe("cmux-tui attach bundle", () => {
     );
     expect(parsed.daemonBuild).toEqual({ commit: "abc123", remoteProtocol: 12, version: "0.13.0" });
     expect(parsed.enrolled).toBe(false);
-    expect(parsed.invitation?.invitationId).toBe("inv-abc");
+    expect(parsed.trustedCarrier).toBe(true);
+    expect(parseCmuxTuiAttachBundle(stdoutFor("{}", "[]", "0"), "freestyle", "vm-1").trustedCarrier).toBe(false);
+    expect(parseCmuxTuiAttachBundle(stdoutFor("{}", "[]", ""), "freestyle", "vm-1").trustedCarrier).toBe(false);
+    expect(parseCmuxTuiAttachBundle("garbage", "freestyle", "vm-1").trustedCarrier).toBe(false);
   });
 
-  test("an enrolled, unrevoked fingerprint needs no invitation; a revoked one does", () => {
+  test("an enrolled, unrevoked fingerprint counts; a revoked one does not", () => {
     const enrolled = parseCmuxTuiAttachBundle(
-      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: null }]), ""),
+      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: null }]), "1"),
       "freestyle", "vm-1", "fp-1",
     );
     expect(enrolled.enrolled).toBe(true);
-    expect(enrolled.invitation).toBeNull();
     expect(enrolled.daemonBuild).toBeNull();
     const revoked = parseCmuxTuiAttachBundle(
-      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: 1 }]), ""),
+      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: 1 }]), "1"),
       "freestyle", "vm-1", "fp-1",
     );
     expect(revoked.enrolled).toBe(false);
-    expect(revoked.invitation).toBeNull();
   });
 });

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -396,8 +396,10 @@ describe("Freestyle platform contract", () => {
     expect(freestyleDaemonHealthyCommand()).toContain(":0539 ");
     const start = freestyleStartDaemonCommand();
     expect(start).toContain("Environment=CMUX_TUI_REMOTE_WS_BIND=[::]:1337");
+    expect(start).toContain("Environment=CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1");
     expect(start).toContain("systemctl restart cmux-tui-daemon");
     expect(start).toContain("--remote-ws [::]:1337"); // non-systemd fallback
+    expect(start).toContain("--remote-ws-trusted-carrier");
   });
 
   test("pin check trusts the pin recorded at bake time, falling back to the live pin on older images", () => {

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -802,6 +802,80 @@ describe("Freestyle machine sizing", () => {
 // is the machine's VPC address over the owner's tunnel, nothing is minted at
 // the platform and nothing public is opened. noVNC on 6901 has no auth of
 // its own, so a machine outside a private network gets no URL at all.
+describe("Freestyle openCmuxRemote: the trusted-listener heal", () => {
+  const PRIVATE = { publicIpv6: "2602:f75c:0:1::2a", vpcs: [{ ipv4: "10.4.0.7", ipv6: "fd00:4::7" }] };
+  const SOURCE_OK = { url: "https://files.cmux.com/cmux-tui/abc/cmux-tui-linux-x64", sha256: "0".repeat(64), commit: "abc", builtAt: null };
+
+  /** The attach bundle's fenced stdout with the trusted-listener probe printing `trusted`. */
+  function bundleStdout(trusted: "0" | "1"): string {
+    return [
+      "__CMUX_PROBE__",
+      JSON.stringify({ build_identity: "abc", remote_protocol: 12, version: "0.1.0" }),
+      "__CMUX_DEVICES__",
+      "[]",
+      "__CMUX_TRUSTED__",
+      trusted,
+      "__CMUX_END__",
+    ].join("\n");
+  }
+
+  /**
+   * A fake machine whose attach bundle answers `trusted[n]` on its n-th run.
+   * Every other exec (pin check, daemon restart, readiness status) succeeds.
+   */
+  function attachFake(input: { readonly trusted: readonly ("0" | "1")[]; readonly manifest: "ok" | "down" }) {
+    const execs: string[] = [];
+    let bundles = 0;
+    const vm = {
+      data: async () => PRIVATE,
+      exec: async ({ command }: { command: string }) => {
+        execs.push(command);
+        if (command.includes("__CMUX_PROBE__")) {
+          const trusted = input.trusted[Math.min(bundles, input.trusted.length - 1)] ?? "0";
+          bundles += 1;
+          return { statusCode: 0, stdout: bundleStdout(trusted), stderr: "" };
+        }
+        return { statusCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    const client = { vms: { ref: () => vm } } as unknown as Freestyle;
+    const provider = new FreestyleProvider({
+      client: () => client,
+      resolveDaemonSource: async () => {
+        if (input.manifest === "down") throw new Error("manifest fetch failed");
+        return SOURCE_OK;
+      },
+    });
+    return { provider, execs, bundles: () => bundles };
+  }
+
+  test("a daemon that already serves the trusted listener attaches without reading the manifest", async () => {
+    const fake = attachFake({ trusted: ["1"], manifest: "down" });
+    const endpoint = await fake.provider.openCmuxRemote(VM_ID, { clientCapabilities: [] });
+    expect(endpoint.trustedCarrier).toBe(true);
+    expect(endpoint.route).toBe("ws://10.4.0.7:1337/v1/link");
+    expect(fake.bundles()).toBe(1);
+    expect(fake.execs.some((command) => command.includes("systemctl restart cmux-tui-daemon"))).toBe(false);
+  });
+
+  test("an older daemon is replaced with the pinned build and the retried bundle proves trusted mode", async () => {
+    const fake = attachFake({ trusted: ["0", "1"], manifest: "ok" });
+    const endpoint = await fake.provider.openCmuxRemote(VM_ID, { clientCapabilities: [] });
+    expect(endpoint.trustedCarrier).toBe(true);
+    expect(fake.bundles()).toBe(2);
+    const start = fake.execs.find((command) => command.includes("systemctl restart cmux-tui-daemon"));
+    expect(start).toBeDefined();
+    // The heal replaces a fallback daemon rather than keeping the untrusted one.
+    expect(start).toContain("pkill -f 'cmux-tui server [s]tart'");
+  });
+
+  test("a heal that leaves the daemon untrusted fails closed instead of returning an unusable endpoint", async () => {
+    const fake = attachFake({ trusted: ["0", "0"], manifest: "ok" });
+    await expect(fake.provider.openCmuxRemote(VM_ID, { clientCapabilities: [] })).rejects.toThrow(ProviderError);
+    await expect(fake.provider.openCmuxRemote(VM_ID, { clientCapabilities: [] })).rejects.toThrow(/still refuses the trusted listener/);
+  });
+});
+
 describe("Freestyle port open: the private address, the desktop healed", () => {
   const PRIVATE = { publicIpv6: "2602:f75c:0:1::2a", vpcs: [{ ipv4: "10.4.0.7", ipv6: "fd00:4::7" }] };
 

--- a/web/tests/vm-review-regressions.test.ts
+++ b/web/tests/vm-review-regressions.test.ts
@@ -93,7 +93,7 @@ describe("VM review regressions", () => {
             operations += 1;
             return {
               transport: "cmux-remote", route: "ws://10.0.0.5:1337/v1/link", token: "test-token",
-              session: "test-session", expiresAtUnix: 2_000_000_000,
+              session: "test-session", expiresAtUnix: 2_000_000_000, trustedCarrier: true,
             };
           }),
         } as unknown as VmProviderGatewayShape;

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -1613,7 +1613,7 @@ describe("VM REST auth", () => {
       token: "t",
       expiresAtUnix: 1_777_000_300,
       session: "cloud",
-      invitation: { uri: "cmux://enroll/abc", invitationId: "inv-1", expiresAtUnix: 1_777_000_200 },
+      trustedCarrier: true,
     });
     const response = await attachRoute.POST(
       new Request("https://cmux.test/api/vm/provider-vm-team-1/attach-endpoint", {
@@ -1637,7 +1637,8 @@ describe("VM REST auth", () => {
     expect(openAttachEndpoint).not.toHaveBeenCalled();
     const payload = await response.json();
     expect(payload.transport).toBe("cmux-remote");
-    expect(payload.invitation.invitationId).toBe("inv-1");
+    expect(payload.trustedCarrier).toBe(true);
+    expect(payload.invitation).toBeUndefined();
   });
 
   test("attach-endpoint answers 409 vm_attach_transport_unsupported when the machine only runs cmux-tui", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -2014,6 +2014,7 @@ describe("VM Effect workflows", () => {
       token: "remote-token",
       expiresAtUnix: Math.floor(Date.now() / 1000) + 300,
       session: "cloud",
+      trustedCarrier: true,
     };
     const callOrder: string[] = [];
     let statusCalls = 0;
@@ -2088,6 +2089,7 @@ describe("VM Effect workflows", () => {
             token: "remote-token",
             expiresAtUnix: Math.floor(Date.now() / 1000) + 300,
             session: "cloud",
+            trustedCarrier: true,
           };
         }),
     };
@@ -2131,6 +2133,7 @@ describe("VM Effect workflows", () => {
             token: "remote-token",
             expiresAtUnix: Math.floor(Date.now() / 1000) + 300,
             session: "cloud",
+            trustedCarrier: true,
           };
         }),
     };


### PR DESCRIPTION
## Why

Cloud attach was failing in production for at least three days: 7,149 `cmux-remote/approve` 502s per day (`no pending enrollment for <id>`) against 2 successful enrollments, ~71 hours/day of Vercel function time. The enrollment handshake needed three parties alive inside one 30-second window (the Mac's open dial, an in-memory pending entry in the VM, a Vercel function doing two 15-second execs) and had no durable record. Every cmux Cloud machine already lives on its owner's private Freestyle network, and the desktop (`noVNC -SecurityTypes None`) already treats that network as the only admission — the daemon was the one surface still asking for a second identity.

## What

**cmux-tui**
- A direct WebSocket listener can be marked trusted (`--remote-ws-trusted-carrier`, or `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1`): every link it admits is granted carrier authentication, keyed by the client's own key (`network:<fingerprint>`), with no enrollment, invitation, or approval. The flag is a property of that one listener; unix/ssh/relay/iroh on the same daemon keep the enrollment model, and plain network evidence on an untrusted listener is still refused (tests pin both).
- `remote connect --carrier` dials `ws`/`wss` in carrier mode. A daemon whose listener is not trusted rejects it.
- Noise still runs (encryption + key binding); only the authorization check changed.

**web**
- `attach-endpoint` returns `trustedCarrier` and mints no invitation. The attach bundle probes the live daemon (env/flag on the process **and** a binary that parses the flag). A daemon from an older bake is brought to the pinned build and restarted with the systemd drop-in — never under a device that is already enrolled there (its sessions would end); that device keeps its stored key.
- `POST /cmux-remote/approve` is a no-op answering `approved`, kept for older Mac builds; delete once nightly has rolled.
- `cmux-devbox-boot` passes the flag for future bakes. **No new Freestyle snapshot is required**: existing and freshly created machines get trusted mode at first attach through the heal (install + drop-in + restart, ~5 s). A bake is a latency follow-up only.

**Mac + CLI**
- Links dial `--carrier`; the approve poll, invite files, `vm-tui-approve`, `vm.cmux_remote_approve`, and the 240 s enrolling window are gone. A per-machine `carrier` marker keeps reattach free of control-plane calls; a real stored fingerprint (pre-trusted enrollment) still dials with the stored key.
- Stops polling `/stats` on shell-only machines (13,677 guaranteed 501s/day).
- Fixes an app abort on every snapshot publish under the Swift runtime in Xcode 26.6 (`orderedSnapshotRows` returned `enumerated()` rows under relabeled tuple labels → runtime array cast failure). Found while dogfooding; unrelated to the trust change but blocked it.

## Tested

- `cargo test -p cmux-remote` / cmux-tui via the hosted lane (`verify-cmux-tui-hosted.sh --filter carrier`): new tests for trusted-network grants, the listener e2e (trusted accepts a carrier dial, untrusted refuses it), and `--carrier` parsing.
- `bun test` on `vm-cmux-tui`, `vm-freestyle-provider`, `vm-route-auth`, `vm-workflows`, `freestyle-cloud-shell-repair`, `vm-product-analytics`; `bun run typecheck`.
- Live, tagged build `cvpc` against a local dev server (branch daemon manifest pinned, fresh Freestyle machine, no device record on the Mac): `vm shell` → `trusted_carrier: true` in 8 s; link process is `remote connect … --carrier --wireguard-hub …`; `vm terminal send/read` round-trips over the link; killing the link reconnects with **zero** new control-plane calls; zero approve calls in the whole session. Machine destroyed afterwards.

## Rollout notes

1. Production is missing migrations `20260903190000_cloud_vm_access_grants`, `…_sessions`, `…_mutation_leases` (every new tunnel enrollment 503s). Run `cloud-vm:migrate staging` then `production` before this lands — independent of this PR, but the private network is the whole admission now.
2. Merging republishes `cmux-tui/latest` from main (~15 min). Until it lands, a first attach to a machine from an older bake installs the previous build, the probe reports untrusted, and the new client fails cleanly with "not serving the trusted listener yet" — retry succeeds once `latest` has the trusted build. To avoid that window, set `CMUX_VM_CMUX_TUI_MANIFEST_URL=https://files.cmux.com/cmux-tui/<this PR's merge sha>/manifest.json` on Vercel prod first, and remove it after.
3. Localization audit: removed `cli.vm.tui.mode.enrolling`, added `cli.vm.tui.mode.carrier` (en/ja); no web message catalog strings changed.

https://claude.ai/code/session_0131fv9uvrXerR4bEfD4ixYA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791278934&installation_model_id=21920&pr_number=12042&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12042&signature=1089f124314dbefc808fceeaf335a811f7e8dcf1c06b9b76978855ec4580d619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud attach now trusts the owner's private network instead of a device-enrollment handshake: every machine's daemon serves a trusted-carrier WebSocket listener that grants carrier auth to each link, and the Mac dials `remote connect --carrier` with no invitation, approval, or enrolling window. The old three-party handshake was failing in production (7,149 `cmux-remote/approve` 502s/day) and is removed.

- The trusted listener (`--remote-ws-trusted-carrier` or `CMUX_TUI_REMOTE_WS_TRUSTED_CARRIER=1`) admits links by the client's own key; unix/ssh/relay/iroh keep the enrollment model, and untrusted listeners still refuse plain network evidence.
- The Mac keeps a per-machine `carrier` marker so reattach makes no control-plane calls; a machine it enrolled with before keeps the stored key.
- `POST /cmux-remote/approve` is now a no-op answering `approved`, kept for older Mac builds until nightly rolls.
- The heal is fail-closed: the manifest is read only when a heal is needed, a running non-systemd daemon is replaced rather than kept, and the attach is rejected if the retried bundle still reports an untrusted daemon.
- Also stops polling `/stats` on shell-only machines (which 501 on every poll) and fixes a Swift 6.x runtime array-cast abort on snapshot publish, a transient VM retry sleep passing the wrong `Duration`, and a `wg hub` start deadline built outside the tokio runtime that panicked every hub start with "there is no reactor running".
- A link client that exits before reporting its socket now surfaces the exit with the stderr tail instead of a misleading timeout.

**Rollout**
- Run migrations `20260903190000_cloud_vm_access_grants`, `_sessions`, and `_mutation_leases` on staging and production before this lands; without them new tunnel enrollments 503.
- Set `CMUX_VM_CMUX_TUI_MANIFEST_URL` on Vercel prod to this PR's merge sha until the `cmux-tui/latest` republish completes, or a first attach to a machine from an older bake fails with "not serving the trusted listener yet".

<sup>Written for commit 821653d59fdd4a4c2d88311c660ce96d07519a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cloud VM cmux-tui connections now use trusted private-network access without enrollment or approval.
  - Added `--carrier` support for remote connections through trusted listeners.
  - Cloud VM access now reports trusted-carrier availability and can recover older daemons automatically.

- **Bug Fixes**
  - Machine statistics polling now excludes shell-only machines without statistics endpoints.
  - Connection errors now report early client exits instead of timing out.

- **Documentation**
  - Updated CLI help and guides to describe trusted listeners and carrier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups landed after review (2026-09-06)

- CodeRabbit: manifest is read only inside the heal, the heal replaces a running fallback daemon and fails closed when the retried bundle is still untrusted, both retry messages are localized (en + ja), `remote_ws_trusted_carrier_from_env` is `#[cfg(unix)]`. Declined with rationale in-thread: a typed auth-mode field for the `carrier` marker, and an endpoint refresh before a carrier dial.
- Merged `main`. Two build fixes for code that arrived from https://github.com/manaflow-ai/cmux/pull/12047: `VMClient` passed a `Duration` to `.seconds(...)` (rejected by the fleet Xcode), and `remote_cli.rs` was not rustfmt-clean, so `cargo fmt --check` failed the cmux-tui lane on `main` too.
- `CloudMachineLink.connect` reported a client that exits before printing its socket line as `timedOut` with the 60 s deadline untouched, hiding stderr. It now reports `exited(status, stderr)`; regression test `linkClientExitingBeforeItsSocketLineReportsTheExitNotATimeout`. Found because a tagged build bundles main's cmux-tui client, which rejects `--carrier`.
