### PR TITLE
docs: migrate agent guidance to GPT-6 Astra

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,7 @@ Detailed contributor rules live in `skills/`. Use the task-specific skill before
   build, and never compile cmux-tui on the Mac. The skill lives in cmuxterm-hq at
   `skills/infra/blacksmith-testbox/SKILL.md`; the workflows, `scripts/blacksmith-*.sh`, and the
   `tests/test_testbox_*` guards stay here. Quickest path: `./scripts/blacksmith-testbox-demo.sh`.
+
+## GPT-6 Astra
+
+Use `gpt-6-astra` as the default OpenAI model for agent work. Use reasoning effort `low`, `medium`, `high`, `xhigh`, or `max`; `none` is unsupported. Prefer the Responses API for tool calling, remove unsupported `temperature`, `top_p`, and log probability parameters, and verify behavior with representative repository tasks before changing prompts or tool workflows.

--- a/skills/cmux/SKILL.md
+++ b/skills/cmux/SKILL.md
@@ -56,3 +56,7 @@ Terminal rendering (font, cursor style, theme, scrollback, `background-opacity`,
 | [../cmux-settings/SKILL.md](../cmux-settings/SKILL.md) | Safe cmux.json settings edits and validation |
 | [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) | Browser automation on surface-backed webviews |
 | [../cmux-markdown/SKILL.md](../cmux-markdown/SKILL.md) | Markdown viewer panel with live file watching |
+
+## GPT-6 Astra agent guidance
+
+Use `gpt-6-astra` for OpenAI-backed agent work in this repository. Start with reasoning effort `low` for routine tasks and increase it when the task needs deeper analysis. Preserve the current effort when it is already `medium`, `high`, `xhigh`, or `max`; `none` is unsupported. For tool-calling integrations, use the Responses API and remove unsupported sampling and log probability parameters.


### PR DESCRIPTION
Updates repository agent guidance and cmux skill defaults to GPT-6 Astra. Official guidance: https://developers.openai.com/api/docs/guides/latest-model#gpt-6-astra-testing-and-verification

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791280498&installation_model_id=21920&pr_number=12046&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12046&signature=0068e8ffdd38eefd5fc68b53fac82a464a77d323a7a18b466bb1a55d8285987b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates agent guidance in `CLAUDE.md` and `skills/cmux/SKILL.md` to default OpenAI-backed agent work to GPT-6 Astra, documenting supported reasoning effort levels and the Responses API requirement.

<sup>Written for commit 2a8484af7c210ad9fb24e4d180ec16dce2e31a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using the GPT-6 Astra model for OpenAI-backed agent work.
  * Documented supported reasoning effort levels and Responses API requirements for tool calling.
  * Added instructions to verify representative repository tasks before changing prompts or tool workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->