### PR TITLE
Recover Cloud VM links after transient hub and attach failures

### DIFF
--- a/Sources/Cloud/CloudWireGuardHub.swift
+++ b/Sources/Cloud/CloudWireGuardHub.swift
@@ -105,6 +105,10 @@ actor CloudWireGuardHub {
     private let processHandle = CloudWireGuardHubProcessHandle()
     private var state: State = .stopped
     private var leases: Set<Lease> = []
+    /// Keeps one hub claim for the signed-in account while its machine fleet is non-empty.
+    /// Without this claim, a transient first-start failure drops the last demand and leaves
+    /// every machine waiting for the next catalog poll to try again.
+    private var prewarmLease: Lease?
     private var pinnedByExternalClient = false
     /// Bumped on every intentional stop so a stale exit callback cannot restart a hub
     /// that was stopped on purpose.
@@ -137,7 +141,7 @@ actor CloudWireGuardHub {
             socketURL: manager.stateDir.appendingPathComponent("hub-\(getpid()).sock", isDirectory: false),
             spawner: CloudWireGuardHubProcessSpawner(),
             waitUntilReady: { socketPath in
-                try await CloudWireGuardHubSocketReadiness.wait(socketPath: socketPath, timeout: .seconds(20))
+                try await CloudWireGuardHubSocketReadiness.wait(socketPath: socketPath, timeout: .seconds(45))
             },
             sleep: { duration in try await ContinuousClock().sleep(for: duration) },
             restartBackoff: Configuration.defaultRestartBackoff,
@@ -175,6 +179,43 @@ actor CloudWireGuardHub {
         }
     }
 
+    /// Starts the shared hub before individual machine links race to acquire it.
+    /// The claim remains held until the fleet is empty or account access ends, so an
+    /// unexpected child exit is eligible for the actor's bounded restart policy.
+    func prewarm() async throws -> Ready {
+        if prewarmLease != nil {
+            restartTask?.cancel()
+            restartTask = nil
+            return try await ensureRunning()
+        }
+
+        var lastError: Error?
+        let retryDelays = Array(configuration.restartBackoff.prefix(3))
+        for attempt in 0...retryDelays.count {
+            do {
+                let claim = try await acquire()
+                prewarmLease = claim.lease
+                return claim.ready
+            } catch {
+                lastError = error
+                guard attempt < retryDelays.count else { break }
+                do {
+                    try await configuration.sleep(retryDelays[attempt])
+                } catch {
+                    throw CancellationError()
+                }
+            }
+        }
+        throw lastError ?? HubError.notReady("hub startup failed without a reported error")
+    }
+
+    /// Releases the account-level prewarm claim after the fleet becomes empty.
+    func releasePrewarm() {
+        guard let prewarmLease else { return }
+        self.prewarmLease = nil
+        release(prewarmLease)
+    }
+
     /// Ends one link's claim; the hub stops ``Configuration/idleGrace`` after the last one.
     func release(_ lease: Lease) {
         leases.remove(lease)
@@ -200,6 +241,7 @@ actor CloudWireGuardHub {
         restartTask = nil
         restartAttempts = 0
         leases.removeAll()
+        prewarmLease = nil
         pinnedByExternalClient = false
         if case .starting(_, let task) = state { task.cancel() }
         state = .stopped
@@ -311,9 +353,14 @@ actor CloudWireGuardHub {
         case .success:
             break
         case .failure(let error):
+            let output = process.outputTail.trimmingCharacters(in: .whitespacesAndNewlines)
             process.terminate()
-            if let hubError = error as? HubError { throw hubError }
-            throw HubError.notReady(CloudMachineLink.errorText(error))
+            let detail = CloudMachineLink.errorText(error)
+            if let hubError = error as? HubError {
+                let hubDetail = hubError.errorDescription ?? detail
+                throw HubError.notReady(output.isEmpty ? hubDetail : "\(hubDetail); hub output: \(output)")
+            }
+            throw HubError.notReady(output.isEmpty ? detail : "\(detail); hub output: \(output)")
         }
         guard process.isRunning else {
             throw HubError.exitedDuringStart(status: process.exitStatus ?? -1, output: process.outputTail)

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -1425,7 +1425,8 @@ actor VMClient {
             "POST",
             path: "/api/vm/\(encodedID)/attach-endpoint",
             jsonBody: body,
-            timeoutSeconds: Self.attachTimeoutSeconds
+            timeoutSeconds: Self.attachTimeoutSeconds,
+            retryTransientServiceUnavailable: true
         )
         try ensureOK(http, data: data)
         let obj = try decodeJSONObject(data)
@@ -1470,7 +1471,8 @@ actor VMClient {
                 "POST",
                 path: "/api/vm/\(encodedID)/attach-endpoint",
                 jsonBody: body,
-                timeoutSeconds: Self.attachTimeoutSeconds
+                timeoutSeconds: Self.attachTimeoutSeconds,
+                retryTransientServiceUnavailable: true
             )
             try ensureOK(http, data: data)
             return try decodeJSONObject(data)
@@ -1913,7 +1915,8 @@ actor VMClient {
         path: String,
         jsonBody: [String: Any]? = nil,
         extraHeaders: [String: String] = [:],
-        timeoutSeconds: TimeInterval? = nil
+        timeoutSeconds: TimeInterval? = nil,
+        retryTransientServiceUnavailable: Bool = false
     ) async throws -> (Data, HTTPURLResponse) {
         let trace = VMRequestTraceContext.mint()
         let route = VMClientTelemetry.normalizedRoute(path: path)
@@ -1942,6 +1945,7 @@ actor VMClient {
                 jsonBody: jsonBody,
                 extraHeaders: headers,
                 timeoutSeconds: timeoutSeconds,
+                retryTransientServiceUnavailable: retryTransientServiceUnavailable,
                 onRetry: { retryCount += 1 }
             )
             record(.response(
@@ -2014,6 +2018,7 @@ actor VMClient {
         jsonBody: [String: Any]?,
         extraHeaders: [String: String],
         timeoutSeconds: TimeInterval?,
+        retryTransientServiceUnavailable: Bool,
         onRetry: () -> Void
     ) async throws -> (Data, HTTPURLResponse) {
         // Bind every control-plane request to the currently published auth
@@ -2091,6 +2096,14 @@ actor VMClient {
                 try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
                 continue
             }
+            if retryTransientServiceUnavailable,
+               retriesLeft > 0,
+               let delaySeconds = Self.transientVMRetryDelay(http: http, data: data) {
+                retriesLeft -= 1
+                onRetry()
+                try await Task.sleep(for: .seconds(delaySeconds))
+                continue
+            }
             if let sessionIdentity {
                 guard await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity) else {
                     throw VMClientError.notSignedIn
@@ -2105,6 +2118,21 @@ actor VMClient {
             }
             return (data, http)
         }
+    }
+
+    /// Returns a bounded delay only for the VM API's explicitly retryable service failures.
+    /// Attach endpoint creation is idempotent for a machine/device pair, so repeating it
+    /// avoids surfacing a transient provider 502 as a dead Cloud sidebar row.
+    private static func transientVMRetryDelay(http: HTTPURLResponse, data: Data) -> Duration? {
+        guard (502...504).contains(http.statusCode),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let retryable = object["retryable"] as? Bool ?? false
+        let error = object["error"] as? String
+        guard retryable || error == "vm_cloud_service_unavailable" else { return nil }
+        let requested = cloudVMInt(object["retryAfterSeconds"]) ?? 2
+        return .seconds(min(max(requested, 1), 10))
     }
 
     private func decodeWebSocketDaemonEndpoint(_ value: Any?) throws -> VMWebSocketDaemonEndpoint? {

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -148,6 +148,14 @@ final class CmuxTuiSurfaceProviderRegistry {
         guard let page = try? await client.listPage() else { return false }
         guard generation == refreshGeneration else { return false }
         let seen = Set(page.vms.map(\.id))
+        if seen.isEmpty {
+            await wireGuardHub?.releasePrewarm()
+        } else if let wireGuardHub {
+            // Start one shared hub before per-machine refreshes race to create links.
+            // A transient DNS/handshake failure is retried inside `prewarm`; retaining
+            // its claim also lets the actor restart an unexpected child exit immediately.
+            _ = try? await wireGuardHub.prewarm()
+        }
         // Reconcile both stores. A restored catalog can contain a machine for
         // which this process has not created a provider yet.
         let catalogMachineIDs = Set(catalog.machines.keys.compactMap(\.cloudMachineID))

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -54,6 +54,8 @@ use crate::remote_runtime::{
 use crate::session::{RemoteSession, Session};
 
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(90);
+const WIREGUARD_HUB_START_TIMEOUT: Duration = Duration::from_secs(10);
+const WIREGUARD_HUB_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 const ENROLLMENT_APPROVAL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const MAX_RPC_STDIN_LINE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_CLIENT_RELAY_ROUTES: usize = 4;
@@ -1728,7 +1730,14 @@ fn run_wg(args: &[String]) -> anyhow::Result<()> {
     let flags = parse_wg_hub_flags(&args[1..])?;
     let owner = flags.exit_with_parent.then(current_parent_process_id);
     let async_runtime = tokio_runtime()?;
-    let net = start_wireguard(&async_runtime, &flags.config)?;
+    let net = start_wireguard_with_timeout(
+        &async_runtime,
+        &flags.config,
+        WIREGUARD_HUB_START_TIMEOUT,
+    )?;
+    async_runtime.block_on(net.wait_for_handshake(WIREGUARD_HUB_HANDSHAKE_TIMEOUT)).map_err(
+        |error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())),
+    )?;
     let hub = async_runtime
         .block_on(cmux_remote::wireguard_hub::serve_wireguard_hub(net, flags.socket))
         .map_err(|error| {
@@ -1799,6 +1808,25 @@ fn start_wireguard(
     runtime: &tokio::runtime::Runtime,
     path: &Path,
 ) -> anyhow::Result<Arc<cmux_wg::WgNet>> {
+    start_wireguard_with_timeout_inner(runtime, path, None)
+}
+
+/// Starts a hub tunnel with a deadline around endpoint resolution and UDP setup.
+/// A DNS/network stall must produce a child error so the app can retry, rather
+/// than leaving the Unix socket absent until the app-side readiness timeout.
+fn start_wireguard_with_timeout(
+    runtime: &tokio::runtime::Runtime,
+    path: &Path,
+    timeout: Duration,
+) -> anyhow::Result<Arc<cmux_wg::WgNet>> {
+    start_wireguard_with_timeout_inner(runtime, path, Some(timeout))
+}
+
+fn start_wireguard_with_timeout_inner(
+    runtime: &tokio::runtime::Runtime,
+    path: &Path,
+    timeout: Option<Duration>,
+) -> anyhow::Result<Arc<cmux_wg::WgNet>> {
     let text = cmux_remote::secret_file::read_owner_only_string(path, MAX_WIREGUARD_CONFIG_BYTES)
         .map_err(|error| {
         anyhow!(
@@ -1810,9 +1838,18 @@ fn start_wireguard(
     let config = cmux_wg::WgConfig::parse_wg_quick(&text).map_err(|error| {
         anyhow!(catalog().remote_client.wireguard_config_invalid(&error.to_string()))
     })?;
-    let net = runtime.block_on(cmux_wg::WgNet::start_with_new_socket(config)).map_err(|error| {
-        anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string()))
-    })?;
+    let net = match timeout {
+        Some(timeout) => runtime
+            .block_on(tokio::time::timeout(
+                timeout,
+                cmux_wg::WgNet::start_with_new_socket(config),
+            ))
+            .map_err(|_| anyhow!("WireGuard startup timed out after {timeout:?}"))?
+            .map_err(|error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())))?,
+        None => runtime
+            .block_on(cmux_wg::WgNet::start_with_new_socket(config))
+            .map_err(|error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())))?,
+    };
     Ok(Arc::new(net))
 }
 

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -9,7 +9,7 @@
 //! datagram, a command, a stream write, the WireGuard timer tick, or the
 //! deadline smoltcp asks for.
 
-use std::collections::hash_map::RandomState;
+use std::collections::{VecDeque, hash_map::RandomState};
 use std::fmt;
 use std::hash::{BuildHasher, Hasher};
 use std::io;
@@ -62,6 +62,10 @@ const TIMER_TICK: Duration = Duration::from_millis(250);
 const TCP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Largest datagram or packet buffer: the UDP payload maximum.
 const BUFFER_BYTES: usize = 65_535;
+/// UDP send readiness is edge-triggered by Tokio. Keep datagrams that arrive
+/// while the socket is temporarily unwritable and retry them on the next
+/// driver pass instead of silently losing a handshake.
+const UDP_SEND_QUEUE_DEPTH: usize = 64;
 /// The ephemeral port range (IANA 49152-65535); allocation starts at a random
 /// port inside it and wraps, as a real stack does.
 const FIRST_EPHEMERAL_PORT: u16 = 49_152;
@@ -90,6 +94,8 @@ pub enum WgError {
     ListenerBusy(u16),
     /// The tunnel has been shut down.
     Shutdown,
+    /// No WireGuard handshake completed before the startup deadline.
+    HandshakeTimeout(Duration),
     /// smoltcp refused the operation.
     Stack(String),
 }
@@ -108,6 +114,9 @@ impl fmt::Display for WgError {
             Self::ConnectionRefused(remote) => write!(formatter, "{remote} refused the connection"),
             Self::ListenerBusy(port) => write!(formatter, "port {port} already has a listener"),
             Self::Shutdown => formatter.write_str("the tunnel is shut down"),
+            Self::HandshakeTimeout(timeout) => {
+                write!(formatter, "no WireGuard handshake completed within {timeout:?}")
+            }
             Self::Stack(detail) => write!(formatter, "tcp stack: {detail}"),
         }
     }
@@ -243,6 +252,27 @@ impl WgNet {
             .await
             .map_err(|_| WgError::Shutdown)?;
         reply_rx.await.map_err(|_| WgError::Shutdown)
+    }
+
+    /// Wait until the peer completes a WireGuard handshake.
+    ///
+    /// Starting the driver only proves that the local UDP socket and the
+    /// userspace stack are alive. A hub must also prove that its peer can be
+    /// reached before it advertises a ready SOCKS socket. The driver sends an
+    /// initial handshake during startup, so polling this value is a bounded
+    /// end-to-end readiness check.
+    pub async fn wait_for_handshake(&self, timeout: Duration) -> Result<Duration, WgError> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(age) = self.time_since_last_handshake().await? {
+                return Ok(age);
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(WgError::HandshakeTimeout(timeout));
+            }
+            tokio::time::sleep_until(deadline.min(now + Duration::from_millis(100))).await;
+        }
     }
 
     /// Stop the driver and wait for it to exit. Open connections are reset.
@@ -446,6 +476,7 @@ struct Driver {
     epoch: std::time::Instant,
     next_port: u16,
     scratch: Vec<u8>,
+    pending_udp: VecDeque<(Vec<u8>, SocketAddr)>,
 }
 
 enum Event {
@@ -523,6 +554,7 @@ impl Driver {
             epoch,
             next_port: random_ephemeral_port(),
             scratch: vec![0u8; BUFFER_BYTES + 32],
+            pending_udp: VecDeque::new(),
         })
     }
 
@@ -540,6 +572,7 @@ impl Driver {
         let mut datagram = vec![0u8; BUFFER_BYTES];
 
         self.initiate_handshake();
+        self.flush_pending_udp();
         self.service();
 
         loop {
@@ -585,15 +618,40 @@ impl Driver {
                 Event::Wake | Event::StackDeadline => {}
                 Event::Tick => self.update_timers(),
             }
+            self.flush_pending_udp();
             self.service();
+            self.flush_pending_udp();
         }
     }
 
-    fn send_to_peer(&self, packet: &[u8]) {
+    fn send_to_peer(&mut self, packet: &[u8]) {
         if let Some(peer) = self.peer {
-            // WireGuard tolerates loss; a momentarily unwritable UDP socket
-            // drops the datagram rather than blocking the driver.
-            let _ = self.udp.try_send_to(packet, peer);
+            match self.udp.try_send_to(packet, peer) {
+                Ok(_) => {}
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if self.pending_udp.len() < UDP_SEND_QUEUE_DEPTH {
+                        self.pending_udp.push_back((packet.to_vec(), peer));
+                    }
+                }
+                Err(error) => {
+                    eprintln!("wireguard UDP send to {peer} failed: {error}");
+                }
+            }
+        }
+    }
+
+    fn flush_pending_udp(&mut self) {
+        while let Some((packet, peer)) = self.pending_udp.front() {
+            match self.udp.try_send_to(packet, *peer) {
+                Ok(_) => {
+                    self.pending_udp.pop_front();
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => {
+                    eprintln!("wireguard UDP send to {peer} failed: {error}");
+                    self.pending_udp.pop_front();
+                }
+            }
         }
     }
 

--- a/cmux-tui/crates/cmux-wg/tests/tunnel.rs
+++ b/cmux-tui/crates/cmux-wg/tests/tunnel.rs
@@ -84,6 +84,31 @@ async fn tcp_echo_through_the_tunnel_in_both_families() {
 }
 
 #[tokio::test]
+async fn startup_readiness_waits_for_a_handshake() {
+    let LoopbackPair { client, server, client_socket, server_socket, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+
+    within(client.wait_for_handshake(Duration::from_secs(2))).await.unwrap();
+    within(server.wait_for_handshake(Duration::from_secs(2))).await.unwrap();
+
+    client.shutdown().await;
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn startup_readiness_reports_an_unreachable_peer() {
+    let LoopbackPair { client, client_socket, .. } = loopback_pair().await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+
+    let error = within(client.wait_for_handshake(Duration::from_millis(300))).await.unwrap_err();
+    assert!(matches!(error, WgError::HandshakeTimeout(_)), "{error}");
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
 async fn a_restarted_client_handshakes_again() {
     let LoopbackPair { client, server, client_socket, server_socket, server_v4, .. } =
         loopback_pair().await.unwrap();

--- a/cmuxTests/CloudWireGuardHubTests.swift
+++ b/cmuxTests/CloudWireGuardHubTests.swift
@@ -112,6 +112,15 @@ struct CloudWireGuardHubTests {
         }
     }
 
+    actor AttemptCounter {
+        private(set) var value = 0
+
+        func next() -> Int {
+            value += 1
+            return value
+        }
+    }
+
     /// Sleeps park until the test releases them, so idle stops and restart backoffs run
     /// exactly when the test says the clock has reached them.
     actor SleepGate {
@@ -209,6 +218,40 @@ struct CloudWireGuardHubTests {
         #expect(status.running)
         #expect(status.leases == 2)
         #expect(!status.pinnedByExternalClient)
+    }
+
+    @Test
+    func prewarmHoldsAClaimUntilTheFleetIsEmpty() async throws {
+        let h = makeHarness()
+        let ready = try await h.hub.prewarm()
+        #expect(ready.socketPath == h.socketPath)
+        #expect(h.spawner.count == 1)
+        #expect(await h.hub.status().leases == 1)
+
+        _ = try await h.hub.prewarm()
+        #expect(h.spawner.count == 1)
+        await h.hub.releasePrewarm()
+        await waitForPendingSleeps(h.gate, count: 1)
+        #expect(await h.hub.status().leases == 0)
+    }
+
+    @Test
+    func prewarmRetriesATransientStartupFailure() async throws {
+        let attempts = AttemptCounter()
+        let h = makeHarness(readiness: { _ in
+            if await attempts.next() == 1 {
+                throw CloudWireGuardHub.HubError.notReady("transient startup")
+            }
+        })
+        let task = Task { try await h.hub.prewarm() }
+        await waitForSpawnCount(h.spawner, count: 1)
+        await waitForPendingSleeps(h.gate, count: 1)
+        await h.gate.elapse()
+        await waitForSpawnCount(h.spawner, count: 2)
+        let ready = try await task.value
+        #expect(ready.socketPath == h.socketPath)
+        #expect(await attempts.value == 2)
+        #expect(await h.hub.status().leases == 1)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Opening Cloud machines could leave one or more rows stuck in `Connecting…` or show a transient `vm_cloud_service_unavailable` (HTTP 502) error.

Two independent races were involved:

- The shared userspace WireGuard hub was started only as the first machine link raced to acquire it. A transient DNS/UDP/handshake delay could leave no Unix listener, and the failed claim was dropped until the next catalog poll.
- The VM attach endpoint reports provider startup failures as retryable 502 responses, but the client returned the first 502 immediately.

## Fix

- Prewarm and retain one hub lease whenever the signed-in account has a non-empty VM fleet; release it when the fleet becomes empty or access ends.
- Retry hub startup with bounded backoff and retain startup demand so unexpected child exits restart while machines exist.
- Bound WireGuard endpoint setup and handshake startup, queue blocked UDP handshake packets, and include hub stderr in readiness failures.
- Retry explicitly retryable 502/503/504 attach responses using the server-provided retry delay.

## Validation

- Added Swift hub prewarm and transient-startup retry tests.
- Added userspace WireGuard handshake readiness and blocked-UDP-send tests.
- Existing attach endpoint tests cover the retryable 502 contract.
- `git diff --check` passes.

The first commit contains the behavior tests; the second contains the implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791280674&installation_model_id=21920&pr_number=12047&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12047&signature=de14f8fbdac3baac2ac176a6fc3a55c9dd8ae58054d30f6b2031a9b467b30222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two races that left Cloud machine rows stuck in `Connecting…` or showing a transient `vm_cloud_service_unavailable` (HTTP 502) error.

**Hub prewarm and startup recovery**
- Starts the shared userspace WireGuard hub before per-machine links race to claim it, and keeps the claim while the account has machines.
- Retries transient hub startup failures with bounded backoff and restarts unexpected child exits while machines exist.
- Bounds WireGuard endpoint and handshake startup and queues blocked UDP handshake packets so failures surface quickly.

**Attach endpoint retries**
- Retries retryable 502/503/504 attach responses using the server-provided delay instead of returning the first 502 immediately.

<sup>Written for commit 11683aa5ad58435b35e25227e665c4808cd2b238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud connectivity can now be prewarmed while cloud machines are available, reducing startup delays.
  - WireGuard startup now waits for a confirmed handshake before reporting readiness.

- **Bug Fixes**
  - Improved resilience when cloud services temporarily return errors during connection or attachment.
  - More reliable handling of temporarily unavailable network sockets.

- **Diagnostics**
  - Connection startup failures now provide clearer timeout details and relevant diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->