### PR TITLE
ci: retry transient R2 upload failures and try every nightly feed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1066,15 +1066,28 @@ jobs:
           # either the old version or the new one, never missing. Thin feeds go
           # first: the app rewrites the legacy feed URL to a thin feed, so those
           # must already be current when the legacy feed changes.
+          # Every feed gets its attempt even when an earlier one fails, so one
+          # broken R2 key (2026-09-06: nightly/appcast-arm64.xml rejected every
+          # write with InternalError) leaves the other tracks updatable. The
+          # step still fails, so the nightly tag stays put and the failure
+          # issue stays open until every feed is current.
+          failed=()
           for appcast in appcast-arm64.xml appcast-x86_64.xml appcast-universal.xml appcast.xml; do
-            python3 scripts/ci/upload-r2-object.py \
+            if python3 scripts/ci/upload-r2-object.py \
               --file "nightly-out/$appcast" \
               --endpoint-url "$R2_ENDPOINT" \
               --bucket cmux-binaries \
               --key "nightly/$appcast" \
-              --cache-control "no-cache, no-store, must-revalidate"
-            echo "R2 appcast upload complete: https://files.cmux.com/nightly/$appcast"
+              --cache-control "no-cache, no-store, must-revalidate"; then
+              echo "R2 appcast upload complete: https://files.cmux.com/nightly/$appcast"
+            else
+              failed+=("$appcast")
+            fi
           done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::R2 appcast upload failed for: ${failed[*]}" >&2
+            exit 1
+          fi
 
       # The nightly tag is the completion marker used by the decide job. Move it
       # to the fixed candidate selected at dispatch only after every publication

--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -7,10 +7,13 @@ import hashlib
 import hmac
 import json
 import os
+import random
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Callable
 
 
 def _sign(key: bytes, message: str) -> bytes:
@@ -27,6 +30,76 @@ def _get_signing_key(secret_key: str, date_stamp: str, region: str) -> bytes:
     region_key = _sign(date_key, region)
     service_key = _sign(region_key, "s3")
     return _sign(service_key, "aws4_request")
+
+
+def _amz_date() -> str:
+    """SigV4 timestamp, fresh per attempt so retries never reuse a stale date.
+
+    CMUX_R2_UPLOAD_AMZ_DATE pins it for signature tests.
+    """
+
+    pinned = os.environ.get("CMUX_R2_UPLOAD_AMZ_DATE")
+    if pinned:
+        return pinned
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _retry_budget() -> tuple[int, float]:
+    """Attempt count and base delay for transient failures.
+
+    R2 answers some PutObject calls with HTTP 500 InternalError ("Please try
+    again") and occasionally 429/503. Those are safe to retry: PutObject is
+    idempotent and write-once uploads fall back to the digest check on 412.
+    """
+
+    attempts = int(os.environ.get("CMUX_R2_UPLOAD_MAX_ATTEMPTS", "5"))
+    base = float(os.environ.get("CMUX_R2_UPLOAD_RETRY_BASE_SECONDS", "2"))
+    return max(1, attempts), max(0.0, base)
+
+
+def _is_transient(error: BaseException) -> bool:
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code == 429 or error.code >= 500
+    # urllib.error.URLError covers refused connections, DNS, and TLS
+    # failures; socket.timeout and other OSErrors cover stalled reads.
+    return isinstance(error, OSError)
+
+
+def _describe(error: BaseException) -> str:
+    if isinstance(error, urllib.error.HTTPError):
+        return f"HTTP {error.code} {error.reason}"
+    return str(error)
+
+
+def _open_with_retry(
+    build_request: Callable[[], urllib.request.Request],
+    *,
+    timeout: float,
+    what: str,
+) -> tuple[int, bytes]:
+    """Send a request, retrying transient failures with jittered backoff.
+
+    `build_request` runs on every attempt so each retry carries a fresh
+    SigV4 date; the final failure propagates to the caller unchanged.
+    """
+
+    attempts, base = _retry_budget()
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(build_request(), timeout=timeout) as response:
+                return response.status, response.read()
+        except (urllib.error.HTTPError, OSError) as error:
+            if attempt >= attempts or not _is_transient(error):
+                raise
+            if isinstance(error, urllib.error.HTTPError):
+                error.read()
+            delay = min(base * (2 ** (attempt - 1)), 30.0) * random.uniform(0.5, 1.5)
+            sys.stderr.write(
+                f"R2 {what} attempt {attempt}/{attempts} failed: {_describe(error)}; "
+                f"retrying in {delay:.1f}s\n"
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")
 
 
 def _build_signed_request(
@@ -107,23 +180,26 @@ def _build_signed_request(
 def _read_existing_object(
     args: argparse.Namespace,
     *,
-    amz_date: str,
     expected_digest: str,
 ) -> bool:
     """Return true when an existing immutable object has the same bytes."""
 
-    head = _build_signed_request(args, b"", amz_date, method="HEAD")
     try:
-        with urllib.request.urlopen(head, timeout=30) as response:
-            response.read()
+        _open_with_retry(
+            lambda: _build_signed_request(args, b"", _amz_date(), method="HEAD"),
+            timeout=30,
+            what=f"HEAD {args.key}",
+        )
     except urllib.error.HTTPError as error:
         if error.code == 404:
             return False
         raise
 
-    get = _build_signed_request(args, b"", amz_date, method="GET")
-    with urllib.request.urlopen(get, timeout=120) as response:
-        existing = response.read()
+    _, existing = _open_with_retry(
+        lambda: _build_signed_request(args, b"", _amz_date(), method="GET"),
+        timeout=120,
+        what=f"GET {args.key}",
+    )
     actual_digest = hashlib.sha256(existing).hexdigest()
     if actual_digest != expected_digest:
         raise RuntimeError(
@@ -151,9 +227,7 @@ def main() -> int:
     with open(args.file, "rb") as file:
         body = file.read()
 
-    amz_date = os.environ.get("CMUX_R2_UPLOAD_AMZ_DATE")
-    if not amz_date:
-        amz_date = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    amz_date = _amz_date()
 
     body_digest = hashlib.sha256(body).hexdigest()
     if args.dry_run_json:
@@ -180,28 +254,28 @@ def main() -> int:
     try:
         if args.write_once and _read_existing_object(
             args,
-            amz_date=amz_date,
             expected_digest=body_digest,
         ):
             print(f"Already present with matching digest: s3://{args.bucket}/{args.key}")
             return 0
 
-        request = _build_signed_request(
-            args,
-            body,
-            amz_date,
-            extra_headers={"if-none-match": "*"} if args.write_once else None,
+        status, _ = _open_with_retry(
+            lambda: _build_signed_request(
+                args,
+                body,
+                _amz_date(),
+                extra_headers={"if-none-match": "*"} if args.write_once else None,
+            ),
+            timeout=30,
+            what=f"PUT {args.key}",
         )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            response.read()
-            print(f"Uploaded {args.file} to s3://{args.bucket}/{args.key} ({response.status})")
-            return 0
+        print(f"Uploaded {args.file} to s3://{args.bucket}/{args.key} ({status})")
+        return 0
     except urllib.error.HTTPError as error:
         if args.write_once and error.code == 412:
             try:
                 if _read_existing_object(
                     args,
-                    amz_date=amz_date,
                     expected_digest=body_digest,
                 ):
                     print(f"Already present with matching digest: s3://{args.bucket}/{args.key}")

--- a/tests/test_ci_r2_upload_python.sh
+++ b/tests/test_ci_r2_upload_python.sh
@@ -54,4 +54,103 @@ if ! grep -Fq "scripts/ci/upload-r2-object.py" "$ROOT_DIR/.github/workflows/rele
   exit 1
 fi
 
+# Transient R2 failures (HTTP 5xx, 429, connection errors) must be retried
+# with backoff. R2 documents InternalError as "please try again"; nightly runs
+# 34020074283, 34022099394, and 34023000234 all died on one such PUT.
+cat >"$TMP_DIR/fake_r2.py" <<'FAKE'
+import http.server
+import sys
+
+PORT = int(sys.argv[1])
+FAIL_FIRST = int(sys.argv[2])
+COUNT_FILE = sys.argv[3]
+seen = 0
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_PUT(self):
+        global seen
+        seen += 1
+        with open(COUNT_FILE, "w", encoding="utf-8") as file:
+            file.write(str(seen))
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        if seen <= FAIL_FIRST:
+            payload = b'<?xml version="1.0"?><Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message></Error>'
+            self.send_response(500)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        assert body == b"<rss>ok</rss>", body
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+server = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
+server.serve_forever()
+FAKE
+
+start_fake_r2() {
+  local fail_first="$1" count_file="$2"
+  FAKE_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1])')"
+  python3 "$TMP_DIR/fake_r2.py" "$FAKE_PORT" "$fail_first" "$count_file" &
+  FAKE_PID=$!
+  for _ in $(seq 1 50); do
+    if python3 -c "import socket,sys; s=socket.socket(); s.settimeout(0.2); sys.exit(0 if s.connect_ex(('127.0.0.1',$FAKE_PORT))==0 else 1)"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "FAIL: fake R2 server did not start" >&2
+  exit 1
+}
+
+stop_fake_r2() {
+  kill "$FAKE_PID" 2>/dev/null || true
+  wait "$FAKE_PID" 2>/dev/null || true
+}
+
+run_upload() {
+  AWS_ACCESS_KEY_ID=AKIDEXAMPLE \
+  AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY \
+  AWS_DEFAULT_REGION=auto \
+  CMUX_R2_UPLOAD_MAX_ATTEMPTS=4 \
+  CMUX_R2_UPLOAD_RETRY_BASE_SECONDS=0.01 \
+  python3 "$ROOT_DIR/scripts/ci/upload-r2-object.py" \
+    --file "$TMP_DIR/appcast.xml" \
+    --endpoint-url "http://127.0.0.1:$FAKE_PORT" \
+    --bucket cmux-binaries \
+    --key nightly/appcast.xml \
+    --cache-control "no-cache, no-store, must-revalidate"
+}
+
+# Two InternalErrors, then success: the upload must succeed on the third PUT.
+start_fake_r2 2 "$TMP_DIR/count-recover"
+if ! run_upload >"$TMP_DIR/recover.log" 2>&1; then
+  cat "$TMP_DIR/recover.log"
+  stop_fake_r2
+  echo "FAIL: uploader gave up on a transient HTTP 500"
+  exit 1
+fi
+stop_fake_r2
+[ "$(cat "$TMP_DIR/count-recover")" = "3" ] || { echo "FAIL: expected 3 PUT attempts, got $(cat "$TMP_DIR/count-recover")"; exit 1; }
+grep -q "retrying" "$TMP_DIR/recover.log" || { cat "$TMP_DIR/recover.log"; echo "FAIL: retries must be logged"; exit 1; }
+
+# Persistent InternalError: the upload must stop after the attempt budget.
+start_fake_r2 1000 "$TMP_DIR/count-giveup"
+if run_upload >"$TMP_DIR/giveup.log" 2>&1; then
+  stop_fake_r2
+  echo "FAIL: uploader reported success while R2 kept failing"
+  exit 1
+fi
+stop_fake_r2
+[ "$(cat "$TMP_DIR/count-giveup")" = "4" ] || { echo "FAIL: expected 4 PUT attempts, got $(cat "$TMP_DIR/count-giveup")"; exit 1; }
+grep -q "HTTP 500" "$TMP_DIR/giveup.log" || { cat "$TMP_DIR/giveup.log"; echo "FAIL: final error must name the HTTP status"; exit 1; }
+
+echo "PASS: Python R2 uploader retries transient failures and gives up after the attempt budget"
 echo "PASS: Python R2 uploader signs appcast uploads without awscli"


### PR DESCRIPTION
Three nightly publishes on 2026-09-06 (https://github.com/manaflow-ai/cmux/actions/runs/34020074283, https://github.com/manaflow-ai/cmux/actions/runs/34022099394, https://github.com/manaflow-ai/cmux/actions/runs/34023000234) failed in the "Upload nightly appcasts to R2" step with `HTTP 500 InternalError` from R2 on the first PUT. The uploader had no retries, and the loop stopped at the first feed, so no nightly feed was updated at all. The same script failed the same way in https://github.com/manaflow-ai/cmux/actions/runs/34020547994 (cmux-tui artifacts).

Commit 1 adds the test: a local fake R2 returns 500 twice then 200 (must succeed, 3 PUTs) and one that never recovers (must exit 1 after the attempt budget). Commit 2 makes it pass.

`scripts/ci/upload-r2-object.py` retries 5xx, 429, and connection errors with jittered exponential backoff (5 attempts, 2s base, 30s cap, env overrides), re-signing each attempt with a fresh `x-amz-date`. 4xx still fail immediately and the write-once 412 path is unchanged. `nightly.yml` attempts all four feeds before failing, so one stuck key no longer blocks the other tracks; the step still exits 1 so the nightly tag stays put and the failure issue stays open.

Root cause note: two R2 objects (`nightly/appcast-arm64.xml`, `cmux-tui/latest/cmux-tui-hook-x86_64-apple-darwin`) currently reject every PUT and DELETE with 500 through both the S3 API and the Cloudflare REST API, while other keys in the bucket write fine. That is an R2-side fault and needs a Cloudflare ticket; this PR does not fix it, it stops one bad key from taking down every feed and absorbs the transient 500s R2 documents as retryable.

Tests: `./tests/test_ci_r2_upload_python.sh` (also run by ci.yml), `actionlint .github/workflows/nightly.yml`.

https://claude.ai/code/session_01CGC18ozwUm8SqmM64DeZGe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791281848&installation_model_id=21920&pr_number=12050&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12050&signature=346dd8c856b4d84592689c94961f64f8b7f98279ce26d3ba4ba76066599a898d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes nightly R2 appcast uploads resilient: the uploader now retries HTTP 5xx, 429, and connection errors with jittered exponential backoff, and the workflow attempts all four feeds instead of stopping at the first failure, which previously left every nightly feed stale on a single HTTP 500. Two R2 keys are currently rejecting every write with 500 — an R2-side fault needing a Cloudflare ticket; this PR doesn't fix that, it just stops one bad key from blocking the other tracks.

- Retry backoff: 5 attempts, 2s base, 30s cap, overridable via `CMUX_R2_UPLOAD_MAX_ATTEMPTS` and `CMUX_R2_UPLOAD_RETRY_BASE_SECONDS`; each attempt re-signs with a fresh `x-amz-date`.
- 4xx responses still fail immediately; the write-once 412 path is unchanged.
- The workflow still exits 1 when any feed fails, so the nightly tag stays put.
- Adds tests with a local fake R2 that returns 500 twice then 200, and one that never recovers.

<sup>Written for commit fd9a8aab507c9a1ea9c5b41276c3c81df9262347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * R2 uploads now retry temporary failures and refresh request authentication on each attempt.
  * Nightly uploads continue processing all feeds when one fails, while reporting failed feeds and preventing nightly tag publication if any upload fails.
  * Successful uploads are logged individually.

* **Tests**
  * Added coverage for retry success, retry exhaustion, backoff logging, and final error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->