### PR TITLE
Fix corrupted PATH bytes in terminal panes

### DIFF
--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -1,4 +1,5 @@
 import CMUXAgentLaunch
+import CmuxFoundation
 import Foundation
 
 extension CMUXCLI {
@@ -421,14 +422,7 @@ extension CMUXCLI {
     }
 
     func prependPathEntries(_ newEntries: [String], to currentPath: String?) -> String {
-        var ordered: [String] = []
-        var seen: Set<String> = []
-        for entry in newEntries + (currentPath?.split(separator: ":").map(String.init) ?? []) where !entry.isEmpty {
-            if seen.insert(entry).inserted {
-                ordered.append(entry)
-            }
-        }
-        return ordered.joined(separator: ":")
+        CmuxPathEnvironment.prependingUniqueEntries(newEntries, to: currentPath)
     }
 
 }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Process/CmuxPathEnvironment.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Process/CmuxPathEnvironment.swift
@@ -1,0 +1,63 @@
+public import Foundation
+
+/// Composes PATH values that cmux exports across process boundaries.
+public enum CmuxPathEnvironment {
+    /// Returns PATH components that can be safely represented as UTF-8.
+    ///
+    /// Foundation decodes malformed inherited environment bytes as the
+    /// replacement scalar. Dropping that component, along with control-byte
+    /// components, prevents cmux from re-exporting a value that strict tools
+    /// reject while preserving empty components and their current-directory
+    /// semantics.
+    public static func components(from path: String?) -> [String] {
+        guard let path else { return [] }
+        return path
+            .split(separator: ":", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { component in
+                !component.unicodeScalars.contains(where: isMalformedScalar)
+            }
+    }
+
+    /// Prepends entries once while discarding malformed inherited components.
+    public static func prependingUniqueEntries(
+        _ newEntries: [String],
+        to currentPath: String?
+    ) -> String {
+        var ordered: [String] = []
+        var seen: Set<String> = []
+        let entries = newEntries + components(from: currentPath)
+        for entry in entries where !entry.isEmpty && !entry.unicodeScalars.contains(where: isMalformedScalar) {
+            if seen.insert(entry).inserted {
+                ordered.append(entry)
+            }
+        }
+        return ordered.joined(separator: ":")
+    }
+
+    /// Prepends a standardized directory once while discarding malformed PATH components.
+    public static func prependingUniqueDirectory(_ directory: String, to path: String) -> String {
+        let trimmedDirectory = directory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDirectory.isEmpty else { return path }
+        let standardizedDirectory = URL(fileURLWithPath: trimmedDirectory, isDirectory: true)
+            .standardizedFileURL
+            .path
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return standardizedDirectory
+        }
+
+        var entries = components(from: path).filter { entry in
+            let trimmedEntry = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedEntry.isEmpty else { return true }
+            return URL(fileURLWithPath: trimmedEntry, isDirectory: true)
+                .standardizedFileURL
+                .path != standardizedDirectory
+        }
+        entries.insert(standardizedDirectory, at: 0)
+        return entries.joined(separator: ":")
+    }
+
+    private static func isMalformedScalar(_ scalar: Unicode.Scalar) -> Bool {
+        CharacterSet.controlCharacters.contains(scalar) || scalar == "\u{FFFD}"
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -1,4 +1,5 @@
 public import Foundation
+internal import CmuxFoundation
 internal import CMUXAgentLaunch
 internal import Darwin
 internal import OSLog
@@ -90,26 +91,7 @@ extension TerminalSurface {
 
     /// Prepends `directory` to a `PATH`-style string exactly once.
     public static func pathByPrependingUniqueDirectory(_ directory: String, to path: String) -> String {
-        let trimmedDirectory = directory.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedDirectory.isEmpty else { return path }
-        let standardizedDirectory = URL(fileURLWithPath: trimmedDirectory, isDirectory: true)
-            .standardizedFileURL
-            .path
-        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return standardizedDirectory
-        }
-        var entries = path
-            .split(separator: ":", omittingEmptySubsequences: false)
-            .map(String.init)
-            .filter { entry in
-                let trimmedEntry = entry.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmedEntry.isEmpty else { return true }
-                return URL(fileURLWithPath: trimmedEntry, isDirectory: true)
-                    .standardizedFileURL
-                    .path != standardizedDirectory
-            }
-        entries.insert(standardizedDirectory, at: 0)
-        return entries.joined(separator: ":")
+        CmuxPathEnvironment.prependingUniqueDirectory(directory, to: path)
     }
 
     /// Merges base, additional, and override environments with key

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
@@ -1,6 +1,7 @@
 internal import AppKit
 internal import Foundation
 internal import GhosttyKit
+internal import CmuxFoundation
 internal import CmuxTerminalCore
 internal import CMUXAgentLaunch
 internal import Darwin
@@ -91,6 +92,18 @@ extension TerminalSurface {
             protectedStartupEnvironmentKeys.insert(key)
         }
 
+        func currentManagedPath() -> String {
+            let inheritedPath = env["PATH"]
+                ?? ProcessInfo.processInfo.environment["PATH"]
+                ?? ""
+            return CmuxPathEnvironment.components(from: inheritedPath).joined(separator: ":")
+        }
+
+        let sanitizedPath = currentManagedPath()
+        if env["PATH"] != nil || !sanitizedPath.isEmpty {
+            setManagedEnvironmentValue("PATH", sanitizedPath)
+        }
+
         if let resolvedUserShell = engine.resolvedUserShell {
             setManagedEnvironmentValue("SHELL", resolvedUserShell)
         }
@@ -174,10 +187,7 @@ extension TerminalSurface {
             if FileManager.default.isExecutableFile(atPath: ghosttyCLIPath) {
                 setManagedEnvironmentValue("GHOSTTY_BIN", ghosttyCLIPath)
             }
-            let currentPath = env["PATH"]
-                ?? getenv("PATH").map { String(cString: $0) }
-                ?? ProcessInfo.processInfo.environment["PATH"]
-                ?? ""
+            let currentPath = currentManagedPath()
             if !currentPath.split(separator: ":").contains(Substring(cliBinPath)) {
                 setManagedEnvironmentValue(
                     "PATH",
@@ -192,10 +202,7 @@ extension TerminalSurface {
                 setManagedEnvironmentValue(shim.wrapperShimEnvironmentKey, shim.executablePath)
                 setManagedEnvironmentValue(shim.wrapperShimRootEnvironmentKey, shim.directoryPath)
             }
-            let currentPath = env["PATH"]
-                ?? getenv("PATH").map { String(cString: $0) }
-                ?? ProcessInfo.processInfo.environment["PATH"]
-                ?? ""
+            let currentPath = currentManagedPath()
             setManagedEnvironmentValue(
                 "PATH",
                 Self.pathByPrependingUniqueDirectory(agentCommandShims.directoryPath, to: currentPath)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2837,6 +2837,7 @@
 		B88358000000000000000003 /* TerminalPastePreparationWorkerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88358000000000000000004 /* TerminalPastePreparationWorkerResponse.swift */; };
 		B88359000000000000000001 /* TerminalPastePreparationWorkerSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88359000000000000000002 /* TerminalPastePreparationWorkerSupervisor.swift */; };
 		2681A216F02BEE5AD12CE00D /* TerminalPastePreparationWorkerTextPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85403EFC95DBB4FA4AE9CE7 /* TerminalPastePreparationWorkerTextPayload.swift */; };
+		C13519000000000000000013 /* TerminalPathEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000014 /* TerminalPathEnvironmentTests.swift */; };
 		F87910110000000000000001 /* TerminalPendingConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87910110000000000000002 /* TerminalPendingConfigurationReload.swift */; };
 		9612A0010000000000000001 /* TerminalPortalReconciliation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612B0010000000000000001 /* TerminalPortalReconciliation.swift */; };
 		D0F101000000000000000003 /* TerminalRawMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F101000000000000000013 /* TerminalRawMode.swift */; };
@@ -6047,6 +6048,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		B88358000000000000000004 /* TerminalPastePreparationWorkerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPastePreparationWorkerResponse.swift; sourceTree = "<group>"; };
 		B88359000000000000000002 /* TerminalPastePreparationWorkerSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPastePreparationWorkerSupervisor.swift; sourceTree = "<group>"; };
 		B85403EFC95DBB4FA4AE9CE7 /* TerminalPastePreparationWorkerTextPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPastePreparationWorkerTextPayload.swift; sourceTree = "<group>"; };
+		C13519000000000000000014 /* TerminalPathEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPathEnvironmentTests.swift; sourceTree = "<group>"; };
 		F87910110000000000000002 /* TerminalPendingConfigurationReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPendingConfigurationReload.swift; sourceTree = "<group>"; };
 		9612B0010000000000000001 /* TerminalPortalReconciliation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPortalReconciliation.swift; sourceTree = "<group>"; };
 		D0F101000000000000000013 /* TerminalRawMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRawMode.swift; sourceTree = "<group>"; };
@@ -9017,6 +9019,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C2035A060000000000000002 /* BrowserSSLTrustBypassStateTests.swift */,
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
 				C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */,
+				C13519000000000000000014 /* TerminalPathEnvironmentTests.swift */,
 				C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */,
 				C65930010000000000000001 /* CrashDiagnosticSessionPolicyTests.swift */,
 				DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */,
@@ -13424,6 +13427,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
 				11189010A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift in Sources */,
 				596100000000000000000007 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift in Sources */,
+				C13519000000000000000013 /* TerminalPathEnvironmentTests.swift in Sources */,
 				D5671101D5671101D5671101 /* TerminalScrollSpeedSettingsFileStoreTests.swift in Sources */,
 				222425EC9FE2E318D8F6F46A /* TerminalSearchNavigationTests.swift in Sources */,
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,

--- a/cmuxTests/TerminalPathEnvironmentTests.swift
+++ b/cmuxTests/TerminalPathEnvironmentTests.swift
@@ -1,0 +1,19 @@
+import CmuxTerminal
+import Testing
+
+@Suite("Terminal PATH environment")
+struct TerminalPathEnvironmentTests {
+    @Test("Drops malformed PATH components when prepending a cmux shim")
+    func dropsMalformedPathComponentsWhenPrependingShim() {
+        let shimDirectory = "/var/folders/demo/cmux-cli-shims/ABC"
+        let malformedComponent = "\u{FFFD}u[\u{FFFD}\u{0008}`\u{FFFD}-\u{FFFD}(\u{FFFD}"
+        let path = "/usr/bin:\(malformedComponent):/bin"
+
+        let result = TerminalSurface.pathByPrependingUniqueDirectory(
+            shimDirectory,
+            to: path
+        )
+
+        #expect(result == "\(shimDirectory):/usr/bin:/bin")
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/11535

## Summary

- Centralize cmux-managed `PATH` composition in `CmuxPathEnvironment`.
- Remove inherited PATH components containing replacement/control scalars before cmux re-exports them.
- Stop reading runtime PATH through raw `getenv`; use the Foundation environment snapshot and sanitize it once per surface creation.
- Reuse the same sanitizer for CLI tmux PATH composition.
- Add a regression test for malformed PATH components; the test-only commit is separate from the fix commit.

## Trade-offs

Malformed components are dropped rather than repaired because the original bytes cannot be reconstructed after Foundation has decoded them as replacement/control scalars. Valid entries and empty components retain their existing semantics where the call site supports them. This favors preventing UTF-8-strict tools from crashing over preserving an entry whose contents are already corrupt.

## Verification

- `swiftc -parse` passed for every changed Swift file.
- `git diff --check` passed.
- `bash scripts/lint-pbxproj-test-wiring.sh` passed (780 test files checked).
- Local deterministic repro confirmed malformed PATH data survives the old composer and is rejected by the new sanitizer.
- The test-only commit `bec514b36a` was run remotely before the upstream `VMClient` fix landed; its two focused workflow attempts stopped before tests executed on that unrelated compile error.
- The current fixed-head focused workflow `34035426924` reached the test target but stopped before execution on existing `SurfaceCatalog` test compile errors (`replaceCloudResources`, `beginCloudWorkspaceRename`, and related members missing from `SurfaceCatalog`).
- Tagged build `cb29e454c4` succeeded after the required cloud attempt failed at backend hostname provisioning and the permitted local fallback was used. In a real plain terminal pane, `/usr/bin/python3` strictly decoded the raw `PATH` and reported `PATH_UTF8_OK bytes=1359`; a second check reported `PATH_STRICT_UTF8_AND_CONTROL_OK` with no control bytes. The tagged app was quit and its derived data/temp sockets removed afterward.
- No local `xcodebuild test` or XCUITest was run.
