### PR TITLE
Fix tmux compatibility read fan-out rate limiting

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientRateLimiter.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientRateLimiter.swift
@@ -10,6 +10,8 @@ public actor ControlClientRateLimiter {
     /// Token-bucket tuning values.
     public struct Configuration: Sendable, Equatable {
         /// Number of polling requests admitted immediately for a new client.
+        /// The default covers the current tmux compatibility read fan-out;
+        /// refill still bounds sustained polling.
         public let burst: Int
         /// Nanoseconds required to refill one token.
         public let refillIntervalNanoseconds: UInt64
@@ -19,7 +21,7 @@ public actor ControlClientRateLimiter {
         /// Values are clamped to a positive burst and a non-zero interval so
         /// the limiter cannot accidentally become an unbounded admission path.
         public init(
-            burst: Int = 4,
+            burst: Int = 9,
             refillIntervalNanoseconds: UInt64 = 100_000_000
         ) {
             self.burst = max(1, burst)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
@@ -157,6 +157,34 @@ struct ControlPlaneConcurrencyTests {
         #expect(await limiter.admit(method: "system.top") == .allowed)
     }
 
+    @Test func pollingLimiterAdmitsTmuxCompatReadFanoutBeforeRefill() async {
+        let clock = TestMonotonicClock()
+        let limiter = ControlClientRateLimiter(now: { clock.now })
+        let tmuxFormatContextMethods = [
+            "surface.current",
+            "pane.list",
+            "surface.list",
+            "workspace.list",
+            "window.list",
+            "workspace.list",
+            "workspace.list",
+            "workspace.current",
+            "workspace.list",
+        ]
+
+        for method in tmuxFormatContextMethods {
+            #expect(await limiter.admit(method: method) == .allowed)
+        }
+        guard case .limited(let retryAfter) = await limiter.admit(method: "surface.list") else {
+            Issue.record("the complete tmux compatibility read fan-out should fit in one burst")
+            return
+        }
+        #expect(retryAfter > 0)
+
+        clock.advance(by: 100_000_000)
+        #expect(await limiter.admit(method: "surface.list") == .allowed)
+    }
+
     @Test func readSnapshotPublishesAtomicallyAndKeysByMethodAndParams() {
         let store = ControlReadSnapshotStore()
         let initial = ControlCallResult.ok(.object(["generation": .int(1)]))


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/11803

## Summary
- Add a behavior regression covering the nine read-plane calls made by `tmuxFormatContext`.
- Follow with a separate fix commit that admits the complete legitimate one-command fan-out while preserving the refill-based sustained polling limit.

## Trade-offs
- The per-connection burst increases only enough to cover the documented tmux compatibility read fan-out (`4 → 9`); the refill interval remains unchanged, so sustained polling is still throttled.
- This keeps the limiter at the control-socket request boundary rather than adding a tmux-specific bypass or weakening read-plane classification.
- A command-scoped batch protocol would be a broader redesign; the measured fan-out-sized burst is the smallest change that fixes the existing protocol without changing its security boundary.

## Verification
- Test-only regression commit: `4ab7795782`.
- Fix commit: `e67004ad9d`.
- `git diff --check` passes.
- GitHub package CI ran `CmuxControlSocket` with 432 tests across 55 suites; all passed.
- Tagged Debug app verification passed both exact probes through its isolated tmux shim:
  - `tmux display-message -p '#{session_name}:#{window_index}.#{pane_index}'` → `cmux:0.0`, exit 0.
  - `tmux has-session` → exit 0.
- Cloud reload was attempted first but backend provisioning failed because `cmux-dev-backend-1` was not resolvable; the required tagged local fallback build succeeded.

## CI note
- The dispatched full CI run's package tests pass. Its unrelated app-host shards fail on pre-existing missing `SurfaceCatalog` members, and the warning-budget gate reports the pre-existing `Sources/TerminalController.swift` `var` warning; neither failure is in this change.
