### PR TITLE
Create workspace by dropping a Finder folder onto the sidebar

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceDirectoryDropValidator.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceDirectoryDropValidator.swift
@@ -1,0 +1,132 @@
+public import Foundation
+
+/// Validates Finder-style file URL payloads for creating a new sidebar workspace.
+///
+/// A successful result is exactly one local directory URL. Workspace identity is
+/// never derived from this path — the directory is only the initial working
+/// context for a newly created workspace.
+public struct ExternalWorkspaceDirectoryDropValidator: Sendable {
+    /// One accepted local directory ready to become a workspace working directory.
+    public struct AcceptedDirectory: Equatable, Sendable {
+        /// Standardized file URL for the directory.
+        public let url: URL
+
+        /// Path spelling used as the workspace working directory.
+        ///
+        /// Matches Finder / Dock external-open normalization: standardized path
+        /// with trailing slashes stripped, without resolving symlinks for identity.
+        public let path: String
+
+        /// Creates an accepted directory snapshot.
+        ///
+        /// - Parameters:
+        ///   - url: Standardized file URL for the directory.
+        ///   - path: Working-directory path spelling to hand to workspace creation.
+        public init(url: URL, path: String) {
+            self.url = url
+            self.path = path
+        }
+    }
+
+    /// Why a Finder payload cannot create a workspace.
+    public enum RejectionReason: Error, Equatable, Sendable {
+        /// The pasteboard carried no file URLs.
+        case emptyPayload
+        /// More than one item was dragged; v1 accepts exactly one directory.
+        case multipleItems
+        /// The URL is not a local `file:` URL.
+        case notLocalFileURL
+        /// The path does not exist on disk at validation time.
+        case missingPath
+        /// The path exists but is not a directory.
+        case notDirectory
+    }
+
+    /// Result of probing one URL against the filesystem.
+    public enum DirectoryProbeResult: Equatable, Sendable {
+        /// Nothing exists at the path.
+        case missing
+        /// A non-directory file exists at the path.
+        case file
+        /// A directory exists at the path (including macOS packages, matching
+        /// current Finder / Dock external-open directory acceptance).
+        case directory
+    }
+
+    /// Filesystem probe used by the validator.
+    public typealias DirectoryProbe = @Sendable (URL) -> DirectoryProbeResult
+
+    private let probe: DirectoryProbe
+
+    /// Creates a validator.
+    ///
+    /// - Parameter probe: Filesystem classification for one URL. Defaults to
+    ///   ``fileManagerProbe(_:)``, which mirrors AppDelegate external-open
+    ///   directory detection (`hasDirectoryPath` / `isDirectory` resource values).
+    public init(probe: @escaping DirectoryProbe = Self.fileManagerProbe) {
+        self.probe = probe
+    }
+
+    /// Validates Finder file URLs for a single-directory workspace drop.
+    ///
+    /// - Parameter urls: Already-normalized file URLs (for example from
+    ///   `PasteboardFileURLReader.fileURLs(from:)`).
+    /// - Returns: The accepted directory, or a rejection reason.
+    public func validate(_ urls: [URL]) -> Result<AcceptedDirectory, RejectionReason> {
+        guard !urls.isEmpty else {
+            return .failure(.emptyPayload)
+        }
+        guard urls.count == 1 else {
+            return .failure(.multipleItems)
+        }
+        let url = urls[0]
+        guard url.isFileURL else {
+            return .failure(.notLocalFileURL)
+        }
+
+        let standardized = url.standardizedFileURL
+        switch probe(standardized) {
+        case .missing:
+            return .failure(.missingPath)
+        case .file:
+            return .failure(.notDirectory)
+        case .directory:
+            let path = Self.canonicalDirectoryPath(
+                standardized.path(percentEncoded: false)
+            )
+            guard !path.isEmpty else {
+                return .failure(.missingPath)
+            }
+            return .success(AcceptedDirectory(url: standardized, path: path))
+        }
+    }
+
+    /// Default probe aligned with `AppDelegate.externalOpenURLIsDirectory`.
+    public static func fileManagerProbe(_ url: URL) -> DirectoryProbeResult {
+        if url.hasDirectoryPath {
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+                return .missing
+            }
+            return isDirectory.boolValue ? .directory : .file
+        }
+        if let values = try? url.resourceValues(forKeys: [.isDirectoryKey]),
+           let isDirectory = values.isDirectory {
+            return isDirectory ? .directory : .file
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return .missing
+        }
+        return isDirectory.boolValue ? .directory : .file
+    }
+
+    private static func canonicalDirectoryPath(_ path: String) -> String {
+        guard path.count > 1 else { return path }
+        var canonical = path
+        while canonical.count > 1 && canonical.hasSuffix("/") {
+            canonical.removeLast()
+        }
+        return canonical
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceDropCommitResolver.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceDropCommitResolver.swift
@@ -1,0 +1,38 @@
+public import Foundation
+
+/// Chooses which external-directory insertion plan to commit on drop release.
+///
+/// Product invariant: if the UI is still showing a painted insertion line, tiny
+/// release-time pointer drift into a row center must not cancel that drop when
+/// the complete root order is unchanged. Viewport / order invalidation still
+/// rejects a stale painted plan.
+public enum ExternalWorkspaceDropCommitResolver: Sendable {
+    /// - Parameters:
+    ///   - replanned: Fresh geometry plan at the release point, if any.
+    ///   - painted: Last accepted plan that was painted for the user.
+    ///   - paintedCompleteTopLevelIds: Complete ungrouped root order when
+    ///     `painted` was accepted.
+    ///   - currentCompleteTopLevelIds: Complete ungrouped root order at commit.
+    public static func resolve(
+        replanned: ExternalWorkspaceInsertionPlanner.Plan?,
+        painted: ExternalWorkspaceInsertionPlanner.Plan?,
+        paintedCompleteTopLevelIds: [UUID],
+        currentCompleteTopLevelIds: [UUID]
+    ) -> ExternalWorkspaceInsertionPlanner.Plan? {
+        if let replanned {
+            return replanned
+        }
+        guard let painted,
+              paintedCompleteTopLevelIds == currentCompleteTopLevelIds,
+              painted.insertionIndex >= 0,
+              painted.insertionIndex <= currentCompleteTopLevelIds.count
+        else {
+            return nil
+        }
+        if let tabId = painted.indicator.tabId,
+           !currentCompleteTopLevelIds.contains(tabId) {
+            return nil
+        }
+        return painted
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
@@ -1,0 +1,135 @@
+public import CoreGraphics
+public import Foundation
+
+/// Plans where a **new** unpinned root workspace should be inserted in the sidebar.
+///
+/// This is intentionally separate from internal workspace reorder planning.
+/// Reorder math answers "where should an existing workspace move?"; this planner
+/// answers "at what index should a brand-new workspace be inserted?"
+///
+/// Geometry reuses ``SidebarDropPlanner``'s new-workspace insertion bands
+/// (edge/gap → insert, row center → reject). Callers must supply **root-level**
+/// targets only so grouped children / group headers are not treated as legal
+/// v1 destinations.
+public struct ExternalWorkspaceInsertionPlanner: Sendable {
+    /// One root-level sidebar row that can host an external directory insertion.
+    public struct RootTarget: Equatable, Sendable {
+        /// Workspace identity for the row (never a filesystem path).
+        public let workspaceId: UUID
+        /// Whether the row sits in the leading pinned segment.
+        public let isPinned: Bool
+        /// Row frame in the drop overlay's coordinate space.
+        public let frame: CGRect
+
+        /// Creates a root-level insertion target.
+        ///
+        /// - Parameters:
+        ///   - workspaceId: Workspace UUID for the row.
+        ///   - isPinned: Whether the row is pinned.
+        ///   - frame: Row frame in drop coordinates.
+        public init(workspaceId: UUID, isPinned: Bool, frame: CGRect) {
+            self.workspaceId = workspaceId
+            self.isPinned = isPinned
+            self.frame = frame
+        }
+    }
+
+    /// Insertion plan for a new unpinned workspace.
+    public struct Plan: Equatable, Sendable {
+        /// Index into the provided `rootTargets` / matching top-level order at
+        /// which the new workspace should be inserted. Already clamped so an
+        /// unpinned workspace cannot land inside the pinned prefix.
+        public let insertionIndex: Int
+        /// Existing-style sidebar insertion indicator to render.
+        public let indicator: SidebarDropIndicator
+
+        /// Creates an external insertion plan.
+        ///
+        /// - Parameters:
+        ///   - insertionIndex: Clamped insertion index for the new workspace.
+        ///   - indicator: Drop indicator matching that index.
+        public init(insertionIndex: Int, indicator: SidebarDropIndicator) {
+            self.insertionIndex = insertionIndex
+            self.indicator = indicator
+        }
+    }
+
+    /// Creates an external new-workspace insertion planner.
+    public init() {}
+
+    /// Resolves a pointer location into a new-workspace insertion plan.
+    ///
+    /// - Parameters:
+    ///   - point: Pointer location in the same coordinate space as `rootTargets`.
+    ///   - rootTargets: Ordered root-level rows only (no group children / headers).
+    /// - Returns: A plan when the pointer is over an insertion band or gap;
+    ///   `nil` when targets are empty, or when the pointer is over a row center
+    ///   (rejected so we never imply opening an existing workspace).
+    public func plan(
+        point: CGPoint,
+        rootTargets: [RootTarget]
+    ) -> Plan? {
+        guard !rootTargets.isEmpty else {
+            return nil
+        }
+
+        let dropTargets = rootTargets.map {
+            SidebarDropPlanner.WorkspaceDropTarget(
+                workspaceId: $0.workspaceId,
+                isPinned: $0.isPinned,
+                frame: $0.frame
+            )
+        }
+        guard let action = SidebarDropPlanner().workspaceAction(
+            for: point,
+            targets: dropTargets
+        ) else {
+            return nil
+        }
+
+        // Mid-row "drop onto existing workspace" is bonsplit semantics, not
+        // Finder directory creation. Reject so we never imply reuse/dedupe.
+        guard case .newWorkspace(let insertionIndex, let indicator) = action else {
+            return nil
+        }
+        return Plan(insertionIndex: insertionIndex, indicator: indicator)
+    }
+
+    /// Insertion plan when the sidebar has no root rows yet.
+    ///
+    /// - Returns: Append-at-zero with an end-of-list indicator.
+    public func planForEmptySidebar() -> Plan {
+        Plan(
+            insertionIndex: 0,
+            indicator: SidebarDropIndicator(tabId: nil, edge: .bottom)
+        )
+    }
+
+    /// Maps a top-level insertion slot to a raw `tabs` array index.
+    ///
+    /// - Parameters:
+    ///   - slot: Index into `topLevelIds` (or `topLevelIds.count` to append).
+    ///   - topLevelIds: Root-level workspace ids in sidebar order.
+    ///   - tabIds: Full workspace storage order (`TabManager.tabs` ids).
+    /// - Returns: Index suitable for `insertionIndexOverride` on workspace creation.
+    public func rawTabInsertionIndex(
+        forTopLevelSlot slot: Int,
+        topLevelIds: [UUID],
+        tabIds: [UUID]
+    ) -> Int {
+        let clampedSlot = max(0, min(slot, topLevelIds.count))
+        guard clampedSlot < topLevelIds.count else {
+            return tabIds.count
+        }
+        let topLevelId = topLevelIds[clampedSlot]
+        if let liveIndex = tabIds.firstIndex(of: topLevelId) {
+            return liveIndex
+        }
+        for nextId in topLevelIds.dropFirst(clampedSlot + 1) {
+            if let nextIndex = tabIds.firstIndex(of: nextId) {
+                return nextIndex
+            }
+        }
+        return tabIds.count
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
@@ -3,30 +3,15 @@ public import Foundation
 
 /// Plans where a **new** unpinned root workspace should be inserted in the sidebar.
 ///
-/// This is intentionally separate from internal workspace reorder planning.
-/// Reorder math answers "where should an existing workspace move?"; this planner
-/// answers "at what index should a brand-new workspace be inserted?"
-///
-/// Geometry reuses ``SidebarDropPlanner``'s new-workspace insertion bands
-/// (edge/gap → insert, row center → reject). Callers must supply **root-level**
-/// targets only so grouped children / group headers are not treated as legal
-/// v1 destinations.
+/// Geometry uses **visible** root rows. ``Plan/insertionIndex`` is always a slot
+/// in the **complete** top-level ungrouped order (not the visible-only array).
 public struct ExternalWorkspaceInsertionPlanner: Sendable {
-    /// One root-level sidebar row that can host an external directory insertion.
+    /// One visible root-level sidebar row used for pointer geometry.
     public struct RootTarget: Equatable, Sendable {
-        /// Workspace identity for the row (never a filesystem path).
         public let workspaceId: UUID
-        /// Whether the row sits in the leading pinned segment.
         public let isPinned: Bool
-        /// Row frame in the drop overlay's coordinate space.
         public let frame: CGRect
 
-        /// Creates a root-level insertion target.
-        ///
-        /// - Parameters:
-        ///   - workspaceId: Workspace UUID for the row.
-        ///   - isPinned: Whether the row is pinned.
-        ///   - frame: Row frame in drop coordinates.
         public init(workspaceId: UUID, isPinned: Bool, frame: CGRect) {
             self.workspaceId = workspaceId
             self.isPinned = isPinned
@@ -36,44 +21,38 @@ public struct ExternalWorkspaceInsertionPlanner: Sendable {
 
     /// Insertion plan for a new unpinned workspace.
     public struct Plan: Equatable, Sendable {
-        /// Index into the provided `rootTargets` / matching top-level order at
-        /// which the new workspace should be inserted. Already clamped so an
-        /// unpinned workspace cannot land inside the pinned prefix.
+        /// Index into the complete top-level ungrouped order, or `count` to append.
+        /// Clamped so an unpinned workspace cannot land inside the pinned prefix.
         public let insertionIndex: Int
         /// Existing-style sidebar insertion indicator to render.
         public let indicator: SidebarDropIndicator
 
-        /// Creates an external insertion plan.
-        ///
-        /// - Parameters:
-        ///   - insertionIndex: Clamped insertion index for the new workspace.
-        ///   - indicator: Drop indicator matching that index.
         public init(insertionIndex: Int, indicator: SidebarDropIndicator) {
             self.insertionIndex = insertionIndex
             self.indicator = indicator
         }
     }
 
-    /// Creates an external new-workspace insertion planner.
     public init() {}
 
     /// Resolves a pointer location into a new-workspace insertion plan.
     ///
     /// - Parameters:
-    ///   - point: Pointer location in the same coordinate space as `rootTargets`.
-    ///   - rootTargets: Ordered root-level rows only (no group children / headers).
-    /// - Returns: A plan when the pointer is over an insertion band or gap;
-    ///   `nil` when targets are empty, or when the pointer is over a row center
-    ///   (rejected so we never imply opening an existing workspace).
+    ///   - point: Pointer in the same coordinate space as `visibleRootTargets`.
+    ///   - visibleRootTargets: On-screen root rows for geometry / indicator.
+    ///   - completeTopLevelIds: Full ungrouped root order for the commit slot.
+    ///   - completePinnedCount: Leading pinned prefix length in that complete order.
     public func plan(
         point: CGPoint,
-        rootTargets: [RootTarget]
+        visibleRootTargets: [RootTarget],
+        completeTopLevelIds: [UUID],
+        completePinnedCount: Int
     ) -> Plan? {
-        guard !rootTargets.isEmpty else {
+        guard !visibleRootTargets.isEmpty else {
             return nil
         }
 
-        let dropTargets = rootTargets.map {
+        let dropTargets = visibleRootTargets.map {
             SidebarDropPlanner.WorkspaceDropTarget(
                 workspaceId: $0.workspaceId,
                 isPinned: $0.isPinned,
@@ -87,17 +66,47 @@ public struct ExternalWorkspaceInsertionPlanner: Sendable {
             return nil
         }
 
-        // Mid-row "drop onto existing workspace" is bonsplit semantics, not
-        // Finder directory creation. Reject so we never imply reuse/dedupe.
-        guard case .newWorkspace(let insertionIndex, let indicator) = action else {
+        guard case .newWorkspace(let visibleSlot, let visibleIndicator) = action else {
             return nil
         }
-        return Plan(insertionIndex: insertionIndex, indicator: indicator)
+
+        let visibleIds = visibleRootTargets.map(\.workspaceId)
+        let completeSlot = completeTopLevelSlot(
+            fromVisibleSlot: visibleSlot,
+            visibleIds: visibleIds,
+            completeTopLevelIds: completeTopLevelIds
+        )
+        let clampedSlot = max(
+            0,
+            min(
+                max(completeSlot, max(0, completePinnedCount)),
+                completeTopLevelIds.count
+            )
+        )
+        let indicator = remappedIndicator(
+            visibleIndicator: visibleIndicator,
+            completeSlot: clampedSlot,
+            completeTopLevelIds: completeTopLevelIds,
+            visibleRootTargets: visibleRootTargets
+        )
+        return Plan(insertionIndex: clampedSlot, indicator: indicator)
+    }
+
+    /// Convenience when every root row is visible (unit tests / short lists).
+    public func plan(
+        point: CGPoint,
+        rootTargets: [RootTarget]
+    ) -> Plan? {
+        let pinnedCount = rootTargets.prefix(while: \.isPinned).count
+        return plan(
+            point: point,
+            visibleRootTargets: rootTargets,
+            completeTopLevelIds: rootTargets.map(\.workspaceId),
+            completePinnedCount: pinnedCount
+        )
     }
 
     /// Insertion plan when the sidebar has no root rows yet.
-    ///
-    /// - Returns: Append-at-zero with an end-of-list indicator.
     public func planForEmptySidebar() -> Plan {
         Plan(
             insertionIndex: 0,
@@ -105,13 +114,25 @@ public struct ExternalWorkspaceInsertionPlanner: Sendable {
         )
     }
 
+    /// Maps a visible-array insertion slot onto the complete top-level order.
+    public func completeTopLevelSlot(
+        fromVisibleSlot visibleSlot: Int,
+        visibleIds: [UUID],
+        completeTopLevelIds: [UUID]
+    ) -> Int {
+        let clampedVisible = max(0, min(visibleSlot, visibleIds.count))
+        if clampedVisible < visibleIds.count {
+            let anchorId = visibleIds[clampedVisible]
+            return completeTopLevelIds.firstIndex(of: anchorId) ?? completeTopLevelIds.count
+        }
+        guard let lastVisibleId = visibleIds.last,
+              let lastCompleteIndex = completeTopLevelIds.firstIndex(of: lastVisibleId) else {
+            return completeTopLevelIds.count
+        }
+        return lastCompleteIndex + 1
+    }
+
     /// Maps a top-level insertion slot to a raw `tabs` array index.
-    ///
-    /// - Parameters:
-    ///   - slot: Index into `topLevelIds` (or `topLevelIds.count` to append).
-    ///   - topLevelIds: Root-level workspace ids in sidebar order.
-    ///   - tabIds: Full workspace storage order (`TabManager.tabs` ids).
-    /// - Returns: Index suitable for `insertionIndexOverride` on workspace creation.
     public func rawTabInsertionIndex(
         forTopLevelSlot slot: Int,
         topLevelIds: [UUID],
@@ -131,5 +152,41 @@ public struct ExternalWorkspaceInsertionPlanner: Sendable {
             }
         }
         return tabIds.count
+    }
+
+    private func remappedIndicator(
+        visibleIndicator: SidebarDropIndicator,
+        completeSlot: Int,
+        completeTopLevelIds: [UUID],
+        visibleRootTargets: [RootTarget]
+    ) -> SidebarDropIndicator {
+        if let tabId = visibleIndicator.tabId,
+           let completeIndex = completeTopLevelIds.firstIndex(of: tabId) {
+            let impliedSlot = visibleIndicator.edge == .bottom ? completeIndex + 1 : completeIndex
+            if impliedSlot == completeSlot {
+                return visibleIndicator
+            }
+        }
+
+        if completeSlot >= completeTopLevelIds.count {
+            if let lastVisible = visibleRootTargets.last {
+                return SidebarDropIndicator(tabId: lastVisible.workspaceId, edge: .bottom)
+            }
+            return SidebarDropIndicator(tabId: nil, edge: .bottom)
+        }
+
+        let anchorId = completeTopLevelIds[completeSlot]
+        if visibleRootTargets.contains(where: { $0.workspaceId == anchorId }) {
+            return SidebarDropIndicator(tabId: anchorId, edge: .top)
+        }
+        if let lastVisible = visibleRootTargets.last,
+           let lastComplete = completeTopLevelIds.firstIndex(of: lastVisible.workspaceId),
+           completeSlot > lastComplete {
+            return SidebarDropIndicator(tabId: lastVisible.workspaceId, edge: .bottom)
+        }
+        if let firstVisible = visibleRootTargets.first {
+            return SidebarDropIndicator(tabId: firstVisible.workspaceId, edge: .top)
+        }
+        return SidebarDropIndicator(tabId: anchorId, edge: .top)
     }
 }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/ExternalWorkspaceInsertionPlanner.swift
@@ -154,6 +154,33 @@ public struct ExternalWorkspaceInsertionPlanner: Sendable {
         return tabIds.count
     }
 
+    /// Filters raw sidebar row descriptors to ungrouped roots before pinned lookup.
+    ///
+    /// Group headers reuse an anchor ``workspaceId`` that can also appear on a
+    /// grouped member. Building `Dictionary(uniqueKeysWithValues:)` from raw
+    /// rows can therefore trap; callers must filter first.
+    public static func eligibleUngroupedRoots(
+        from rows: [(workspaceId: UUID, isPinned: Bool, isGroupHeader: Bool, groupId: UUID?)]
+    ) -> [(workspaceId: UUID, isPinned: Bool)] {
+        rows.compactMap { row in
+            guard !row.isGroupHeader, row.groupId == nil else { return nil }
+            return (row.workspaceId, row.isPinned)
+        }
+    }
+
+    /// Pinned flags for eligible ungrouped roots. Uses assignment (last write
+    /// wins) rather than `uniqueKeysWithValues`, so duplicate ids cannot trap.
+    public static func pinnedFlagsByWorkspaceId(
+        fromEligibleUngroupedRoots roots: [(workspaceId: UUID, isPinned: Bool)]
+    ) -> [UUID: Bool] {
+        var result: [UUID: Bool] = [:]
+        result.reserveCapacity(roots.count)
+        for root in roots {
+            result[root.workspaceId] = root.isPinned
+        }
+        return result
+    }
+
     private func remappedIndicator(
         visibleIndicator: SidebarDropIndicator,
         completeSlot: Int,

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import CmuxFoundation
+
+@Suite struct ExternalWorkspaceDirectoryDropValidatorTests {
+    @Test func acceptsExactlyOneLocalDirectory() {
+        let directory = URL(fileURLWithPath: "/tmp/Jimmy", isDirectory: true)
+        let validator = ExternalWorkspaceDirectoryDropValidator { url in
+            #expect(url.path == directory.path)
+            return .directory
+        }
+
+        let result = validator.validate([directory])
+        guard case .success(let accepted) = result else {
+            Issue.record("Expected success, got \(result)")
+            return
+        }
+        #expect(accepted.path == "/tmp/Jimmy")
+        #expect(accepted.url.standardizedFileURL == directory.standardizedFileURL)
+    }
+
+    @Test func rejectsRegularFile() {
+        let file = URL(fileURLWithPath: "/tmp/photo.png", isDirectory: false)
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .file }
+        #expect(validator.validate([file]) == .failure(.notDirectory))
+    }
+
+    @Test func rejectsMultipleURLs() {
+        let first = URL(fileURLWithPath: "/tmp/a", isDirectory: true)
+        let second = URL(fileURLWithPath: "/tmp/b", isDirectory: true)
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .directory }
+        #expect(validator.validate([first, second]) == .failure(.multipleItems))
+    }
+
+    @Test func rejectsEmptyPayload() {
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .directory }
+        #expect(validator.validate([]) == .failure(.emptyPayload))
+    }
+
+    @Test func rejectsMissingPath() {
+        let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString)", isDirectory: true)
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .missing }
+        #expect(validator.validate([missing]) == .failure(.missingPath))
+    }
+
+    @Test func rejectsNonFileURL() {
+        let remote = URL(string: "https://example.com/project")!
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .directory }
+        #expect(validator.validate([remote]) == .failure(.notLocalFileURL))
+    }
+
+    @Test func stripsTrailingSlashWithoutResolvingSymlinkIdentity() {
+        let directory = URL(fileURLWithPath: "/tmp/Jimmy/", isDirectory: true)
+        let validator = ExternalWorkspaceDirectoryDropValidator { _ in .directory }
+        let result = validator.validate([directory])
+        guard case .success(let accepted) = result else {
+            Issue.record("Expected success, got \(result)")
+            return
+        }
+        #expect(accepted.path == "/tmp/Jimmy")
+    }
+
+    @Test func liveFileManagerProbeAcceptsCreatedDirectoryAndRejectsFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-external-dir-drop-\(UUID().uuidString)", isDirectory: true)
+        let directory = root.appendingPathComponent("Jimmy", isDirectory: true)
+        let file = root.appendingPathComponent("notes.txt", isDirectory: false)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("hi".utf8).write(to: file)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let validator = ExternalWorkspaceDirectoryDropValidator()
+        guard case .success(let accepted) = validator.validate([directory]) else {
+            Issue.record("Expected live directory to be accepted")
+            return
+        }
+        #expect(accepted.path == directory.path)
+        #expect(validator.validate([file]) == .failure(.notDirectory))
+    }
+}
+
+@Suite struct ExternalWorkspaceInsertionPlannerTests {
+    private func targets(
+        _ ids: [UUID],
+        pinned: Set<UUID> = [],
+        height: CGFloat = 32,
+        gap: CGFloat = 8
+    ) -> [ExternalWorkspaceInsertionPlanner.RootTarget] {
+        ids.enumerated().map { index, id in
+            ExternalWorkspaceInsertionPlanner.RootTarget(
+                workspaceId: id,
+                isPinned: pinned.contains(id),
+                frame: CGRect(
+                    x: 0,
+                    y: CGFloat(index) * (height + gap),
+                    width: 180,
+                    height: height
+                )
+            )
+        }
+    }
+
+    @Test func emptyRootTargetsReturnNilFromPlan() {
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 2),
+            rootTargets: []
+        )
+        #expect(plan == nil)
+        let empty = ExternalWorkspaceInsertionPlanner().planForEmptySidebar()
+        #expect(empty.insertionIndex == 0)
+    }
+
+    @Test func insertsBeforeFirstOrdinaryWorkspace() {
+        let first = UUID()
+        let second = UUID()
+        let rootTargets = targets([first, second])
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 2),
+            rootTargets: rootTargets
+        )
+        #expect(plan?.insertionIndex == 0)
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: first, edge: .top))
+    }
+
+    @Test func insertsBetweenOrdinaryWorkspaces() {
+        let first = UUID()
+        let second = UUID()
+        let rootTargets = targets([first, second])
+        // Top edge of second row (y=40..72): edge band → insert before second.
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 42),
+            rootTargets: rootTargets
+        )
+        #expect(plan?.insertionIndex == 1)
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: second, edge: .top))
+    }
+
+    @Test func appendsAfterLastWorkspace() {
+        let first = UUID()
+        let second = UUID()
+        let rootTargets = targets([first, second])
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 65),
+            rootTargets: rootTargets
+        )
+        #expect(plan?.insertionIndex == 2)
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: nil, edge: .bottom))
+    }
+
+    @Test func rejectsRowCenterSoExistingWorkspaceIsNotImplied() {
+        let first = UUID()
+        let second = UUID()
+        let rootTargets = targets([first, second])
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 56),
+            rootTargets: rootTargets
+        )
+        #expect(plan == nil)
+    }
+
+    @Test func clampsUnpinnedInsertionAfterPinnedPrefix() {
+        let pinned = UUID()
+        let first = UUID()
+        let second = UUID()
+        let rootTargets = targets([pinned, first, second], pinned: [pinned])
+        // Point on the top edge of the pinned row would propose index 0; clamp
+        // keeps a new unpinned workspace after the pinned segment.
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 2),
+            rootTargets: rootTargets
+        )
+        #expect(plan?.insertionIndex == 1)
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: first, edge: .top))
+    }
+
+    @Test func mapsTopLevelSlotToRawTabIndex() {
+        let a = UUID()
+        let b = UUID()
+        let c = UUID()
+        let planner = ExternalWorkspaceInsertionPlanner()
+        #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 1, topLevelIds: [a, b, c], tabIds: [a, b, c]) == 1)
+        #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 3, topLevelIds: [a, b, c], tabIds: [a, b, c]) == 3)
+        #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 0, topLevelIds: [a, b], tabIds: [a, b, c]) == 0)
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
@@ -146,7 +146,7 @@ import Testing
             rootTargets: rootTargets
         )
         #expect(plan?.insertionIndex == 2)
-        #expect(plan?.indicator == SidebarDropIndicator(tabId: nil, edge: .bottom))
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: second, edge: .bottom))
     }
 
     @Test func rejectsRowCenterSoExistingWorkspaceIsNotImplied() {
@@ -183,5 +183,67 @@ import Testing
         #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 1, topLevelIds: [a, b, c], tabIds: [a, b, c]) == 1)
         #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 3, topLevelIds: [a, b, c], tabIds: [a, b, c]) == 3)
         #expect(planner.rawTabInsertionIndex(forTopLevelSlot: 0, topLevelIds: [a, b], tabIds: [a, b, c]) == 0)
+    }
+
+    @Test func mapsVisibleSlotOntoCompleteOrderWhenRootsAreOffscreen() {
+        let ids = (0..<10).map { _ in UUID() }
+        // Viewport shows only D E F (indices 3,4,5).
+        let visible = Array(ids[3...5])
+        let planner = ExternalWorkspaceInsertionPlanner()
+
+        #expect(
+            planner.completeTopLevelSlot(
+                fromVisibleSlot: 0,
+                visibleIds: visible,
+                completeTopLevelIds: ids
+            ) == 3
+        )
+        #expect(
+            planner.completeTopLevelSlot(
+                fromVisibleSlot: 1,
+                visibleIds: visible,
+                completeTopLevelIds: ids
+            ) == 4
+        )
+        // After last visible (F) must land beside F in the complete order,
+        // not at the end after J.
+        #expect(
+            planner.completeTopLevelSlot(
+                fromVisibleSlot: 3,
+                visibleIds: visible,
+                completeTopLevelIds: ids
+            ) == 6
+        )
+    }
+
+    @Test func visibleGeometryDropBelowLastVisibleUsesCompleteOrderSlot() {
+        let ids = (0..<10).map { _ in UUID() }
+        let visibleIds = Array(ids[3...5])
+        let visibleTargets = targets(visibleIds)
+        // Bottom edge of last visible row (F): y near maxY of third visible frame.
+        // frames: 0→0..32, 1→40..72, 2→80..112 ⇒ bottom band of F around y=102.
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 102),
+            visibleRootTargets: visibleTargets,
+            completeTopLevelIds: ids,
+            completePinnedCount: 0
+        )
+        #expect(plan?.insertionIndex == 6)
+        #expect(plan?.indicator.tabId == ids[5])
+        #expect(plan?.indicator.edge == .bottom)
+    }
+
+    @Test func visibleGeometryDropAboveFirstVisibleUsesCompleteOrderSlot() {
+        let ids = (0..<10).map { _ in UUID() }
+        let visibleIds = Array(ids[3...5])
+        let visibleTargets = targets(visibleIds)
+        let plan = ExternalWorkspaceInsertionPlanner().plan(
+            point: CGPoint(x: 12, y: 2),
+            visibleRootTargets: visibleTargets,
+            completeTopLevelIds: ids,
+            completePinnedCount: 0
+        )
+        #expect(plan?.insertionIndex == 3)
+        #expect(plan?.indicator == SidebarDropIndicator(tabId: ids[3], edge: .top))
     }
 }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/ExternalWorkspaceDirectoryDropTests.swift
@@ -246,4 +246,106 @@ import Testing
         #expect(plan?.insertionIndex == 3)
         #expect(plan?.indicator == SidebarDropIndicator(tabId: ids[3], edge: .top))
     }
+
+    @Test func groupedSidebarRowsDoNotTrapPinnedLookup() {
+        let anchor = UUID()
+        let other = UUID()
+        let groupId = UUID()
+        // Mirrors production: group header reuses anchor workspace id; member
+        // shares that id under a groupId. Raw uniqueKeysWithValues would trap.
+        let rows: [(workspaceId: UUID, isPinned: Bool, isGroupHeader: Bool, groupId: UUID?)] = [
+            (anchor, false, true, nil),
+            (anchor, false, false, groupId),
+            (other, true, false, nil),
+        ]
+        let eligible = ExternalWorkspaceInsertionPlanner.eligibleUngroupedRoots(from: rows)
+        #expect(eligible.map(\.workspaceId) == [other])
+        let pinned = ExternalWorkspaceInsertionPlanner.pinnedFlagsByWorkspaceId(
+            fromEligibleUngroupedRoots: eligible
+        )
+        #expect(pinned[other] == true)
+        #expect(pinned[anchor] == nil)
+    }
+
+    @Test func pinnedLookupSurvivesDuplicateEligibleIdsWithoutTrapping() {
+        let id = UUID()
+        let pinned = ExternalWorkspaceInsertionPlanner.pinnedFlagsByWorkspaceId(
+            fromEligibleUngroupedRoots: [
+                (id, true),
+                (id, false),
+            ]
+        )
+        #expect(pinned[id] == false)
+    }
+}
+
+@Suite struct ExternalWorkspaceDropCommitResolverTests {
+    @Test func releaseDriftOntoRowCenterKeepsPaintedPlanWhenOrderUnchanged() {
+        let first = UUID()
+        let second = UUID()
+        let painted = ExternalWorkspaceInsertionPlanner.Plan(
+            insertionIndex: 1,
+            indicator: SidebarDropIndicator(tabId: second, edge: .top)
+        )
+        let resolved = ExternalWorkspaceDropCommitResolver.resolve(
+            replanned: nil,
+            painted: painted,
+            paintedCompleteTopLevelIds: [first, second],
+            currentCompleteTopLevelIds: [first, second]
+        )
+        #expect(resolved == painted)
+    }
+
+    @Test func replannedPlanWinsOverPainted() {
+        let first = UUID()
+        let second = UUID()
+        let painted = ExternalWorkspaceInsertionPlanner.Plan(
+            insertionIndex: 1,
+            indicator: SidebarDropIndicator(tabId: second, edge: .top)
+        )
+        let replanned = ExternalWorkspaceInsertionPlanner.Plan(
+            insertionIndex: 2,
+            indicator: SidebarDropIndicator(tabId: second, edge: .bottom)
+        )
+        let resolved = ExternalWorkspaceDropCommitResolver.resolve(
+            replanned: replanned,
+            painted: painted,
+            paintedCompleteTopLevelIds: [first, second],
+            currentCompleteTopLevelIds: [first, second]
+        )
+        #expect(resolved == replanned)
+    }
+
+    @Test func rejectsPaintedPlanWhenCompleteOrderChanged() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        let painted = ExternalWorkspaceInsertionPlanner.Plan(
+            insertionIndex: 1,
+            indicator: SidebarDropIndicator(tabId: second, edge: .top)
+        )
+        let resolved = ExternalWorkspaceDropCommitResolver.resolve(
+            replanned: nil,
+            painted: painted,
+            paintedCompleteTopLevelIds: [first, second],
+            currentCompleteTopLevelIds: [first, third, second]
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func rejectsPaintedPlanWhenIndicatorTabMissing() {
+        let first = UUID()
+        let second = UUID()
+        let painted = ExternalWorkspaceInsertionPlanner.Plan(
+            insertionIndex: 1,
+            indicator: SidebarDropIndicator(tabId: second, edge: .top)
+        )
+        let resolved = ExternalWorkspaceDropCommitResolver.resolve(
+            replanned: nil,
+            painted: painted,
+            paintedCompleteTopLevelIds: [first, second],
+            currentCompleteTopLevelIds: [first]
+        )
+        #expect(resolved == nil)
+    }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12445,6 +12445,31 @@ struct VerticalTabsSidebar: View, Equatable {
             setBonsplitDropIndicator: { indicator in
                 dragState.setDropIndicator(indicator)
             },
+            createWorkspaceFromExternalDirectory: { workingDirectory, topLevelSlot, rootWorkspaceIds in
+                let tabIds = tabManager.tabs.map(\.id)
+                // `rootWorkspaceIds` is the same ordered root list the insertion
+                // planner used for the painted indicator. Mapping through the
+                // full `tabs` array converts that slot into a storage index
+                // without inventing a second ordering source of truth.
+                let rawIndex = ExternalWorkspaceInsertionPlanner().rawTabInsertionIndex(
+                    forTopLevelSlot: topLevelSlot,
+                    topLevelIds: rootWorkspaceIds,
+                    tabIds: tabIds
+                )
+                guard let workspace = tabManager.addWorkspaceIfActive(
+                    workingDirectory: workingDirectory,
+                    inheritWorkingDirectory: false,
+                    select: true,
+                    insertionIndexOverride: rawIndex,
+                    autoWelcomeIfNeeded: false
+                ) else {
+                    return false
+                }
+                selectedTabIds = [workspace.id]
+                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == workspace.id }
+                selection = .tabs
+                return true
+            },
             nativeWorkspaceDragLifecycle: SidebarWorkspaceTableActions.NativeWorkspaceDragLifecycle(
                 currentSessionId: { dragState.currentWorkspaceDragSessionId },
                 finish: { sessionId, capabilityValue in

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -349,7 +349,9 @@ final class FileDropOverlayView: NSView {
     }
 
     func clearExternalDirectorySidebarRoute() {
-        guard isRoutingExternalDirectoryToSidebar else { return }
+        // Always clear sidebar external state on leave/cancel — not only when
+        // a prior update returned a legal plan. Rejected hover can still leave
+        // reusable drag state on the router.
         isRoutingExternalDirectoryToSidebar = false
         if let window {
             SidebarExternalDirectoryDropRouter.router(for: window)?.clearExternalDirectoryDrop()

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -323,6 +323,20 @@ final class FileDropOverlayView: NSView {
         exitActiveDragTargets(sender)
     }
 
+    /// Escape / session teardown while the pointer is still over the overlay
+    /// often skips `draggingExited`. Match pane drop targets and clear the
+    /// sidebar insertion affordance here.
+    override func draggingEnded(_ sender: any NSDraggingInfo) {
+        hintBadgeView.hide()
+        preparedDragWebView = nil
+        preparedPaneDropTarget = nil
+        didPerformDragAsText = false
+        performedTextDragWebView = nil
+        performedTextPaneDropTarget = nil
+        clearExternalDirectorySidebarRoute()
+        exitActiveDragTargets(sender)
+    }
+
     func exitActiveDragTargets(_ sender: (any NSDraggingInfo)?) {
         if let prev = activeDragWebView {
             prev.draggingExited(sender)
@@ -337,7 +351,9 @@ final class FileDropOverlayView: NSView {
     func clearExternalDirectorySidebarRoute() {
         guard isRoutingExternalDirectoryToSidebar else { return }
         isRoutingExternalDirectoryToSidebar = false
-        SidebarExternalDirectoryDropRouter.current?.clearExternalDirectoryDrop()
+        if let window {
+            SidebarExternalDirectoryDropRouter.router(for: window)?.clearExternalDirectoryDrop()
+        }
     }
 
     private func exitActiveDragTargets(

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -66,6 +66,8 @@ final class FileDropOverlayView: NSView {
     var lastDragRouteLogSignatureByPhase: [String: String] = [:]
     weak var hitTestReferenceView: NSView?
     var dragUpdateHitTest: (location: NSPoint, view: NSView?)?
+    /// True while the current Finder session is routed to sidebar workspace insertion.
+    var isRoutingExternalDirectoryToSidebar = false
 
     override var acceptsFirstResponder: Bool { false }
 
@@ -201,6 +203,9 @@ final class FileDropOverlayView: NSView {
         if shouldDeferFileDropOverlayToBonsplitTabBar(at: point) {
             return nil
         }
+        // Finder / file-URL sessions stay on this window overlay. Sidebar
+        // workspace insertion is an adapter route inside updateDragTarget —
+        // do not defer hit-testing to a nested Finder destination.
 
         return super.hitTest(point)
     }
@@ -314,10 +319,11 @@ final class FileDropOverlayView: NSView {
         didPerformDragAsText = false
         performedTextDragWebView = nil
         performedTextPaneDropTarget = nil
+        clearExternalDirectorySidebarRoute()
         exitActiveDragTargets(sender)
     }
 
-    private func exitActiveDragTargets(_ sender: (any NSDraggingInfo)?) {
+    func exitActiveDragTargets(_ sender: (any NSDraggingInfo)?) {
         if let prev = activeDragWebView {
             prev.draggingExited(sender)
             activeDragWebView = nil
@@ -326,6 +332,12 @@ final class FileDropOverlayView: NSView {
             prev.fileDropDraggingExited(sender)
             activePaneDropTarget = nil
         }
+    }
+
+    func clearExternalDirectorySidebarRoute() {
+        guard isRoutingExternalDirectoryToSidebar else { return }
+        isRoutingExternalDirectoryToSidebar = false
+        SidebarExternalDirectoryDropRouter.current?.clearExternalDirectoryDrop()
     }
 
     private func exitActiveDragTargets(
@@ -353,6 +365,9 @@ final class FileDropOverlayView: NSView {
     }
 
     override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        if let accepted = prepareExternalDirectorySidebarRoute(sender) {
+            return accepted
+        }
         let hasLocalDraggingSource = sender.draggingSource != nil
         let types = sender.draggingPasteboard.types
         let shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -415,6 +430,9 @@ final class FileDropOverlayView: NSView {
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        if let handled = performExternalDirectorySidebarRoute(sender) {
+            return handled
+        }
         let hasLocalDraggingSource = sender.draggingSource != nil
         let types = sender.draggingPasteboard.types
         let shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -524,6 +542,7 @@ final class FileDropOverlayView: NSView {
             didPerformDragAsText = false
             performedTextDragWebView = nil
             performedTextPaneDropTarget = nil
+            clearExternalDirectorySidebarRoute()
         }
         guard let sender else { return }
         if didPerformDragAsText {

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -486,7 +486,8 @@ extension FileDropOverlayView {
             clearExternalDirectorySidebarRoute()
             return nil
         }
-        guard let router = SidebarExternalDirectoryDropRouter.current else {
+        guard let window,
+              let router = SidebarExternalDirectoryDropRouter.router(for: window) else {
             clearExternalDirectorySidebarRoute()
             return nil
         }

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -493,9 +493,9 @@ extension FileDropOverlayView {
         }
         let windowPoint = sender.draggingLocation
         guard router.containsExternalDirectoryDropWindowPoint(windowPoint) else {
-            if isRoutingExternalDirectoryToSidebar {
-                clearExternalDirectorySidebarRoute()
-            }
+            // Leaving the sidebar must clear unconditionally, including after
+            // a rejected hover that never set `isRouting… = true`.
+            clearExternalDirectorySidebarRoute()
             return nil
         }
         return ExternalDirectorySidebarRoute(

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import CmuxFoundation
 import Foundation
 import WebKit
 
@@ -9,6 +10,11 @@ extension FileDropOverlayView {
         let previousHitTest = dragUpdateHitTest
         dragUpdateHitTest = (loc, uncachedViewUnderPoint(loc))
         defer { dragUpdateHitTest = previousHitTest }
+
+        if let sidebarOperation = updateExternalDirectorySidebarRoute(sender) {
+            return sidebarOperation
+        }
+
         let hasLocalDraggingSource = sender.draggingSource != nil
         let types = sender.draggingPasteboard.types
         let shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -404,6 +410,117 @@ extension FileDropOverlayView {
         guard let window else { return false }
         let windowPoint = convert(point, to: nil)
         return BonsplitTabBarHitRegionRegistry.containsWindowPoint(windowPoint, in: window)
+    }
+
+    /// Routes a validated Finder directory drag into the live workspace sidebar
+    /// insertion system. Returns a non-nil operation when this overlay should
+    /// stop here (including `[]` for illegal sidebar targets). Returns `nil`
+    /// when the drag should keep the existing terminal/browser file-drop path.
+    func updateExternalDirectorySidebarRoute(
+        _ sender: any NSDraggingInfo
+    ) -> NSDragOperation? {
+        guard let route = externalDirectorySidebarRoute(sender) else {
+            return nil
+        }
+
+        exitActiveDragTargets(sender)
+        preparedDragWebView = nil
+        preparedPaneDropTarget = nil
+        hintBadgeView.hide()
+
+        let plannedIndex = route.router.updateExternalDirectoryDrop(
+            atWindowPoint: route.windowPoint
+        )
+        isRoutingExternalDirectoryToSidebar = plannedIndex != nil
+        // Over sidebar with a valid directory payload: either `.copy` with a
+        // legal plan, or reject (group / illegal) without falling through to
+        // terminal/file-drop behavior under the list.
+        return plannedIndex != nil ? .copy : []
+    }
+
+    func prepareExternalDirectorySidebarRoute(_ sender: any NSDraggingInfo) -> Bool? {
+        guard let route = externalDirectorySidebarRoute(sender) else {
+            return nil
+        }
+        exitActiveDragTargets(sender)
+        preparedDragWebView = nil
+        preparedPaneDropTarget = nil
+        let plannedIndex = route.router.updateExternalDirectoryDrop(
+            atWindowPoint: route.windowPoint
+        )
+        isRoutingExternalDirectoryToSidebar = plannedIndex != nil
+        return plannedIndex != nil
+    }
+
+    func performExternalDirectorySidebarRoute(_ sender: any NSDraggingInfo) -> Bool? {
+        guard let route = externalDirectorySidebarRoute(sender) else {
+            return nil
+        }
+
+        exitActiveDragTargets(sender)
+        preparedDragWebView = nil
+        preparedPaneDropTarget = nil
+        hintBadgeView.hide()
+
+        let created = route.router.performExternalDirectoryDrop(
+            directoryPath: route.accepted.path,
+            atWindowPoint: route.windowPoint
+        )
+        isRoutingExternalDirectoryToSidebar = false
+        return created
+    }
+
+    private struct ExternalDirectorySidebarRoute {
+        let router: any SidebarExternalDirectoryDropRouting
+        let accepted: ExternalWorkspaceDirectoryDropValidator.AcceptedDirectory
+        let windowPoint: NSPoint
+    }
+
+    /// Shared preamble for sidebar routing: validated directory + pointer over
+    /// the live sidebar surface. Clears leftover indicator when the session
+    /// leaves the sidebar or the payload is not a v1 directory drop.
+    private func externalDirectorySidebarRoute(
+        _ sender: any NSDraggingInfo
+    ) -> ExternalDirectorySidebarRoute? {
+        guard let accepted = validatedExternalDirectory(from: sender) else {
+            clearExternalDirectorySidebarRoute()
+            return nil
+        }
+        guard let router = SidebarExternalDirectoryDropRouter.current else {
+            clearExternalDirectorySidebarRoute()
+            return nil
+        }
+        let windowPoint = sender.draggingLocation
+        guard router.containsExternalDirectoryDropWindowPoint(windowPoint) else {
+            if isRoutingExternalDirectoryToSidebar {
+                clearExternalDirectorySidebarRoute()
+            }
+            return nil
+        }
+        return ExternalDirectorySidebarRoute(
+            router: router,
+            accepted: accepted,
+            windowPoint: windowPoint
+        )
+    }
+
+    private func validatedExternalDirectory(
+        from sender: any NSDraggingInfo
+    ) -> ExternalWorkspaceDirectoryDropValidator.AcceptedDirectory? {
+        // Prefer internal workspace reorder when both payloads are present.
+        if sender.draggingPasteboard.types?.contains(
+            SidebarWorkspaceReorderDropOverlay.pasteboardType
+        ) == true {
+            return nil
+        }
+        guard PasteboardFileURLReader.hasFileURLType(sender.draggingPasteboard.types ?? []) else {
+            return nil
+        }
+        let urls = PasteboardFileURLReader.fileURLs(from: sender.draggingPasteboard)
+        guard case .success(let accepted) = ExternalWorkspaceDirectoryDropValidator().validate(urls) else {
+            return nil
+        }
+        return accepted
     }
 
     func paneDropTargetUnderPoint(_ windowPoint: NSPoint) -> (any FileDropPaneTarget)? {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableActions.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableActions.swift
@@ -65,6 +65,13 @@ struct SidebarWorkspaceTableActions {
     let updateDragAutoscroll: () -> Void
     let setBonsplitDropTargetCollectionActive: (Bool) -> Void
     let setBonsplitDropIndicator: (SidebarDropIndicator?) -> Void
+    /// Creates one new workspace rooted at `workingDirectory`.
+    ///
+    /// - Parameters:
+    ///   - workingDirectory: Absolute directory path for the new workspace cwd.
+    ///   - topLevelInsertionSlot: Index into `rootWorkspaceIds` (or count to append).
+    ///   - rootWorkspaceIds: Ordered ungrouped root workspace ids used for planning.
+    let createWorkspaceFromExternalDirectory: (String, Int, [UUID]) -> Bool
     /// Returns the live group-to-anchor map captured at the beginning of a
     /// native drag. The table controller caches it for the whole drag so a
     /// multi-row drag does not rescan all groups for every item.
@@ -99,6 +106,7 @@ struct SidebarWorkspaceTableActions {
         updateDragAutoscroll: @escaping () -> Void,
         setBonsplitDropTargetCollectionActive: @escaping (Bool) -> Void,
         setBonsplitDropIndicator: @escaping (SidebarDropIndicator?) -> Void,
+        createWorkspaceFromExternalDirectory: @escaping (String, Int, [UUID]) -> Bool = { _, _, _ in false },
         workspaceIdForDrag: ((SidebarWorkspaceRenderItemID, UUID) -> UUID)? = nil,
         nativeWorkspaceDragLifecycle: NativeWorkspaceDragLifecycle? = nil
     ) {
@@ -124,6 +132,7 @@ struct SidebarWorkspaceTableActions {
         self.updateDragAutoscroll = updateDragAutoscroll
         self.setBonsplitDropTargetCollectionActive = setBonsplitDropTargetCollectionActive
         self.setBonsplitDropIndicator = setBonsplitDropIndicator
+        self.createWorkspaceFromExternalDirectory = createWorkspaceFromExternalDirectory
         self.workspaceIdForDrag = workspaceIdForDrag
         self.nativeWorkspaceDragLifecycle = nativeWorkspaceDragLifecycle
     }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 /// Main-actor owner of the default sidebar table lifecycle and its AppKit interactions.
 @MainActor
-final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate, SidebarExternalDirectoryDropRouting {
     private struct DeferredRowClick {
         let rowId: SidebarWorkspaceRenderItemID
         let modifiers: NSEvent.ModifierFlags
@@ -250,11 +250,12 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         )
         scrollView.applySidebarOverlayScrollerConfiguration()
 
-        container.reorderDropView.registerForDraggedTypes([
-            SidebarWorkspaceReorderDropOverlay.pasteboardType,
-        ])
+        container.reorderDropView.registerForDraggedTypes(
+            [SidebarWorkspaceReorderDropOverlay.pasteboardType]
+        )
         dropTargetGeometry.attach(containerView: container)
         container.bonsplitDropView.targetBridge = dropTargetGeometry.bonsplitTargetBridge
+        SidebarExternalDirectoryDropRouter.register(self)
 
         clipBoundsObserver = NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
@@ -376,6 +377,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             detachController(from: container.tableView)
         }
         container.clipView.workspaceController = nil
+        SidebarExternalDirectoryDropRouter.unregister(self)
         containerView = nil
         mutationScheduler.stagePostUpdateActions(postUpdateActions)
     }
@@ -1725,6 +1727,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     /// before the coalesced repaint).
     private var lastAcceptedReorderDropPlan: SidebarWorkspaceReorderDropPlan?
 
+    /// Last accepted Finder-directory insertion plan painted for an external
+    /// drop. Committed verbatim on release, same rationale as reorder.
+    private var lastAcceptedExternalDirectoryDropPlan: ExternalWorkspaceInsertionPlanner.Plan?
+
     /// One-shot: the next apply comes from this window's own drop, so the
     /// selected-workspace scroll policy must not yank the viewport away from
     /// the release position.
@@ -1769,9 +1775,114 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     func reorderDropDragExited() {
         reorderDragPayloadWorkspaceId = nil
+        lastAcceptedExternalDirectoryDropPlan = nil
         guard reorderDragWindowPoint != nil || reorderIndicatorPainter != nil else { return }
         reorderDragWindowPoint = nil
         retireReorderIndicator()
+    }
+
+    // MARK: - SidebarExternalDirectoryDropRouting (window FileDropOverlayView)
+
+    func containsExternalDirectoryDropWindowPoint(_ windowPoint: NSPoint) -> Bool {
+        guard let dropView = containerView?.reorderDropView, dropView.window != nil else {
+            return false
+        }
+        let point = dropView.convert(windowPoint, from: nil)
+        return dropView.bounds.contains(point)
+    }
+
+    /// Updates the insertion indicator for a Finder directory drag using
+    /// root-level (ungrouped) rows only. Group headers and grouped children
+    /// are rejected for v1 so drops never invent group membership.
+    @discardableResult
+    func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int? {
+        guard let container = containerView else { return nil }
+        let point = container.reorderDropView.convert(windowPoint, from: nil)
+        return updateExternalDirectoryDrag(
+            point: point,
+            targets: refreshReorderDropTargets()
+        )
+    }
+
+    func clearExternalDirectoryDrop() {
+        lastAcceptedExternalDirectoryDropPlan = nil
+        retireReorderIndicator()
+    }
+
+    @discardableResult
+    func performExternalDirectoryDrop(
+        directoryPath: String,
+        atWindowPoint windowPoint: NSPoint
+    ) -> Bool {
+        guard let actions else {
+            clearExternalDirectoryDrop()
+            return false
+        }
+        defer {
+            lastAcceptedExternalDirectoryDropPlan = nil
+            retireReorderIndicator()
+        }
+
+        let planner = ExternalWorkspaceInsertionPlanner()
+        let targets = refreshReorderDropTargets()
+        let rootTargets = externalDirectoryRootTargets(from: targets)
+        let point = containerView?.reorderDropView.convert(windowPoint, from: nil) ?? .zero
+        let plan = lastAcceptedExternalDirectoryDropPlan ?? {
+            if rootTargets.isEmpty {
+                return rows.isEmpty ? planner.planForEmptySidebar() : nil
+            }
+            return planner.plan(point: point, rootTargets: rootTargets)
+        }()
+        guard let plan else { return false }
+
+        let topLevelIds = rootTargets.map(\.workspaceId)
+        let created = actions.createWorkspaceFromExternalDirectory(
+            directoryPath,
+            plan.insertionIndex,
+            topLevelIds
+        )
+        if created {
+            suppressSelectedScrollAfterLocalDrop = true
+        }
+        return created
+    }
+
+    private func updateExternalDirectoryDrag(
+        point: CGPoint,
+        targets: [SidebarWorkspaceReorderDropOverlay.Target]
+    ) -> Int? {
+        actions?.updateDragAutoscroll()
+        let rootTargets = externalDirectoryRootTargets(from: targets)
+        let planner = ExternalWorkspaceInsertionPlanner()
+        let plan: ExternalWorkspaceInsertionPlanner.Plan?
+        if rootTargets.isEmpty {
+            plan = rows.isEmpty ? planner.planForEmptySidebar() : nil
+        } else {
+            plan = planner.plan(point: point, rootTargets: rootTargets)
+        }
+        guard let plan else {
+            lastAcceptedExternalDirectoryDropPlan = nil
+            retireReorderIndicator()
+            return nil
+        }
+        lastAcceptedExternalDirectoryDropPlan = plan
+        setAppKitDropIndicator(plan.indicator, scope: .topLevel, includeRowTargets: true)
+        return plan.insertionIndex
+    }
+
+    private func externalDirectoryRootTargets(
+        from targets: [SidebarWorkspaceReorderDropOverlay.Target]
+    ) -> [ExternalWorkspaceInsertionPlanner.RootTarget] {
+        targets.compactMap { target in
+            // v1: reject group headers and grouped children entirely.
+            guard !target.isGroupHeader, target.groupId == nil else { return nil }
+            let isPinned = rows.first(where: { $0.workspaceId == target.workspaceId })?.isPinned ?? false
+            return ExternalWorkspaceInsertionPlanner.RootTarget(
+                workspaceId: target.workspaceId,
+                isPinned: isPinned,
+                frame: target.frame
+            )
+        }
     }
 
     /// Runs the shared reorder planner for a drag hovering at `windowPoint`

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -1728,8 +1728,13 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var lastAcceptedReorderDropPlan: SidebarWorkspaceReorderDropPlan?
 
     /// Last accepted Finder-directory insertion plan painted for an external
-    /// drop. Committed verbatim on release, same rationale as reorder.
+    /// drop. Committed after a fresh replan on release.
     private var lastAcceptedExternalDirectoryDropPlan: ExternalWorkspaceInsertionPlanner.Plan?
+
+    /// Window-space pointer for an active external-directory sidebar route.
+    /// Viewport / autoscroll changes replan from this point (same idea as
+    /// ``reorderDragWindowPoint`` for internal reorder).
+    private var externalDirectoryDragWindowPoint: NSPoint?
 
     /// One-shot: the next apply comes from this window's own drop, so the
     /// selected-workspace scroll policy must not yank the viewport away from
@@ -1775,13 +1780,17 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     func reorderDropDragExited() {
         reorderDragPayloadWorkspaceId = nil
-        lastAcceptedExternalDirectoryDropPlan = nil
+        clearExternalDirectoryDrop()
         guard reorderDragWindowPoint != nil || reorderIndicatorPainter != nil else { return }
         reorderDragWindowPoint = nil
         retireReorderIndicator()
     }
 
     // MARK: - SidebarExternalDirectoryDropRouting (window FileDropOverlayView)
+
+    var externalDirectoryDropHostingWindow: NSWindow? {
+        containerView?.window
+    }
 
     func containsExternalDirectoryDropWindowPoint(_ windowPoint: NSPoint) -> Bool {
         guard let dropView = containerView?.reorderDropView, dropView.window != nil else {
@@ -1792,20 +1801,25 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     /// Updates the insertion indicator for a Finder directory drag using
-    /// root-level (ungrouped) rows only. Group headers and grouped children
-    /// are rejected for v1 so drops never invent group membership.
+    /// visible root-level rows for geometry and the complete ungrouped root
+    /// order for the commit slot.
     @discardableResult
     func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int? {
-        guard let container = containerView else { return nil }
+        externalDirectoryDragWindowPoint = windowPoint
+        guard let container = containerView else {
+            clearExternalDirectoryDrop()
+            return nil
+        }
         let point = container.reorderDropView.convert(windowPoint, from: nil)
         return updateExternalDirectoryDrag(
             point: point,
-            targets: refreshReorderDropTargets()
+            visibleTargets: refreshReorderDropTargets()
         )
     }
 
     func clearExternalDirectoryDrop() {
         lastAcceptedExternalDirectoryDropPlan = nil
+        externalDirectoryDragWindowPoint = nil
         retireReorderIndicator()
     }
 
@@ -1818,28 +1832,20 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             clearExternalDirectoryDrop()
             return false
         }
-        defer {
-            lastAcceptedExternalDirectoryDropPlan = nil
-            retireReorderIndicator()
+        defer { clearExternalDirectoryDrop() }
+
+        // Replan from the release point so autoscroll / viewport drift cannot
+        // commit a stale hover plan.
+        _ = updateExternalDirectoryDrop(atWindowPoint: windowPoint)
+        guard let plan = lastAcceptedExternalDirectoryDropPlan else {
+            return false
         }
 
-        let planner = ExternalWorkspaceInsertionPlanner()
-        let targets = refreshReorderDropTargets()
-        let rootTargets = externalDirectoryRootTargets(from: targets)
-        let point = containerView?.reorderDropView.convert(windowPoint, from: nil) ?? .zero
-        let plan = lastAcceptedExternalDirectoryDropPlan ?? {
-            if rootTargets.isEmpty {
-                return rows.isEmpty ? planner.planForEmptySidebar() : nil
-            }
-            return planner.plan(point: point, rootTargets: rootTargets)
-        }()
-        guard let plan else { return false }
-
-        let topLevelIds = rootTargets.map(\.workspaceId)
+        let completeOrder = completeExternalDirectoryRootOrder()
         let created = actions.createWorkspaceFromExternalDirectory(
             directoryPath,
             plan.insertionIndex,
-            topLevelIds
+            completeOrder.ids
         )
         if created {
             suppressSelectedScrollAfterLocalDrop = true
@@ -1849,16 +1855,25 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     private func updateExternalDirectoryDrag(
         point: CGPoint,
-        targets: [SidebarWorkspaceReorderDropOverlay.Target]
+        visibleTargets: [SidebarWorkspaceReorderDropOverlay.Target]
     ) -> Int? {
         actions?.updateDragAutoscroll()
-        let rootTargets = externalDirectoryRootTargets(from: targets)
+        let completeOrder = completeExternalDirectoryRootOrder()
+        let visibleRootTargets = externalDirectoryRootTargets(from: visibleTargets)
         let planner = ExternalWorkspaceInsertionPlanner()
         let plan: ExternalWorkspaceInsertionPlanner.Plan?
-        if rootTargets.isEmpty {
+        if completeOrder.ids.isEmpty {
             plan = rows.isEmpty ? planner.planForEmptySidebar() : nil
+        } else if visibleRootTargets.isEmpty {
+            // Complete roots exist but none are on screen — no legal geometry.
+            plan = nil
         } else {
-            plan = planner.plan(point: point, rootTargets: rootTargets)
+            plan = planner.plan(
+                point: point,
+                visibleRootTargets: visibleRootTargets,
+                completeTopLevelIds: completeOrder.ids,
+                completePinnedCount: completeOrder.pinnedCount
+            )
         }
         guard let plan else {
             lastAcceptedExternalDirectoryDropPlan = nil
@@ -1870,13 +1885,23 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         return plan.insertionIndex
     }
 
+    private func completeExternalDirectoryRootOrder() -> (ids: [UUID], pinnedCount: Int) {
+        let roots = rows.filter { !$0.isGroupHeader && $0.groupId == nil }
+        let ids = roots.map(\.workspaceId)
+        let pinnedCount = roots.prefix(while: \.isPinned).count
+        return (ids, pinnedCount)
+    }
+
     private func externalDirectoryRootTargets(
         from targets: [SidebarWorkspaceReorderDropOverlay.Target]
     ) -> [ExternalWorkspaceInsertionPlanner.RootTarget] {
-        targets.compactMap { target in
+        let pinnedByWorkspaceId = Dictionary(
+            uniqueKeysWithValues: rows.map { ($0.workspaceId, $0.isPinned) }
+        )
+        return targets.compactMap { target in
             // v1: reject group headers and grouped children entirely.
             guard !target.isGroupHeader, target.groupId == nil else { return nil }
-            let isPinned = rows.first(where: { $0.workspaceId == target.workspaceId })?.isPinned ?? false
+            let isPinned = pinnedByWorkspaceId[target.workspaceId] ?? false
             return ExternalWorkspaceInsertionPlanner.RootTarget(
                 workspaceId: target.workspaceId,
                 isPinned: isPinned,
@@ -2226,6 +2251,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         enforceHoverOnVisibleCells()
         updateDropTargets()
         replanReorderDragIfActive()
+        replanExternalDirectoryDropIfActive()
     }
 
     /// Edge autoscroll moves rows under a stationary pointer, and AppKit only
@@ -2235,6 +2261,11 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private func replanReorderDragIfActive() {
         guard let windowPoint = reorderDragWindowPoint else { return }
         updateReorderDrag(windowPoint: windowPoint)
+    }
+
+    private func replanExternalDirectoryDropIfActive() {
+        guard let windowPoint = externalDirectoryDragWindowPoint else { return }
+        _ = updateExternalDirectoryDrop(atWindowPoint: windowPoint)
     }
 
     private let selectionCoalescer = SidebarSelectionCoalescer<ContinuousClock>()

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -1728,12 +1728,19 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var lastAcceptedReorderDropPlan: SidebarWorkspaceReorderDropPlan?
 
     /// Last accepted Finder-directory insertion plan painted for an external
-    /// drop. Committed after a fresh replan on release.
+    /// drop. Release prefers a fresh replan, then falls back to this painted
+    /// plan when order is unchanged (tiny release drift into row center).
     private var lastAcceptedExternalDirectoryDropPlan: ExternalWorkspaceInsertionPlanner.Plan?
+
+    /// Complete ungrouped root order captured with
+    /// ``lastAcceptedExternalDirectoryDropPlan``. Used to reject stale painted
+    /// plans after workspace order changes.
+    private var lastAcceptedExternalDirectoryCompleteOrderIds: [UUID]?
 
     /// Window-space pointer for an active external-directory sidebar route.
     /// Viewport / autoscroll changes replan from this point (same idea as
-    /// ``reorderDragWindowPoint`` for internal reorder).
+    /// ``reorderDragWindowPoint`` for internal reorder). Cleared on rejected
+    /// hover so viewport ticks cannot revive an illegal plan.
     private var externalDirectoryDragWindowPoint: NSPoint?
 
     /// One-shot: the next apply comes from this window's own drop, so the
@@ -1805,20 +1812,24 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     /// order for the commit slot.
     @discardableResult
     func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int? {
-        externalDirectoryDragWindowPoint = windowPoint
         guard let container = containerView else {
             clearExternalDirectoryDrop()
             return nil
         }
         let point = container.reorderDropView.convert(windowPoint, from: nil)
-        return updateExternalDirectoryDrag(
+        let plannedIndex = updateExternalDirectoryDrag(
             point: point,
             visibleTargets: refreshReorderDropTargets()
         )
+        // Rejected hover must not leave a reusable window point for viewport
+        // replan; only retain the point while a legal plan is painted.
+        externalDirectoryDragWindowPoint = plannedIndex == nil ? nil : windowPoint
+        return plannedIndex
     }
 
     func clearExternalDirectoryDrop() {
         lastAcceptedExternalDirectoryDropPlan = nil
+        lastAcceptedExternalDirectoryCompleteOrderIds = nil
         externalDirectoryDragWindowPoint = nil
         retireReorderIndicator()
     }
@@ -1834,14 +1845,23 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
         defer { clearExternalDirectoryDrop() }
 
-        // Replan from the release point so autoscroll / viewport drift cannot
-        // commit a stale hover plan.
+        // Preserve the painted plan before release replan. Narrow edge bands
+        // mean a couple pixels of release drift can hit row center and return
+        // nil even though the insertion line was still visible.
+        let paintedPlan = lastAcceptedExternalDirectoryDropPlan
+        let paintedOrderIds = lastAcceptedExternalDirectoryCompleteOrderIds ?? []
+
         _ = updateExternalDirectoryDrop(atWindowPoint: windowPoint)
-        guard let plan = lastAcceptedExternalDirectoryDropPlan else {
+        let completeOrder = completeExternalDirectoryRootOrder()
+        guard let plan = ExternalWorkspaceDropCommitResolver.resolve(
+            replanned: lastAcceptedExternalDirectoryDropPlan,
+            painted: paintedPlan,
+            paintedCompleteTopLevelIds: paintedOrderIds,
+            currentCompleteTopLevelIds: completeOrder.ids
+        ) else {
             return false
         }
 
-        let completeOrder = completeExternalDirectoryRootOrder()
         let created = actions.createWorkspaceFromExternalDirectory(
             directoryPath,
             plan.insertionIndex,
@@ -1877,10 +1897,12 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
         guard let plan else {
             lastAcceptedExternalDirectoryDropPlan = nil
+            lastAcceptedExternalDirectoryCompleteOrderIds = nil
             retireReorderIndicator()
             return nil
         }
         lastAcceptedExternalDirectoryDropPlan = plan
+        lastAcceptedExternalDirectoryCompleteOrderIds = completeOrder.ids
         setAppKitDropIndicator(plan.indicator, scope: .topLevel, includeRowTargets: true)
         return plan.insertionIndex
     }
@@ -1895,8 +1917,21 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private func externalDirectoryRootTargets(
         from targets: [SidebarWorkspaceReorderDropOverlay.Target]
     ) -> [ExternalWorkspaceInsertionPlanner.RootTarget] {
-        let pinnedByWorkspaceId = Dictionary(
-            uniqueKeysWithValues: rows.map { ($0.workspaceId, $0.isPinned) }
+        // Filter to eligible ungrouped roots BEFORE pinned lookup. Group
+        // headers reuse anchor workspace ids; Dictionary(uniqueKeysWithValues:)
+        // on raw rows can trap.
+        let eligibleRoots = ExternalWorkspaceInsertionPlanner.eligibleUngroupedRoots(
+            from: rows.map {
+                (
+                    workspaceId: $0.workspaceId,
+                    isPinned: $0.isPinned,
+                    isGroupHeader: $0.isGroupHeader,
+                    groupId: $0.groupId
+                )
+            }
+        )
+        let pinnedByWorkspaceId = ExternalWorkspaceInsertionPlanner.pinnedFlagsByWorkspaceId(
+            fromEligibleUngroupedRoots: eligibleRoots
         )
         return targets.compactMap { target in
             // v1: reject group headers and grouped children entirely.

--- a/Sources/SidebarExternalDirectoryDropRouter.swift
+++ b/Sources/SidebarExternalDirectoryDropRouter.swift
@@ -6,14 +6,18 @@ import CmuxFoundation
 ///
 /// Spatial planning and indicator painting stay in the sidebar; the overlay only
 /// owns pasteboard / drag lifecycle and delegates here when the pointer is over
-/// a live workspace list.
+/// a live workspace list in the **same** window.
 @MainActor
 protocol SidebarExternalDirectoryDropRouting: AnyObject {
+    /// Window that owns this sidebar presentation. Used to scope Finder routing
+    /// so window A's overlay never consults window B's sidebar.
+    var externalDirectoryDropHostingWindow: NSWindow? { get }
+
     /// Whether `windowPoint` lies inside this sidebar's visible drop surface.
     func containsExternalDirectoryDropWindowPoint(_ windowPoint: NSPoint) -> Bool
 
     /// Updates insertion indicator for a validated directory drag at `windowPoint`.
-    /// - Returns: planned insertion index when a legal plan is active; otherwise `nil`.
+    /// - Returns: planned complete top-level insertion slot when legal; otherwise `nil`.
     @discardableResult
     func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int?
 
@@ -28,20 +32,49 @@ protocol SidebarExternalDirectoryDropRouting: AnyObject {
     ) -> Bool
 }
 
-/// Process-local registration of the active AppKit workspace sidebar router.
+/// Per-window registration of AppKit workspace sidebar routers.
+///
+/// Finder drops are owned by each window's ``FileDropOverlayView``. Resolution
+/// is always keyed by that overlay's `NSWindow` so multi-window sessions cannot
+/// cross-wire sidebars.
 @MainActor
 enum SidebarExternalDirectoryDropRouter {
-    private static weak var active: (any SidebarExternalDirectoryDropRouting)?
+    private struct WeakRouter {
+        weak var value: (any SidebarExternalDirectoryDropRouting)?
+    }
+
+    private static var routersByIdentity: [ObjectIdentifier: WeakRouter] = [:]
 
     static func register(_ router: any SidebarExternalDirectoryDropRouting) {
-        active = router
+        prune()
+        routersByIdentity[ObjectIdentifier(router)] = WeakRouter(value: router)
     }
 
     static func unregister(_ router: any SidebarExternalDirectoryDropRouting) {
-        if active === router {
-            active = nil
-        }
+        routersByIdentity.removeValue(forKey: ObjectIdentifier(router))
+        prune()
     }
 
-    static var current: (any SidebarExternalDirectoryDropRouting)? { active }
+    /// Returns the sidebar router hosted by `window`, or `nil` (fail closed).
+    static func router(for window: NSWindow) -> (any SidebarExternalDirectoryDropRouting)? {
+        prune()
+        for entry in routersByIdentity.values {
+            guard let router = entry.value,
+                  router.externalDirectoryDropHostingWindow === window else {
+                continue
+            }
+            return router
+        }
+        return nil
+    }
+
+    /// Test seam: number of live registered routers after pruning.
+    static var registeredRouterCountForTests: Int {
+        prune()
+        return routersByIdentity.values.compactMap(\.value).count
+    }
+
+    private static func prune() {
+        routersByIdentity = routersByIdentity.filter { $0.value.value != nil }
+    }
 }

--- a/Sources/SidebarExternalDirectoryDropRouter.swift
+++ b/Sources/SidebarExternalDirectoryDropRouter.swift
@@ -68,12 +68,6 @@ enum SidebarExternalDirectoryDropRouter {
         return nil
     }
 
-    /// Test seam: number of live registered routers after pruning.
-    static var registeredRouterCountForTests: Int {
-        prune()
-        return routersByIdentity.values.compactMap(\.value).count
-    }
-
     private static func prune() {
         routersByIdentity = routersByIdentity.filter { $0.value.value != nil }
     }

--- a/Sources/SidebarExternalDirectoryDropRouter.swift
+++ b/Sources/SidebarExternalDirectoryDropRouter.swift
@@ -1,0 +1,47 @@
+import AppKit
+import CmuxFoundation
+
+/// Sidebar authority for Finder-directory → new-workspace insertion, driven by
+/// the window-level ``FileDropOverlayView`` (the native NSDraggingDestination).
+///
+/// Spatial planning and indicator painting stay in the sidebar; the overlay only
+/// owns pasteboard / drag lifecycle and delegates here when the pointer is over
+/// a live workspace list.
+@MainActor
+protocol SidebarExternalDirectoryDropRouting: AnyObject {
+    /// Whether `windowPoint` lies inside this sidebar's visible drop surface.
+    func containsExternalDirectoryDropWindowPoint(_ windowPoint: NSPoint) -> Bool
+
+    /// Updates insertion indicator for a validated directory drag at `windowPoint`.
+    /// - Returns: planned insertion index when a legal plan is active; otherwise `nil`.
+    @discardableResult
+    func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int?
+
+    /// Clears any painted external-directory insertion affordance.
+    func clearExternalDirectoryDrop()
+
+    /// Creates one new workspace for `directoryPath` at the current / resolved plan.
+    @discardableResult
+    func performExternalDirectoryDrop(
+        directoryPath: String,
+        atWindowPoint windowPoint: NSPoint
+    ) -> Bool
+}
+
+/// Process-local registration of the active AppKit workspace sidebar router.
+@MainActor
+enum SidebarExternalDirectoryDropRouter {
+    private static weak var active: (any SidebarExternalDirectoryDropRouting)?
+
+    static func register(_ router: any SidebarExternalDirectoryDropRouting) {
+        active = router
+    }
+
+    static func unregister(_ router: any SidebarExternalDirectoryDropRouting) {
+        if active === router {
+            active = nil
+        }
+    }
+
+    static var current: (any SidebarExternalDirectoryDropRouting)? { active }
+}

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -127,7 +127,9 @@ extension TabManager {
         return Self.clampedDetachedWorkspaceInsertIndex(insertionIndexOverride, tabs: snapshot.tabs)
     }
 
-    private static func clampedDetachedWorkspaceInsertIndex(
+    /// Clamps a proposed create-at-index slot so a new unpinned workspace cannot
+    /// land inside the leading pinned segment.
+    static func clampedDetachedWorkspaceInsertIndex(
         _ proposedInsertion: Int,
         tabs: [WorkspaceCreationTabSnapshot]
     ) -> Int {

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -124,7 +124,8 @@ extension TabManager {
         guard let insertionIndexOverride else {
             return newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
         }
-        return Self.clampedDetachedWorkspaceInsertIndex(insertionIndexOverride, tabs: snapshot.tabs)
+        let liveTabs = orderedLiveWorkspaceCreationTabs(from: snapshot) ?? snapshot.tabs
+        return Self.clampedDetachedWorkspaceInsertIndex(insertionIndexOverride, tabs: liveTabs)
     }
 
     /// Clamps a proposed create-at-index slot so a new unpinned workspace cannot

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1320,6 +1320,7 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: WorkspacePlacement? = nil,
+        insertionIndexOverride: Int? = nil,
         autoWelcomeIfNeeded: Bool = true,
         autoRefreshMetadata: Bool = true,
         normalizeWorkspaceGroupsAfterInsert: Bool = true,
@@ -1371,7 +1372,18 @@ class TabManager: ObservableObject {
             // Resolve placement against the pre-creation snapshot before Workspace init
             // boots terminal state. The ssh/new-workspace path can otherwise crash while
             // reading @Published placement state from existing workspaces mid-creation.
-            let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
+            // `insertionIndexOverride` mirrors detached/new-workspace create-at-index:
+            // nil preserves every existing call site; an explicit index clamps into the
+            // unpinned region (new Finder sidebar drops always create unpinned workspaces).
+            let insertIndex: Int = {
+                if let insertionIndexOverride {
+                    return Self.clampedDetachedWorkspaceInsertIndex(
+                        insertionIndexOverride,
+                        tabs: snapshot.tabs
+                    )
+                }
+                return newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
+            }()
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
             let defaultTitle: String
@@ -1627,6 +1639,7 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: WorkspacePlacement? = nil,
+        insertionIndexOverride: Int? = nil,
         autoWelcomeIfNeeded: Bool = true,
         autoRefreshMetadata: Bool = true,
         normalizeWorkspaceGroupsAfterInsert: Bool = true,
@@ -1651,6 +1664,7 @@ class TabManager: ObservableObject {
             select: select,
             eagerLoadTerminal: eagerLoadTerminal,
             placementOverride: placementOverride,
+            insertionIndexOverride: insertionIndexOverride,
             autoWelcomeIfNeeded: autoWelcomeIfNeeded,
             autoRefreshMetadata: autoRefreshMetadata,
             normalizeWorkspaceGroupsAfterInsert: normalizeWorkspaceGroupsAfterInsert,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1374,12 +1374,14 @@ class TabManager: ObservableObject {
             // reading @Published placement state from existing workspaces mid-creation.
             // `insertionIndexOverride` mirrors detached/new-workspace create-at-index:
             // nil preserves every existing call site; an explicit index clamps into the
-            // unpinned region (new Finder sidebar drops always create unpinned workspaces).
+            // unpinned region against the same reconciled live order used by
+            // `newTabInsertIndex` (new Finder sidebar drops always create unpinned workspaces).
             let insertIndex: Int = {
                 if let insertionIndexOverride {
+                    let liveTabs = orderedLiveWorkspaceCreationTabs(from: snapshot) ?? snapshot.tabs
                     return Self.clampedDetachedWorkspaceInsertIndex(
                         insertionIndexOverride,
-                        tabs: snapshot.tabs
+                        tabs: liveTabs
                     )
                 }
                 return newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
@@ -1736,7 +1738,7 @@ class TabManager: ObservableObject {
         )
     }
 
-    private func orderedLiveWorkspaceCreationTabs(
+    func orderedLiveWorkspaceCreationTabs(
         from snapshot: WorkspaceCreationSnapshot
     ) -> [WorkspaceCreationTabSnapshot]? {
         let currentTabs = tabs

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1287,6 +1287,7 @@
 		E4C001000000000000000001 /* ExtensionSidebarWorkspaceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */; };
 		E4C001000000000000000003 /* ExtensionWorktreePrototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C001000000000000000004 /* ExtensionWorktreePrototype.swift */; };
 		E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */; };
+		E8F1D202E8F1D202E8F1D202 /* ExternalWorkspaceDirectoryDropCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F1D201E8F1D201E8F1D201 /* ExternalWorkspaceDirectoryDropCreationTests.swift */; };
 		C0DEA7710000000000000007 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEA7710000000000000008 /* FeatureFlags.swift */; };
 		FEED0A00000000000000F007 /* feed-tui in Resources */ = {isa = PBXBuildFile; fileRef = FEED0A00000000000000F006 /* feed-tui */; };
 		9466A07A0000000000000001 /* FeedAttentionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9466A07A0000000000000002 /* FeedAttentionTarget.swift */; };
@@ -2326,6 +2327,7 @@
 		D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */; };
 		EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000004 /* SidebarDirectoryText.swift */; };
 		B804A0270000000000000027 /* SidebarDividerTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0270000000000000027 /* SidebarDividerTrackingView.swift */; };
+		E1F2A3B4C5D6E7F8091A2B02 /* SidebarExternalDirectoryDropRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F8091A2B01 /* SidebarExternalDirectoryDropRouter.swift */; };
 		A7FD1002 /* SidebarFileDropFindRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FD1001 /* SidebarFileDropFindRoutingTests.swift */; };
 		B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */; };
 		A8624F0C0000000000000001 /* SidebarFocusBoundaryReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */; };
@@ -4547,6 +4549,7 @@
 		E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSidebarWorkspaceRowView.swift; sourceTree = "<group>"; };
 		E4C001000000000000000004 /* ExtensionWorktreePrototype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionWorktreePrototype.swift; sourceTree = "<group>"; };
 		E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionWorktreeSpawnArgsTests.swift; sourceTree = "<group>"; };
+		E8F1D201E8F1D201E8F1D201 /* ExternalWorkspaceDirectoryDropCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalWorkspaceDirectoryDropCreationTests.swift; sourceTree = "<group>"; };
 		C0DEA7710000000000000008 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		FEED0A00000000000000F006 /* feed-tui */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "feed-tui"; sourceTree = "<group>"; };
 		9466A07A0000000000000002 /* FeedAttentionTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAttentionTarget.swift; sourceTree = "<group>"; };
@@ -5578,6 +5581,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000004 /* SidebarDirectoryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDirectoryText.swift; sourceTree = "<group>"; };
 		B804B0270000000000000027 /* SidebarDividerTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDividerTrackingView.swift; sourceTree = "<group>"; };
+		E1F2A3B4C5D6E7F8091A2B01 /* SidebarExternalDirectoryDropRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarExternalDirectoryDropRouter.swift; sourceTree = "<group>"; };
 		A7FD1001 /* SidebarFileDropFindRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFileDropFindRoutingTests.swift; sourceTree = "<group>"; };
 		B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFocusBoundaryLifecycleTests.swift; sourceTree = "<group>"; };
 		A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarFocusBoundaryReference.swift; sourceTree = "<group>"; };
@@ -7171,6 +7175,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */,
 				F0A1100E0000000000000001 /* FileDropOverlayMouseDragButton.swift */,
 				F0A110100000000000000001 /* FileDropOverlayMouseDragTarget.swift */,
+				E1F2A3B4C5D6E7F8091A2B01 /* SidebarExternalDirectoryDropRouter.swift */,
 				D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */,
 				D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */,
 				C0DE35010000000000000002 /* SidebarScrim.swift */,
@@ -9715,6 +9720,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */,
+				E8F1D201E8F1D201E8F1D201 /* ExternalWorkspaceDirectoryDropCreationTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
 				B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */,
@@ -11900,6 +11906,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */,
 				EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */,
 				B804A0270000000000000027 /* SidebarDividerTrackingView.swift in Sources */,
+				E1F2A3B4C5D6E7F8091A2B02 /* SidebarExternalDirectoryDropRouter.swift in Sources */,
 				A8624F0C0000000000000001 /* SidebarFocusBoundaryReference.swift in Sources */,
 				F10753000000000000000001 /* SidebarGroupHeaderRowActions+NotificationState.swift in Sources */,
 				B804A0200000000000000020 /* SidebarGroupHeaderRowModel.swift in Sources */,
@@ -13160,6 +13167,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,
 				E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */,
+				E8F1D202E8F1D202E8F1D202 /* ExternalWorkspaceDirectoryDropCreationTests.swift in Sources */,
 				8672E0048672E0048672E004 /* FeedCoordinatorIngressTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				FEED49850000000000000001 /* FeedEventClassificationTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2328,6 +2328,7 @@
 		EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000004 /* SidebarDirectoryText.swift */; };
 		B804A0270000000000000027 /* SidebarDividerTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0270000000000000027 /* SidebarDividerTrackingView.swift */; };
 		E1F2A3B4C5D6E7F8091A2B02 /* SidebarExternalDirectoryDropRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F8091A2B01 /* SidebarExternalDirectoryDropRouter.swift */; };
+		E8F1D204E8F1D204E8F1D204 /* SidebarExternalDirectoryDropRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F1D203E8F1D203E8F1D203 /* SidebarExternalDirectoryDropRouterTests.swift */; };
 		A7FD1002 /* SidebarFileDropFindRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FD1001 /* SidebarFileDropFindRoutingTests.swift */; };
 		B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */; };
 		A8624F0C0000000000000001 /* SidebarFocusBoundaryReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */; };
@@ -5582,6 +5583,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		EA1F00000000000000000004 /* SidebarDirectoryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDirectoryText.swift; sourceTree = "<group>"; };
 		B804B0270000000000000027 /* SidebarDividerTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDividerTrackingView.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F8091A2B01 /* SidebarExternalDirectoryDropRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarExternalDirectoryDropRouter.swift; sourceTree = "<group>"; };
+		E8F1D203E8F1D203E8F1D203 /* SidebarExternalDirectoryDropRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarExternalDirectoryDropRouterTests.swift; sourceTree = "<group>"; };
 		A7FD1001 /* SidebarFileDropFindRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFileDropFindRoutingTests.swift; sourceTree = "<group>"; };
 		B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFocusBoundaryLifecycleTests.swift; sourceTree = "<group>"; };
 		A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarFocusBoundaryReference.swift; sourceTree = "<group>"; };
@@ -9720,6 +9722,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */,
+				E8F1D203E8F1D203E8F1D203 /* SidebarExternalDirectoryDropRouterTests.swift */,
 				E8F1D201E8F1D201E8F1D201 /* ExternalWorkspaceDirectoryDropCreationTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
@@ -13455,6 +13458,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */,
 				C3467AB10000000000000001 /* ShortcutWhenClauseTests.swift in Sources */,
 				B804C0030000000000000003 /* SidebarAppKitRowCellTests.swift in Sources */,
+				E8F1D204E8F1D204E8F1D204 /* SidebarExternalDirectoryDropRouterTests.swift in Sources */,
 				A7FD1002 /* SidebarFileDropFindRoutingTests.swift in Sources */,
 				B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */,
 				8175A0010000000000000001 /* SidebarGitProcessCompositionTests.swift in Sources */,

--- a/cmuxTests/ExternalWorkspaceDirectoryDropCreationTests.swift
+++ b/cmuxTests/ExternalWorkspaceDirectoryDropCreationTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Identity and create-at-index coverage for Finder-directory → new workspace.
+///
+/// Workspace identity is always the workspace UUID. Working directories and
+/// titles are context/presentation only and must never dedupe creation.
+@Suite struct ExternalWorkspaceDirectoryDropCreationTests {
+    @MainActor
+    @Test func sameWorkingDirectoryCreatesDistinctWorkspaces() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ext-drop-same-cwd-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = TabManager()
+        let first = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: root.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            autoWelcomeIfNeeded: false
+        ))
+        let second = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: root.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: manager.tabs.count,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(first.id != second.id)
+        #expect(first.currentDirectory == root.path)
+        #expect(second.currentDirectory == root.path)
+        #expect(manager.selectedTabId == second.id)
+    }
+
+    @MainActor
+    @Test func childAndParentDirectoriesCreateDistinctWorkspaces() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ext-drop-nest-\(UUID().uuidString)", isDirectory: true)
+        let child = root.appendingPathComponent("mobile", isDirectory: true)
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = TabManager()
+        let parentWorkspace = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: root.path,
+            inheritWorkingDirectory: false,
+            select: false,
+            autoWelcomeIfNeeded: false
+        ))
+        let childWorkspace = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: child.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: manager.tabs.count,
+            autoWelcomeIfNeeded: false
+        ))
+        let parentAgain = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: root.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: manager.tabs.count,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(Set([parentWorkspace.id, childWorkspace.id, parentAgain.id]).count == 3)
+        #expect(childWorkspace.currentDirectory == child.path)
+        #expect(parentAgain.currentDirectory == root.path)
+    }
+
+    @MainActor
+    @Test func sameBasenameDifferentPathsCreateDistinctWorkspaces() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ext-drop-basename-\(UUID().uuidString)", isDirectory: true)
+        let clientA = root.appendingPathComponent("client-a/frontend", isDirectory: true)
+        let clientB = root.appendingPathComponent("client-b/frontend", isDirectory: true)
+        try FileManager.default.createDirectory(at: clientA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: clientB, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = TabManager()
+        let workspaceA = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: clientA.path,
+            inheritWorkingDirectory: false,
+            select: false,
+            autoWelcomeIfNeeded: false
+        ))
+        let workspaceB = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: clientB.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: manager.tabs.count,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(workspaceA.id != workspaceB.id)
+        #expect(workspaceA.currentDirectory == clientA.path)
+        #expect(workspaceB.currentDirectory == clientB.path)
+        #expect(URL(fileURLWithPath: clientA.path).lastPathComponent == "frontend")
+        #expect(URL(fileURLWithPath: clientB.path).lastPathComponent == "frontend")
+    }
+
+    @MainActor
+    @Test func duplicateVisibleTitlesDoNotBlockCreation() throws {
+        let manager = TabManager()
+        let first = try #require(manager.addWorkspaceIfActive(
+            title: "Jimmy",
+            inheritWorkingDirectory: false,
+            select: false,
+            autoWelcomeIfNeeded: false
+        ))
+        let second = try #require(manager.addWorkspaceIfActive(
+            title: "Jimmy",
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: manager.tabs.count,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(first.id != second.id)
+        #expect(first.title == "Jimmy")
+        #expect(second.title == "Jimmy")
+    }
+
+    @MainActor
+    @Test func insertionIndexOverridePlacesWorkspaceBetweenNeighbors() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ext-drop-order-\(UUID().uuidString)", isDirectory: true)
+        let jimmy = root.appendingPathComponent("Jimmy", isDirectory: true)
+        try FileManager.default.createDirectory(at: jimmy, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = TabManager()
+        // TabManager boots with one workspace; build A B C explicitly.
+        let a = try #require(manager.tabs.first)
+        let b = try #require(manager.addWorkspaceIfActive(
+            select: false,
+            placementOverride: .end,
+            autoWelcomeIfNeeded: false
+        ))
+        let c = try #require(manager.addWorkspaceIfActive(
+            select: false,
+            placementOverride: .end,
+            autoWelcomeIfNeeded: false
+        ))
+        #expect(manager.tabs.map(\.id) == [a.id, b.id, c.id])
+
+        let jimmyWorkspace = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: jimmy.path,
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: 1,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(manager.tabs.map(\.id) == [a.id, jimmyWorkspace.id, b.id, c.id])
+        #expect(jimmyWorkspace.currentDirectory == jimmy.path)
+        #expect(manager.selectedTabId == jimmyWorkspace.id)
+        #expect(!jimmyWorkspace.isPinned)
+    }
+
+    @MainActor
+    @Test func insertionIndexOverrideClampsAfterPinnedPrefix() throws {
+        let manager = TabManager()
+        let pinned = try #require(manager.tabs.first)
+        manager.setPinned(pinned, pinned: true)
+        let unpinned = try #require(manager.addWorkspaceIfActive(
+            select: false,
+            placementOverride: .end,
+            autoWelcomeIfNeeded: false
+        ))
+
+        let inserted = try #require(manager.addWorkspaceIfActive(
+            workingDirectory: "/tmp",
+            inheritWorkingDirectory: false,
+            select: true,
+            insertionIndexOverride: 0,
+            autoWelcomeIfNeeded: false
+        ))
+
+        #expect(manager.tabs.map(\.id) == [pinned.id, inserted.id, unpinned.id])
+        #expect(!inserted.isPinned)
+    }
+}

--- a/cmuxTests/SidebarExternalDirectoryDropRouterTests.swift
+++ b/cmuxTests/SidebarExternalDirectoryDropRouterTests.swift
@@ -7,7 +7,7 @@ import Testing
 @testable import cmux
 #endif
 
-/// Multi-window scoping for Finder-directory → sidebar routing.
+/// Multi-window scoping and leave/cancel lifecycle for Finder-directory → sidebar routing.
 @Suite struct SidebarExternalDirectoryDropRouterTests {
     @MainActor
     private final class StubRouter: SidebarExternalDirectoryDropRouting {
@@ -67,7 +67,6 @@ import Testing
             SidebarExternalDirectoryDropRouter.unregister(routerB)
         }
 
-        #expect(SidebarExternalDirectoryDropRouter.registeredRouterCountForTests == 2)
         #expect(SidebarExternalDirectoryDropRouter.router(for: windowA) === routerA)
         #expect(SidebarExternalDirectoryDropRouter.router(for: windowB) === routerB)
     }
@@ -97,7 +96,6 @@ import Testing
 
         #expect(SidebarExternalDirectoryDropRouter.router(for: windowA) == nil)
         #expect(SidebarExternalDirectoryDropRouter.router(for: windowB) === routerB)
-        #expect(SidebarExternalDirectoryDropRouter.registeredRouterCountForTests == 1)
     }
 
     @MainActor
@@ -109,5 +107,25 @@ import Testing
             defer: false
         )
         #expect(SidebarExternalDirectoryDropRouter.router(for: window) == nil)
+    }
+
+    @MainActor
+    @Test func clearExternalDirectorySidebarRouteAlwaysClearsRouterEvenWhenNotActivelyRouting() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let overlay = FileDropOverlayView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+        window.contentView = overlay
+        let router = StubRouter(window: window)
+        SidebarExternalDirectoryDropRouter.register(router)
+        defer { SidebarExternalDirectoryDropRouter.unregister(router) }
+
+        overlay.isRoutingExternalDirectoryToSidebar = false
+        overlay.clearExternalDirectorySidebarRoute()
+        #expect(router.clearCount == 1)
+        #expect(overlay.isRoutingExternalDirectoryToSidebar == false)
     }
 }

--- a/cmuxTests/SidebarExternalDirectoryDropRouterTests.swift
+++ b/cmuxTests/SidebarExternalDirectoryDropRouterTests.swift
@@ -1,0 +1,113 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Multi-window scoping for Finder-directory → sidebar routing.
+@Suite struct SidebarExternalDirectoryDropRouterTests {
+    @MainActor
+    private final class StubRouter: SidebarExternalDirectoryDropRouting {
+        let window: NSWindow
+        private(set) var updateCount = 0
+        private(set) var clearCount = 0
+        private(set) var lastUpdatePoint: NSPoint?
+
+        init(window: NSWindow) {
+            self.window = window
+        }
+
+        var externalDirectoryDropHostingWindow: NSWindow? { window }
+
+        func containsExternalDirectoryDropWindowPoint(_ windowPoint: NSPoint) -> Bool {
+            true
+        }
+
+        func updateExternalDirectoryDrop(atWindowPoint windowPoint: NSPoint) -> Int? {
+            updateCount += 1
+            lastUpdatePoint = windowPoint
+            return 0
+        }
+
+        func clearExternalDirectoryDrop() {
+            clearCount += 1
+        }
+
+        func performExternalDirectoryDrop(
+            directoryPath: String,
+            atWindowPoint windowPoint: NSPoint
+        ) -> Bool {
+            true
+        }
+    }
+
+    @MainActor
+    @Test func resolvesRouterForMatchingWindowOnly() {
+        let windowA = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let windowB = NSWindow(
+            contentRect: NSRect(x: 220, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let routerA = StubRouter(window: windowA)
+        let routerB = StubRouter(window: windowB)
+        SidebarExternalDirectoryDropRouter.register(routerA)
+        SidebarExternalDirectoryDropRouter.register(routerB)
+        defer {
+            SidebarExternalDirectoryDropRouter.unregister(routerA)
+            SidebarExternalDirectoryDropRouter.unregister(routerB)
+        }
+
+        #expect(SidebarExternalDirectoryDropRouter.registeredRouterCountForTests == 2)
+        #expect(SidebarExternalDirectoryDropRouter.router(for: windowA) === routerA)
+        #expect(SidebarExternalDirectoryDropRouter.router(for: windowB) === routerB)
+    }
+
+    @MainActor
+    @Test func unregisteringOneWindowDoesNotBreakTheOther() {
+        let windowA = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let windowB = NSWindow(
+            contentRect: NSRect(x: 220, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let routerA = StubRouter(window: windowA)
+        let routerB = StubRouter(window: windowB)
+        SidebarExternalDirectoryDropRouter.register(routerA)
+        SidebarExternalDirectoryDropRouter.register(routerB)
+        SidebarExternalDirectoryDropRouter.unregister(routerA)
+        defer {
+            SidebarExternalDirectoryDropRouter.unregister(routerB)
+        }
+
+        #expect(SidebarExternalDirectoryDropRouter.router(for: windowA) == nil)
+        #expect(SidebarExternalDirectoryDropRouter.router(for: windowB) === routerB)
+        #expect(SidebarExternalDirectoryDropRouter.registeredRouterCountForTests == 1)
+    }
+
+    @MainActor
+    @Test func unknownWindowFailsClosed() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        #expect(SidebarExternalDirectoryDropRouter.router(for: window) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Drag a local Finder directory between workspace rows to create a new workspace rooted at that directory.
- Show the existing sidebar insertion affordance and create the workspace at the indicated position.
- Preserve existing terminal/browser file-drop behavior outside the workspace sidebar.
- Keep workspace identity independent from cwd: dropping the same or nested directories creates distinct workspaces.

## Why

cmux already supports opening directories as workspaces through Finder/Dock, but there is no spatial way to place a folder directly into the workspace list.

This makes initial workspace setup faster while keeping existing workspace and filesystem semantics unchanged.

## Implementation

Finder file drags continue to use the existing window-level `FileDropOverlayView` as the native AppKit drag destination.

When the pointer is over the workspace sidebar:

`FileDropOverlayView`
→ directory validation
→ sidebar routing
→ existing sidebar drop geometry
→ new-workspace insertion plan
→ workspace creation at the planned index

Outside the sidebar, existing file-drop behavior continues unchanged.

Normal workspace creation gains an optional exact insertion-index override; callers that do not provide it retain their existing placement behavior.

## Behavior

- one local directory per drop
- `.copy` / non-destructive Finder semantics
- new workspace is selected after creation
- no cwd/title/basename deduplication
- no filesystem-derived workspace grouping
- grouped sidebar targets are not supported in this first version
- `ui.newWorkspace.action` behavior is unchanged

## Test plan

Manually validated in the tagged dev build:

- [x] Drag a Finder folder between workspace rows → workspace appears at the indicated index with the correct cwd and becomes selected
- [x] Drop at the end of the list → workspace appends
- [x] Drop the same directory twice → two distinct workspaces
- [x] Drop parent/nested directories → separate workspaces
- [x] Multiple-folder drag → rejected
- [x] Drag into sidebar and leave without dropping → insertion indicator clears
- [x] Regular file on workspace sidebar → no workspace created
- [x] Existing terminal file-drop behavior still works
- [x] Internal workspace reorder still works

Automated:

- [x] `swift test --filter ExternalWorkspace` in `CmuxFoundation` — 15/15 passing
- [ ] broader `cmux-unit` filtered run is currently blocked by unrelated compile errors already present on `main` in `CLILocalTmuxReviewRegressionTests`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791402801&installation_model_id=21920&pr_number=12085&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12085&signature=17df0976d7b56d88152d08cb413d1159093223e39fef999cd06f3e2d1af8a2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows creating a new workspace by dropping a Finder folder onto the workspace sidebar, inserting it at the indicated position.

**Behavior**
- Only a single local directory is accepted; multi-folder drags are rejected.
- The new workspace is selected after creation; existing file-drop behavior in terminal and browser is unchanged.
- Dropping the same or nested directories creates distinct workspaces; no deduplication.
- Grouped sidebar targets are not supported in this version.

**Bug Fixes**
- Finder drops route only to the sidebar in the same window, and insertion indices map visible rows onto the complete root order so scrolled lists place correctly.
- Plans replan on viewport and autoscroll changes; insertion is clamped so a new unpinned workspace can't land inside the pinned prefix.
- Release keeps the last painted plan when the root order is unchanged, and grouped rows are filtered before pinned lookup to avoid a crash.

<sup>Written for commit a8f1f5211a1d44b4cae7854669733bd96d39616a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dragging Finder directories into the sidebar to create workspaces.
  - Directories can be inserted before, between, or after eligible root-level workspaces.
  - New workspaces preserve the dropped directory as their working directory and are selected after creation.
  - Invalid drops, including files, missing locations, multiple items, and grouped or pinned targets, are rejected.

- **Bug Fixes**
  - Workspace placement now respects the requested insertion position while keeping pinned workspaces together.
  - Drop placement is refreshed when sidebar content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->