### PR TITLE
Fix App Store resubmission workflow and preserve existing listing

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      refresh_store_listing:
+        description: Replace an existing version's metadata and screenshots from the repository
+        required: false
+        default: false
+        type: boolean
       retarget_initial_draft:
         description: Change the app's sole PREPARE_FOR_SUBMISSION version to the configured initial version
         required: false
@@ -32,7 +37,8 @@ permissions:
 jobs:
   upload-and-validate:
     name: Upload and validate production App Store build
-    if: github.ref == 'refs/heads/main'
+    # The app source is always main, including dispatches of workflow repairs.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.MACOS_RUNNER_IOS || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 90
     env:
@@ -44,15 +50,20 @@ jobs:
       INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
       INPUT_COPY_METADATA_FROM: ${{ github.event.inputs.copy_metadata_from }}
       INPUT_SUBMIT_FOR_REVIEW: ${{ github.event.inputs.submit_for_review }}
+      INPUT_REFRESH_STORE_LISTING: ${{ github.event.inputs.refresh_store_listing }}
       INPUT_RETARGET_INITIAL_DRAFT: ${{ github.event.inputs.retarget_initial_draft }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Record app source
+        run: git rev-parse HEAD | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Select Xcode
         run: ./scripts/select-ci-xcode.sh
@@ -225,6 +236,10 @@ jobs:
               --version-id "$VERSION_ID" \
               --copyright "2026 Manaflow, Inc." \
               --release-type MANUAL
+            if [ "${INPUT_REFRESH_STORE_LISTING:-false}" != "true" ]; then
+              echo "Keeping existing App Store metadata and screenshots for $VERSION"
+              exit 0
+            fi
           fi
           asc metadata validate --dir ios/AppStoreReview/metadata
           asc metadata apply \
@@ -251,7 +266,7 @@ jobs:
             --platform IOS \
             --path ios/AppStoreReview/screenshots \
             --device-type IPHONE_69 \
-            --replace
+            --replace --confirm
           asc screenshots validate \
             --path ios/AppStoreReview/screenshots/en-US/ipad \
             --device-type IPAD_PRO_3GEN_129
@@ -261,7 +276,7 @@ jobs:
             --platform IOS \
             --path ios/AppStoreReview/screenshots \
             --device-type IPAD_PRO_3GEN_129 \
-            --replace
+            --replace --confirm
 
       - name: Ensure App Store availability
         run: python3 ios/scripts/asc_bootstrap_app_availability.py --app "$ASC_APP_ID"


### PR DESCRIPTION
App Store resubmissions currently stop before archive because screenshot replacement requires confirmation. Existing listings also get overwritten with repository templates. Preserve existing metadata and screenshots unless refresh_store_listing is explicitly selected; confirm replacements when selected. Always check out main for the app source, including maintenance-branch workflow dispatches, and record the source SHA. Validation: YAML parses, git diff --check passes; exercising the production submission workflow against main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791430105&installation_model_id=21920&pr_number=12091&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12091&signature=38921c61b30f5a1863f69180dbaad785b7a9977066b0826942650edc09a28c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production App Store release pipeline and App Store Connect listing mutations, though default behavior now reduces accidental metadata/screenshot overwrites.
> 
> **Overview**
> Production **iOS App Store** workflow changes so **resubmissions** no longer blindly overwrite live listing assets and no longer stall on screenshot replacement.
> 
> A new manual input **`refresh_store_listing`** (default off) controls whether an **existing** App Store version gets repo metadata and screenshots applied. When it is off, the prepare step updates copyright/release type only, logs that listing is kept, and **exits before** validate/apply/upload—so routine resubmits skip template overwrites. When refresh is on, iPhone and iPad **`asc screenshots upload`** calls add **`--confirm`** alongside **`--replace`**, matching CLI requirements that were blocking archive.
> 
> The **upload-and-validate** job now runs only on **`workflow_dispatch`** (not merely `main` ref), always **checks out `main`** for the app build (including repair runs from other branches), and writes the resolved **source SHA** to the job summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c7c409c2db77517acc0f2dd2c777696f3ff10a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the App Store resubmission workflow so `asc metadata apply` and screenshot replacement no longer overwrite existing listing content unless the new `refresh_store_listing` input is explicitly selected, and screenshot replacements now pass `--confirm` when selected. The job now triggers only on `workflow_dispatch`, always checks out `main` for the app source, and records the source SHA in the step summary.

<sup>Written for commit 58c7c409c2db77517acc0f2dd2c777696f3ff10a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Production App Store releases now require an explicit manual trigger.
  - Releases use the selected main-branch revision, improving traceability.
  - Existing App Store metadata and screenshots are preserved by default during version updates.
  - An optional refresh setting allows metadata and screenshots to be replaced when needed.
  - Screenshot uploads now require confirmation before changes are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->