### PR TITLE
Cloud: always open the port before navigating a Desktop or Ports pane

### DIFF
--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -1796,11 +1796,15 @@ actor VMClient {
     func openPort(id: String, port: Int) async throws -> VMOpenPortEndpoint {
         let encodedID = try pathSegment(id, fieldName: "vm id")
         try await requireCloudBrowserAccess(machineID: id)
+        // The server may resume a paused machine and, for the desktop port,
+        // start the desktop unit and wait for noVNC to listen (bounded at 90 s
+        // guest-side). Give up after that bound, not before it, so a slow cold
+        // start does not report failure for a desktop that then comes up.
         let (data, http) = try await request(
             "POST",
             path: "/api/vm/\(encodedID)/open-port",
             jsonBody: ["port": port],
-            timeoutSeconds: 60
+            timeoutSeconds: 120
         )
         try ensureOK(http, data: data)
         let obj = try decodeJSONObject(data)

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -92,6 +92,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// Panels this provider created (or replaced) in this process. A projection whose
     /// panel is not here came back from a restored session as a placeholder shell.
     var materializedPanels: Set<UUID> = []
+    /// The in-flight open-port request behind each browser pane this provider
+    /// materialized, by panel id. It is cancelled with the pane (or the provider),
+    /// so a request that may wait up to 120 s never outlives what it was for.
+    private var browserEndpointTasks: [UUID: Task<Void, Never>] = [:]
     /// Native cloud terminals own a manual attachment separate from their
     /// catalog projection. The provider retains it for the life of the pane.
     var manualMirrorSessions: [UUID: CloudTuiManualMirrorSession] = [:]
@@ -197,6 +201,8 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         for session in manualMirrorSessions.values { session.stop() }
         manualMirrorSessions.removeAll()
         manualMirrorSurfaceIDsSocketPath = nil
+        for task in browserEndpointTasks.values { task.cancel() }
+        browserEndpointTasks.removeAll()
         for task in remoteTerminalProjectionTasks.values { task.cancel() }
         remoteTerminalProjectionTasks.removeAll()
         pendingRemoteCreations.removeAll()
@@ -1053,8 +1059,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             created = try SurfacePaneFactory.makeBrowserPane(url: SurfacePaneFactory.blankURL, at: destination, focus: focus)
             SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(label), panelID: created.panelID, in: created.workspaceID)
             let pane = created
-            Task { @MainActor [weak self] in
+            browserEndpointTasks[pane.panelID]?.cancel()
+            browserEndpointTasks[pane.panelID] = Task { @MainActor [weak self] in
                 guard let self else { return }
+                defer { self.browserEndpointTasks.removeValue(forKey: pane.panelID) }
                 do {
                     guard let client = VMClient.shared else { throw ProviderError.notSignedIn }
                     try await client.requireCloudBrowserAccess(machineID: self.machineID)
@@ -1071,6 +1079,9 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                     _ = try await client.openPort(id: self.machineID, port: port)
                     SurfacePaneFactory.navigate(panelID: pane.panelID, in: pane.workspaceID, to: directURL)
                 } catch {
+                    // The pane (or this provider) went away while the control plane
+                    // was still opening the port: nothing is left to report to.
+                    if Task.isCancelled { return }
                     let text = CloudMachineLink.errorText(error)
                     SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.failed(label, error: text), panelID: pane.panelID, in: pane.workspaceID)
                     #if DEBUG
@@ -1556,12 +1567,14 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     func projectionDidEnd(_ projection: SurfaceProjection) {
         materializedPanels.remove(projection.panelID)
         manualMirrorSessions.removeValue(forKey: projection.panelID)?.stop()
+        browserEndpointTasks.removeValue(forKey: projection.panelID)?.cancel()
     }
 
     @discardableResult
     func discardMaterialization(_ projection: SurfaceProjection) -> Bool {
         materializedPanels.remove(projection.panelID)
         manualMirrorSessions.removeValue(forKey: projection.panelID)?.stop()
+        browserEndpointTasks.removeValue(forKey: projection.panelID)?.cancel()
         SurfacePaneFactory.close(panelID: projection.panelID, in: projection.workspaceID)
         return false
     }

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1050,7 +1050,6 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             // address until the Network Extension is connected. This is the
             // only action that can cause the one-time macOS approval request.
             let label = Self.paneLabel(machineID: machineID, port: port, desktop: desktop)
-            let machineWasAwake = isAwake
             created = try SurfacePaneFactory.makeBrowserPane(url: SurfacePaneFactory.blankURL, at: destination, focus: focus)
             SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(label), panelID: created.panelID, in: created.workspaceID)
             let pane = created
@@ -1059,12 +1058,17 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 do {
                     guard let client = VMClient.shared else { throw ProviderError.notSignedIn }
                     try await client.requireCloudBrowserAccess(machineID: self.machineID)
-                    if !machineWasAwake {
-                        // Waking a paused machine is an explicit management
-                        // operation. Ignore the returned URL and keep the
-                        // private address captured above.
-                        _ = try await client.openPort(id: self.machineID, port: port)
-                    }
+                    // Always ask the control plane to open the port, even when
+                    // the cached status says the machine is running. The server
+                    // probes the provider live (a machine can idle-pause while
+                    // the row still says running), resumes it when needed, and
+                    // for the desktop port starts the desktop unit and waits
+                    // until noVNC listens. Skipping this for "awake" machines
+                    // opened the Desktop row onto a dead private URL. The
+                    // returned endpoint is intentionally ignored: the browser
+                    // must use the catalog's private URL over the approved
+                    // tunnel.
+                    _ = try await client.openPort(id: self.machineID, port: port)
                     SurfacePaneFactory.navigate(panelID: pane.panelID, in: pane.workspaceID, to: directURL)
                 } catch {
                     let text = CloudMachineLink.errorText(error)


### PR DESCRIPTION
## Summary

Split out of #12090 at Austin's request so that PR stays sidebar-only.

Opening a Desktop or Ports row on a Cloud machine only asked the control plane to open the port when the cached status said the machine was asleep; a machine that looked `running` navigated straight to its private URL. On Freestyle the desktop only comes up through open-port: the server starts the `cmux-desktop` unit and waits until noVNC listens on 6901 (`freestyleDesktopHealCommand`), and open-port also probes the provider live, so a machine that idle-paused while the row still said `running` is resumed instead of showing a dead page.

- **Always call open-port before navigating** a Desktop or Ports pane. The returned endpoint is still ignored; the browser uses the catalog's private URL over the approved tunnel.
- **Client timeout 60 s → 120 s** for open-port, so it outlasts the server's 90 s desktop-heal bound instead of reporting failure for a desktop that then comes up.
- **The request is tracked per pane and cancelled** from `projectionDidEnd`, `discardMaterialization`, and `stop`; a cancelled request never writes a failure placeholder into a pane that is gone (CodeRabbit finding on #12090, carried over).

## Trade-offs

- Every port open on a running machine now waits one control-plane round trip (a live provider status probe plus lease and usage records) before the pane navigates; the pane shows its connecting placeholder meanwhile.
- No unit test: `materialize` creates real panes through `SurfacePaneFactory` and reads `VMClient.shared`, with no injection seam. Verification is a live-machine smoke test (Desktop row on a running machine renders noVNC; a Ports row renders the served page), pending.
- The pane's failure text stays the existing Cloud error contract (server `message` + `action` + support reference); this change makes that path reachable for running machines too.

## Validation

- `swiftc -parse` on the two changed files; `git diff --check`.
- Live-machine smoke test: pending (tagged dev build queued behind the machine-wide build lock).

Refs #12044, #12051, #12090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791432821&installation_model_id=21920&pr_number=12096&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12096&signature=979a9655eabe95269d75430d543a8c08b909630281ee0f8dc7c3b7863d566b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Cloud browser open path for every Desktop/Ports open (extra control-plane round trip and longer waits) and extends long-running HTTP behavior; scope is limited to client UX and does not alter auth or tunnel credentials.
> 
> **Overview**
> Fixes Cloud **Desktop** and **Ports** browser panes loading a dead private URL when the sidebar still showed the machine as running (e.g. idle-pause while status was stale).
> 
> **`CmuxTuiSurfaceProvider`** now **always** calls `VMClient.openPort` after tunnel approval and before `navigate`, even when cached status says the VM is awake; the response URL is still discarded and the catalog private URL is used. In-flight work is stored in **`browserEndpointTasks`** per panel and cancelled on pane close, discard, or provider `stop`, with **`Task.isCancelled`** so a late failure does not paint a placeholder on a closed pane.
> 
> **`VMClient.openPort`** HTTP timeout rises **60 s → 120 s** so the client outlasts the server’s ~90 s desktop/noVNC heal wait instead of timing out first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df1f4039cf9610911dac99afb5d64f746e0c32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud Desktop and Ports panes opening onto dead pages when a machine's cached status looked running. The control plane's open-port is now always called before navigating, so idle-paused machines get resumed and the desktop unit starts; the returned endpoint is still ignored in favor of the private URL over the approved tunnel.

**Details**
- The open-port client timeout goes from 60 s to 120 s so slow cold starts don't report failure before the server's 90 s desktop-heal bound.
- Each open now waits one control-plane round trip on running machines; the pane shows its connecting placeholder during it.
- The in-flight request is tracked per pane and cancelled when the pane is closed, so a cancelled request never writes a failure placeholder into a gone pane.
- No unit test was added: `materialize` builds real panes with no injection seam, so verification is a live-machine smoke test.

<sup>Written for commit 2664a1f7bcbda88589c326446ea19114ee4c1938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved port-forwarding connections by checking and resuming the machine before each new connection.
  - Preserved the configured private route when establishing connections, improving connection consistency across cached states and different providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->