### PR TITLE
Cloud terminals: Option+Backspace word delete, and close the pane when the shell exits

### DIFF
--- a/Sources/Cloud/CloudTuiLegacySnapshotParser.swift
+++ b/Sources/Cloud/CloudTuiLegacySnapshotParser.swift
@@ -19,7 +19,8 @@ struct CloudTuiLegacySnapshotParser: Sendable {
     }
 
     /// Decodes the resolver response without conflating a valid zero-view
-    /// terminal (`surface:null`) with malformed or failed data.
+    /// terminal (`surface:null`) with an exited terminal, or with malformed or
+    /// failed data.
     func resolvedSurface(from data: Data) -> CloudTuiResolvedSurface {
         guard let root = try? JSONSerialization.jsonObject(with: data),
               let object = (root as? [String: Any])?["data"] as? [String: Any]
@@ -27,6 +28,10 @@ struct CloudTuiLegacySnapshotParser: Sendable {
             return .malformed
         }
         guard object.keys.contains("surface") else { return .malformed }
+        // An exited terminal also reports `surface:null`, so read the
+        // lifecycle first: a zero-view live terminal is worth reprojecting,
+        // an exited one is not.
+        if object["lifecycle"] as? String == "exited" { return .exited }
         if object["surface"] is NSNull { return .noPlacement }
         guard let surface = number(from: object["surface"]) else { return .malformed }
         return .surface(surface)

--- a/Sources/Cloud/CloudTuiResolvedSurface.swift
+++ b/Sources/Cloud/CloudTuiResolvedSurface.swift
@@ -4,5 +4,9 @@ import Foundation
 enum CloudTuiResolvedSurface: Equatable, Sendable {
     case surface(UInt64)
     case noPlacement
+    /// The remote shell is gone: the daemon reports the terminal as exited, or
+    /// no longer has a record for it. A pane showing it must close, the way a
+    /// local pane closes when its shell exits.
+    case exited
     case malformed
 }

--- a/Sources/Surfaces/CloudTerminalPaneClosure.swift
+++ b/Sources/Surfaces/CloudTerminalPaneClosure.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Decides which cloud attach panes must close after a graph publication.
+///
+/// A cloud pane owns no process: when the remote shell ends (`exit`, Ctrl+D)
+/// the daemon drops the terminal from its graph, and the pane is the only
+/// thing left holding it open. Closing is driven by the accepted graph, so the
+/// rule lives here instead of inside the provider's refresh.
+enum CloudTerminalPaneClosure {
+    /// Panels whose bound terminal is gone from an authoritative graph.
+    ///
+    /// - Parameters:
+    ///   - boundTerminals: local pane id -> remote terminal resource key.
+    ///   - liveTerminalKeys: terminal keys in the freshly published graph.
+    ///   - freshness: whether that graph is current. A stale graph means the
+    ///     machine is unreachable, not that a terminal ended, so nothing closes.
+    /// - Returns: panel ids in a stable order.
+    static func panelsToClose(
+        boundTerminals: [UUID: String],
+        liveTerminalKeys: Set<String>,
+        freshness: CloudVMStateFreshness
+    ) -> [UUID] {
+        guard freshness == .current else { return [] }
+        return boundTerminals
+            .filter { !liveTerminalKeys.contains($0.value) }
+            .keys
+            .sorted { $0.uuidString < $1.uuidString }
+    }
+}

--- a/Sources/Surfaces/CloudTuiSurfaceIDResolution.swift
+++ b/Sources/Surfaces/CloudTuiSurfaceIDResolution.swift
@@ -5,6 +5,8 @@
 enum CloudTuiSurfaceIDResolution: Equatable, Sendable {
     case resolved(UInt64)
     case noPlacement
+    /// The remote terminal exited (or the daemon has no record of it).
+    case exited
     case unsupported
     case failed
 }

--- a/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
@@ -102,6 +102,10 @@ extension CmuxTuiSurfaceProvider {
             throw ProviderError.terminalNotCreated(terminalID)
         case .failed:
             throw ProviderError.terminalNotCreated(terminalID)
+        case .exited:
+            // The remote shell already ended. Opening a pane for it would show
+            // a frozen screen that never reconnects.
+            throw ProviderError.terminalNotCreated(terminalID)
         case .noPlacement:
             try await ensureRemoteTerminalView(
                 terminalID: terminalID,
@@ -172,9 +176,10 @@ extension CmuxTuiSurfaceProvider {
             ) {
             case .resolved:
                 return
-            case .failed, .unsupported:
+            case .failed, .unsupported, .exited:
                 // This helper is reached only after a modern resolver reported no placement;
-                // a generation change or malformed response is fail-closed.
+                // a generation change, a malformed response, and a terminal that
+                // exited in the meantime are all fail-closed.
                 throw ProviderError.terminalNotCreated(terminalID)
             case .noPlacement:
                 break
@@ -316,7 +321,7 @@ extension CmuxTuiSurfaceProvider {
                 arguments: CloudTuiCommandLine.legacyListWorkspacesArguments(socketPath: socketPath)
             ) else { return nil }
             return parser.surfaceID(from: tree, terminalID: terminalID)
-        case .noPlacement, .failed:
+        case .noPlacement, .exited, .failed:
             return nil
         }
     }
@@ -345,6 +350,8 @@ extension CmuxTuiSurfaceProvider {
                 return .resolved(surfaceID)
             case .noPlacement:
                 return .noPlacement
+            case .exited:
+                return .exited
             case .malformed:
                 return .failed
             }

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -378,11 +378,18 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 )
                 guard isCurrentRefresh(lifecycle: lifecycle, refresh: generation) else { return false }
                 var allSurfaceIDsResolved = true
+                var exitedTerminalIDs: Set<String> = []
                 for session in sessions {
                     switch resolutions[session.terminalID] {
                     case let .resolved(surfaceID):
                         session.updateRemoteSurfaceID(surfaceID)
                         reconnectableSessionIDs.insert(ObjectIdentifier(session))
+                    case .exited:
+                        // The remote shell ended. Stop reconnecting; the pane
+                        // closes when this graph is published.
+                        exitedTerminalIDs.insert(session.terminalID)
+                        session.markSurfaceResolutionUnavailable()
+                        reconnectableSessionIDs.remove(ObjectIdentifier(session))
                     case .none, .noPlacement, .unsupported, .failed:
                         session.markSurfaceResolutionUnavailable()
                         reconnectableSessionIDs.remove(ObjectIdentifier(session))
@@ -392,6 +399,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 if allSurfaceIDsResolved {
                     manualMirrorSurfaceIDsSocketPath = connected.socketPath
                 }
+                closePanes(forExitedTerminals: exitedTerminalIDs)
             }
             for session in manualMirrorSessions.values
             where reconnectableSessionIDs.contains(ObjectIdentifier(session)) {
@@ -623,6 +631,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         if reconcileTitles {
             catalog.reconcileCloudRemoteState(machine: machine, state: state)
         }
+        closePanesForVanishedRemoteTerminals(observation: observation)
     }
 
     /// Applies a contiguous event to the catalog's canonical graph. Row-local changes rebuild
@@ -672,6 +681,58 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         // need a full projection scan for every title event.
         if changed.contains(where: { $0.kind == .terminal && !previousIDs.contains($0) }) {
             reprojectRestoredPanes(generation: lifecycleGeneration)
+        }
+        closePanesForVanishedRemoteTerminals(observation: .current)
+    }
+
+    /// Closes the panes of terminals the resolver reported as exited. The
+    /// graph-driven sweep covers the usual case; this covers a daemon that
+    /// still lists an exited terminal because a stale tab row survives it.
+    private func closePanes(forExitedTerminals terminalIDs: Set<String>) {
+        guard !terminalIDs.isEmpty else { return }
+        for (panelID, session) in manualMirrorSessions where terminalIDs.contains(session.terminalID) {
+            closeManualMirrorPane(panelID: panelID, terminalID: session.terminalID)
+        }
+    }
+
+    private func closeManualMirrorPane(panelID: UUID, terminalID: String) {
+        materializedPanels.remove(panelID)
+        manualMirrorSessions.removeValue(forKey: panelID)?.stop()
+        guard let workspace = AppDelegate.shared?.workspace(containingSurfaceID: panelID) else { return }
+        SurfacePaneFactory.closeExited(panelID: panelID, in: workspace.id)
+    }
+
+    /// Closes attach panes whose remote terminal is gone from the accepted
+    /// graph.
+    ///
+    /// A cloud pane owns no process, so nothing local notices when the remote
+    /// shell ends: after `exit` or Ctrl+D the daemon drops the tab and marks
+    /// the terminal exited, the byte attachment reports `detached`, and the
+    /// session would otherwise keep reconnecting behind a frozen pane. Closing
+    /// it here matches a local pane, which disappears when its shell exits, and
+    /// it goes through the same close path as the menu, the CLI, and the
+    /// keyboard shortcut.
+    ///
+    /// Only a current graph may close a pane: a stale or unavailable read means
+    /// the machine is unreachable, not that the terminal ended.
+    private func closePanesForVanishedRemoteTerminals(observation: CloudVMStateObservation) {
+        guard !manualMirrorSessions.isEmpty else { return }
+        let live = Set(
+            catalog.snapshot.resources(on: machine)
+                .filter { $0.id.kind == .terminal }
+                .map(\.id.key)
+        )
+        let closing = CloudTerminalPaneClosure.panelsToClose(
+            boundTerminals: manualMirrorSessions.mapValues(\.terminalID),
+            liveTerminalKeys: live,
+            freshness: observation.freshness
+        )
+        for panelID in closing {
+            guard let terminalID = manualMirrorSessions[panelID]?.terminalID else { continue }
+#if DEBUG
+            cmuxDebugLog("cloud.pane.closeExited panel=\(panelID) terminal=\(terminalID)")
+#endif
+            closeManualMirrorPane(panelID: panelID, terminalID: terminalID)
         }
     }
 

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -87,12 +87,14 @@ enum SurfacePaneFactory {
               let workspace = appDelegate.workspace(containingSurfaceID: panelID) else { return }
         // A workspace whose only pane is the dead terminal goes with it, which
         // is what a local workspace does when its last shell exits. Closing
-        // just the pane would leave the workspace to open a fresh local shell
-        // in place of the cloud terminal, which reads as the pane never having
-        // closed at all.
+        // only the pane there leaves the workspace to open a fresh local shell
+        // in the cloud pane's place.
         if workspace.panels.count <= 1 {
             let manager = workspace.owningTabManager ?? TerminalController.shared.tabManager
             if manager?.closeWorkspaceNonInteractively(workspace) == true { return }
+            // The workspace refused to close (pinned, or the window's last one
+            // during teardown). Close the pane anyway: a replacement local
+            // shell is still better than a frozen pane that swallows input.
         }
         workspace.markCloseHistoryEligible(panelId: panelID)
         _ = workspace.closePanel(panelID, force: true)

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -74,6 +74,30 @@ enum SurfacePaneFactory {
         _ = TerminalController.shared.controlSurfaceClose(routing: routing(workspaceID: workspaceID), surfaceID: panelID, hasSurfaceIDParam: true)
     }
 
+    /// Closes a pane whose process has ended, the way a local terminal pane
+    /// disappears when its shell exits.
+    ///
+    /// This is not ``close(panelID:in:)``: the socket close refuses a
+    /// workspace's last surface, so an agent cannot empty a workspace by
+    /// accident. A shell that ended is not an accident, and a cloud workspace
+    /// opened by `cmux vm workspace new` holds exactly one pane, so the socket
+    /// rule would leave the dead pane on screen forever.
+    static func closeExited(panelID: UUID, in workspaceID: UUID) {
+        guard let appDelegate = AppDelegate.shared,
+              let workspace = appDelegate.workspace(containingSurfaceID: panelID) else { return }
+        // A workspace whose only pane is the dead terminal goes with it, which
+        // is what a local workspace does when its last shell exits. Closing
+        // just the pane would leave the workspace to open a fresh local shell
+        // in place of the cloud terminal, which reads as the pane never having
+        // closed at all.
+        if workspace.panels.count <= 1 {
+            let manager = workspace.owningTabManager ?? TerminalController.shared.tabManager
+            if manager?.closeWorkspaceNonInteractively(workspace) == true { return }
+        }
+        workspace.markCloseHistoryEligible(panelId: panelID)
+        _ = workspace.closePanel(panelID, force: true)
+    }
+
     /// A fresh local workspace (⌘N) titled `title`, returned with the id of the starter
     /// pane it opened with so a caller projecting a group can take that pane's place.
     static func createLocalWorkspace(title: String) throws -> (workspaceID: UUID, starterPanelID: UUID?) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -665,6 +665,8 @@
 		7A0CE1000000000000000504 /* CloudPrivateNetworkPurpose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CE1000000000000000503 /* CloudPrivateNetworkPurpose.swift */; };
 		7A0CE1000000000000000304 /* CloudPrivateNetworkUse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CE1000000000000000303 /* CloudPrivateNetworkUse.swift */; };
 		4DB42AF8827945DFADF7C4D4 /* CloudSidebarSurfaceRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E5958FB85E4B97957D4F73 /* CloudSidebarSurfaceRegressionTests.swift */; };
+		FA0000000000000000000005 /* CloudTerminalPaneClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000006 /* CloudTerminalPaneClosure.swift */; };
+		FA0000000000000000000003 /* CloudTerminalPaneClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000004 /* CloudTerminalPaneClosureTests.swift */; };
 		C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986A0070000000000000001 /* CloudTreeActiveDrag.swift */; };
 		3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E286761D314959F64AA002 /* CloudTreeCellView.swift */; };
 		46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */; };
@@ -4021,6 +4023,8 @@
 		7A0CE1000000000000000503 /* CloudPrivateNetworkPurpose.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudPrivateNetworkPurpose.swift; sourceTree = "<group>"; };
 		7A0CE1000000000000000303 /* CloudPrivateNetworkUse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudPrivateNetworkUse.swift; sourceTree = "<group>"; };
 		F3E5958FB85E4B97957D4F73 /* CloudSidebarSurfaceRegressionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudSidebarSurfaceRegressionTests.swift; sourceTree = "<group>"; };
+		FA0000000000000000000006 /* CloudTerminalPaneClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTerminalPaneClosure.swift; sourceTree = "<group>"; };
+		FA0000000000000000000004 /* CloudTerminalPaneClosureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTerminalPaneClosureTests.swift; sourceTree = "<group>"; };
 		C986A0070000000000000001 /* CloudTreeActiveDrag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTreeActiveDrag.swift; sourceTree = "<group>"; };
 		47E286761D314959F64AA002 /* CloudTreeCellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeCellView.swift; sourceTree = "<group>"; };
 		B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeExpansionStore.swift; sourceTree = "<group>"; };
@@ -6920,6 +6924,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			children = (
 				C11324820000000000000001 /* CloudManualMirrorMaterialization.swift */,
 				C11324920000000000000001 /* CloudTuiSurfaceIDResolution.swift */,
+				FA0000000000000000000006 /* CloudTerminalPaneClosure.swift */,
 				C11323020000000000000001 /* Workspace+CloudManualMirror.swift */,
 				C11323120000000000000001 /* SurfacePaneFactory+CloudManualMirror.swift */,
 				C11323220000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift */,
@@ -9099,6 +9104,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */,
+				FA0000000000000000000004 /* CloudTerminalPaneClosureTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
 				D5935002A1B2C3D4E5F60718 /* GhosttyDECCKMArrowKeyTests.swift */,
 				D11495000000000000000004 /* GhosttyCopyActionResolverAppTests.swift */,
@@ -10943,6 +10949,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				7A0CE1000000000000000302 /* CloudPrivateNetworkNoopGate.swift in Sources */,
 				7A0CE1000000000000000504 /* CloudPrivateNetworkPurpose.swift in Sources */,
 				7A0CE1000000000000000304 /* CloudPrivateNetworkUse.swift in Sources */,
+				FA0000000000000000000005 /* CloudTerminalPaneClosure.swift in Sources */,
 				C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */,
 				3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */,
 				46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */,
@@ -13087,6 +13094,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C11322A10000000000000001 /* CloudManualMirrorTransportTests.swift in Sources */,
 				F11347000000000000000003 /* CloudPortOpenRegressionTests.swift in Sources */,
 				4DB42AF8827945DFADF7C4D4 /* CloudSidebarSurfaceRegressionTests.swift in Sources */,
+				FA0000000000000000000003 /* CloudTerminalPaneClosureTests.swift in Sources */,
 				C986A0030000000000000001 /* CloudTreeNativeDragOwnershipTests.swift in Sources */,
 				45F29E8BB64E4EE4BF204AC7 /* CloudTreeOneMachineManyWorkspacesTests.swift in Sources */,
 				7A0CE1000000000000000106 /* CloudTunnelBackendSelectorTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 		5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */; };
 		0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9143D900F124494A55F859F /* CloudMachinesFeature.swift */; };
 		A1B2C3D4E5F6071827364951 /* CloudMachineSurfacePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6071827364950 /* CloudMachineSurfacePresentation.swift */; };
+		FA0000000000000000000001 /* CloudManualInputOptionBackspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */; };
 		C11324810000000000000001 /* CloudManualMirrorMaterialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11324820000000000000001 /* CloudManualMirrorMaterialization.swift */; };
 		C11322A10000000000000001 /* CloudManualMirrorTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */; };
 		F11347000000000000000003 /* CloudPortOpenRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11347000000000000000004 /* CloudPortOpenRegressionTests.swift */; };
@@ -4011,6 +4012,7 @@
 		874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineLinkManager.swift; sourceTree = "<group>"; };
 		D9143D900F124494A55F859F /* CloudMachinesFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachinesFeature.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6071827364950 /* CloudMachineSurfacePresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineSurfacePresentation.swift; sourceTree = "<group>"; };
+		FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudManualInputOptionBackspaceTests.swift; sourceTree = "<group>"; };
 		C11324820000000000000001 /* CloudManualMirrorMaterialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudManualMirrorMaterialization.swift; sourceTree = "<group>"; };
 		C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudManualMirrorTransportTests.swift; sourceTree = "<group>"; };
 		F11347000000000000000004 /* CloudPortOpenRegressionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudPortOpenRegressionTests.swift; sourceTree = "<group>"; };
@@ -9096,6 +9098,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
+				FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
 				D5935002A1B2C3D4E5F60718 /* GhosttyDECCKMArrowKeyTests.swift */,
 				D11495000000000000000004 /* GhosttyCopyActionResolverAppTests.swift */,
@@ -13080,6 +13083,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 				C6D4C5A38097BB05AB98E460 /* CloudAgentSkillLauncherTests.swift in Sources */,
 				C10D0A200000000000000001 /* CloudDomainsCLIIntegrationTests.swift in Sources */,
+				FA0000000000000000000001 /* CloudManualInputOptionBackspaceTests.swift in Sources */,
 				C11322A10000000000000001 /* CloudManualMirrorTransportTests.swift in Sources */,
 				F11347000000000000000003 /* CloudPortOpenRegressionTests.swift in Sources */,
 				4DB42AF8827945DFADF7C4D4 /* CloudSidebarSurfaceRegressionTests.swift in Sources */,

--- a/cmuxTests/CloudManualInputOptionBackspaceTests.swift
+++ b/cmuxTests/CloudManualInputOptionBackspaceTests.swift
@@ -63,20 +63,37 @@ struct CloudManualInputOptionBackspaceTests {
         ))
 
         var collected = Data()
-        var iterator = inputs.makeAsyncIterator()
-        let deadline = Date().addingTimeInterval(2)
-        while Date() < deadline {
-            guard let next = await iterator.next() else { break }
-            switch next {
-            case .bytes(let data): collected.append(data)
-            case .namedKey(let name): Issue.record("unexpected named key \(name)")
-            }
-            if !collected.isEmpty { break }
+        switch await Self.firstInput(from: inputs, timeout: .seconds(5)) {
+        case .bytes(let data): collected.append(data)
+        case .namedKey(let name): Issue.record("unexpected named key \(name)")
+        case nil: break
         }
 
         #expect(
             Array(collected) == [0x1B, 0x7F],
             "Option+Backspace must reach a cloud pane as ESC DEL, got \(Array(collected).map { String(format: "0x%02X", $0) })"
         )
+    }
+
+    /// The first manual input, or `nil` once `timeout` passes. A surface that
+    /// never encodes the key must fail this test, not hang it: `next()` on a
+    /// live stream suspends forever, so the wait needs its own deadline.
+    private static func firstInput(
+        from stream: AsyncStream<TerminalManualInput>,
+        timeout: Duration
+    ) async -> TerminalManualInput? {
+        await withTaskGroup(of: TerminalManualInput?.self) { group in
+            group.addTask {
+                for await input in stream { return input }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
     }
 }

--- a/cmuxTests/CloudManualInputOptionBackspaceTests.swift
+++ b/cmuxTests/CloudManualInputOptionBackspaceTests.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+import Testing
+import CmuxTerminal
+import GhosttyKit
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Diagnostic coverage for Option+Backspace (backward word delete) on a
+/// manual-I/O mirror surface, the surface kind a cloud terminal pane uses.
+///
+/// A cloud pane owns no PTY: Ghostty encodes the key and hands the bytes to
+/// `manualInputHandler`, which forwards them to the remote shell. The remote
+/// shell's word-delete binding is `ESC DEL` (0x1B 0x7F), so that is exactly
+/// what this surface must emit.
+@MainActor
+@Suite(.serialized)
+struct CloudManualInputOptionBackspaceTests {
+    @Test
+    func manualMirrorSurfaceEncodesOptionBackspaceAsEscDelete() async throws {
+        _ = NSApplication.shared
+
+        let (inputs, continuation) = AsyncStream<TerminalManualInput>.makeStream()
+        defer { continuation.finish() }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            ioMode: .manualMirror,
+            manualInputHandler: { input in continuation.yield(input) }
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        // Real macOS produces "∂" (U+2202) for Option+Delete on a US layout.
+        #expect(hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
+            characters: "\u{2202}",
+            charactersIgnoringModifiers: "\u{7F}",
+            keyCode: UInt16(kVK_Delete),
+            modifierFlags: [.option]
+        ))
+
+        var collected = Data()
+        var iterator = inputs.makeAsyncIterator()
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            guard let next = await iterator.next() else { break }
+            switch next {
+            case .bytes(let data): collected.append(data)
+            case .namedKey(let name): Issue.record("unexpected named key \(name)")
+            }
+            if !collected.isEmpty { break }
+        }
+
+        #expect(
+            Array(collected) == [0x1B, 0x7F],
+            "Option+Backspace must reach a cloud pane as ESC DEL, got \(Array(collected).map { String(format: "0x%02X", $0) })"
+        )
+    }
+}

--- a/cmuxTests/CloudManualInputOptionBackspaceTests.swift
+++ b/cmuxTests/CloudManualInputOptionBackspaceTests.swift
@@ -63,10 +63,11 @@ struct CloudManualInputOptionBackspaceTests {
         ))
 
         var collected = Data()
-        switch await Self.firstInput(from: inputs, timeout: .seconds(5)) {
-        case .bytes(let data): collected.append(data)
-        case .namedKey(let name): Issue.record("unexpected named key \(name)")
-        case nil: break
+        if let first = await Self.firstInput(from: inputs, timeout: .seconds(5)) {
+            switch first {
+            case .bytes(let data): collected.append(data)
+            case .namedKey(let name): Issue.record("unexpected named key \(name)")
+            }
         }
 
         #expect(

--- a/cmuxTests/CloudManualMirrorTransportTests.swift
+++ b/cmuxTests/CloudManualMirrorTransportTests.swift
@@ -206,6 +206,29 @@ struct CloudManualMirrorTransportTests {
     }
 
     @Test
+    func resolverReportsAnExitedTerminalInsteadOfAnEmptyPlacement() throws {
+        // A cloud pane owns no process: the only signal that the remote shell
+        // ended (`exit`, Ctrl+D) is the resolver's lifecycle. It shares
+        // `surface:null` with a live terminal that has no view, so a pane must
+        // not be kept alive for the exited one.
+        #expect(
+            parser.resolvedSurface(
+                from: try Self.line(["surface": NSNull(), "lifecycle": "exited"])
+            ) == .exited
+        )
+        #expect(
+            parser.resolvedSurface(
+                from: try Self.line(["surface": NSNull(), "lifecycle": "running"])
+            ) == .noPlacement
+        )
+        #expect(
+            parser.resolvedSurface(
+                from: try Self.line(["surface": 12, "lifecycle": "running"])
+            ) == .surface(12)
+        )
+    }
+
+    @Test
     func resizeSamplesAreLatestWinsAndResumeAfterGeometryClaim() throws {
         var scheduler = CloudTuiManualIOResizeScheduler()
         let first = try #require(CloudTuiManualIOGrid(columns: 99, rows: 35))

--- a/cmuxTests/CloudTerminalPaneClosureTests.swift
+++ b/cmuxTests/CloudTerminalPaneClosureTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// A cloud pane owns no process, so nothing local notices when its remote
+/// shell exits. The graph is the signal, and these are the rules that turn a
+/// published graph into pane closures.
+@Suite
+struct CloudTerminalPaneClosureTests {
+    private let paneA = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let paneB = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+
+    @Test
+    func closesPanesWhoseTerminalLeftTheGraph() {
+        let closing = CloudTerminalPaneClosure.panelsToClose(
+            boundTerminals: [paneA: "term_alive", paneB: "term_exited"],
+            liveTerminalKeys: ["term_alive"],
+            freshness: .current
+        )
+        #expect(closing == [paneB])
+    }
+
+    @Test
+    func keepsEveryPaneWhileTheGraphIsLive() {
+        let closing = CloudTerminalPaneClosure.panelsToClose(
+            boundTerminals: [paneA: "term_alive", paneB: "term_also_alive"],
+            liveTerminalKeys: ["term_alive", "term_also_alive"],
+            freshness: .current
+        )
+        #expect(closing.isEmpty)
+    }
+
+    @Test
+    func aStaleGraphNeverClosesAPane() {
+        // An unreachable machine reports no terminals. That is a lost link,
+        // not an exited shell, and it must not take the user's panes with it.
+        let closing = CloudTerminalPaneClosure.panelsToClose(
+            boundTerminals: [paneA: "term_alive", paneB: "term_also_alive"],
+            liveTerminalKeys: [],
+            freshness: .stale
+        )
+        #expect(closing.isEmpty)
+    }
+}

--- a/web/services/vms/images/devbox/cmux-bashrc
+++ b/web/services/vms/images/devbox/cmux-bashrc
@@ -53,6 +53,16 @@ if [ -f /usr/local/share/blesh/ble.sh ] && [ -z "${BLE_VERSION:-}" ]; then
   # foreground gray.
   bleopt highlight_syntax= highlight_filename= highlight_variable=
   ble-face auto_complete=fg=245
+  # Alt+Backspace (Option+Delete on macOS) word delete. Once ble.sh identifies
+  # the terminal from its DA2 reply it turns on xterm modifyOtherKeys, and from
+  # then on it neither keeps the legacy ESC DEL binding nor decodes the
+  # modifyOtherKeys form (CSI 27;3;127~) back to M-C-?, so the key does nothing
+  # (ble.sh nightly, also reproducible under tmux). Keep the terminal on the
+  # legacy encoding, which Ghostty and the cmux cloud pane send by default, and
+  # bind both backspace forms explicitly.
+  bleopt term_modifyOtherKeys_internal=0 term_modifyOtherKeys_external=0
+  ble-bind -f 'M-C-?' kill-backward-cword
+  ble-bind -f 'M-C-h' kill-backward-cword
 fi
 
 # half-life palette: purple 135, lime 118, orange 166, hotpink 161. The machine

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -193,6 +193,19 @@ describe("devbox image template", () => {
     }
   });
 
+  test("keeps Alt+Backspace word delete working in ble.sh", () => {
+    // Once ble.sh identifies the terminal from its DA2 reply it enables xterm
+    // modifyOtherKeys, and then Alt+Backspace does nothing: the legacy ESC DEL
+    // binding is gone and CSI 27;3;127~ does not decode back to M-C-?. Cloud
+    // panes send the legacy form, so the bashrc pins the legacy encoding and
+    // binds both backspace spellings.
+    expect(bashrc).toContain(
+      "bleopt term_modifyOtherKeys_internal=0 term_modifyOtherKeys_external=0",
+    );
+    expect(bashrc).toContain("ble-bind -f 'M-C-?' kill-backward-cword");
+    expect(bashrc).toContain("ble-bind -f 'M-C-h' kill-backward-cword");
+  });
+
   test("bakes ble.sh cache seeds for every shared devbox provider", () => {
     // The shared bashrc guard is useful only when each bake creates the seed.
     for (const term of ["xterm-256color", "screen-256color", "tmux-256color", "linux"]) {


### PR DESCRIPTION
Two cloud terminal bugs, both verified on a real Freestyle Cloud VM through a tagged build.

## Option+Backspace did nothing

ble.sh (the devbox bash line editor) queries the terminal at startup. Once the DA2 reply completes terminal identification, ble.sh switches to xterm modifyOtherKeys, and from that point Alt+Backspace is dead: the legacy `ESC DEL` binding is gone and ble.sh's decode of the modifyOtherKeys form (`CSI 27;3;127~`) does not reach `M-C-?`. Alt+d and Alt+u keep working because letters decode fine. The same break reproduces under tmux, so it is upstream ble.sh behavior, not something specific to the cmux terminal host.

`/etc/cmux/bashrc` now pins ble.sh to the legacy encoding and binds both backspace spellings.

How it was found: a cmux-tui daemon hosting an Ubuntu container with the same ble.sh nightly reproduces it exactly, and a plain PTY hosting the same container does not. Injecting bytes through the daemon's manual-I/O attach (the path a cloud pane uses) showed `ESC DEL`, `ESC BS`, `CSI 27;3;127~` and `CSI 127;3u` all no-ops while `C-w` worked.

The first commit adds the macOS-side contract this depends on: a cloud manual-mirror pane encodes Option+Backspace as `ESC DEL` (0x1B 0x7F). It passes on `cmuxTests/CloudManualInputOptionBackspaceTests` (fleet mini, scheme `cmux-unit`).

Tradeoff: ble.sh's line editor loses modifyOtherKeys, so it can no longer tell chords such as Shift+Enter apart at the bash prompt. Programs started inside the terminal set their own modes and are unaffected.

Deploy note: `cmux-bashrc` is baked into the devbox image, so this reaches machines only after a devbox rebake and snapshot promotion. Existing VMs keep the old shell config.

## Ctrl+D left a dead pane on screen

A cloud pane owns no process, so nothing local noticed when the remote shell ended. The daemon dropped the tab and marked the terminal exited, the byte attachment reported `detached`, and the pane kept reconnecting behind a frozen screen that swallowed input.

The accepted graph is now the signal: after each publication, panes whose terminal is gone from a *current* graph close through the shared close path. A stale graph closes nothing, because an unreachable machine reports no terminals and that is a lost link, not an exited shell.

Two details only a live VM exposed: the socket close refuses a workspace's last surface, which is exactly the shape `cmux vm workspace new` creates, and closing only the tab there leaves the workspace to open a fresh local shell in the cloud pane's place. A single-pane cloud workspace now closes with its pane, matching a local workspace when its last shell exits.

Live verification (tagged build, Freestyle VM): single-pane cloud workspace closes on Ctrl+D; a cloud pane split beside another pane closes alone and leaves the workspace; `echo hello world` + Option+Backspace leaves `echo hello`.

https://claude.ai/code/session_01GQSu7X1ybGzWsfGKgG8jn3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace/pane teardown and graph-driven closure; incorrect freshness or resolver handling could close panes while a machine is merely unreachable, though stale graphs are explicitly guarded.
> 
> **Overview**
> Fixes two cloud-terminal UX issues: **dead panes after the remote shell exits**, and **Option+Backspace doing nothing** in devbox shells.
> 
> **Pane closure when the shell ends.** The resolver now treats `lifecycle: "exited"` separately from a live zero-view terminal (`surface:null`), propagating an `.exited` outcome through parsing and surface-ID resolution. Manual-mirror refresh stops reconnecting exited terminals and closes those panes immediately; after each **current** VM graph publish, `CloudTerminalPaneClosure` closes attach panes whose terminal keys are no longer in the graph (stale graphs close nothing). `SurfacePaneFactory.closeExited` force-closes the pane—and the whole workspace when it is the only pane—bypassing the socket rule that blocks closing a workspace’s last surface.
> 
> **Option+Backspace.** Adds a unit test that manual-mirror surfaces emit `ESC DEL` for Option+Delete. Devbox `cmux-bashrc` disables ble.sh `modifyOtherKeys` and binds backward word-delete for the legacy encoding cloud panes send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f447743285f61bc3f653677ec9b2331309639574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->