### PR TITLE
build(setup): preflight the Metal toolchain and document missing prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@
 - macOS 14+
 - Xcode 15+
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
+- [Rust](https://rustup.rs) (install via `brew install rustup && rustup-init`) — `scripts/setup.sh`
+  requires `rustup`, and the app build compiles the bundled `cmux-cua` engine with `cargo`
+- On Xcode 26, the Metal toolchain is a separate download and the build fails without it:
+  ```bash
+  xcodebuild -downloadComponent MetalToolchain
+  ```
 
 ## Getting Started
 
@@ -21,7 +27,9 @@
 
    This will:
    - Initialize git submodules (ghostty, homebrew-cmux)
-   - Build the GhosttyKit.xcframework from source
+   - Install the pinned Rust toolchain
+   - Fetch a checksum-pinned prebuilt GhosttyKit.xcframework, falling back to building it
+     from source with Zig (force the source build with `CMUX_GHOSTTYKIT_NO_PREBUILT=1`)
    - Create the necessary symlinks
 
 3. Build the debug app:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,19 @@
 - macOS 14+
 - Xcode 15+
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
-- [Rust](https://rustup.rs) (install via `brew install rustup && rustup-init`) — `scripts/setup.sh`
-  requires `rustup`, and the app build compiles the bundled `cmux-cua` engine with `cargo`
-- On Xcode 26, the Metal toolchain is a separate download and the build fails without it:
+- [Rust](https://rustup.rs) — `scripts/setup.sh` requires `rustup`, and every app build compiles
+  the bundled `cmux-cua` engine with `cargo`. The official installer puts both in `~/.cargo/bin`,
+  which is where `setup.sh` looks:
+
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+  Homebrew's `rustup` formula works too, but it is keg-only and no longer ships `rustup-init`, so
+  add `$(brew --prefix rustup)/bin` to `PATH` and run `rustup default stable` yourself.
+- On Xcode 26 the Metal compiler is a separately downloaded component, and the build fails
+  without it:
+
   ```bash
   xcodebuild -downloadComponent MetalToolchain
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@
   Homebrew's `rustup` formula works too, but it is keg-only and no longer ships `rustup-init`, so
   add `$(brew --prefix rustup)/bin` to `PATH` and run `rustup default stable` yourself.
 - On Xcode 26 the Metal compiler is a separately downloaded component, and the build fails
-  without it:
+  without it. Select the intended full Xcode installation first (`DEVELOPER_DIR`, if
+  exported, overrides `xcode-select`), then install the component:
 
   ```bash
   xcodebuild -downloadComponent MetalToolchain

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,6 +51,18 @@ if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     exit 1
 fi
 
+# Xcode 26 ships the Metal compiler as a separately downloaded component rather
+# than inside Xcode.app. Without it the app target fails partway through the
+# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
+# the Swift modules have already compiled. Fail here instead, where the fix is
+# one command. Older Xcode bundles metal, so this check simply passes there.
+echo "==> Checking for the Metal toolchain..."
+if ! xcrun metal --version &> /dev/null; then
+    echo "Error: the Metal toolchain is not installed."
+    echo "Install via: xcodebuild -downloadComponent MetalToolchain"
+    exit 1
+fi
+
 # The Cloud tunnel system extension embeds wireguard-go, built by
 # scripts/build-wireguard-go.sh. Release builds require Go; a Debug build
 # without it gets a stub engine (the extension cannot load in a Debug build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,7 +47,9 @@ rustup run "$DIFF_RUST_TOOLCHAIN" rustc --version
 echo "==> Checking for cargo (bundled cmux-cua)..."
 if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     echo "Error: a working Rust toolchain (cargo) is required to build the bundled cmux-cua."
-    echo "Install via rustup: https://rustup.rs (or \`brew install rustup && rustup-init\`)"
+    echo "Install via rustup: https://rustup.rs"
+    echo "(Homebrew's rustup is keg-only and ships no rustup-init: add"
+    echo " \"\$(brew --prefix rustup)/bin\" to PATH, then run \`rustup default stable\`.)"
     exit 1
 fi
 
@@ -56,10 +58,16 @@ fi
 # build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
 # the Swift modules have already compiled. Fail here instead, where the fix is
 # one command. Older Xcode bundles metal, so this check simply passes there.
+# The Command Line Tools do not ship metal at all, so the message names both
+# causes rather than assuming the component is merely missing.
 echo "==> Checking for the Metal toolchain..."
 if ! xcrun metal --version &> /dev/null; then
-    echo "Error: the Metal toolchain is not installed."
-    echo "Install via: xcodebuild -downloadComponent MetalToolchain"
+    echo "Error: the Metal compiler is not available."
+    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
+    echo "If that is a full Xcode, install the toolchain component:"
+    echo "    xcodebuild -downloadComponent MetalToolchain"
+    echo "If it is the Command Line Tools, select Xcode first:"
+    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,6 +6,26 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_DIR"
 
+# Xcode 26 ships the Metal compiler as a separately downloaded component rather
+# than inside Xcode.app. Without it the app target fails partway through the
+# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
+# the Swift modules have already compiled. Fail here instead, where the fix is
+# one command. Older Xcode bundles metal, so this check simply passes there.
+# The Command Line Tools do not ship metal at all, so the message names both
+# causes rather than assuming the component is merely missing.
+echo "==> Checking for the Metal toolchain..."
+if ! xcrun metal --version &> /dev/null; then
+    echo "Error: the Metal compiler is not available."
+    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
+    echo "For Xcode 26 or later, install the toolchain component:"
+    echo "    xcodebuild -downloadComponent MetalToolchain"
+    echo "If it is the Command Line Tools, select Xcode first:"
+    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
+    echo "If DEVELOPER_DIR is exported, unset it or point it to the intended Xcode;"
+    echo "it overrides the system selection."
+    exit 1
+fi
+
 echo "==> Initializing submodules..."
 git submodule update --init --recursive
 
@@ -50,24 +70,6 @@ if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     echo "Install via rustup: https://rustup.rs"
     echo "(Homebrew's rustup is keg-only and ships no rustup-init: add"
     echo " \"\$(brew --prefix rustup)/bin\" to PATH, then run \`rustup default stable\`.)"
-    exit 1
-fi
-
-# Xcode 26 ships the Metal compiler as a separately downloaded component rather
-# than inside Xcode.app. Without it the app target fails partway through the
-# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
-# the Swift modules have already compiled. Fail here instead, where the fix is
-# one command. Older Xcode bundles metal, so this check simply passes there.
-# The Command Line Tools do not ship metal at all, so the message names both
-# causes rather than assuming the component is merely missing.
-echo "==> Checking for the Metal toolchain..."
-if ! xcrun metal --version &> /dev/null; then
-    echo "Error: the Metal compiler is not available."
-    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
-    echo "If that is a full Xcode, install the toolchain component:"
-    echo "    xcodebuild -downloadComponent MetalToolchain"
-    echo "If it is the Command Line Tools, select Xcode first:"
-    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Three things a first-time contributor hits on a clean machine, none of them documented:

1. `scripts/setup.sh` hard-requires `rustup`, and every app build compiles the bundled `cmux-cua` engine with `cargo`, but Rust is not in the prerequisites. Without it the build dies at `error: cargo is required to build the bundled cmux-cua`.
2. Xcode 26 ships the Metal compiler as a separately downloaded component. Without it the app target fails with `cannot execute tool 'metal' due to missing Metal Toolchain` — and it fails *late*, after all Swift modules have compiled. This adds a preflight check to `setup.sh` next to the existing zig/rustup/cargo ones, so the failure lands where the fix is one command.
3. CONTRIBUTING says setup will "Build the GhosttyKit.xcframework from source", but `ensure-ghosttykit.sh` prefers a checksum-pinned prebuilt and only falls back to a source build. Corrected, and documented the `CMUX_GHOSTTYKIT_NO_PREBUILT=1` opt-out.

Deliberately not touching the `Xcode 15+` line — #11922 is already revising it.

## Validation

- Builds were not run. This update was performed on Linux only; no Swift/macOS builds, xcodebuild, reload, cloud-build, or dogfood commands were run.
- `bash -n scripts/setup.sh` and `git diff --check` passed.
- Executed `scripts/setup.sh` with isolated Linux command stubs: available Metal reaches the submodule step; unavailable Metal exits 1 before submodule or Rust mutations. Covered default Xcode, Command Line Tools, and a custom developer directory containing spaces. These checks do not validate actual Apple toolchain behavior.
- Localization audit: reviewed changed contributor documentation and shell diagnostics; no app or web catalog strings changed. These developer-facing surfaces remain English-only.

The Metal preflight now runs before submodule initialization and Rust installation. Recovery guidance names Xcode 26+ for component downloads and explains that an exported `DEVELOPER_DIR` overrides the system selection. The existing `xcode-select -p` diagnostic is retained because it already honors that override.

## Demo Video

N/A — build tooling and docs, no UI or behavior change.

## Checklist

- [x] Verified setup control flow with Linux command stubs; native macOS validation not run
- [x] No behavior change to the app itself

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791439443&installation_model_id=21920&pr_number=12107&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12107&signature=7c1b17cf6c18e8ff1ddc27b427c4bc48fefaa33942e6f3721eccdea16806864a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and setup-script checks only; no runtime app behavior changes.
> 
> **Overview**
> **Adds contributor setup guardrails** so common first-build failures surface during `./scripts/setup.sh` instead of mid-compile.
> 
> `scripts/setup.sh` now **preflights the Metal compiler** (`xcrun metal --version`) and exits with install/`xcode-select`/`DEVELOPER_DIR` guidance when it is missing (notably the separate **MetalToolchain** component on Xcode 26). The **cargo** error text is expanded for **Homebrew keg-only `rustup`**.
> 
> **`CONTRIBUTING.md`** documents **Rust/rustup/cargo** as prerequisites, the Xcode 26 Metal toolchain step, and corrects setup copy: **checksum-pinned prebuilt GhosttyKit** with Zig source fallback and **`CMUX_GHOSTTYKIT_NO_PREBUILT=1`** to force a local build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1fc181a1213ca51f89c217f929835d92f7f845c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preflights the Metal toolchain in `scripts/setup.sh` so Xcode 26 builds fail during setup with the fix instead of partway through compilation. Also documents Rust as a prerequisite and corrects the `CONTRIBUTING` description of how GhosttyKit is obtained.

- The check runs `xcrun metal --version` before any setup job mutates the repo, and exits with guidance naming both the uninstalled Xcode 26 MetalToolchain component and the Command Line Tools case, which ship no `metal` at all.
- `CONTRIBUTING.md` now lists Rust via the official rustup installer and documents the Homebrew caveat (keg-only, no `rustup-init`), since `setup.sh` requires `rustup` and builds use `cargo`.
- Corrected: setup fetches a checksum-pinned prebuilt `GhosttyKit.xcframework` and falls back to a Zig source build; `CMUX_GHOSTTYKIT_NO_PREBUILT=1` forces the source build.

<sup>Written for commit d1fc181a1213ca51f89c217f929835d92f7f845c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance with Rust, `rustup`, and Metal toolchain prerequisites.
  - Documented setup behavior for installing Rust, obtaining GhosttyKit, and building from source when needed.
  - Added guidance for Homebrew’s keg-only `rustup` installation and configuring the required PATH.

- **Bug Fixes**
  - Setup now verifies that the Metal toolchain is available and provides installation guidance when it is missing.
  - Improved Rust installation error guidance, including selecting the stable toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->