### PR TITLE
Polish Find and Vault search spacing, corners, and hover

### DIFF
--- a/Sources/FileExplorerHeaderView.swift
+++ b/Sources/FileExplorerHeaderView.swift
@@ -38,10 +38,10 @@ final class FileExplorerHeaderView: NSView {
         NSLayoutConstraint.activate([
             heightConstraint,
 
-            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: RightSidebarChromeMetrics.contentIconLeadingPadding),
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: 14),
-            iconView.heightAnchor.constraint(equalToConstant: 14),
+            iconView.widthAnchor.constraint(equalToConstant: RightSidebarChromeMetrics.contentIconFrameSize),
+            iconView.heightAnchor.constraint(equalToConstant: RightSidebarChromeMetrics.contentIconFrameSize),
 
             pathLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 4),
             pathLabel.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/Sources/FileExplorerHeaderView.swift
+++ b/Sources/FileExplorerHeaderView.swift
@@ -43,7 +43,7 @@ final class FileExplorerHeaderView: NSView {
             iconView.widthAnchor.constraint(equalToConstant: RightSidebarChromeMetrics.contentIconFrameSize),
             iconView.heightAnchor.constraint(equalToConstant: RightSidebarChromeMetrics.contentIconFrameSize),
 
-            pathLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 4),
+            pathLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: RightSidebarChromeMetrics.contentIconTextSpacing),
             pathLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             pathLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ])

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1141,9 +1141,9 @@ final class FileExplorerContainerView: NSView {
             searchBarView.trailingAnchor.constraint(equalTo: trailingAnchor),
             searchBarHeightConstraint,
 
-            searchField.leadingAnchor.constraint(equalTo: searchBarView.leadingAnchor, constant: 8),
+            searchField.leadingAnchor.constraint(equalTo: searchBarView.leadingAnchor, constant: SidebarSearchField.leadingPadding),
             searchField.trailingAnchor.constraint(equalTo: searchBarView.trailingAnchor, constant: -8),
-            searchField.topAnchor.constraint(equalTo: searchBarView.topAnchor, constant: 4),
+            searchField.topAnchor.constraint(equalTo: searchBarView.topAnchor, constant: SidebarSearchField.verticalPadding),
             searchFieldHeightConstraint,
             searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 120),
 

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1143,7 +1143,7 @@ final class FileExplorerContainerView: NSView {
 
             searchField.leadingAnchor.constraint(equalTo: searchBarView.leadingAnchor, constant: SidebarSearchField.leadingPadding),
             searchField.trailingAnchor.constraint(equalTo: searchBarView.trailingAnchor, constant: -8),
-            searchField.topAnchor.constraint(equalTo: searchBarView.topAnchor, constant: SidebarSearchField.verticalPadding),
+            searchField.topAnchor.constraint(equalTo: searchBarView.topAnchor, constant: SidebarSearchField.topPadding),
             searchFieldHeightConstraint,
             searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 120),
 

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -614,6 +614,7 @@ private struct GroupingButton: View {
                     pointSize: RightSidebarChromeControlStyle.secondaryIconSize,
                     weight: RightSidebarChromeControlStyle.iconWeight
                 )
+                .frame(width: RightSidebarChromeMetrics.contentIconFrameSize)
                 Text(mode.label)
                     .cmuxFont(
                         size: RightSidebarChromeControlStyle.labelSize,

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -608,7 +608,7 @@ private struct GroupingButton: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 3) {
+            HStack(spacing: RightSidebarChromeMetrics.contentIconTextSpacing) {
                 CmuxSystemSymbolImage(
                     magnified: mode.symbolName,
                     pointSize: RightSidebarChromeControlStyle.secondaryIconSize,

--- a/Sources/SidebarSearchField.swift
+++ b/Sources/SidebarSearchField.swift
@@ -4,6 +4,9 @@ import CmuxFoundation
 /// Native search control shared by Find and Vault.
 @MainActor
 class SidebarSearchField: NSSearchField {
+    static let leadingPadding: CGFloat = 4
+    static let verticalPadding: CGFloat = 3
+
     var onCommandSubmit: (() -> Void)?
 
     override class var cellClass: AnyClass? {

--- a/Sources/SidebarSearchField.swift
+++ b/Sources/SidebarSearchField.swift
@@ -33,6 +33,30 @@ class SidebarSearchField: NSSearchField {
         font = GlobalFontMagnification.systemFont(ofSize: 13, weight: .regular)
     }
 
+    override var searchButtonBounds: NSRect {
+        Self.alignedSearchButtonRect(super.searchButtonBounds, in: bounds)
+    }
+
+    override var searchTextBounds: NSRect {
+        Self.alignedSearchTextRect(super.searchTextBounds, in: bounds)
+    }
+
+    static func alignedSearchButtonRect(_ nativeRect: NSRect, in bounds: NSRect) -> NSRect {
+        var rect = nativeRect
+        rect.size.width = RightSidebarChromeMetrics.contentIconFrameSize
+        rect.origin.x = bounds.minX + RightSidebarChromeMetrics.contentIconCenter - leadingPadding - rect.width / 2
+        return rect
+    }
+
+    static func alignedSearchTextRect(_ nativeRect: NSRect, in bounds: NSRect) -> NSRect {
+        var rect = nativeRect
+        // Native text drawing and the field editor both add this inner inset.
+        let leading = bounds.minX + RightSidebarChromeMetrics.contentTextLeadingPadding - leadingPadding - 2
+        rect.origin.x = min(leading, nativeRect.maxX)
+        rect.size.width = max(0, nativeRect.maxX - rect.minX)
+        return rect
+    }
+
     override func resetCursorRects() {
         super.resetCursorRects()
         guard isEnabled, isEditable else { return }

--- a/Sources/SidebarSearchField.swift
+++ b/Sources/SidebarSearchField.swift
@@ -5,9 +5,10 @@ import CmuxFoundation
 @MainActor
 class SidebarSearchField: NSSearchField {
     static let leadingPadding: CGFloat = 4
-    static let verticalPadding: CGFloat = 3
+    static let topPadding: CGFloat = 0
 
     var onCommandSubmit: (() -> Void)?
+    private var hoverTrackingArea: NSTrackingArea?
 
     override class var cellClass: AnyClass? {
         get { SidebarSearchFieldCell.self }
@@ -30,6 +31,36 @@ class SidebarSearchField: NSSearchField {
 
     func applyFontScale() {
         font = GlobalFontMagnification.systemFont(ofSize: 13, weight: .regular)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        guard isEnabled, isEditable else { return }
+        addCursorRect(searchTextBounds, cursor: .iBeam)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea) }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.inVisibleRect, .activeAlways, .cursorUpdate, .mouseEnteredAndExited, .mouseMoved],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func cursorUpdate(with event: NSEvent) { updateHoverCursor(with: event) }
+    override func mouseEntered(with event: NSEvent) { updateHoverCursor(with: event) }
+    override func mouseMoved(with event: NSEvent) { updateHoverCursor(with: event) }
+    override func mouseExited(with event: NSEvent) { NSCursor.arrow.set() }
+
+    private func updateHoverCursor(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let cursor: NSCursor = isEnabled && isEditable && searchTextBounds.contains(point) ? .iBeam : .arrow
+        cursor.set()
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {

--- a/Sources/SidebarSearchField.swift
+++ b/Sources/SidebarSearchField.swift
@@ -44,7 +44,7 @@ class SidebarSearchField: NSSearchField {
         if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea) }
         let area = NSTrackingArea(
             rect: .zero,
-            options: [.inVisibleRect, .activeAlways, .cursorUpdate, .mouseEnteredAndExited, .mouseMoved],
+            options: [.inVisibleRect, .activeInKeyWindow, .cursorUpdate, .mouseEnteredAndExited, .mouseMoved],
             owner: self,
             userInfo: nil
         )

--- a/Sources/SidebarSearchFieldCell.swift
+++ b/Sources/SidebarSearchFieldCell.swift
@@ -1,11 +1,20 @@
 import AppKit
+import SwiftUI
 
 /// Replace only the bezel drawing; native search and editor geometry stay intact.
 @MainActor
 final class SidebarSearchFieldCell: NSSearchFieldCell {
     override func draw(withFrame frame: NSRect, in controlView: NSView) {
-        NSColor.labelColor.withAlphaComponent(0.06).setFill()
-        NSBezierPath(roundedRect: frame, xRadius: 7, yRadius: 7).fill()
+        if let context = NSGraphicsContext.current?.cgContext {
+            context.saveGState()
+            context.setFillColor(NSColor.labelColor.withAlphaComponent(0.06).cgColor)
+            context.addPath(RoundedRectangle(
+                cornerRadius: RightSidebarChromeMetrics.controlCornerRadius,
+                style: .continuous
+            ).path(in: frame).cgPath)
+            context.fillPath()
+            context.restoreGState()
+        }
         super.drawInterior(withFrame: frame, in: controlView)
     }
 }

--- a/Sources/SidebarSearchFieldCell.swift
+++ b/Sources/SidebarSearchFieldCell.swift
@@ -5,10 +5,11 @@ import SwiftUI
 @MainActor
 final class SidebarSearchFieldCell: NSSearchFieldCell {
     override func searchButtonRect(forBounds rect: NSRect) -> NSRect {
-        var buttonRect = super.searchButtonRect(forBounds: rect)
-        let center = RightSidebarChromeMetrics.contentIconCenter - SidebarSearchField.leadingPadding
-        buttonRect.origin.x = rect.minX + center - buttonRect.width / 2
-        return buttonRect
+        SidebarSearchField.alignedSearchButtonRect(super.searchButtonRect(forBounds: rect), in: rect)
+    }
+
+    override func searchTextRect(forBounds rect: NSRect) -> NSRect {
+        SidebarSearchField.alignedSearchTextRect(super.searchTextRect(forBounds: rect), in: rect)
     }
 
     override func draw(withFrame frame: NSRect, in controlView: NSView) {

--- a/Sources/SidebarSearchFieldCell.swift
+++ b/Sources/SidebarSearchFieldCell.swift
@@ -1,9 +1,16 @@
 import AppKit
 import SwiftUI
 
-/// Replace only the bezel drawing; native search and editor geometry stay intact.
+/// Shared bezel and icon alignment; AppKit owns text editing and button handling.
 @MainActor
 final class SidebarSearchFieldCell: NSSearchFieldCell {
+    override func searchButtonRect(forBounds rect: NSRect) -> NSRect {
+        var buttonRect = super.searchButtonRect(forBounds: rect)
+        let center = RightSidebarChromeMetrics.contentIconCenter - SidebarSearchField.leadingPadding
+        buttonRect.origin.x = rect.minX + center - buttonRect.width / 2
+        return buttonRect
+    }
+
     override func draw(withFrame frame: NSRect, in controlView: NSView) {
         if let context = NSGraphicsContext.current?.cgContext {
             context.saveGState()

--- a/Sources/VaultAllSessionsBar.swift
+++ b/Sources/VaultAllSessionsBar.swift
@@ -21,20 +21,18 @@ struct VaultAllSessionsBar: View {
         return SidebarSearchField.visibleHeight
     }
 
-    private var searchBarHeight: CGFloat {
-        max(RightSidebarChromeMetrics.secondaryBarHeight, searchFieldHeight + 2 * SidebarSearchField.verticalPadding)
-    }
-
     var body: some View {
         HStack(spacing: 0) {
             searchField
             overflowMenu
         }
-        // Keep Vault's compact toolbar spacing around the shared field.
+        .frame(height: searchFieldHeight)
+        // The grouping row already supplies the gap below Recent. Do not add
+        // another top inset or center the editor inside a taller menu button.
         .padding(.leading, SidebarSearchField.leadingPadding)
         .padding(.trailing, 0)
-        .padding(.vertical, SidebarSearchField.verticalPadding)
-        .frame(height: searchBarHeight)
+        .padding(.top, SidebarSearchField.topPadding)
+        .padding(.bottom, RightSidebarChromeMetrics.barVerticalPadding)
     }
 
     private var searchField: some View {
@@ -70,7 +68,7 @@ struct VaultAllSessionsBar: View {
             Text("⋮")
                 .font(.system(size: 18, weight: .bold, design: .rounded))
                 .foregroundStyle(Color.secondary.opacity(0.72))
-                .frame(width: 24, height: 28)
+                .frame(width: 24, height: searchFieldHeight)
                 .background(
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .fill(Color.primary.opacity(0.10))
@@ -86,7 +84,7 @@ struct VaultAllSessionsBar: View {
         .accessibilityHint(Text(String(localized: "sessionIndex.view.tooltip", defaultValue: "Choose session view")))
         .accessibilityValue(viewSelectionLabel)
         .accessibilityIdentifier("VaultSessionOptionsMenu")
-        .frame(width: 24, height: 28)
+        .frame(width: 24, height: searchFieldHeight)
         .layoutPriority(2)
         .titlebarInteractiveControl()
     }

--- a/Sources/VaultAllSessionsBar.swift
+++ b/Sources/VaultAllSessionsBar.swift
@@ -22,7 +22,7 @@ struct VaultAllSessionsBar: View {
     }
 
     private var searchBarHeight: CGFloat {
-        max(RightSidebarChromeMetrics.secondaryBarHeight, searchFieldHeight + 6)
+        max(RightSidebarChromeMetrics.secondaryBarHeight, searchFieldHeight + 2 * SidebarSearchField.verticalPadding)
     }
 
     var body: some View {
@@ -31,9 +31,9 @@ struct VaultAllSessionsBar: View {
             overflowMenu
         }
         // Keep Vault's compact toolbar spacing around the shared field.
-        .padding(.leading, 4)
+        .padding(.leading, SidebarSearchField.leadingPadding)
         .padding(.trailing, 0)
-        .padding(.vertical, 3)
+        .padding(.vertical, SidebarSearchField.verticalPadding)
         .frame(height: searchBarHeight)
     }
 

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -45,6 +45,11 @@ enum RightSidebarChromeMetrics {
         return max(baseHeight, scaledContentHeight)
     }
     static let controlHorizontalPadding: CGFloat = 8
+    static let contentIconLeadingPadding: CGFloat = 12
+    static let contentIconFrameSize: CGFloat = 14
+    static var contentIconCenter: CGFloat {
+        contentIconLeadingPadding + contentIconFrameSize / 2
+    }
     static var controlCornerRadius: CGFloat {
         min(10, max(5, controlHeight * 0.25))
     }

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -47,6 +47,10 @@ enum RightSidebarChromeMetrics {
     static let controlHorizontalPadding: CGFloat = 8
     static let contentIconLeadingPadding: CGFloat = 12
     static let contentIconFrameSize: CGFloat = 14
+    static let contentIconTextSpacing: CGFloat = 4
+    static var contentTextLeadingPadding: CGFloat {
+        contentIconLeadingPadding + contentIconFrameSize + contentIconTextSpacing
+    }
     static var contentIconCenter: CGFloat {
         contentIconLeadingPadding + contentIconFrameSize / 2
     }

--- a/cmuxTests/SidebarSearchFieldTests.swift
+++ b/cmuxTests/SidebarSearchFieldTests.swift
@@ -10,6 +10,45 @@ import Testing
 
 @MainActor
 @Suite struct SidebarSearchFieldTests {
+    @Test func hoveringAnUnfocusedSearchFieldUsesTheTextCursor() throws {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 100), styleMask: [.borderless], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        let previousCursor = NSCursor.current
+        defer { previousCursor.set(); window.close() }
+        let field = SidebarSearchField(frame: NSRect(x: 20, y: 20, width: 240, height: SidebarSearchField.visibleHeight))
+        window.contentView?.addSubview(field)
+        #expect(field.currentEditor() == nil)
+        NSCursor.arrow.set()
+        field.mouseMoved(with: try hoverEvent(in: field.searchTextBounds, field: field, window: window))
+        #expect(NSCursor.current == NSCursor.iBeam)
+        #expect(field.currentEditor() == nil)
+    }
+
+    @Test func hoveringSearchButtonsKeepsTheArrowCursor() throws {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 100), styleMask: [.borderless], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        let previousCursor = NSCursor.current
+        defer { previousCursor.set(); window.close() }
+        let field = SidebarSearchField(frame: NSRect(x: 20, y: 20, width: 240, height: SidebarSearchField.visibleHeight))
+        field.stringValue = "query"
+        window.contentView?.addSubview(field)
+        for bounds in [field.searchButtonBounds, field.cancelButtonBounds] {
+            #expect(!bounds.isEmpty)
+            NSCursor.iBeam.set()
+            field.mouseMoved(with: try hoverEvent(in: bounds, field: field, window: window))
+            #expect(NSCursor.current == NSCursor.arrow)
+        }
+    }
+
+    private func hoverEvent(in bounds: NSRect, field: SidebarSearchField, window: NSWindow) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: field.convert(NSPoint(x: bounds.midX, y: bounds.midY), to: nil),
+            modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber,
+            context: nil, eventNumber: 0, clickCount: 0, pressure: 0
+        ))
+    }
+
     @Test func focusedEditorDoesNotOverlapSearchIcon() throws {
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 100), styleMask: [.borderless], backing: .buffered, defer: false)
         window.isReleasedWhenClosed = false

--- a/cmuxTests/SidebarSearchFieldTests.swift
+++ b/cmuxTests/SidebarSearchFieldTests.swift
@@ -49,6 +49,23 @@ import Testing
         ))
     }
 
+    @Test func searchTextAlignsWithSidebarLabelsBeforeAndDuringEditing() throws {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 100), styleMask: [.borderless], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let field = SidebarSearchField(frame: NSRect(x: 4, y: 20, width: 240, height: SidebarSearchField.visibleHeight))
+        field.placeholderString = "Search"
+        window.contentView?.addSubview(field)
+        let expectedLeading: CGFloat = 30
+        #expect(field.frame.minX + field.searchTextBounds.minX == expectedLeading)
+        field.stringValue = "alpha beta"
+        #expect(window.makeFirstResponder(field))
+        let editor = try #require(field.currentEditor() as? NSTextView)
+        let insertionRect = editor.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        let textRect = field.convert(window.convertFromScreen(insertionRect), from: nil)
+        #expect(abs(field.frame.minX + textRect.minX - expectedLeading) <= 1)
+    }
+
     @Test func focusedEditorDoesNotOverlapSearchIcon() throws {
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 100), styleMask: [.borderless], backing: .buffered, defer: false)
         window.isReleasedWhenClosed = false

--- a/cmuxTests/SidebarSearchFieldTests.swift
+++ b/cmuxTests/SidebarSearchFieldTests.swift
@@ -57,7 +57,8 @@ import Testing
         field.placeholderString = "Search"
         window.contentView?.addSubview(field)
         let expectedLeading: CGFloat = 30
-        #expect(field.frame.minX + field.searchTextBounds.minX == expectedLeading)
+        let placeholderRect = field.cell!.titleRect(forBounds: field.bounds)
+        #expect(field.frame.minX + placeholderRect.minX + 2 == expectedLeading)
         field.stringValue = "alpha beta"
         #expect(window.makeFirstResponder(field))
         let editor = try #require(field.currentEditor() as? NSTextView)


### PR DESCRIPTION
Find’s folder icon, both search icons, and Vault’s Recent icon share one horizontal center. A shared 14-point icon frame aligns the SwiftUI grouping symbols with the AppKit folder image. The native search cell uses the same center for drawing and button hit testing.

Vault now has a uniform 4-point surround around Recent, including the gap to search below it. The search row and menu use the same height, removing the extra vertical centering space. Find stays aligned with Vault. Both search fields use the same continuous corner shape and radius as Recent.

The shared native search control handles hover before editing starts: editable text uses an I-beam, while search and clear buttons keep an arrow. Cursor handling uses AppKit tracking without timers.

Validation at 6b5ea047d95:

- Tagged macOS app compiled and installed. Open [svtext](http://127.0.0.1:17320/svtext).
- Ten native search tests passed on macOS 15 and macOS 26 using production controls and font/metric code. The new alignment test fails before the fix and passes after it.
- Computer Use screenshots show Vault with Agent selected. Recent and search placeholder ink both start at x=755 in a 1000-point window. Find uses the same text column (glyph edges differ by one pixel).
- Focused Find and Vault search, typed Sample in Vault, and cleared it with Escape. The active editor and restored placeholder keep the shared column.
- Previous rounds verified equal spacing, continuous corners, and hover cursors.
- Whitespace checks passed. No user-facing strings added; all three grouping label keys are present in the catalog.

The shared layout now owns both icon and text positions. It applies through the native search field bounds and cell drawing methods, including AppKit's inner text inset. Vault grouping labels and the Find folder label use the same icon-to-text spacing.

Current screenshots and logs: hq `artifacts/svtext/`. Earlier evidence: `artifacts/svico/` and `artifacts/svpad2/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual layout and native search-field geometry/cursor behavior only; no auth, data, or API changes.
> 
> **Overview**
> **Unifies right-sidebar icon and search layout** by moving Find folder icons, Vault grouping symbols, and native search magnifiers onto shared `RightSidebarChromeMetrics` (14pt icon frame, leading padding, text spacing) so horizontal centers line up across AppKit and SwiftUI.
> 
> **Reworks `SidebarSearchField`** to position the search icon and text via overridden cell/control rects (matching sidebar label leading edge before and while editing), draw the bezel with the same continuous corner radius as other chrome, and show an I-beam over editable text before focus while keeping arrow cursors on search/clear buttons through AppKit tracking areas.
> 
> **Tightens Vault’s search row** so the field and overflow menu share `SidebarSearchField.visibleHeight` and consistent 4pt leading padding instead of a taller bar with extra vertical centering; Find adopts the same padding constants in its constraints.
> 
> **Adds regression tests** for hover cursors, text alignment, and related search-field behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5ea047d9514bf3fdbcc8e85c5b56d07b69bff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search fields now display the text cursor only when hovering over editable text, while search and cancel buttons retain the arrow cursor.
  * Search text alignment is consistent with sidebar labels before and during editing.

* **Improvements**
  * Sidebar and session-bar layouts now use consistent spacing, sizing, icon alignment, and corner styling.
  * File explorer headers and grouping controls have more consistent icon and label positioning.

* **Tests**
  * Added coverage for cursor behavior and search-field text alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
