### PR TITLE
fix(cloud): finish the cmux hostname snapshot rollout

### DIFF
--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -245,6 +245,7 @@ try {
 
   // The machine's name, before anything records it (host keys, caches, the
   // daemon, the journal): see the identity contract in the header.
+  await put("cmux-devbox-rekey", "/usr/local/bin/cmux-devbox-rekey", 0o755);
   await step("identity", devboxIdentityInstallCommand());
 
   await step(

--- a/web/scripts/devbox-image-common.ts
+++ b/web/scripts/devbox-image-common.ts
@@ -35,6 +35,7 @@ export const DEVBOX_TEMPLATE_FILES = [
   "chrome-managed-policy.json",
   "cmux-bashrc",
   "cmux-devbox-boot",
+  "cmux-devbox-rekey",
   "cmux-motd",
   "cmux-terminfo.sh",
   "cmux-terminfo.src",
@@ -378,15 +379,7 @@ export function devboxHostsAliasRewriteCommand(hostname = DEVBOX_HOSTNAME, hosts
  * alone where nothing does. cmux-devbox-boot does the same on every clone.
  */
 export function devboxSshHostKeyRegenerateCommand(): string {
-  return [
-    'staging="$(mktemp -d /etc/ssh/.cmux-rekey.XXXXXX)"',
-    'mkdir -p "$staging/etc/ssh"',
-    'ssh-keygen -A -f "$staging" >/dev/null',
-    '[ -n "$(ls "$staging"/etc/ssh/ssh_host_*_key 2>/dev/null)" ]',
-    'for key in "$staging"/etc/ssh/ssh_host_*_key; do mv -f "$key.pub" /etc/ssh/ && mv -f "$key" /etc/ssh/ || exit 1; done',
-    'rm -rf "$staging"',
-    "{ [ ! -d /run/systemd/system ] || systemctl try-restart ssh; }",
-  ].join(" && ");
+  return "/usr/local/bin/cmux-devbox-rekey";
 }
 
 /**

--- a/web/scripts/verify-devbox-image.ts
+++ b/web/scripts/verify-devbox-image.ts
@@ -62,6 +62,7 @@ const FILE_PIN_CHECKS = [
   ["agent-config.sh", "/etc/cmux/agent-config.sh"],
   ["seed-history", "/etc/cmux/seed-history"],
   ["cmux-devbox-boot", "/usr/local/bin/cmux-devbox-boot"],
+  ["cmux-devbox-rekey", "/usr/local/bin/cmux-devbox-rekey"],
   ["chrome-managed-policy.json", "/etc/opt/chrome/policies/managed/cmux.json"],
 ].map(([source, target]) => `echo '${shaOf(source)}  ${target}' | sha256sum -c -`);
 

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -135,15 +135,18 @@ Image policy:
   `expectNoCloudVmImplementationLeaks` in `tests/vm-route-auth.test.ts`).
 - Local development and every deployed runtime serve the same `defaultForKind` entry; there is no
   separate local default and nothing to copy into `.env`.
-- Today's default (both kinds, every size) is the `freestyle-cmux-devbox-11761b` ladder, baked and
-  verified on cmux's Freestyle account from https://github.com/manaflow-ai/cmux/pull/11776
-  (`090e3daddd`, epoch `2026-09-02-r4`: the desktop session with owner-signalled readiness
-  (`Type=notify`), the accessibility bus, clipboard helper and published `DISPLAY`, baked cmux-tui
-  daemon, `freestyle/ubuntu-sm` base): `sm` `sh-60effaffd5404e5ab8dbdb08bd5f5eed`, `md`
-  `sh-1ce6c11f5d6e4f8e98c19454e9a38751`, `lg` `sh-bda89603f1ab41a2902ac5d781e2c6ce`, `xl`
-  `sh-95b526e17c234593a45edfb572e49396`, `2xl` `sh-236a1866dd244082ba0f06829df2358d`. The retired
-  beta entry stays listed for the record and is never a default; earlier public entries (the
-  `11761a`, `20260903b` and `edge1` ladders before it) stay for rollback.
+- Today's defaults (both kinds, every size) are the `freestyle-cmux-hostname-12045-*-v2`
+  ladders, baked and verified on cmux's Freestyle account from
+  https://github.com/manaflow-ai/cmux/pull/12114 (`408e0142ef`, epoch `2026-09-08-r1`:
+  hostname `cmux`, recoverable SSH host-key rotation at bake and on clone, cold-boot
+  daemon recovery, baked cmux-tui daemon `71eb616d6f`). Desktop: `sm`
+  `sh-83c92d87356542f2bde9fe3e5a664bf2`, `md` `sh-a024bf739e05445a85fc17f8caf85c4c`,
+  `lg` `sh-bc1ef322ad2e4d168634d293690885e3`, `lgx` `sh-eb2666192f5e4414b63354e1561f1bbb`,
+  `xl` `sh-09b797d2ca0642e7a73f2aa6d474c678`, `2xl` `sh-b588cd3a9c9e4f9bbd19c35eef1cf008`.
+  Base: `sm` `sh-02be1d7394564fb7a693645b596ee478`, `md` `sh-8fa821c2f710499e897cc83b8e8afa0b`,
+  `lg` `sh-959d822635934e4ba4c7bbd8aa86b9cc`, `lgx` `sh-3e3e49d551f24b7f831f4a41a6b2dd2f`,
+  `xl` `sh-452bdbc9ec3e412c927a042c1a68050a`, `2xl` `sh-9649d7e4086845c7a32060298a9b2a71`.
+  Earlier public entries stay listed for rollback and are never a default.
 - Snapshots are account-scoped: a manifest id is only bootable by the Freestyle account whose
   `FREESTYLE_API_KEY` the deployment uses; promote under cmux's key.
 - Promotion is `bun run devbox:promote -- freestyle` (bake → verify → manifest write), then a PR

--- a/web/services/vms/images/devbox/Dockerfile
+++ b/web/services/vms/images/devbox/Dockerfile
@@ -32,7 +32,7 @@ FROM ubuntu:24.04
 # Cache-buster: bump the date to force remote builders past stale layer
 # caches (a remote builder served stale layers for chatmux on 2026-08-21 and
 # 2026-08-25). Also the image version /etc/cmux/image-stamp carries.
-ENV CMUX_IMAGE_EPOCH=2026-09-07-r1
+ENV CMUX_IMAGE_EPOCH=2026-09-08-r1
 
 ENV LANG=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
@@ -339,6 +339,8 @@ RUN bash -n /etc/cmux/agent-config.sh \
 # by the driver at create time, never baked). Without systemd it also runs the
 # desktop supervisor as the work user.
 COPY cmux-devbox-boot /usr/local/bin/cmux-devbox-boot
+COPY cmux-devbox-rekey /usr/local/bin/cmux-devbox-rekey
+RUN chmod 0755 /usr/local/bin/cmux-devbox-rekey
 RUN chmod 0755 /usr/local/bin/cmux-devbox-boot \
   && sh -n /usr/local/bin/cmux-devbox-boot
 

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -123,11 +123,18 @@ the base inventory, renames it:
   and every other line stay byte for byte.
 - **SSH host keys regenerated** under the new name (the base's keys were
   generated when Freestyle built its rootfs and are shared by every VM booted
-  from that base). `cmux-devbox-boot` regenerates them again on every clone,
-  in a detached subshell so the daemon start never waits, so no two machines
-  from one snapshot share a host key.
+  from that base). Bake and clone share `cmux-devbox-rekey`: keys are generated
+  into a staging dir and moved only once the full set exists, and any
+  generation, replacement, or sshd restart failure restores the previous set.
+  `cmux-devbox-boot` runs that helper on every clone and retries until it
+  succeeds before binding the instance id or starting the daemon, so a clone
+  never serves the builder's keys.
 - **The journal starts over** in the cleanup step, so a machine's log begins
   under its own name instead of with the base's boot as `freestyle-vm`.
+- **Cold boots** (kernel `boot_id` differs from `/etc/cmux/daemon-boot-id`)
+  run the daemon's own fenced recovery (`cmux-tui remote stop
+  --acknowledge-failed-finalization`) when stale cloud session runtime exists,
+  then update the boot marker. Same-boot supervisor restarts skip this path.
 
 The `identity-final` step before the stamp re-runs the check plus a
 whole-word residue audit (`freestyle-vm` under `/etc`, `/home`, `/root`,
@@ -177,7 +184,9 @@ daemon would give every machine the builder's Noise identity. The
 unit with `CMUX_TUI_REMOTE_WS_BIND=[::]:1337` (the driver reaches the daemon
 at the VM's IPv6 address, so the listener must be dual-stack), reads the
 platform instance id from the metadata service, wipes the remote identity
-when the machine is a clone, and starts the daemon. The driver runs no
+when the machine is a clone (after regenerating SSH host keys), and starts
+the daemon. A cold boot finalizes a predecessor that could not publish an
+outcome before the daemon starts. The driver runs no
 bootstrap at create; it heals pin drift and a missing listener on attach
 (`web/services/vms/drivers/cmuxTuiDaemon.ts`). The container Dockerfile still
 ships only the supervisor and waits for a driver install.

--- a/web/services/vms/images/devbox/cmux-devbox-boot
+++ b/web/services/vms/images/devbox/cmux-devbox-boot
@@ -35,10 +35,9 @@
 # The SSH host keys are per machine for the same reason: a clone would
 # otherwise present the builder's keys (and every other clone's). The clone
 # branch regenerates them under the machine's own name
-# (web/services/vms/images/identity.ts) in a detached subshell, so the daemon
-# start never waits on key generation (sshd is not the daemon's readiness),
-# and restarts sshd so it serves them. The new keys are staged before the old
-# ones go, so a failed generation keeps a working sshd.
+# (web/services/vms/images/identity.ts) before binding the instance id or
+# starting its daemon. Failed rekeying is retried, with the previous complete
+# key set restored by the shared bake/clone helper.
 #
 # The Freestyle public-platform bake runs this script from the cmux-tui-daemon
 # systemd unit.
@@ -62,6 +61,7 @@ DESKTOP_DISPLAY=:1
 REMOTE_STATE_DIR=/root/.local/state/cmux/remote
 BOUND_INSTANCE_FILE=/etc/cmux/daemon-instance-id
 BAKE_INSTANCE_FILE=/etc/cmux/bake-instance-id
+BOUND_BOOT_FILE=/etc/cmux/daemon-boot-id
 METADATA=http://169.254.169.254
 
 instance_id() {
@@ -86,25 +86,25 @@ start_desktop() {
   desktop_pid=$!
 }
 
-# New host keys are generated into a staging dir on the same filesystem and
-# moved over the old ones only once all of them exist, so a failed generation
-# leaves the previous keys in place (logged to the unit's journal) and sshd is
-# never left without a key. sshd loads keys at start, so it is restarted last.
 rekey_ssh_host() {
-  command -v ssh-keygen >/dev/null 2>&1 || return 0
-  staging=$(mktemp -d /etc/ssh/.cmux-rekey.XXXXXX) || { echo "cmux-devbox-boot: could not stage new ssh host keys; keeping the existing ones" >&2; return 1; }
-  mkdir -p "$staging/etc/ssh"
-  if ! ssh-keygen -A -f "$staging" >/dev/null 2>&1 || [ -z "$(ls "$staging"/etc/ssh/ssh_host_*_key 2>/dev/null)" ]; then
-    rm -rf "$staging"
-    echo "cmux-devbox-boot: ssh host key generation failed; keeping the existing keys" >&2
-    return 1
+  /usr/local/bin/cmux-devbox-rekey
+}
+
+# A cold boot cannot leave a predecessor process alive to finish its durable
+# authorization shutdown. Use the daemon's own fenced recovery (which takes
+# the auth lease and flushes state), preserving its identity and enrollments.
+# Same-boot restarts and memory-snapshot wakes never acknowledge a predecessor.
+prepare_daemon_boot() {
+  boot_id=$(cat /proc/sys/kernel/random/boot_id) || return 1
+  previous_boot=$(cat "$BOUND_BOOT_FILE" 2>/dev/null) || previous_boot=""
+  if [ -n "$previous_boot" ] && [ "$previous_boot" != "$boot_id" ] &&
+      [ -f "$REMOTE_STATE_DIR/sessions/Y2xvdWQ/runtime.json" ]; then
+    env HOME=/root "$BIN" remote stop --session cloud --acknowledge-failed-finalization || return 1
   fi
-  for key in "$staging"/etc/ssh/ssh_host_*_key; do
-    mv -f "$key.pub" /etc/ssh/ && mv -f "$key" /etc/ssh/
-  done
-  rm -rf "$staging"
-  [ -d /run/systemd/system ] && systemctl try-restart ssh >/dev/null 2>&1
-  return 0
+  if [ "$previous_boot" != "$boot_id" ]; then
+    mkdir -p /etc/cmux && printf '%s\n' "$boot_id" > "$BOUND_BOOT_FILE.tmp" &&
+      mv -f "$BOUND_BOOT_FILE.tmp" "$BOUND_BOOT_FILE" || return 1
+  fi
 }
 
 stop_daemon() {
@@ -127,9 +127,10 @@ while true; do
       if [ -n "$id" ] && [ "$id" != "$(cat "$BOUND_INSTANCE_FILE" 2>/dev/null)" ]; then
         stop_daemon
         rm -rf "$REMOTE_STATE_DIR"
-        ( rekey_ssh_host & )
-        mkdir -p /etc/cmux && printf '%s\n' "$id" > "$BOUND_INSTANCE_FILE"
+        rekey_ssh_host || { sleep 1; continue; }
+        mkdir -p /etc/cmux && printf '%s\n' "$id" > "$BOUND_INSTANCE_FILE" || { sleep 1; continue; }
       fi
+      prepare_daemon_boot || { sleep 1; continue; }
       if [ -z "$daemon_pid" ] || ! kill -0 "$daemon_pid" 2>/dev/null; then
         [ -n "$daemon_pid" ] && wait "$daemon_pid" 2>/dev/null
         # --remote-ws-trusted-carrier: the listener is reachable only inside the

--- a/web/services/vms/images/devbox/cmux-devbox-rekey
+++ b/web/services/vms/images/devbox/cmux-devbox-rekey
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Replace a guest's SSH host keys as one recoverable operation. Both the bake
+# and the clone supervisor execute this file; a failed replacement must never
+# bind a clone to the builder's keys or leave sshd without its previous keys.
+set -eu
+SSH_DIR=/etc/ssh
+staging=$(mktemp -d "$SSH_DIR/.cmux-rekey.XXXXXX")
+replacing=0
+
+rollback() {
+  while IFS= read -r name; do
+    if [ -e "$staging/old/$name" ]; then
+      cp -p "$staging/old/$name" "$SSH_DIR/$name" || return 1
+    else
+      rm -f "$SSH_DIR/$name" || return 1
+    fi
+  done < "$staging/keys"
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [ "$status" -ne 0 ] && [ "$replacing" = 1 ]; then
+    if ! rollback; then
+      echo "cmux-devbox-rekey: rollback failed; original keys retained in $staging/old" >&2
+      exit 1
+    fi
+    if [ -d /run/systemd/system ]; then
+      systemctl try-restart ssh >/dev/null 2>&1 || true
+    fi
+  fi
+  rm -rf "$staging"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+mkdir -p "$staging/etc/ssh" "$staging/old"
+ssh-keygen -A -f "$staging" >/dev/null
+: > "$staging/keys"
+for key in "$staging"/etc/ssh/ssh_host_*_key; do
+  [ -s "$key" ] && [ -s "$key.pub" ]
+  name=$(basename "$key")
+  printf '%s\n%s\n' "$name" "$name.pub" >> "$staging/keys"
+  for file in "$name" "$name.pub"; do
+    if [ -e "$SSH_DIR/$file" ]; then cp -p "$SSH_DIR/$file" "$staging/old/$file"; fi
+  done
+done
+[ -s "$staging/keys" ]
+
+# Every backup exists before the first replacement. A move or sshd restart
+# failure restores the entire set, including public/private key pairing.
+replacing=1
+while IFS= read -r name; do
+  mv -f "$staging/etc/ssh/$name" "$SSH_DIR/$name"
+done < "$staging/keys"
+if [ -d /run/systemd/system ]; then systemctl try-restart ssh; fi

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -3075,7 +3075,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -3105,7 +3105,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -3135,7 +3135,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -3165,7 +3165,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -3194,7 +3194,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -3224,7 +3224,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "2xl",
         "cpu": 32,
@@ -3433,7 +3433,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -3441,7 +3441,7 @@
         "storageMb": 16384,
         "freestyleBase": "freestyle/ubuntu-sm"
       },
-      "defaultForLocalDev": true
+      "defaultForLocalDev": false
     },
     {
       "provider": "freestyle",
@@ -3464,7 +3464,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -3494,7 +3494,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -3524,7 +3524,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -3553,7 +3553,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -3583,6 +3583,365 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
       "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
       "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-sm",
+      "imageId": "sh-02be1d7394564fb7a693645b596ee478",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      },
+      "defaultForLocalDev": true
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-md",
+      "imageId": "sh-8fa821c2f710499e897cc83b8e8afa0b",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-lg",
+      "imageId": "sh-959d822635934e4ba4c7bbd8aa86b9cc",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-lgx",
+      "imageId": "sh-3e3e49d551f24b7f831f4a41a6b2dd2f",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-xl",
+      "imageId": "sh-452bdbc9ec3e412c927a042c1a68050a",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-base-v2-2xl",
+      "imageId": "sh-9649d7e4086845c7a32060298a9b2a71",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:25:48.735Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-02be1d7394564fb7a693645b596ee478, md=sh-8fa821c2f710499e897cc83b8e8afa0b, lg=sh-959d822635934e4ba4c7bbd8aa86b9cc, lgx=sh-3e3e49d551f24b7f831f4a41a6b2dd2f, xl=sh-452bdbc9ec3e412c927a042c1a68050a, 2xl=sh-9649d7e4086845c7a32060298a9b2a71.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-sm",
+      "imageId": "sh-83c92d87356542f2bde9fe3e5a664bf2",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-md",
+      "imageId": "sh-a024bf739e05445a85fc17f8caf85c4c",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-lg",
+      "imageId": "sh-bc1ef322ad2e4d168634d293690885e3",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-lgx",
+      "imageId": "sh-eb2666192f5e4414b63354e1561f1bbb",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-xl",
+      "imageId": "sh-09b797d2ca0642e7a73f2aa6d474c678",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-hostname-12045-desktop-v2-2xl",
+      "imageId": "sh-b588cd3a9c9e4f9bbd19c35eef1cf008",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "408e0142ef0594bcca4151c21026e13543a1e0e3",
+      "builtAt": "2026-09-08T07:26:52.272Z",
+      "builderScriptVersion": "c62877fc2bba5f879b778c3a0ac552cb5b915c1f364e70f70f2b262a9631e8f3",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-08-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-83c92d87356542f2bde9fe3e5a664bf2, md=sh-a024bf739e05445a85fc17f8caf85c4c, lg=sh-bc1ef322ad2e4d168634d293690885e3, lgx=sh-eb2666192f5e4414b63354e1561f1bbb, xl=sh-09b797d2ca0642e7a73f2aa6d474c678, 2xl=sh-b588cd3a9c9e4f9bbd19c35eef1cf008.",
+      "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
+      "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
       "defaultForKind": true,
       "size": {
         "name": "2xl",

--- a/web/tests/vm-devbox-boot.test.ts
+++ b/web/tests/vm-devbox-boot.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { devboxDir } from "../scripts/devbox-image-common";
+
+const boot = readFileSync(path.join(devboxDir, "cmux-devbox-boot"), "utf8");
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function fixture(options: { clone?: boolean; coldBoot?: boolean; failRekey?: boolean; failRecovery?: boolean }) {
+  const root = mkdtempSync(path.join(tmpdir(), "cmux-boot-test-"));
+  const config = path.join(root, "etc/cmux");
+  const auth = path.join(root, "root/.local/state/cmux/remote/sessions/Y2xvdWQ/auth");
+  const bin = path.join(root, "bin");
+  const events = path.join(root, "events");
+  for (const dir of [config, auth, bin, path.join(root, "root/.cmux/bin"), path.join(root, "usr/local/bin")]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(path.join(config, "daemon-instance-id"), options.clone ? "builder\n" : "instance\n");
+  writeFileSync(path.join(config, "bake-instance-id"), "builder\n");
+  writeFileSync(path.join(config, "daemon-boot-id"), options.coldBoot ? "old-boot\n" : "current-boot\n");
+  writeFileSync(path.join(root, "boot-id"), "current-boot\n");
+  writeFileSync(path.join(auth, "identity.json"), "preserved daemon identity\n");
+  writeFileSync(path.join(auth, "../runtime.json"), '{"lifecycle_id":"old-lifecycle"}\n');
+  writeFileSync(events, "");
+  const executable = (file: string, body: string) => writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  executable(path.join(bin, "curl"), 'case "$*" in *latest/api/token*) echo token;; *) echo instance;; esac');
+  executable(path.join(root, "usr/local/bin/cmux-devbox-rekey"), `
+    echo rekey >> "$TEST_ROOT/events"
+    [ ! -e "$TEST_ROOT/fail-rekey" ]
+  `);
+  executable(path.join(root, "root/.cmux/bin/cmux-tui"), `
+    case "$*" in
+      *acknowledge-failed-finalization*)
+        echo recover >> "$TEST_ROOT/events"
+        [ ! -e "$TEST_ROOT/fail-recovery" ] || exit 1
+        rm -f "$TEST_ROOT/root/.local/state/cmux/remote/sessions/Y2xvdWQ/runtime.json"
+        ;;
+      *"server start"*)
+        echo start >> "$TEST_ROOT/events"
+        exec /bin/sleep 30
+        ;;
+    esac
+  `);
+  if (options.failRekey) writeFileSync(path.join(root, "fail-rekey"), "");
+  if (options.failRecovery) writeFileSync(path.join(root, "fail-recovery"), "");
+  const redirected = boot
+    .replaceAll("/root", `${root}/root`)
+    .replaceAll("/etc/cmux", config)
+    .replaceAll("/usr/local/bin", `${root}/usr/local/bin`)
+    .replaceAll("/proc/sys/kernel/random/boot_id", `${root}/boot-id`);
+  let child: ChildProcess | undefined;
+  return {
+    root,
+    config,
+    auth,
+    events: () => readFileSync(events, "utf8").trim().split("\n").filter(Boolean),
+    start: () => {
+      child = spawn("sh", ["-c", redirected], {
+        detached: true,
+        stdio: "ignore",
+        env: { PATH: `${bin}:${process.env.PATH}`, TEST_ROOT: root },
+      });
+    },
+    close: async () => {
+      if (child?.pid) {
+        try { process.kill(-child.pid, "SIGKILL"); } catch { /* The owned process already exited. */ }
+        await new Promise<void>((resolve) => {
+          if (child?.exitCode !== null || child?.signalCode !== null) resolve();
+          else child.once("exit", () => resolve());
+        });
+      }
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function waitUntil(predicate: () => boolean) {
+  const deadline = Date.now() + 4000;
+  while (!predicate() && Date.now() < deadline) await delay(20);
+  expect(predicate()).toBe(true);
+}
+
+describe("devbox supervisor identity lifecycle", () => {
+  test("a clone retries failed rekeying before binding its id or starting the daemon", async () => {
+    const f = fixture({ clone: true, failRekey: true });
+    try {
+      f.start();
+      await waitUntil(() => f.events().filter((event) => event === "rekey").length >= 2);
+      expect(f.events()).not.toContain("start");
+      expect(readFileSync(path.join(f.config, "daemon-instance-id"), "utf8")).toBe("builder\n");
+      rmSync(path.join(f.root, "fail-rekey"));
+      await waitUntil(() => f.events().includes("start"));
+      expect(readFileSync(path.join(f.config, "daemon-instance-id"), "utf8")).toBe("instance\n");
+    } finally { await f.close(); }
+  });
+
+  test("same-instance supervisor restart keeps keys and daemon identity", async () => {
+    const f = fixture({});
+    try {
+      f.start();
+      await waitUntil(() => f.events().includes("start"));
+      expect(f.events()).toEqual(["start"]);
+      expect(readFileSync(path.join(f.auth, "identity.json"), "utf8")).toBe("preserved daemon identity\n");
+    } finally { await f.close(); }
+  });
+
+  test("a cold boot finalizes the previous daemon before starting, without rekeying", async () => {
+    const f = fixture({ coldBoot: true });
+    try {
+      f.start();
+      await waitUntil(() => f.events().includes("start"));
+      expect(f.events()).toEqual(["recover", "start"]);
+      expect(readFileSync(path.join(f.config, "daemon-boot-id"), "utf8")).toBe("current-boot\n");
+      expect(readFileSync(path.join(f.auth, "identity.json"), "utf8")).toBe("preserved daemon identity\n");
+    } finally { await f.close(); }
+  });
+
+  test("failed cold-boot recovery preserves the prior boot marker and retries", async () => {
+    const f = fixture({ coldBoot: true, failRecovery: true });
+    try {
+      f.start();
+      await waitUntil(() => f.events().filter((event) => event === "recover").length >= 2);
+      expect(f.events()).not.toContain("start");
+      expect(readFileSync(path.join(f.config, "daemon-boot-id"), "utf8")).toBe("old-boot\n");
+      expect(existsSync(path.join(f.auth, "../runtime.json"))).toBe(true);
+      rmSync(path.join(f.root, "fail-recovery"));
+      await waitUntil(() => f.events().includes("start"));
+    } finally { await f.close(); }
+  });
+});

--- a/web/tests/vm-devbox-boot.test.ts
+++ b/web/tests/vm-devbox-boot.test.ts
@@ -60,7 +60,7 @@ function fixture(options: { clone?: boolean; coldBoot?: boolean; failRekey?: boo
       child = spawn("sh", ["-c", redirected], {
         detached: true,
         stdio: "ignore",
-        env: { PATH: `${bin}:${process.env.PATH}`, TEST_ROOT: root },
+        env: { NODE_ENV: "test", PATH: `${bin}:${process.env.PATH}`, TEST_ROOT: root },
       });
     },
     close: async () => {

--- a/web/tests/vm-devbox-identity.test.ts
+++ b/web/tests/vm-devbox-identity.test.ts
@@ -9,7 +9,6 @@ import {
   devboxIdentityCheckCommand,
   devboxIdentityInstallCommand,
   devboxProviderResidueCommand,
-  devboxSshHostKeyRegenerateCommand,
 } from "../scripts/devbox-image-common";
 import { DEVBOX_HOSTNAME, DEVBOX_HOSTNAME_LOOPBACK, DEVBOX_PROVIDER_HOSTNAME } from "../services/vms/images/identity";
 
@@ -139,27 +138,6 @@ describe("devbox identity contract (services/vms/images/identity.ts)", () => {
     expect(derive).toContain("assertIdentity(`${name}: derived snapshot ${imageId}`, measured);");
   });
 
-  test("the boot supervisor gives every clone its own SSH host keys, off the daemon's start path", () => {
-    expect(devboxBoot).toContain("rekey_ssh_host() {");
-    // Staged: the new keys exist before the old ones are replaced, a failed
-    // generation keeps the previous keys and says so, sshd restarts last.
-    expect(devboxBoot).toContain('ssh-keygen -A -f "$staging"');
-    expect(devboxBoot).toContain('mv -f "$key.pub" /etc/ssh/ && mv -f "$key" /etc/ssh/');
-    expect(devboxBoot).toContain("ssh host key generation failed; keeping the existing keys");
-    expect(devboxBoot).not.toContain("rm -f /etc/ssh/ssh_host_*_key");
-    expect(devboxBoot).toContain("systemctl try-restart ssh");
-    const regenerate = devboxSshHostKeyRegenerateCommand();
-    expect(regenerate).toContain('ssh-keygen -A -f "$staging"');
-    expect(regenerate).toContain('mv -f "$key.pub" /etc/ssh/ && mv -f "$key" /etc/ssh/');
-    expect(regenerate).not.toContain("rm -f /etc/ssh/ssh_host_*_key");
-    // Detached: a subshell backgrounds the job and exits, so the loop never
-    // waits on it, the daemon starts in the same tick, and no zombie is left.
-    expect(devboxBoot).toContain("( rekey_ssh_host & )");
-    const wipe = devboxBoot.indexOf('rm -rf "$REMOTE_STATE_DIR"');
-    const rekey = devboxBoot.indexOf("( rekey_ssh_host & )");
-    const bound = devboxBoot.indexOf(`printf '%s\\n' "$id" > "$BOUND_INSTANCE_FILE"`);
-    expect(wipe).toBeGreaterThan(-1);
-    expect(rekey).toBeGreaterThan(wipe);
-    expect(bound).toBeGreaterThan(rekey);
-  });
+  // Rekey failure/rollback and clone readiness are exercised by the shell
+  // harnesses in vm-devbox-rekey.test.ts and vm-devbox-boot.test.ts.
 });

--- a/web/tests/vm-devbox-identity.test.ts
+++ b/web/tests/vm-devbox-identity.test.ts
@@ -9,6 +9,7 @@ import {
   devboxIdentityCheckCommand,
   devboxIdentityInstallCommand,
   devboxProviderResidueCommand,
+  devboxSshHostKeyRegenerateCommand,
 } from "../scripts/devbox-image-common";
 import { DEVBOX_HOSTNAME, DEVBOX_HOSTNAME_LOOPBACK, DEVBOX_PROVIDER_HOSTNAME } from "../services/vms/images/identity";
 

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -91,6 +91,7 @@ describe("devbox image template", () => {
       "chrome-managed-policy.json",
       "cmux-bashrc",
       "cmux-devbox-boot",
+      "cmux-devbox-rekey",
       "cmux-motd",
       "cmux-terminfo.sh",
       "cmux-terminfo.src",

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -76,6 +76,7 @@ describe("devbox image template", () => {
       "chrome-managed-policy.json",
       "cmux-bashrc",
       "cmux-devbox-boot",
+      "cmux-devbox-rekey",
       "cmux-motd",
       "cmux-terminfo.sh",
       "cmux-terminfo.src",

--- a/web/tests/vm-devbox-rekey.test.ts
+++ b/web/tests/vm-devbox-rekey.test.ts
@@ -58,7 +58,7 @@ function runRekey(owner: "bake" | "supervisor", failure: string) {
     const result = spawnSync("sh", ["-c", command], {
       encoding: "utf8",
       timeout: 5000,
-      env: { PATH: `${bin}:${process.env.PATH}`, FAILURE: failure, TEST_ROOT: root },
+      env: { NODE_ENV: "test", PATH: `${bin}:${process.env.PATH}`, FAILURE: failure, TEST_ROOT: root },
     });
     return {
       status: result.status,
@@ -70,16 +70,20 @@ function runRekey(owner: "bake" | "supervisor", failure: string) {
   }
 }
 
-describe.each(["bake", "supervisor"] as const)("%s SSH host-key replacement", (owner) => {
-  test("installs every generated key on success", () => {
-    const result = runRekey(owner, "none");
-    expect(result).toMatchObject({ status: 0, stderr: "" });
-    expect(result.keys).toEqual(keyNames.map((name) => `new ${name}\n`));
-  });
+for (const owner of ["bake", "supervisor"] as const) {
+  describe(`${owner} SSH host-key replacement`, () => {
+    test("installs every generated key on success", () => {
+      const result = runRekey(owner, "none");
+      expect(result).toMatchObject({ status: 0, stderr: "" });
+      expect(result.keys).toEqual(keyNames.map((name) => `new ${name}\n`));
+    });
 
-  test.each(["generate", "replace", "restart"])("reports %s failure and preserves the complete original key set", (failure) => {
-    const result = runRekey(owner, failure);
-    expect(result.status).not.toBe(0);
-    expect(result.keys).toEqual(keyNames.map((name) => `old ${name}\n`));
+    for (const failure of ["generate", "replace", "restart"]) {
+      test(`reports ${failure} failure and preserves the complete original key set`, () => {
+        const result = runRekey(owner, failure);
+        expect(result.status).not.toBe(0);
+        expect(result.keys).toEqual(keyNames.map((name) => `old ${name}\n`));
+      });
+    }
   });
-});
+}

--- a/web/tests/vm-devbox-rekey.test.ts
+++ b/web/tests/vm-devbox-rekey.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { devboxDir, devboxSshHostKeyRegenerateCommand } from "../scripts/devbox-image-common";
+
+const keyNames = ["ssh_host_ed25519_key", "ssh_host_ed25519_key.pub", "ssh_host_rsa_key", "ssh_host_rsa_key.pub"];
+const supervisor = readFileSync(path.join(devboxDir, "cmux-devbox-boot"), "utf8");
+const supervisorFunctions = supervisor.slice(0, supervisor.indexOf("\nwhile true; do"));
+
+function rekeyCommand(owner: "bake" | "supervisor"): string {
+  return owner === "bake" ? devboxSshHostKeyRegenerateCommand() : `${supervisorFunctions}\nrekey_ssh_host`;
+}
+
+function runRekey(owner: "bake" | "supervisor", failure: string) {
+  const root = mkdtempSync(path.join(tmpdir(), "cmux-rekey-test-"));
+  const ssh = path.join(root, "etc/ssh");
+  const systemd = path.join(root, "run/systemd/system");
+  const bin = path.join(root, "bin");
+  const realMv = spawnSync("which", ["mv"], { encoding: "utf8" }).stdout.trim();
+  try {
+    for (const dir of [ssh, systemd, bin]) mkdirSync(dir, { recursive: true });
+    for (const name of keyNames) writeFileSync(path.join(ssh, name), `old ${name}\n`);
+    const executable = (name: string, body: string) => writeFileSync(path.join(bin, name), `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+    executable("ssh-keygen", `
+      [ "$FAILURE" != generate ] || exit 1
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = -f ]; then shift; staging=$1; fi
+        shift
+      done
+      for name in ssh_host_ed25519_key ssh_host_rsa_key; do
+        printf 'new %s\\n' "$name" > "$staging/etc/ssh/$name"
+        printf 'new %s.pub\\n' "$name" > "$staging/etc/ssh/$name.pub"
+      done
+    `);
+    executable("sshd", "exit 0");
+    executable("systemctl", `
+      printf '%s\\n' "$*" >> "$TEST_ROOT/restarts"
+      [ "$FAILURE" != restart ]
+    `);
+    executable("mv", `
+      if [ "$FAILURE" = replace ]; then
+        for arg do
+          case "$arg" in */.cmux-rekey.*/etc/ssh/ssh_host_rsa_key) exit 1;; esac
+        done
+      fi
+      exec '${realMv}' "$@"
+    `);
+    // Run the real shell logic against disposable filesystem paths and
+    // fault-injected commands; no root access or host sshd changes are needed.
+    const command = rekeyCommand(owner)
+      .replace(/(\$staging"?)?\/etc\/ssh/g, (match, staging) => staging ? match : ssh)
+      .replaceAll("/run/systemd/system", systemd);
+    const result = spawnSync("sh", ["-c", command], {
+      encoding: "utf8",
+      timeout: 5000,
+      env: { PATH: `${bin}:${process.env.PATH}`, FAILURE: failure, TEST_ROOT: root },
+    });
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      keys: keyNames.map((name) => readFileSync(path.join(ssh, name), "utf8")),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe.each(["bake", "supervisor"] as const)("%s SSH host-key replacement", (owner) => {
+  test("installs every generated key on success", () => {
+    const result = runRekey(owner, "none");
+    expect(result).toMatchObject({ status: 0, stderr: "" });
+    expect(result.keys).toEqual(keyNames.map((name) => `new ${name}\n`));
+  });
+
+  test.each(["generate", "replace", "restart"])("reports %s failure and preserves the complete original key set", (failure) => {
+    const result = runRekey(owner, failure);
+    expect(result.status).not.toBe(0);
+    expect(result.keys).toEqual(keyNames.map((name) => `old ${name}\n`));
+  });
+});

--- a/web/tests/vm-devbox-rekey.test.ts
+++ b/web/tests/vm-devbox-rekey.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { devboxDir, devboxSshHostKeyRegenerateCommand } from "../scripts/devbox-image-common";
@@ -49,9 +49,12 @@ function runRekey(owner: "bake" | "supervisor", failure: string) {
     `);
     // Run the real shell logic against disposable filesystem paths and
     // fault-injected commands; no root access or host sshd changes are needed.
-    const command = rekeyCommand(owner)
+    const redirect = (source: string) => source
       .replace(/(\$staging"?)?\/etc\/ssh/g, (match, staging) => staging ? match : ssh)
       .replaceAll("/run/systemd/system", systemd);
+    const helperPath = path.join(devboxDir, "cmux-devbox-rekey");
+    if (existsSync(helperPath)) executable("cmux-devbox-rekey", redirect(readFileSync(helperPath, "utf8")));
+    const command = redirect(rekeyCommand(owner)).replaceAll("/usr/local/bin/cmux-devbox-rekey", path.join(bin, "cmux-devbox-rekey"));
     const result = spawnSync("sh", ["-c", command], {
       encoding: "utf8",
       timeout: 5000,


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/12045 leftover: #12094 merged the bake/identity code without publishing snapshots, so production still served September 4 `freestyle-vm` images. Also covers the clone rekey and cold-boot daemon recovery found while verifying that work (#12095).

## What was wrong

A disposable production VM selected `sh-3a917ad675fb4e458a3e55b02c612f27`. Kernel/static hostname, `/etc/hosts`, journal, and real root/ubuntu PTY prompts all reported `freestyle-vm`. Pause/wake preserved that identity. A cold boot reproduced #12095 on the published daemon.

Failed SSH host-key replacement could leave mixed key pairs, and the clone supervisor could report success after replacement or sshd restart failure. Clone rekeying ran in a background subshell, so a machine could bind its instance id and start the daemon while still presenting the builder's keys.

## What changed

- Bake and clone share `cmux-devbox-rekey`: generate into staging, replace the full set, roll back on generation/replacement/sshd-restart failure.
- `cmux-devbox-boot` retries rekeying until it succeeds before binding the instance id or starting the daemon.
- Cold boots run `cmux-tui remote stop --acknowledge-failed-finalization` when stale cloud session runtime exists, then update `/etc/cmux/daemon-boot-id`. Same-boot supervisor restarts skip that path.
- Account-correct epoch `2026-09-08-r1` ladders are now the manifest defaults (baked cmux-tui `71eb616d6f`):

  Desktop: sm `sh-83c92d87356542f2bde9fe3e5a664bf2`, md `sh-a024bf739e05445a85fc17f8caf85c4c`, lg `sh-bc1ef322ad2e4d168634d293690885e3`, lgx `sh-eb2666192f5e4414b63354e1561f1bbb`, xl `sh-09b797d2ca0642e7a73f2aa6d474c678`, 2xl `sh-b588cd3a9c9e4f9bbd19c35eef1cf008`

  Base: sm `sh-02be1d7394564fb7a693645b596ee478`, md `sh-8fa821c2f710499e897cc83b8e8afa0b`, lg `sh-959d822635934e4ba4c7bbd8aa86b9cc`, lgx `sh-3e3e49d551f24b7f831f4a41a6b2dd2f`, xl `sh-452bdbc9ec3e412c927a042c1a68050a`, 2xl `sh-9649d7e4086845c7a32060298a9b2a71`

Merging this PR is what flips production/staging onto those snapshots after deploy. Existing machines keep their current image until recreate.

## Validation

- `bun test tests/vm-devbox-rekey.test.ts tests/vm-devbox-boot.test.ts tests/vm-devbox-identity.test.ts tests/vm-devbox-image.test.ts tests/vm-image-manifest.test.ts` — 49 pass
- `bun run typecheck` and `bun run devbox:manifest:check` — 12 validated Freestyle defaults
- Verifier: identity-cmux-ok, distinct SSH host keys across clones, desktop contract on 5901/6901
- Derive: every size re-booted with `host cmux` (desktop units `active,active`)
- Live probe of the new desktop md snapshot `sh-a024bf739e05445a85fc17f8caf85c4c`: `HOSTNAME=cmux`, `127.0.1.1 cmux`, `root@cmux` / `ubuntu@cmux` prompts, journal host `cmux`, host-key comment `root@cmux`. After guest poweroff and wake, boot id changed, hostname stayed `cmux`, and the daemon came back running.

Related: #12045, #12094, #12095. Merge and production deploy still need explicit approval.

Preview: https://cmux166-git-issue-12045-snapshot-hostname-rollout-manaflow.vercel.app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes clone SSH identity and cold-boot daemon startup for every new Freestyle VM via manifest defaults; failures are mitigated by rollback rekey logic and manifest rollback, but misbehavior would affect attach/SSH until reverted.
> 
> **Overview**
> Finishes the **cmux hostname** rollout by promoting validated **`freestyle-cmux-hostname-12045-*-v2`** defaults (epoch **`2026-09-08-r1`**) and baking the boot/rekey behavior those snapshots depend on.
> 
> **SSH host keys:** Inline rekey shell is replaced by a shared **`cmux-devbox-rekey`** helper (image COPY + Freestyle bake `put`). It stages new keys, backs up the full set, and **rolls back** on generation, move, or **sshd** restart failure. **`cmux-devbox-boot`** now runs rekey **synchronously** and **retries** until success before binding the instance id or starting the daemon—replacing the old background rekey that could report success with a broken key set.
> 
> **Cold boots:** **`prepare_daemon_boot`** compares kernel **`boot_id`** to **`/etc/cmux/daemon-boot-id`**; on a real reboot with stale cloud runtime it runs **`cmux-tui remote stop --acknowledge-failed-finalization`** before starting the daemon, with retry on failure.
> 
> Docs, **`CMUX_IMAGE_EPOCH`**, manifest demotion of prior defaults, and **`vm-devbox-rekey`** / **`vm-devbox-boot`** harness tests accompany the image template changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ec9b0757f2f17be97df292d185d3e23628ce8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Devbox clones now receive unique SSH host keys through a recoverable rekeying process.
  * Cold boots automatically recover unfinished cloud sessions before starting the daemon.
  * Clone initialization retries key rekeying, identity binding, and startup steps until successful.
  * Updated default VM images are available across supported sizes.

* **Bug Fixes**
  * Failed SSH key generation, replacement, or service restart now preserves existing keys and supports rollback.

* **Tests**
  * Added coverage for rekeying, clone startup retries, identity preservation, and cold-boot recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->