### PR TITLE
analytics: attribute paid checkouts to the surface, client and channel that opened them

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5862,7 +5862,8 @@ struct CMUXCLI {
                     if let expiresAtMs {
                         let expiresAt = Date(timeIntervalSince1970: TimeInterval(expiresAtMs) / 1000)
                         let remaining = expiresAt.timeIntervalSinceNow
-                        let upgradeURL = "https://cmux.com/pricing"
+                        // Attribution only: the pricing page forwards it to checkout.
+                        let upgradeURL = "https://cmux.com/pricing?cmux_source=cli_free_access_expiry&cmux_client=cli"
                         // "6d 23h" / "5h 12m" / "1m": whole units, truncated, never overstated.
                         func countdown(_ remaining: TimeInterval) -> String {
                             let total = max(Int(remaining), 60)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -135281,13 +135281,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Upgrade to cmux Pro at https://cmux.com/pricing to create Cloud VMs."
+            "value": "Upgrade to cmux Pro at https://cmux.com/pricing?cmux_source=mac_vm_requires_pro_error&cmux_client=mac to create Cloud VMs."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cloud VM を作成するには https://cmux.com/pricing で cmux Pro にアップグレードしてください。"
+            "value": "Cloud VM を作成するには https://cmux.com/pricing?cmux_source=mac_vm_requires_pro_error&cmux_client=mac で cmux Pro にアップグレードしてください。"
           }
         }
       }

--- a/Sources/App/CmuxHelpCommands.swift
+++ b/Sources/App/CmuxHelpCommands.swift
@@ -25,7 +25,7 @@ extension cmuxApp {
             helpResourceButton(.discord)
             if CmuxFeatureFlags.shared.isProUpgradeUIEnabled {
                 Button(String(localized: "menu.help.upgradeToPro", defaultValue: "Upgrade to cmux Pro…")) {
-                    ProUpgradePresenter.present()
+                    ProUpgradePresenter.present(source: .helpMenu)
                 }
                 #if DEBUG
                 Button(String(localized: "menu.help.previewNativePricing", defaultValue: "Preview Native Pro Pricing…")) {

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -203,12 +203,12 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         }
     }
 
-    func openProUpgrade() {
-        ProUpgradePresenter.present()
+    func openProUpgrade(source: ProUpgradeSource) {
+        ProUpgradePresenter.present(source: source)
     }
 
-    func prefetchProUpgrade() {
-        ProUpgradePresenter.prefetch()
+    func prefetchProUpgrade(source: ProUpgradeSource) {
+        ProUpgradePresenter.prefetch(source: source)
     }
 
     func openBillingPortal() {

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -203,6 +203,16 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         }
     }
 
+    // `AccountFlow` (CmuxSettingsUI) cannot see `ProUpgradeSource`; its
+    // parameterless calls come from the Settings account card.
+    func openProUpgrade() {
+        openProUpgrade(source: .settingsAccountCard)
+    }
+
+    func prefetchProUpgrade() {
+        prefetchProUpgrade(source: .settingsAccountCard)
+    }
+
     func openProUpgrade(source: ProUpgradeSource) {
         ProUpgradePresenter.present(source: source)
     }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -331,7 +331,7 @@ struct MachinesPanelView: View {
         .multilineTextAlignment(.center)
         .padding(.horizontal, 24)
         Button {
-            ProUpgradePresenter.present()
+            ProUpgradePresenter.present(source: .machinesPanelRequiresPro)
         } label: {
             Text(String(localized: "machines.requiresPro.upgrade", defaultValue: "Upgrade to Pro"))
                 .cmuxFont(size: 12)
@@ -497,7 +497,7 @@ struct MachinesPanelView: View {
                     // The upgrade nudge under the create button: same Pro flow
                     // as the meter's at-limit hint and the ＋ at the ceiling.
                     Button {
-                        ProUpgradePresenter.present()
+                        ProUpgradePresenter.present(source: .machinesPanelUpgradeNudge)
                     } label: {
                         Text(upgradeNudgeLabel(plan))
                             .cmuxFont(size: 11)
@@ -623,7 +623,7 @@ private struct MachinesFreeAccessBanner: View {
 
     var body: some View {
         Button {
-            ProUpgradePresenter.present()
+            ProUpgradePresenter.present(source: .machinesPanelTrialBanner)
         } label: {
             HStack(spacing: 5) {
                 Image(systemName: isExpired ? "lock.fill" : "clock")
@@ -753,7 +753,7 @@ struct MachineRowActions {
                 }
             },
             promptUpgrade: {
-                ProUpgradePresenter.present()
+                ProUpgradePresenter.present(source: .machinesPanelMachineAction)
             }
         )
     }

--- a/Sources/Cloud/NewMachineSheetPresenter.swift
+++ b/Sources/Cloud/NewMachineSheetPresenter.swift
@@ -71,7 +71,7 @@ final class NewMachineSheetPresenter {
     ) {
         let coordinator = coordinator ?? .shared
         if let plan, plan.isAtLimit, !plan.isPaidPlan {
-            ProUpgradePresenter.present()
+            ProUpgradePresenter.present(source: .newMachineAtLimit)
             return
         }
         let model = NewMachineModel(

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -178,7 +178,7 @@ private func defaultCloudVMAction(status: Int, errorCode: String) -> String {
     case "vm_requires_pro":
         return String(
             localized: "cloudVM.error.requiresPro.action",
-            defaultValue: "Upgrade to cmux Pro at https://cmux.com/pricing to create Cloud VMs."
+            defaultValue: "Upgrade to cmux Pro at https://cmux.com/pricing?cmux_source=mac_vm_requires_pro_error&cmux_client=mac to create Cloud VMs."
         )
     case "vm_create_credits_insufficient":
         return "Ask a team admin to upgrade the plan or grant more Cloud VM create credits, then retry."

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -167,7 +167,7 @@ private func defaultCloudVMMessage(status: Int) -> String {
     }
 }
 
-private func defaultCloudVMAction(status: Int, errorCode: String) -> String {
+func defaultCloudVMAction(status: Int, errorCode: String) -> String {
     switch errorCode {
     case "vm_active_limit_exceeded":
         return "Run `cmux vm ls`, then stop or delete an active VM with `cmux vm rm <id>` before retrying."

--- a/Sources/ContentView+ProCommandPalette.swift
+++ b/Sources/ContentView+ProCommandPalette.swift
@@ -42,7 +42,7 @@ extension ContentView {
 #if DEBUG
             cmuxDebugLog("palette.pro.upgrade.invoke")
 #endif
-            ProUpgradePresenter.present()
+            ProUpgradePresenter.present(source: .commandPalette)
         }
         registry.register(commandId: Self.commandPaletteProWelcomeChecklistCommandId) {
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15594,7 +15594,7 @@ private struct SidebarHelpMenuButton: View {
     private func perform(_ action: SidebarHelpMenuAction) {
         switch action {
         case .upgrade:
-            ProUpgradePresenter.present()
+            ProUpgradePresenter.present(source: .sidebarHelpMenu)
         case .importBrowserData:
             isPopoverPresented = false
             DispatchQueue.main.async {

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -414,7 +414,7 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     func openCloudMachinesBilling() {
-        ProUpgradePresenter.present()
+        ProUpgradePresenter.present(source: .settingsCloudMachines)
     }
 
     func mobilePhonePushSettings() -> MobilePhonePushSettingsSnapshot {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -293,8 +293,13 @@ final class PostHogAnalytics: @unchecked Sendable {
         }
     }
 
-    nonisolated private static func versionProperties(infoDictionary: [String: Any]) -> [String: Any] {
-        var properties: [String: Any] = [:]
+    nonisolated private static func versionProperties(
+        infoDictionary: [String: Any],
+        flavor: BuildFlavor = BuildFlavor.current
+    ) -> [String: Any] {
+        // `channel` answers "stable, NIGHTLY or DEV?" for every Mac event; the
+        // web side carries the same value on checkout as `checkout_channel`.
+        var properties: [String: Any] = ["channel": flavor.rawValue]
         if let value = infoDictionary["CFBundleShortVersionString"] as? String, !value.isEmpty {
             properties["app_version"] = value
         }

--- a/Sources/PricingPlansScreen.swift
+++ b/Sources/PricingPlansScreen.swift
@@ -35,6 +35,9 @@ enum ProUpgradeSource: String, CaseIterable, Sendable {
     case newMachineAtLimit = "mac_new_machine_at_limit"
     /// DEBUG native pricing window.
     case nativePricingPreview = "mac_native_pricing_preview"
+    /// Link inside the `vm_requires_pro` error text (`VMClient`); the token
+    /// is spelled out in the localized string, so the test pins it here.
+    case vmRequiresProError = "mac_vm_requires_pro_error"
 }
 
 /// Checkout attribution query parameters: the upgrade source plus the app's

--- a/Sources/PricingPlansScreen.swift
+++ b/Sources/PricingPlansScreen.swift
@@ -3,25 +3,118 @@ import Bonsplit
 import Foundation
 import SwiftUI
 
+/// Which in-app surface opened the upgrade flow. The raw value travels to the
+/// web as `cmux_source`, is stored on the Stripe Checkout Session, and comes
+/// back on every PostHog billing event, so a paid subscription can be traced to
+/// the button that started it. Raw values are lowercase `[a-z0-9_]` tokens;
+/// the server drops anything else.
+enum ProUpgradeSource: String, CaseIterable, Sendable {
+    /// "Upgrade" capsule in the sidebar footer.
+    case sidebarBadge = "mac_sidebar_badge"
+    /// "Upgrade to cmux Pro…" in the sidebar footer account menu.
+    case sidebarAccountMenu = "mac_sidebar_account_menu"
+    /// "Upgrade to cmux Pro…" in the sidebar help (?) menu.
+    case sidebarHelpMenu = "mac_sidebar_help_menu"
+    /// Help > "Upgrade to cmux Pro…" in the main menu bar.
+    case helpMenu = "mac_help_menu"
+    /// Command palette "Upgrade to cmux Pro".
+    case commandPalette = "mac_command_palette"
+    /// Settings > Cloud machines billing.
+    case settingsCloudMachines = "mac_settings_cloud_machines"
+    /// Machines panel empty state: plan does not include Cloud machines.
+    case machinesPanelRequiresPro = "mac_machines_panel_requires_pro"
+    /// Machines panel nudge under the create button.
+    case machinesPanelUpgradeNudge = "mac_machines_panel_upgrade_nudge"
+    /// Machines panel free-access countdown / expired banner.
+    case machinesPanelTrialBanner = "mac_machines_panel_trial_banner"
+    /// Machines panel row action that needs a paid plan.
+    case machinesPanelMachineAction = "mac_machines_panel_machine_action"
+    /// New machine sheet refused because the free plan is at its limit.
+    case newMachineAtLimit = "mac_new_machine_at_limit"
+    /// DEBUG native pricing window.
+    case nativePricingPreview = "mac_native_pricing_preview"
+}
+
+/// Checkout attribution query parameters: the upgrade source plus the app's
+/// client, release channel, version and build. Mirrors
+/// `web/services/analytics/checkoutAttribution.ts`.
+enum CheckoutAttribution {
+    static let sourceParam = "cmux_source"
+    static let clientParam = "cmux_client"
+    static let channelParam = "cmux_channel"
+    static let appVersionParam = "cmux_app_version"
+    static let appBuildParam = "cmux_app_build"
+    static let paramNames: [String] = [sourceParam, clientParam, channelParam, appVersionParam, appBuildParam]
+
+    nonisolated static func queryItems(
+        source: ProUpgradeSource,
+        flavor: BuildFlavor = BuildFlavor.current,
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:]
+    ) -> [URLQueryItem] {
+        var items = [
+            URLQueryItem(name: sourceParam, value: source.rawValue),
+            URLQueryItem(name: clientParam, value: "mac"),
+            URLQueryItem(name: channelParam, value: flavor.rawValue),
+        ]
+        if let version = infoDictionary["CFBundleShortVersionString"] as? String, !version.isEmpty {
+            items.append(URLQueryItem(name: appVersionParam, value: version))
+        }
+        if let build = infoDictionary["CFBundleVersion"] as? String, !build.isEmpty {
+            items.append(URLQueryItem(name: appBuildParam, value: build))
+        }
+        return items
+    }
+
+    /// Replace any attribution already on `url` with this source's.
+    nonisolated static func applying(
+        to url: URL,
+        source: ProUpgradeSource,
+        flavor: BuildFlavor = BuildFlavor.current,
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:]
+    ) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var queryItems = components.queryItems ?? []
+        queryItems.removeAll { paramNames.contains($0.name) }
+        queryItems.append(contentsOf: self.queryItems(source: source, flavor: flavor, infoDictionary: infoDictionary))
+        components.queryItems = queryItems
+        return components.url ?? url
+    }
+
+    /// PostHog properties for the Mac-side intent event, so the funnel has a
+    /// client-side count of upgrade clicks per surface and channel even before
+    /// the web page loads.
+    nonisolated static func intentProperties(
+        source: ProUpgradeSource,
+        flavor: BuildFlavor = BuildFlavor.current
+    ) -> [String: Any] {
+        ["source": source.rawValue, "client": "mac", "channel": flavor.rawValue]
+    }
+}
+
 /// Shared entrypoint for every "Upgrade to cmux Pro" surface (sidebar badge,
 /// titlebar badge, Settings Account card, command palette, Help menu). Opens
 /// the app-specific pricing page in a dedicated browser workspace in the
 /// current window, falling back through the older in-window browser paths if
-/// workspace creation is unavailable.
+/// workspace creation is unavailable. Every caller names its
+/// ``ProUpgradeSource`` so the resulting checkout is attributable.
 enum ProUpgradePresenter {
+    static let intentEvent = "cmux_upgrade_entrypoint_opened"
+
     @MainActor
     private static var workspaceReuseState = ProUpgradeWorkspaceReuseState()
 
     @MainActor
-    static func present() {
-        presentAppPricingWeb()
+    static func present(source: ProUpgradeSource) {
+        PostHogAnalytics.shared.capture(intentEvent, properties: CheckoutAttribution.intentProperties(source: source))
+        presentAppPricingWeb(source: source)
     }
 
     /// Hover hook for upgrade entrypoints: loads the pricing page into a
-    /// hidden webview so a subsequent ``present()`` adopts it and opens
-    /// instantly. Safe to call repeatedly; a live matching entry is a no-op.
+    /// hidden webview so a subsequent ``present(source:)`` with the same source
+    /// adopts it and opens instantly. Safe to call repeatedly; a live matching
+    /// entry is a no-op.
     @MainActor
-    static func prefetch() {
+    static func prefetch(source: ProUpgradeSource) {
         guard BrowserAvailabilitySettings.isEnabled() else { return }
         // When an upgrade workspace already exists, present() refocuses it and
         // navigates its existing panel, so a prewarmed webview would go unused.
@@ -31,14 +124,14 @@ enum ProUpgradePresenter {
             return
         }
         BrowserPrewarmedWebViewPool.shared.prewarm(
-            url: appPricingURLForCurrentAppearance(),
+            url: appPricingURLForCurrentAppearance(source: source),
             profileID: BrowserPanel.resolvedProfileID(requested: nil)
         )
     }
 
     @MainActor
-    static func presentAppPricingWeb() {
-        let url = appPricingURLForCurrentAppearance()
+    static func presentAppPricingWeb(source: ProUpgradeSource) {
+        let url = appPricingURLForCurrentAppearance(source: source)
         guard BrowserAvailabilitySettings.isEnabled() else {
             NSWorkspace.shared.open(url)
             return
@@ -55,8 +148,9 @@ enum ProUpgradePresenter {
     }
 
     @MainActor
-    static func presentCheckout() {
-        NSWorkspace.shared.open(AuthEnvironment.billingCheckoutURL)
+    static func presentCheckout(source: ProUpgradeSource) {
+        PostHogAnalytics.shared.capture(intentEvent, properties: CheckoutAttribution.intentProperties(source: source))
+        NSWorkspace.shared.open(CheckoutAttribution.applying(to: AuthEnvironment.billingCheckoutURL, source: source))
     }
 
     @MainActor
@@ -114,8 +208,8 @@ enum ProUpgradePresenter {
     }
 
     @MainActor
-    private static func appPricingURLForCurrentAppearance() -> URL {
-        decoratedAppWebURL(AuthEnvironment.appPricingURL)
+    static func appPricingURLForCurrentAppearance(source: ProUpgradeSource) -> URL {
+        CheckoutAttribution.applying(to: decoratedAppWebURL(AuthEnvironment.appPricingURL), source: source)
     }
 }
 
@@ -413,7 +507,7 @@ private struct NativePricingPlansView: View {
                 period: String(localized: "pricing.native.period.month", defaultValue: "/month"),
                 isCurrent: snapshot.isPro,
                 actionTitle: proActionTitle,
-                action: snapshot.isPro ? nil : { ProUpgradePresenter.presentCheckout() },
+                action: snapshot.isPro ? nil : { ProUpgradePresenter.presentCheckout(source: .nativePricingPreview) },
                 isProminent: true,
                 features: [
                     String(localized: "pricing.native.pro.feature.vms", defaultValue: "Cloud agents on isolated Cloud VMs"),

--- a/Sources/PricingPlansScreen.swift
+++ b/Sources/PricingPlansScreen.swift
@@ -19,6 +19,8 @@ enum ProUpgradeSource: String, CaseIterable, Sendable {
     case helpMenu = "mac_help_menu"
     /// Command palette "Upgrade to cmux Pro".
     case commandPalette = "mac_command_palette"
+    /// Settings > Account card "Upgrade" (via `AccountFlow`).
+    case settingsAccountCard = "mac_settings_account_card"
     /// Settings > Cloud machines billing.
     case settingsCloudMachines = "mac_settings_cloud_machines"
     /// Machines panel empty state: plan does not include Cloud machines.

--- a/Sources/ProBadgeStyle.swift
+++ b/Sources/ProBadgeStyle.swift
@@ -262,7 +262,7 @@ struct ProBadgeView: View {
             let foreground = ProBadgePalette.foreground(for: style)
             HStack(spacing: 0) {
                 Button {
-                    ProUpgradePresenter.present()
+                    ProUpgradePresenter.present(source: .sidebarBadge)
                 } label: {
                     ProBadgeContent(style: style)
                         .contentShape(Rectangle())
@@ -302,7 +302,7 @@ struct ProBadgeView: View {
                     isHovered = hovering
                 }
                 if hovering {
-                    ProUpgradePresenter.prefetch()
+                    ProUpgradePresenter.prefetch(source: .sidebarBadge)
                 }
             }
         }

--- a/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
+++ b/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
@@ -373,7 +373,7 @@ private struct SidebarAccountPopover: View {
                 }
                 Button {
                     dismiss()
-                    accountFlow?.openProUpgrade()
+                    accountFlow?.openProUpgrade(source: .sidebarAccountMenu)
                 } label: {
                     Label(
                         String(localized: "menu.help.upgradeToPro", defaultValue: "Upgrade to cmux Pro…"),

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -736,6 +736,13 @@ struct CheckoutAttributionTests {
     }
 
     @Test
+    func vmRequiresProErrorTextLinksWithATypedSource() {
+        let text = defaultCloudVMAction(status: 402, errorCode: "vm_requires_pro")
+        #expect(text.contains("cmux_source=\(ProUpgradeSource.vmRequiresProError.rawValue)"))
+        #expect(text.contains("cmux_client=mac"))
+    }
+
+    @Test
     func intentPropertiesNameSurfaceAndChannel() {
         let properties = CheckoutAttribution.intentProperties(source: .helpMenu, flavor: .stable)
         #expect(properties["source"] as? String == "mac_help_menu")

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -689,3 +689,57 @@ private func isLocalePathSegment(_ segment: String) -> Bool {
         (2...4).contains(subtag.count) && subtag.allSatisfy(\.isLetter)
     }
 }
+
+@Suite("Checkout attribution")
+struct CheckoutAttributionTests {
+    @Test
+    func queryItemsCarrySourceClientChannelAndVersion() throws {
+        let items = CheckoutAttribution.queryItems(
+            source: .sidebarBadge,
+            flavor: .nightly,
+            infoDictionary: ["CFBundleShortVersionString": "0.65.1", "CFBundleVersion": "2026090101"]
+        )
+        let values = Dictionary(uniqueKeysWithValues: items.compactMap { item in item.value.map { (item.name, $0) } })
+
+        #expect(values["cmux_source"] == "mac_sidebar_badge")
+        #expect(values["cmux_client"] == "mac")
+        #expect(values["cmux_channel"] == "nightly")
+        #expect(values["cmux_app_version"] == "0.65.1")
+        #expect(values["cmux_app_build"] == "2026090101")
+    }
+
+    @Test
+    func applyingReplacesStaleAttributionAndKeepsOtherQuery() throws {
+        let base = try #require(URL(string: "https://cmux.com/app-pricing?cmux_app=1&cmux_source=mac_help_menu&cmux_channel=stable"))
+        let url = CheckoutAttribution.applying(
+            to: base,
+            source: .commandPalette,
+            flavor: .dev,
+            infoDictionary: [:]
+        )
+        let items = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+
+        #expect(items.filter { $0.name == "cmux_source" }.map(\.value) == ["mac_command_palette"])
+        #expect(items.filter { $0.name == "cmux_channel" }.map(\.value) == ["dev"])
+        #expect(items.contains { $0.name == "cmux_app" && $0.value == "1" })
+        #expect(!items.contains { $0.name == "cmux_app_version" })
+    }
+
+    @Test
+    func everySourceIsAServerSafeToken() {
+        for source in ProUpgradeSource.allCases {
+            let token = source.rawValue
+            #expect(token.hasPrefix("mac_"), "\(token)")
+            #expect(token.count <= 64, "\(token)")
+            #expect(token.unicodeScalars.allSatisfy { ("a"..."z").contains($0) || ("0"..."9").contains($0) || $0 == "_" }, "\(token)")
+        }
+    }
+
+    @Test
+    func intentPropertiesNameSurfaceAndChannel() {
+        let properties = CheckoutAttribution.intentProperties(source: .helpMenu, flavor: .stable)
+        #expect(properties["source"] as? String == "mac_help_menu")
+        #expect(properties["client"] as? String == "mac")
+        #expect(properties["channel"] as? String == "stable")
+    }
+}

--- a/docs/posthog/billing-attribution.md
+++ b/docs/posthog/billing-attribution.md
@@ -15,7 +15,7 @@ Query parameters accepted by `/api/billing/checkout`, `/app-pricing` and `/prici
 | `cmux_app_version`, `cmux_app_build` | `CFBundleShortVersionString`, `CFBundleVersion` | Mac |
 | `utm_source` `utm_medium` `utm_campaign` `utm_content` `utm_term` | free text, max 100 | campaigns |
 
-The `Referer` header adds `checkout_referrer_host` and `checkout_referrer_path` for links that carry no `cmux_source`.
+The `Referer` header adds `checkout_referrer_host` and `checkout_referrer_path` on every checkout, tagged or not; for untagged links it is the only origin signal.
 
 Sources today:
 

--- a/docs/posthog/billing-attribution.md
+++ b/docs/posthog/billing-attribution.md
@@ -29,6 +29,7 @@ Sources today:
 | `mac_sidebar_help_menu` | sidebar help (?) menu item |
 | `mac_help_menu` | Help menu bar item |
 | `mac_command_palette` | command palette |
+| `mac_settings_account_card` | Settings > Account card |
 | `mac_settings_cloud_machines` | Settings > Cloud machines billing |
 | `mac_machines_panel_requires_pro` | machines panel empty state |
 | `mac_machines_panel_upgrade_nudge` | nudge under the create button |

--- a/docs/posthog/billing-attribution.md
+++ b/docs/posthog/billing-attribution.md
@@ -1,0 +1,75 @@
+# Billing attribution (PostHog)
+
+Answers "how did this paying customer get to Stripe?": which page or app button, from which client (Mac, web, CLI) and release channel (stable, NIGHTLY, DEV), with which campaign tags. Every checkout entrypoint tags its link, the checkout route stores the tags on the Stripe Checkout Session and Subscription, and the webhook copies them onto every PostHog billing event. Attribution never changes what is sold; malformed values normalize to `unknown` / `web` rather than failing checkout.
+
+## Link contract
+
+Query parameters accepted by `/api/billing/checkout`, `/app-pricing` and `/pricing` (both pages forward them to their checkout links):
+
+| parameter | values | set by |
+| --- | --- | --- |
+| `cmux_source` | `[a-z0-9_.:-]` token, max 64 | the surface that shows the link (table below) |
+| `cmux_placement` | same shape | the button inside the surface (`pricing_page`, `pricing_compare_header`, `app_pricing`, `dashboard_billing`) |
+| `cmux_client` | `web` `mac` `ios` `tui` `cli` | the app that opened the link; default `web` |
+| `cmux_channel` | `stable` `nightly` `dev` `rc` `staging` | Mac `BuildFlavor`; web has none |
+| `cmux_app_version`, `cmux_app_build` | `CFBundleShortVersionString`, `CFBundleVersion` | Mac |
+| `utm_source` `utm_medium` `utm_campaign` `utm_content` `utm_term` | free text, max 100 | campaigns |
+
+The `Referer` header adds `checkout_referrer_host` and `checkout_referrer_path` for links that carry no `cmux_source`.
+
+Sources today:
+
+| `cmux_source` | where |
+| --- | --- |
+| `pricing_page` | cmux.com/pricing (default; an inbound `cmux_source` on the page URL wins) |
+| `app_pricing` | `/app-pricing` opened by an app build that predates the Mac tags |
+| `dashboard_billing` | dashboard billing page |
+| `mac_sidebar_badge` | sidebar footer "Upgrade" capsule |
+| `mac_sidebar_account_menu` | sidebar account menu item |
+| `mac_sidebar_help_menu` | sidebar help (?) menu item |
+| `mac_help_menu` | Help menu bar item |
+| `mac_command_palette` | command palette |
+| `mac_settings_cloud_machines` | Settings > Cloud machines billing |
+| `mac_machines_panel_requires_pro` | machines panel empty state |
+| `mac_machines_panel_upgrade_nudge` | nudge under the create button |
+| `mac_machines_panel_trial_banner` | free-access countdown / expired banner |
+| `mac_machines_panel_machine_action` | row action that needs a paid plan |
+| `mac_new_machine_at_limit` | new machine sheet at the free limit |
+| `mac_native_pricing_preview` | DEBUG native pricing window |
+| `mac_vm_requires_pro_error` | link inside the `vm_requires_pro` error text |
+| `cli_free_access_expiry` | link printed by the CLI free-access notice |
+| `unknown` | link with no tag (old builds, hand-typed URL) |
+
+The Mac enum is `ProUpgradeSource` in `Sources/PricingPlansScreen.swift`; `ProUpgradePresenter.present(source:)` is the only way to open the upgrade flow, so a new surface must name itself.
+
+## Events
+
+All billing events use the Stack user id as `distinct_id` (teams: `stack-team:<id>` plus the `stack_team` group). Every event below carries `checkout_source`, `checkout_placement`, `checkout_client`, `checkout_channel`, `checkout_app_version`, `checkout_app_build`, `checkout_referrer_host`, `checkout_referrer_path`, `utm_*`.
+
+| event | when | extra properties |
+| --- | --- | --- |
+| `cmux_billing_checkout_started` | checkout route created a Stripe session | `plan`, `billing_interval`, `signed_in` (false = anonymous Stack user minted for a signed-out visitor), `existing_stripe_customer` (lapsed or canceled before), `stripe_checkout_session_id` |
+| `cmux_billing_checkout_completed` | `checkout.session.completed` / `async_payment_succeeded` | `amount_total`, `amount_discount`, `promotion_applied`, `payment_method_types`, `customer_country`, `checkout_duration_seconds` (Stripe form time), `$set.billing_plan`, `$set_once.first_paid_checkout_*` |
+| `cmux_billing_checkout_expired` | `checkout.session.expired` (buyer never paid, ~24h) | `plan`, `billing_interval`, `amount_total` |
+| `cmux_billing_subscription_created/updated/deleted` | subscription webhooks; attribution read from subscription metadata | `subscription_status`, `cancel_at_period_end`, `cancellation_reason`, `cancellation_feedback` |
+| `cmux_billing_invoice_paid`, `cmux_billing_invoice_payment_failed`, `cmux_billing_charge_refunded` | unchanged | |
+| `cmux_upgrade_entrypoint_opened` | Mac client, on every upgrade click, anonymous PostHog id | `source`, `client`, `channel`, `app_version`, `app_build` |
+
+Person properties written on the first paid checkout and never overwritten: `first_paid_checkout_at`, `first_paid_checkout_source`, `first_paid_checkout_placement`, `first_paid_checkout_client`, `first_paid_checkout_channel`, `first_paid_checkout_app_version`, `first_paid_checkout_utm_source`, `first_paid_checkout_utm_campaign`.
+
+Mac events also carry `channel` (`stable`, `nightly`, `dev`) next to `app_version` and `app_build`.
+
+`checkout.session.expired` must be enabled on the production Stripe webhook endpoint (`https://cmux.com/api/stripe/webhook`); the route ignores unknown event types, so enabling it early is safe.
+
+## Questions this answers
+
+- Paid conversions by surface: `cmux_billing_checkout_completed` broken down by `checkout_source`.
+- Pricing page vs in-app Upgrade button: `checkout_client = web` vs `mac`, then `checkout_source`.
+- Stable vs NIGHTLY buyers: `checkout_channel` on completed events; `first_paid_checkout_channel` on persons.
+- Conversion rate per surface: started vs completed vs expired, grouped by `checkout_source`.
+- Which CTA on the pricing page converts: `checkout_placement`.
+- Signed-in vs signed-out starts and whether lapsed customers come back: `signed_in`, `existing_stripe_customer` on started events.
+- Promo usage, payment method, country, form time: the completed event's extra properties.
+- Churn feedback by acquisition surface: `cmux_billing_subscription_deleted` keeps the original `checkout_source` from subscription metadata.
+
+Dashboard: cmuxterm-hq `scripts/posthog-billing-dashboard.py` ("Billing attribution").

--- a/web/app/[locale]/dashboard/billing/page.tsx
+++ b/web/app/[locale]/dashboard/billing/page.tsx
@@ -2,9 +2,11 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
+import { CHECKOUT_SOURCE_DASHBOARD_BILLING } from "@/services/analytics/checkoutAttribution";
 import {
   PRO_CHECKOUT_URL,
   TEAM_CHECKOUT_URL,
+  withCheckoutSource,
   withCheckoutInterval,
 } from "@/app/lib/billing";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
@@ -300,13 +302,15 @@ function FreePlanUpsell({
     },
   });
   const teamFeatures = pricingT.raw("team.features") as string[];
+  const proCheckoutURL = withCheckoutSource(PRO_CHECKOUT_URL, CHECKOUT_SOURCE_DASHBOARD_BILLING);
+  const teamCheckoutURL = withCheckoutSource(TEAM_CHECKOUT_URL, CHECKOUT_SOURCE_DASHBOARD_BILLING);
   const proCheckoutHrefs = {
-    month: withCheckoutInterval(PRO_CHECKOUT_URL, "month"),
-    year: withCheckoutInterval(PRO_CHECKOUT_URL, "year"),
+    month: withCheckoutInterval(proCheckoutURL, "month"),
+    year: withCheckoutInterval(proCheckoutURL, "year"),
   };
   const teamCheckoutHrefs = {
-    month: withCheckoutInterval(TEAM_CHECKOUT_URL, "month"),
-    year: withCheckoutInterval(TEAM_CHECKOUT_URL, "year"),
+    month: withCheckoutInterval(teamCheckoutURL, "month"),
+    year: withCheckoutInterval(teamCheckoutURL, "year"),
   };
 
   return (

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -9,6 +9,12 @@ import {
   TEAM_CHECKOUT_URL,
   withCheckoutInterval,
 } from "../../lib/billing";
+import {
+  CHECKOUT_SOURCE_PARAM,
+  CHECKOUT_SOURCE_PRICING_PAGE,
+  checkoutAttributionParamsFrom,
+  withCheckoutAttribution,
+} from "../../../services/analytics/checkoutAttribution";
 import { DOWNLOAD_CONFIRMATION_HREF } from "../../lib/download";
 import { getStackServerApp, isStackConfigured } from "../../lib/stack";
 import { resolveProPlanStatus } from "../../../services/billing/pro";
@@ -101,13 +107,22 @@ export default async function PricingPage({
   const snapshot = await currentPlanSnapshot();
   const canManageBilling = snapshot.billingManagement === "stripe";
   const interval = proBillingInterval(firstParam(query.interval) ?? "year");
+  // A link into /pricing may name its own origin (the CLI trial notice, a
+  // campaign with utm_* tags); that beats the page default so the checkout
+  // is attributed to the surface that sent the visitor here.
+  const attribution = {
+    [CHECKOUT_SOURCE_PARAM]: CHECKOUT_SOURCE_PRICING_PAGE,
+    ...checkoutAttributionParamsFrom(query),
+  };
+  const proCheckoutURL = withCheckoutAttribution(PRO_CHECKOUT_URL, attribution);
+  const teamCheckoutURL = withCheckoutAttribution(TEAM_CHECKOUT_URL, attribution);
   const proCheckoutHrefs = {
-    month: withCheckoutInterval(PRO_CHECKOUT_URL, "month"),
-    year: withCheckoutInterval(PRO_CHECKOUT_URL, "year"),
+    month: withCheckoutInterval(proCheckoutURL, "month"),
+    year: withCheckoutInterval(proCheckoutURL, "year"),
   };
   const teamCheckoutHrefs = {
-    month: withCheckoutInterval(TEAM_CHECKOUT_URL, "month"),
-    year: withCheckoutInterval(TEAM_CHECKOUT_URL, "year"),
+    month: withCheckoutInterval(teamCheckoutURL, "month"),
+    year: withCheckoutInterval(teamCheckoutURL, "year"),
   };
   const annualComparePrice = t("annualComparePrice", {
     monthly: PRO_PRICING_USD.year.monthlyEquivalent,

--- a/web/app/api/billing/checkout/route.ts
+++ b/web/app/api/billing/checkout/route.ts
@@ -33,6 +33,11 @@ import {
   type BillingInterval,
 } from "../../../../services/billing/plans";
 import { captureBillingCheckoutStarted } from "../../../../services/analytics/stripeBilling";
+import {
+  checkoutAttributionFromRequest,
+  checkoutAttributionMetadata,
+  type CheckoutAttribution,
+} from "../../../../services/analytics/checkoutAttribution";
 
 
 type CheckoutStackServerApp = StackServerApp<true>;
@@ -94,6 +99,12 @@ async function resolveCheckout(request: NextRequest): Promise<NextResponse> {
     interval,
     cmuxScheme: callbackScheme,
   });
+  // Analytics only. Which page or app button opened checkout, and from which
+  // build channel; see services/analytics/checkoutAttribution.ts.
+  const attribution = checkoutAttributionFromRequest({
+    searchParams: request.nextUrl.searchParams,
+    referer: request.headers.get("referer"),
+  });
   if (configuredRelayURL) {
     return NextResponse.redirect(configuredRelayURL);
   }
@@ -120,6 +131,7 @@ async function resolveCheckout(request: NextRequest): Promise<NextResponse> {
       stackServerApp,
       interval,
       callbackScheme,
+      attribution,
     );
   }
   if (plan === "team") {
@@ -128,6 +140,7 @@ async function resolveCheckout(request: NextRequest): Promise<NextResponse> {
       stackServerApp,
       interval,
       callbackScheme,
+      attribution,
     );
   }
   // checkoutPlan only yields "pro" | "team" | null (null handled above); this is
@@ -140,6 +153,7 @@ async function stripeProCheckout(
   stackServerApp: CheckoutStackServerApp,
   interval: BillingInterval,
   callbackScheme: string,
+  attribution: CheckoutAttribution,
 ) {
   try {
     const user =
@@ -177,6 +191,7 @@ async function stripeProCheckout(
       app: "cmux",
       billingInterval: interval,
       nativeCallbackScheme: callbackScheme,
+      ...checkoutAttributionMetadata(attribution),
     };
 
     const session = await stripe().checkout.sessions.create({
@@ -208,6 +223,9 @@ async function stripeProCheckout(
       subject: { scope: "user", stackUserId },
       plan: "pro",
       billingInterval: interval,
+      attribution,
+      signedIn: !user.isAnonymous,
+      existingStripeCustomer: Boolean(stripeBillingStatus.customerId),
     }));
     return NextResponse.redirect(session.url);
   } catch (error) {
@@ -225,6 +243,7 @@ async function stripeTeamCheckout(
   stackServerApp: CheckoutStackServerApp,
   interval: BillingInterval,
   callbackScheme: string,
+  attribution: CheckoutAttribution,
 ) {
   let teamId: string | undefined;
   try {
@@ -259,6 +278,7 @@ async function stripeTeamCheckout(
       app: "cmux",
       billingInterval: interval,
       nativeCallbackScheme: callbackScheme,
+      ...checkoutAttributionMetadata(attribution),
     };
 
     const customerId =
@@ -291,6 +311,9 @@ async function stripeTeamCheckout(
       subject: { scope: "team", stackTeamId: resolvedTeamId },
       plan: "team",
       billingInterval: interval,
+      attribution,
+      signedIn: !user.isAnonymous,
+      existingStripeCustomer: Boolean(stripeBillingStatus.customerId),
     }));
     return NextResponse.redirect(session.url);
   } catch (error) {

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -147,167 +147,193 @@ export function makeStripeWebhookHandler(
   };
 }
 
-async function processStripeEvent(
-  event: Stripe.Event,
-  dependencies: StripeWebhookDependencies,
-): Promise<{
+type StripeEventOutcome = {
   processed?: string;
   skipped?: string;
   analytics?: () => Promise<void>;
-}> {
+};
+
+async function processStripeEvent(
+  event: Stripe.Event,
+  dependencies: StripeWebhookDependencies,
+): Promise<StripeEventOutcome> {
   switch (event.type) {
     case "checkout.session.completed":
-    case "checkout.session.async_payment_succeeded": {
-      const session = event.data.object;
-      // Preserve an explicit foreign marker from the signed event payload.
-      // Stripe's retrieve response is authoritative for expanded fields, but
-      // a test or a delayed provider read must not turn an explicitly foreign
-      // event into a cmux purchase.
-      if (
-        session.metadata?.app &&
-        session.metadata.app !== "cmux" &&
-        session.metadata.founders_edition !== "true"
-      ) {
-        return { skipped: "foreign_checkout" };
-      }
-      const expanded = await dependencies.stripe().checkout.sessions.retrieve(session.id, {
-        expand: ["subscription", "customer"],
-      });
-      const subscription = expandedSubscription(expanded);
-      if (!isCmuxCheckoutSession(expanded, subscription)) {
-        return { skipped: "foreign_checkout" };
-      }
-      if (
-        hasConflictingFounderMetadata(expanded, subscription, [
-          session.metadata,
-        ])
-      ) {
-        return { skipped: "conflicting_checkout_metadata" };
-      }
-      if (!checkoutPaymentSettled(expanded)) {
-        return { skipped: "checkout_payment_pending" };
-      }
-      const isFounderCheckout =
-        session.metadata?.founders_edition === "true" ||
-        expanded.metadata?.founders_edition === "true" ||
-        subscription?.metadata?.founders_edition === "true";
-      const result = isFounderCheckout
-        ? await (dependencies.recordFoundersCheckoutCompletion ?? recordFoundersCheckoutCompletionDefault)({
-            session: expanded,
-            subscription,
-            customer: expandedCustomer(expanded),
-          })
-        : await dependencies.recordCheckoutCompletion({
-            session: expanded,
-            subscription,
-            customer: expandedCustomer(expanded),
-          });
-      if (result && "skipped" in result) return { skipped: result.skipped };
-      // Personal Pro checkouts use the founders-welcome endpoint's canonical
-      // Austin/Lawrence message. Keep the older templated pro@cmux.com sender
-      // only as a fallback for deployments that have not configured the
-      // personal endpoint; when both endpoints are configured this gate avoids
-      // double-sending the customer.
-      // The personal endpoint's Pro message contains the TestFlight signup
-      // link. TestFlight enrollment remains an explicit signed-in user action
-      // in /api/testflight, so this webhook must not auto-enroll the buyer.
-      if (
-        result.scope === "user" &&
-        isPersonalProCheckout(expanded, subscription) &&
-        !(dependencies.isPersonalWelcomeConfigured ?? isPersonalWelcomeConfigured)()
-      ) {
-        await dependencies.sendProSignupWelcome({
-          session: expanded,
-          stackUserId: result.stackUserId,
-        });
-      }
-      const subscriptionStatus = isFounderCheckout
-        ? "active"
-        : subscription?.status ?? "unknown";
-      const subject = analyticsSubject(
-        result,
-        isActiveStripeSubscriptionStatus(subscriptionStatus),
-        subscriptionStatus,
-      );
-      return {
-        processed: event.type,
-        analytics: () => dependencies.captureStripeBillingEvent(event, subject),
-      };
-    }
+    case "checkout.session.async_payment_succeeded":
+      return processCheckoutCompleted(event, event.data.object, dependencies);
+    case "checkout.session.expired":
+      return processExpiredCheckout(event, event.data.object, dependencies);
     case "customer.subscription.created":
     case "customer.subscription.updated":
-    case "customer.subscription.deleted": {
+    case "customer.subscription.deleted":
       // Stripe can deliver events late or out of order. Always reconcile the
       // provider's current object rather than allowing an older event payload
       // to overwrite a newer entitlement state.
-      const subscription = await dependencies.stripe().subscriptions.retrieve(
-        event.data.object.id,
-      );
-      const result = await applySubscriptionEntitlementUpdate(
-        subscription,
-        dependencies,
-      );
-      return "skipped" in result
-        ? { skipped: "subscription_unmapped" }
-        : {
-            processed: event.type,
-            analytics: () => dependencies.captureStripeBillingEvent(
-              event,
-              analyticsSubject(result, result.isActive, subscription.status),
-            ),
-          };
-    }
+      return reconcileSubscriptionEvent(event, event.data.object.id, "subscription_unmapped", dependencies);
     case "invoice.paid":
     case "invoice.payment_failed": {
       const subscriptionId = invoiceSubscriptionId(event.data.object);
       if (!subscriptionId) return { skipped: "invoice_without_subscription" };
-      const subscription = await dependencies.stripe().subscriptions.retrieve(subscriptionId);
-      const result = await applySubscriptionEntitlementUpdate(
-        subscription,
-        dependencies,
-      );
-      return "skipped" in result
-        ? { skipped: "invoice_subscription_unmapped" }
-        : {
-            processed: event.type,
-            analytics: () => dependencies.captureStripeBillingEvent(
-              event,
-              analyticsSubject(result, result.isActive, subscription.status),
-            ),
-          };
+      return reconcileSubscriptionEvent(event, subscriptionId, "invoice_subscription_unmapped", dependencies);
     }
-    case "charge.refunded": {
-      const charge = event.data.object as Stripe.Charge & {
-        invoice?: string | Stripe.Invoice | null;
-      };
-      const invoiceId = stringId(charge.invoice);
-      if (!invoiceId) return { skipped: "refund_without_invoice" };
-      const invoice = await dependencies.stripe().invoices.retrieve(invoiceId);
-      const subscriptionId = invoiceSubscriptionId(invoice);
-      if (!subscriptionId) return { skipped: "refund_without_subscription" };
-      const subscription = await dependencies.stripe().subscriptions.retrieve(
-        subscriptionId,
-      );
-      // Refunds do not inherently revoke a subscription. Re-applying Stripe's
-      // current subscription state preserves that policy while mapping the
-      // event to the correct privacy-safe analytics principal.
-      const result = await applySubscriptionEntitlementUpdate(
-        subscription,
-        dependencies,
-      );
-      return "skipped" in result
-        ? { skipped: "refund_subscription_unmapped" }
-        : {
-            processed: event.type,
-            analytics: () => dependencies.captureStripeBillingEvent(
-              event,
-              analyticsSubject(result, result.isActive, subscription.status),
-            ),
-          };
-    }
+    case "charge.refunded":
+      return processRefund(event, event.data.object, dependencies);
     default:
       return { skipped: "event_type" };
   }
+}
+
+async function processCheckoutCompleted(
+  event: Stripe.Event,
+  session: Stripe.Checkout.Session,
+  dependencies: StripeWebhookDependencies,
+): Promise<StripeEventOutcome> {
+  // Preserve an explicit foreign marker from the signed event payload.
+  // Stripe's retrieve response is authoritative for expanded fields, but
+  // a test or a delayed provider read must not turn an explicitly foreign
+  // event into a cmux purchase.
+  if (
+    session.metadata?.app &&
+    session.metadata.app !== "cmux" &&
+    session.metadata.founders_edition !== "true"
+  ) {
+    return { skipped: "foreign_checkout" };
+  }
+  const expanded = await dependencies.stripe().checkout.sessions.retrieve(session.id, {
+    expand: ["subscription", "customer"],
+  });
+  const subscription = expandedSubscription(expanded);
+  if (!isCmuxCheckoutSession(expanded, subscription)) {
+    return { skipped: "foreign_checkout" };
+  }
+  if (hasConflictingFounderMetadata(expanded, subscription, [session.metadata])) {
+    return { skipped: "conflicting_checkout_metadata" };
+  }
+  if (!checkoutPaymentSettled(expanded)) {
+    return { skipped: "checkout_payment_pending" };
+  }
+  const isFounderCheckout = isFoundersCheckout(session, expanded, subscription);
+  const completion = { session: expanded, subscription, customer: expandedCustomer(expanded) };
+  const result = isFounderCheckout
+    ? await (dependencies.recordFoundersCheckoutCompletion ?? recordFoundersCheckoutCompletionDefault)(completion)
+    : await dependencies.recordCheckoutCompletion(completion);
+  if (result && "skipped" in result) return { skipped: result.skipped };
+  await sendLegacyProWelcomeIfNeeded(result, expanded, subscription, dependencies);
+  const subscriptionStatus = isFounderCheckout
+    ? "active"
+    : subscription?.status ?? "unknown";
+  const subject = analyticsSubject(
+    result,
+    isActiveStripeSubscriptionStatus(subscriptionStatus),
+    subscriptionStatus,
+  );
+  return {
+    processed: event.type,
+    analytics: () => dependencies.captureStripeBillingEvent(event, subject),
+  };
+}
+
+// Personal Pro checkouts use the founders-welcome endpoint's canonical
+// Austin/Lawrence message. Keep the older templated pro@cmux.com sender
+// only as a fallback for deployments that have not configured the
+// personal endpoint; when both endpoints are configured this gate avoids
+// double-sending the customer.
+// The personal endpoint's Pro message contains the TestFlight signup
+// link. TestFlight enrollment remains an explicit signed-in user action
+// in /api/testflight, so this webhook must not auto-enroll the buyer.
+async function sendLegacyProWelcomeIfNeeded(
+  result: { readonly scope: "user"; readonly stackUserId: string } | { readonly scope: "team" },
+  expanded: Stripe.Checkout.Session,
+  subscription: Stripe.Subscription | null,
+  dependencies: StripeWebhookDependencies,
+): Promise<void> {
+  if (
+    result.scope === "user" &&
+    isPersonalProCheckout(expanded, subscription) &&
+    !(dependencies.isPersonalWelcomeConfigured ?? isPersonalWelcomeConfigured)()
+  ) {
+    await dependencies.sendProSignupWelcome({
+      session: expanded,
+      stackUserId: result.stackUserId,
+    });
+  }
+}
+
+async function reconcileSubscriptionEvent(
+  event: Stripe.Event,
+  subscriptionId: string,
+  unmappedSkip: string,
+  dependencies: StripeWebhookDependencies,
+): Promise<StripeEventOutcome> {
+  const subscription = await dependencies.stripe().subscriptions.retrieve(subscriptionId);
+  const result = await applySubscriptionEntitlementUpdate(subscription, dependencies);
+  return "skipped" in result
+    ? { skipped: unmappedSkip }
+    : {
+        processed: event.type,
+        analytics: () => dependencies.captureStripeBillingEvent(
+          event,
+          analyticsSubject(result, result.isActive, subscription.status),
+        ),
+      };
+}
+
+async function processRefund(
+  event: Stripe.Event,
+  charge: Stripe.Charge & { invoice?: string | Stripe.Invoice | null },
+  dependencies: StripeWebhookDependencies,
+): Promise<StripeEventOutcome> {
+  const invoiceId = stringId(charge.invoice);
+  if (!invoiceId) return { skipped: "refund_without_invoice" };
+  const invoice = await dependencies.stripe().invoices.retrieve(invoiceId);
+  const subscriptionId = invoiceSubscriptionId(invoice);
+  if (!subscriptionId) return { skipped: "refund_without_subscription" };
+  // Refunds do not inherently revoke a subscription. Re-applying Stripe's
+  // current subscription state preserves that policy while mapping the
+  // event to the correct privacy-safe analytics principal.
+  return reconcileSubscriptionEvent(event, subscriptionId, "refund_subscription_unmapped", dependencies);
+}
+
+function isFoundersCheckout(
+  session: Stripe.Checkout.Session,
+  expanded: Stripe.Checkout.Session,
+  subscription: Stripe.Subscription | null | undefined,
+): boolean {
+  return (
+    session.metadata?.founders_edition === "true" ||
+    expanded.metadata?.founders_edition === "true" ||
+    subscription?.metadata?.founders_edition === "true"
+  );
+}
+
+// Nothing to fulfil: the buyer never paid. Report the abandoned checkout under
+// the principal that started it so the funnel has a denominator.
+function processExpiredCheckout(
+  event: Stripe.Event,
+  session: Stripe.Checkout.Session,
+  dependencies: StripeWebhookDependencies,
+): { processed?: string; skipped?: string; analytics?: () => Promise<void> } {
+  if (session.metadata?.app !== "cmux") return { skipped: "foreign_checkout" };
+  const subject = expiredCheckoutSubject(session.metadata);
+  if (!subject) return { skipped: "checkout_unmapped" };
+  return {
+    processed: event.type,
+    analytics: () => dependencies.captureStripeBillingEvent(event, subject),
+  };
+}
+
+function expiredCheckoutSubject(
+  metadata: Record<string, string> | null | undefined,
+): StripeBillingAnalyticsSubject | null {
+  const stackTeamId = metadata?.stackTeamId;
+  if (typeof stackTeamId === "string" && stackTeamId.length > 0) {
+    return { scope: "team", stackTeamId, isActive: false, status: "expired" };
+  }
+  const stackUserId = metadata?.stackUserId;
+  if (typeof stackUserId === "string" && stackUserId.length > 0) {
+    return { scope: "user", stackUserId, isActive: false, status: "expired" };
+  }
+  return null;
 }
 
 function analyticsSubject(

--- a/web/app/app-pricing/page.tsx
+++ b/web/app/app-pricing/page.tsx
@@ -15,6 +15,12 @@ import {
   isAppStoreDistributionMode,
   withExternalBrowserIntent,
 } from "../lib/billing";
+import {
+  CHECKOUT_CLIENT_PARAM,
+  CHECKOUT_SOURCE_APP_PRICING,
+  CHECKOUT_SOURCE_PARAM,
+  checkoutAttributionParamsFrom,
+} from "../../services/analytics/checkoutAttribution";
 import { DOWNLOAD_CONFIRMATION_HREF } from "../lib/download";
 import {
   appPricingTheme,
@@ -71,13 +77,21 @@ export default async function AppPricingPage({
   );
   const appStorePaymentGated = isAppStoreDistributionMode(params);
   const interval = proBillingInterval(firstParam(params.interval));
+  // The app that opened this page tags it with the button it came from and
+  // its release channel; forward that to checkout. An app build that predates
+  // the tags still counts as an app-originated checkout.
+  const attribution = {
+    [CHECKOUT_SOURCE_PARAM]: CHECKOUT_SOURCE_APP_PRICING,
+    [CHECKOUT_CLIENT_PARAM]: appStorePaymentGated ? "ios" : "mac",
+    ...checkoutAttributionParamsFrom(params),
+  };
   const proCheckoutHrefs = {
-    month: appPricingCheckoutURL("pro", requestOrigin, cmuxScheme, "month"),
-    year: appPricingCheckoutURL("pro", requestOrigin, cmuxScheme, "year"),
+    month: appPricingCheckoutURL("pro", requestOrigin, cmuxScheme, "month", attribution),
+    year: appPricingCheckoutURL("pro", requestOrigin, cmuxScheme, "year", attribution),
   };
   const teamCheckoutHrefs = {
-    month: appPricingCheckoutURL("team", requestOrigin, cmuxScheme, "month"),
-    year: appPricingCheckoutURL("team", requestOrigin, cmuxScheme, "year"),
+    month: appPricingCheckoutURL("team", requestOrigin, cmuxScheme, "month", attribution),
+    year: appPricingCheckoutURL("team", requestOrigin, cmuxScheme, "year", attribution),
   };
   const signInHref = appPricingSignInHref(cmuxScheme, params);
   const banner = appPricingBanner(params, snapshot, signInHref);

--- a/web/app/components/pricing-interval-selector.tsx
+++ b/web/app/components/pricing-interval-selector.tsx
@@ -18,6 +18,10 @@ import {
   type BillingInterval,
 } from "../../services/billing/plans";
 import { CheckoutButton } from "./checkout-navigation";
+import {
+  CHECKOUT_PLACEMENT_PARAM,
+  withCheckoutAttribution,
+} from "../../services/analytics/checkoutAttribution";
 import type { PricingActionSize } from "./pricing-shared";
 
 type PricingSurface = "public_pricing" | "app_pricing" | "dashboard_billing";
@@ -189,9 +193,15 @@ export function PricingCheckoutButton({
     ? PRO_PRICING_USD[interval]
     : TEAM_PRICING_USD[interval];
 
+  // The button position rides to the server as `cmux_placement`, so the
+  // Stripe session and the paid webhook events know which CTA converted.
+  const href = withCheckoutAttribution(hrefs[interval], {
+    [CHECKOUT_PLACEMENT_PARAM]: location,
+  });
+
   return (
     <CheckoutButton
-      href={hrefs[interval]}
+      href={href}
       size={size}
       analytics={{
         event:

--- a/web/app/lib/billing.ts
+++ b/web/app/lib/billing.ts
@@ -1,5 +1,12 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import {
+  CHECKOUT_SOURCE_PARAM,
+  forwardCheckoutAttribution,
+  withCheckoutAttribution,
+  type CheckoutAttributionParam,
+} from "../../services/analytics/checkoutAttribution";
+
 export const EXTERNAL_BROWSER_PARAM = "cmux_external_browser";
 export const CHECKOUT_EXTERNAL_BROWSER_PARAM = EXTERNAL_BROWSER_PARAM;
 export const CHECKOUT_NATIVE_SCHEME_PARAM = "cmux_scheme";
@@ -24,6 +31,9 @@ export type AppPricingCheckoutRelayParameters = {
   interval: CheckoutInterval | null;
   cmuxScheme: string;
 };
+export type CheckoutAttributionParams = Partial<
+  Record<CheckoutAttributionParam, string | null | undefined>
+>;
 export const PRO_CHECKOUT_PATH = withCheckoutPlan(CHECKOUT_PATH, "pro");
 export const TEAM_CHECKOUT_PATH = withCheckoutPlan(CHECKOUT_PATH, "team");
 export const PRO_CHECKOUT_URL = withExternalBrowserIntent(PRO_CHECKOUT_PATH);
@@ -52,11 +62,17 @@ export function withCheckoutInterval(
   return withSearchParam(href, CHECKOUT_INTERVAL_PARAM, interval);
 }
 
+/** Tag a checkout link with the surface that shows it (`cmux_source`). */
+export function withCheckoutSource(href: string, source: string): string {
+  return withCheckoutAttribution(href, { [CHECKOUT_SOURCE_PARAM]: source });
+}
+
 export function appPricingCheckoutURL(
   plan: CheckoutPlan,
   requestOrigin: string | null,
   cmuxScheme?: string | null,
   interval?: CheckoutInterval,
+  attribution?: CheckoutAttributionParams,
 ): string {
   let href = withExternalBrowserIntent(
     withCheckoutPlan(appPricingCheckoutEntryURL(requestOrigin), plan),
@@ -66,6 +82,7 @@ export function appPricingCheckoutURL(
   }
   if (cmuxScheme) href = withSearchParam(href, CHECKOUT_NATIVE_SCHEME_PARAM, cmuxScheme);
   if (interval) href = withCheckoutInterval(href, interval);
+  if (attribution) href = withCheckoutAttribution(href, attribution);
   return href;
 }
 
@@ -96,6 +113,8 @@ export function appPricingCheckoutRelayURL(
     target.searchParams.set(CHECKOUT_RELAY_EXPIRES_PARAM, assertion.expires);
     target.searchParams.set(CHECKOUT_RELAY_SIGNATURE_PARAM, assertion.signature);
   }
+  // Attribution is analytics only, so it rides along unsigned.
+  forwardCheckoutAttribution(requestURL.searchParams, target);
   return target;
 }
 

--- a/web/oxlint-complexity-baseline.txt
+++ b/web/oxlint-complexity-baseline.txt
@@ -18,7 +18,6 @@ app/api/enterprise/contact/route.ts	59834d0588bbdc79cd51791500241b2d478ccdf71f75
 app/api/freestyle/forward-auth/route.ts	260875e349335e792f8c384a1297e9f43ef0d7f657421e070b32e247d998db18	async function `handleForwardAuthRequest` has a complexity of 24. Maximum allowed is 20.
 app/api/relay/token/route.ts	6ade4cdb012efa149c005e993066a799394f97204b9570d914e1302af530bac9	async function `handleRelayTokenRequest` has a complexity of 27. Maximum allowed is 20.
 app/api/stripe/founders-welcome/route.ts	c0c0ad634aa3a9cd96e424f10f245fa73ca6d19e66486cd3b95898c0e7e7b64e	async function has a complexity of 41. Maximum allowed is 20.
-app/api/stripe/webhook/route.ts	214ba60f30a93ed61420bbc68fa93617b6d695549e763ec3c4154300bf58be7c	async function `processStripeEvent` has a complexity of 39. Maximum allowed is 20.
 app/api/support/contact/route.ts	3ae990ffbae762e5770962a2520b8aa9f2844e682db6b9a0a115ea2382b21d8f	async function has a complexity of 22. Maximum allowed is 20.
 app/api/vm/[id]/attach-endpoint/route.ts	ce87df58f06a519c4054277e1938664ffb3a293929b0b3ada55464e433e20877	async function has a complexity of 21. Maximum allowed is 20.
 app/api/vm/route.ts	ffca5263fa12e33ada44f9018aab9a8b94593dc727c97e350e55066f8cc46d22	async function has a complexity of 68. Maximum allowed is 20.

--- a/web/scripts/stripe/provision-catalog.sh
+++ b/web/scripts/stripe/provision-catalog.sh
@@ -25,6 +25,7 @@ WEBHOOK_DESCRIPTION="cmux billing (webhook-driven entitlements)"
 EVENTS=(
   "checkout.session.completed"
   "checkout.session.async_payment_succeeded"
+  "checkout.session.expired"
   "customer.subscription.created"
   "customer.subscription.updated"
   "customer.subscription.deleted"

--- a/web/services/analytics/checkoutAttribution.ts
+++ b/web/services/analytics/checkoutAttribution.ts
@@ -1,0 +1,303 @@
+// Where a paid checkout came from.
+//
+// Every checkout entrypoint (the /pricing page, the in-app /app-pricing page,
+// the dashboard billing page, every "Upgrade" button in the Mac app) tags its
+// link with the `cmux_*` query parameters below. The checkout route reads
+// them, stores them as Stripe Checkout Session and Subscription metadata, and
+// PostHog receives them on `cmux_billing_checkout_started`, on the webhook
+// events (`cmux_billing_checkout_completed`, `cmux_billing_subscription_*`),
+// and as first-paid person properties. Attribution is analytics only: nothing
+// here changes what gets sold or to whom, so unknown values are normalized,
+// never rejected.
+export const CHECKOUT_SOURCE_PARAM = "cmux_source";
+export const CHECKOUT_PLACEMENT_PARAM = "cmux_placement";
+export const CHECKOUT_CLIENT_PARAM = "cmux_client";
+export const CHECKOUT_CHANNEL_PARAM = "cmux_channel";
+export const CHECKOUT_APP_VERSION_PARAM = "cmux_app_version";
+export const CHECKOUT_APP_BUILD_PARAM = "cmux_app_build";
+
+/** Query parameters an entrypoint may forward unchanged to the checkout URL. */
+export const CHECKOUT_ATTRIBUTION_PARAMS = [
+  CHECKOUT_SOURCE_PARAM,
+  CHECKOUT_PLACEMENT_PARAM,
+  CHECKOUT_CLIENT_PARAM,
+  CHECKOUT_CHANNEL_PARAM,
+  CHECKOUT_APP_VERSION_PARAM,
+  CHECKOUT_APP_BUILD_PARAM,
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+export type CheckoutAttributionParam = (typeof CHECKOUT_ATTRIBUTION_PARAMS)[number];
+
+/** Web surfaces that link to checkout. Mac surfaces use `mac_*` tokens. */
+export const CHECKOUT_SOURCE_PRICING_PAGE = "pricing_page";
+export const CHECKOUT_SOURCE_APP_PRICING = "app_pricing";
+export const CHECKOUT_SOURCE_DASHBOARD_BILLING = "dashboard_billing";
+export const CHECKOUT_SOURCE_UNKNOWN = "unknown";
+
+export const CHECKOUT_CLIENTS = ["web", "mac", "ios", "tui", "cli"] as const;
+export type CheckoutClient = (typeof CHECKOUT_CLIENTS)[number];
+export const CHECKOUT_CHANNELS = ["stable", "nightly", "dev", "rc", "staging"] as const;
+export type CheckoutChannel = (typeof CHECKOUT_CHANNELS)[number];
+
+export type CheckoutAttribution = {
+  /** Entry surface, e.g. `pricing_page`, `mac_sidebar_badge`. */
+  readonly source: string;
+  /** Position inside the surface, e.g. `hero`, `compare`. */
+  readonly placement: string | null;
+  readonly client: CheckoutClient;
+  /** Release channel of the app that opened checkout; `web` clients have none. */
+  readonly channel: CheckoutChannel | null;
+  readonly appVersion: string | null;
+  readonly appBuild: string | null;
+  /** Path of the page that linked here (Referer header), no query string. */
+  readonly referrerPath: string | null;
+  readonly referrerHost: string | null;
+  readonly utmSource: string | null;
+  readonly utmMedium: string | null;
+  readonly utmCampaign: string | null;
+  readonly utmContent: string | null;
+  readonly utmTerm: string | null;
+};
+
+const TOKEN_MAX_LENGTH = 64;
+const VERSION_MAX_LENGTH = 32;
+const UTM_MAX_LENGTH = 100;
+const PATH_MAX_LENGTH = 200;
+
+/** Lowercase `[a-z0-9_.:-]` token; anything else becomes null. */
+export function normalizeAttributionToken(
+  raw: string | null | undefined,
+  maxLength = TOKEN_MAX_LENGTH,
+): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim().toLowerCase();
+  if (value.length === 0 || value.length > maxLength) return null;
+  return /^[a-z0-9][a-z0-9_.:-]*$/.test(value) ? value : null;
+}
+
+function normalizeVersion(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim();
+  if (value.length === 0 || value.length > VERSION_MAX_LENGTH) return null;
+  return /^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(value) ? value : null;
+}
+
+function normalizeUtm(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim().slice(0, UTM_MAX_LENGTH);
+  return value.length > 0 ? value : null;
+}
+
+function normalizeClient(raw: string | null | undefined): CheckoutClient {
+  const token = normalizeAttributionToken(raw);
+  return (CHECKOUT_CLIENTS as readonly string[]).includes(token ?? "")
+    ? (token as CheckoutClient)
+    : "web";
+}
+
+function normalizeChannel(raw: string | null | undefined): CheckoutChannel | null {
+  const token = normalizeAttributionToken(raw);
+  return (CHECKOUT_CHANNELS as readonly string[]).includes(token ?? "")
+    ? (token as CheckoutChannel)
+    : null;
+}
+
+function referrerParts(referer: string | null | undefined): {
+  host: string | null;
+  path: string | null;
+} {
+  if (!referer) return { host: null, path: null };
+  try {
+    const url = new URL(referer);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return { host: null, path: null };
+    return {
+      host: url.hostname.toLowerCase().slice(0, PATH_MAX_LENGTH),
+      path: url.pathname.slice(0, PATH_MAX_LENGTH),
+    };
+  } catch {
+    return { host: null, path: null };
+  }
+}
+
+/**
+ * Read attribution from a checkout request. Missing or malformed values fall
+ * back to `unknown` / `web` so the funnel still counts the checkout.
+ */
+export function checkoutAttributionFromRequest(input: {
+  readonly searchParams: URLSearchParams;
+  readonly referer?: string | null;
+}): CheckoutAttribution {
+  const params = input.searchParams;
+  const referrer = referrerParts(input.referer);
+  return {
+    source: normalizeAttributionToken(params.get(CHECKOUT_SOURCE_PARAM)) ?? CHECKOUT_SOURCE_UNKNOWN,
+    placement: normalizeAttributionToken(params.get(CHECKOUT_PLACEMENT_PARAM)),
+    client: normalizeClient(params.get(CHECKOUT_CLIENT_PARAM)),
+    channel: normalizeChannel(params.get(CHECKOUT_CHANNEL_PARAM)),
+    appVersion: normalizeVersion(params.get(CHECKOUT_APP_VERSION_PARAM)),
+    appBuild: normalizeVersion(params.get(CHECKOUT_APP_BUILD_PARAM)),
+    referrerHost: referrer.host,
+    referrerPath: referrer.path,
+    utmSource: normalizeUtm(params.get("utm_source")),
+    utmMedium: normalizeUtm(params.get("utm_medium")),
+    utmCampaign: normalizeUtm(params.get("utm_campaign")),
+    utmContent: normalizeUtm(params.get("utm_content")),
+    utmTerm: normalizeUtm(params.get("utm_term")),
+  };
+}
+
+// Stripe metadata keys. Stripe shows them in the dashboard on the Checkout
+// Session and the Subscription, and the webhook reads them back so the paid
+// events carry the same attribution as the started event.
+const METADATA_KEYS = {
+  source: "cmuxSource",
+  placement: "cmuxPlacement",
+  client: "cmuxClient",
+  channel: "cmuxChannel",
+  appVersion: "cmuxAppVersion",
+  appBuild: "cmuxAppBuild",
+  referrerHost: "cmuxReferrerHost",
+  referrerPath: "cmuxReferrerPath",
+  utmSource: "utmSource",
+  utmMedium: "utmMedium",
+  utmCampaign: "utmCampaign",
+  utmContent: "utmContent",
+  utmTerm: "utmTerm",
+} as const satisfies Record<keyof CheckoutAttribution, string>;
+
+// PostHog property names shared by every billing event.
+const PROPERTY_KEYS = {
+  source: "checkout_source",
+  placement: "checkout_placement",
+  client: "checkout_client",
+  channel: "checkout_channel",
+  appVersion: "checkout_app_version",
+  appBuild: "checkout_app_build",
+  referrerHost: "checkout_referrer_host",
+  referrerPath: "checkout_referrer_path",
+  utmSource: "utm_source",
+  utmMedium: "utm_medium",
+  utmCampaign: "utm_campaign",
+  utmContent: "utm_content",
+  utmTerm: "utm_term",
+} as const satisfies Record<keyof CheckoutAttribution, string>;
+
+type AttributionKey = keyof CheckoutAttribution;
+const ATTRIBUTION_KEYS = Object.keys(METADATA_KEYS) as readonly AttributionKey[];
+
+/** Stripe metadata (strings only; null fields are omitted). */
+export function checkoutAttributionMetadata(
+  attribution: CheckoutAttribution,
+): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = attribution[key];
+    if (typeof value === "string" && value.length > 0) metadata[METADATA_KEYS[key]] = value;
+  }
+  return metadata;
+}
+
+/**
+ * Attribution as stored on a Stripe object. Sessions created before this
+ * contract existed have no keys and read back as `unknown`/`web`, which keeps
+ * old and new checkouts in the same breakdown.
+ */
+export function checkoutAttributionFromMetadata(
+  metadata: Record<string, string | null | undefined> | null | undefined,
+): CheckoutAttribution {
+  const read = (key: AttributionKey): string | null => {
+    const value = metadata?.[METADATA_KEYS[key]];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  };
+  return {
+    source: normalizeAttributionToken(read("source")) ?? CHECKOUT_SOURCE_UNKNOWN,
+    placement: normalizeAttributionToken(read("placement")),
+    client: normalizeClient(read("client")),
+    channel: normalizeChannel(read("channel")),
+    appVersion: normalizeVersion(read("appVersion")),
+    appBuild: normalizeVersion(read("appBuild")),
+    referrerHost: read("referrerHost"),
+    referrerPath: read("referrerPath"),
+    utmSource: normalizeUtm(read("utmSource")),
+    utmMedium: normalizeUtm(read("utmMedium")),
+    utmCampaign: normalizeUtm(read("utmCampaign")),
+    utmContent: normalizeUtm(read("utmContent")),
+    utmTerm: normalizeUtm(read("utmTerm")),
+  };
+}
+
+/** PostHog event properties. Every key is always present so breakdowns on a
+ * missing value show `null` instead of silently dropping the event. */
+export function checkoutAttributionProperties(
+  attribution: CheckoutAttribution,
+): Record<string, string | null> {
+  const properties: Record<string, string | null> = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    properties[PROPERTY_KEYS[key]] = attribution[key];
+  }
+  return properties;
+}
+
+/**
+ * Person properties written once, on the first paid checkout, so "which
+ * surface converted this customer" survives later portal visits and renewals.
+ */
+export function firstPaidCheckoutPersonProperties(
+  attribution: CheckoutAttribution,
+  paidAt: Date,
+): Record<string, string | null> {
+  return {
+    first_paid_checkout_at: paidAt.toISOString(),
+    first_paid_checkout_source: attribution.source,
+    first_paid_checkout_placement: attribution.placement,
+    first_paid_checkout_client: attribution.client,
+    first_paid_checkout_channel: attribution.channel,
+    first_paid_checkout_app_version: attribution.appVersion,
+    first_paid_checkout_utm_source: attribution.utmSource,
+    first_paid_checkout_utm_campaign: attribution.utmCampaign,
+  };
+}
+
+/** Append attribution to a checkout link. `null` values are skipped. */
+export function withCheckoutAttribution(
+  href: string,
+  attribution: Partial<Record<CheckoutAttributionParam, string | null | undefined>>,
+): string {
+  const [withoutHash, hash] = href.split("#", 2);
+  const [path, query = ""] = withoutHash.split("?", 2);
+  const params = new URLSearchParams(query);
+  for (const name of CHECKOUT_ATTRIBUTION_PARAMS) {
+    const value = attribution[name];
+    if (typeof value !== "string" || value.length === 0) continue;
+    params.set(name, value);
+  }
+  const nextQuery = params.toString();
+  const nextHref = nextQuery ? `${path}?${nextQuery}` : path;
+  return hash === undefined ? nextHref : `${nextHref}#${hash}`;
+}
+
+/** Copy every attribution parameter present on `from` onto `to`. */
+export function forwardCheckoutAttribution(from: URLSearchParams, to: URL): void {
+  for (const name of CHECKOUT_ATTRIBUTION_PARAMS) {
+    const value = from.get(name);
+    if (value) to.searchParams.set(name, value);
+  }
+}
+
+/** Attribution parameters from a page's search params, for link building. */
+export function checkoutAttributionParamsFrom(
+  params: Record<string, string | string[] | undefined>,
+): Partial<Record<CheckoutAttributionParam, string>> {
+  const result: Partial<Record<CheckoutAttributionParam, string>> = {};
+  for (const name of CHECKOUT_ATTRIBUTION_PARAMS) {
+    const raw = params[name];
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value === "string" && value.length > 0) result[name] = value;
+  }
+  return result;
+}

--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -5,6 +5,12 @@ import {
   POSTHOG_HOST,
   POSTHOG_PROJECT_KEY,
 } from "./iosEventPolicy";
+import {
+  checkoutAttributionFromMetadata,
+  checkoutAttributionProperties,
+  firstPaidCheckoutPersonProperties,
+  type CheckoutAttribution,
+} from "./checkoutAttribution";
 
 const CAPTURE_TIMEOUT_MS = 2_000;
 
@@ -49,6 +55,12 @@ export async function captureBillingCheckoutStarted(
     readonly subject: StripeBillingAnalyticsSubject;
     readonly plan: "pro" | "team";
     readonly billingInterval: "month" | "year";
+    /** Where the checkout link was opened from (page, app button, channel). */
+    readonly attribution: CheckoutAttribution;
+    /** False when checkout minted an anonymous Stack user for a signed-out visitor. */
+    readonly signedIn: boolean;
+    /** True when the principal already had a Stripe customer (lapsed or canceled). */
+    readonly existingStripeCustomer: boolean;
   },
   postHogFetch?: typeof fetch,
 ): Promise<void> {
@@ -61,14 +73,48 @@ export async function captureBillingCheckoutStarted(
       billing_scope: input.subject.scope,
       plan: input.plan,
       billing_interval: input.billingInterval,
+      stripe_checkout_session_id: input.sessionId,
+      signed_in: input.signedIn,
+      existing_stripe_customer: input.existingStripeCustomer,
+      ...checkoutAttributionProperties(input.attribution),
     },
   }, postHogFetch);
 }
 
+type MappedBillingEvent = {
+  readonly name: string;
+  readonly properties: Record<string, unknown>;
+};
+
 function mappedBillingEvent(
   event: Stripe.Event,
   subject: StripeBillingAnalyticsSubject,
-): { readonly name: string; readonly properties: Record<string, unknown> } | null {
+): MappedBillingEvent | null {
+  const common = commonBillingProperties(event, subject);
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded":
+      return checkoutCompletedEvent(event.data.object, event.created, subject, common);
+    case "checkout.session.expired":
+      return checkoutExpiredEvent(event.data.object, common);
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted":
+      return subscriptionEvent(event.data.object, subscriptionEventAction(event.type), common);
+    case "invoice.paid":
+    case "invoice.payment_failed":
+      return invoiceEvent(event.data.object, event.type, common);
+    case "charge.refunded":
+      return refundEvent(event.data.object, common);
+    default:
+      return null;
+  }
+}
+
+function commonBillingProperties(
+  event: Stripe.Event,
+  subject: StripeBillingAnalyticsSubject,
+): Record<string, unknown> {
   const common: Record<string, unknown> = {
     source: "stripe_webhook",
     stripe_event_type: event.type,
@@ -76,89 +122,141 @@ function mappedBillingEvent(
     is_active: subject.isActive,
     billing_status: subject.status,
   };
-
   if (subject.scope === "user") {
     common.stack_user_id = subject.stackUserId;
   } else {
     common.stack_team_id = subject.stackTeamId;
     common.$groups = { stack_team: subject.stackTeamId };
   }
+  return common;
+}
 
-  switch (event.type) {
-    case "checkout.session.completed":
-    case "checkout.session.async_payment_succeeded": {
-      const session = event.data.object;
-      const customerId = stringId(session.customer);
-      return {
-        name: "cmux_billing_checkout_completed",
-        properties: {
-          ...common,
-          plan: session.metadata?.plan ?? null,
-          billing_interval: session.metadata?.billingInterval ?? null,
-          amount_total: session.amount_total,
-          currency: session.currency,
-          payment_status: session.payment_status,
-          stripe_checkout_session_id: session.id,
-          stripe_subscription_id: stringId(session.subscription),
-          stripe_customer_id: customerId,
-        },
-      };
-    }
-    case "customer.subscription.created":
-    case "customer.subscription.updated":
-    case "customer.subscription.deleted": {
-      const subscription = event.data.object;
-      const customerId = stringId(subscription.customer);
-      return {
-        name: `cmux_billing_subscription_${subscriptionEventAction(event.type)}`,
-        properties: {
-          ...common,
-          plan: subscription.metadata?.plan ?? null,
-          billing_interval: subscription.metadata?.billingInterval ?? null,
-          subscription_status: subscription.status,
-          cancel_at_period_end: subscription.cancel_at_period_end,
-          stripe_subscription_id: subscription.id,
-          stripe_customer_id: customerId,
-        },
-      };
-    }
-    case "invoice.paid":
-    case "invoice.payment_failed": {
-      const invoice = event.data.object;
-      const customerId = stringId(invoice.customer);
-      return {
-        name: event.type === "invoice.paid"
-          ? "cmux_billing_invoice_paid"
-          : "cmux_billing_invoice_payment_failed",
-        properties: {
-          ...common,
-          amount_due: invoice.amount_due,
-          amount_paid: invoice.amount_paid,
-          currency: invoice.currency,
-          billing_reason: invoice.billing_reason,
-          stripe_invoice_id: invoice.id,
-          stripe_customer_id: customerId,
-        },
-      };
-    }
-    case "charge.refunded": {
-      const charge = event.data.object;
-      return {
-        name: "cmux_billing_charge_refunded",
-        properties: {
-          ...common,
-          amount: charge.amount,
-          amount_refunded: charge.amount_refunded,
-          currency: charge.currency,
-          fully_refunded: charge.refunded,
-          stripe_charge_id: charge.id,
-          stripe_customer_id: stringId(charge.customer),
-        },
-      };
-    }
-    default:
-      return null;
-  }
+function metadataString(
+  metadata: Record<string, string | null | undefined> | null | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function checkoutCompletedEvent(
+  session: Stripe.Checkout.Session,
+  eventCreated: number | undefined,
+  subject: StripeBillingAnalyticsSubject,
+  common: Record<string, unknown>,
+): MappedBillingEvent {
+  const attribution = checkoutAttributionFromMetadata(session.metadata);
+  const paidAt = typeof eventCreated === "number" ? new Date(eventCreated * 1000) : new Date();
+  const plan = metadataString(session.metadata, "plan");
+  const amountDiscount = session.total_details?.amount_discount ?? null;
+  return {
+    name: "cmux_billing_checkout_completed",
+    properties: {
+      ...common,
+      plan,
+      billing_interval: metadataString(session.metadata, "billingInterval"),
+      amount_total: session.amount_total,
+      amount_discount: amountDiscount,
+      promotion_applied: (amountDiscount ?? 0) > 0,
+      currency: session.currency,
+      payment_status: session.payment_status,
+      payment_method_types: session.payment_method_types ?? null,
+      customer_country: session.customer_details?.address?.country ?? null,
+      // Seconds between Stripe creating the session and the payment
+      // settling: how long the Stripe form itself took.
+      checkout_duration_seconds: checkoutDurationSeconds(session.created, eventCreated),
+      stripe_checkout_session_id: session.id,
+      stripe_subscription_id: stringId(session.subscription),
+      stripe_customer_id: stringId(session.customer),
+      ...checkoutAttributionProperties(attribution),
+      $set: { billing_plan: plan, billing_customer_type: subject.scope },
+      $set_once: firstPaidCheckoutPersonProperties(attribution, paidAt),
+    },
+  };
+}
+
+// Stripe expires a Checkout Session ~24h after creation when the buyer never
+// paid. Attribution tells which surface loses people at the form.
+function checkoutExpiredEvent(
+  session: Stripe.Checkout.Session,
+  common: Record<string, unknown>,
+): MappedBillingEvent {
+  const attribution = checkoutAttributionFromMetadata(session.metadata);
+  return {
+    name: "cmux_billing_checkout_expired",
+    properties: {
+      ...common,
+      plan: metadataString(session.metadata, "plan"),
+      billing_interval: metadataString(session.metadata, "billingInterval"),
+      amount_total: session.amount_total,
+      currency: session.currency,
+      stripe_checkout_session_id: session.id,
+      stripe_customer_id: stringId(session.customer),
+      ...checkoutAttributionProperties(attribution),
+    },
+  };
+}
+
+function subscriptionEvent(
+  subscription: Stripe.Subscription,
+  action: "created" | "updated" | "deleted",
+  common: Record<string, unknown>,
+): MappedBillingEvent {
+  const attribution = checkoutAttributionFromMetadata(subscription.metadata);
+  return {
+    name: `cmux_billing_subscription_${action}`,
+    properties: {
+      ...common,
+      plan: metadataString(subscription.metadata, "plan"),
+      billing_interval: metadataString(subscription.metadata, "billingInterval"),
+      subscription_status: subscription.status,
+      cancel_at_period_end: subscription.cancel_at_period_end,
+      cancellation_reason: subscription.cancellation_details?.reason ?? null,
+      cancellation_feedback: subscription.cancellation_details?.feedback ?? null,
+      stripe_subscription_id: subscription.id,
+      stripe_customer_id: stringId(subscription.customer),
+      ...checkoutAttributionProperties(attribution),
+    },
+  };
+}
+
+function invoiceEvent(
+  invoice: Stripe.Invoice,
+  type: "invoice.paid" | "invoice.payment_failed",
+  common: Record<string, unknown>,
+): MappedBillingEvent {
+  return {
+    name: type === "invoice.paid"
+      ? "cmux_billing_invoice_paid"
+      : "cmux_billing_invoice_payment_failed",
+    properties: {
+      ...common,
+      amount_due: invoice.amount_due,
+      amount_paid: invoice.amount_paid,
+      currency: invoice.currency,
+      billing_reason: invoice.billing_reason,
+      stripe_invoice_id: invoice.id,
+      stripe_customer_id: stringId(invoice.customer),
+    },
+  };
+}
+
+function refundEvent(
+  charge: Stripe.Charge,
+  common: Record<string, unknown>,
+): MappedBillingEvent {
+  return {
+    name: "cmux_billing_charge_refunded",
+    properties: {
+      ...common,
+      amount: charge.amount,
+      amount_refunded: charge.amount_refunded,
+      currency: charge.currency,
+      fully_refunded: charge.refunded,
+      stripe_charge_id: charge.id,
+      stripe_customer_id: stringId(charge.customer),
+    },
+  };
 }
 
 function subjectDistinctId(subject: StripeBillingAnalyticsSubject): string | null {
@@ -223,6 +321,15 @@ function subscriptionEventAction(
     | "created"
     | "updated"
     | "deleted";
+}
+
+function checkoutDurationSeconds(
+  sessionCreated: number | null | undefined,
+  eventCreated: number | null | undefined,
+): number | null {
+  if (typeof sessionCreated !== "number" || typeof eventCreated !== "number") return null;
+  const seconds = eventCreated - sessionCreated;
+  return seconds >= 0 ? seconds : null;
 }
 
 function stringId(

--- a/web/tests/app-pricing-page.test.tsx
+++ b/web/tests/app-pricing-page.test.tsx
@@ -114,6 +114,28 @@ describe("app pricing page", () => {
     expect(html).not.toContain("/api/billing/portal");
   });
 
+  test("forwards the Mac app's checkout attribution to every checkout link", async () => {
+    const element = await AppPricingPage({
+      searchParams: Promise.resolve({
+        cmux_app: "1",
+        cmux_scheme: "cmux-dev-test",
+        cmux_source: "mac_help_menu",
+        cmux_client: "mac",
+        cmux_channel: "nightly",
+        cmux_app_version: "0.65.1",
+        cmux_app_build: "2026090101",
+      }),
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain(
+      "http://localhost:9210/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=month&amp;cmux_source=mac_help_menu&amp;cmux_client=mac&amp;cmux_channel=nightly&amp;cmux_app_version=0.65.1&amp;cmux_app_build=2026090101&amp;cmux_placement=app_pricing",
+    );
+    expect(html).toContain(
+      "http://localhost:9210/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=month&amp;cmux_source=mac_help_menu&amp;cmux_client=mac&amp;cmux_channel=nightly&amp;cmux_app_version=0.65.1&amp;cmux_app_build=2026090101&amp;cmux_placement=app_pricing",
+    );
+  });
+
   test("renders signed-out recovery without claiming Free is the current plan", async () => {
     const element = await AppPricingPage({
       searchParams: Promise.resolve({
@@ -172,10 +194,10 @@ describe("app pricing page", () => {
     expect(html).not.toContain("$480/year");
     expect(html).not.toContain("$576/user/year");
     expect(html).toContain(
-      "http://localhost:9210/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=year",
+      "http://localhost:9210/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=year&amp;cmux_source=app_pricing&amp;cmux_client=mac&amp;cmux_placement=app_pricing",
     );
     expect(html).toContain(
-      "http://localhost:9210/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=year",
+      "http://localhost:9210/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_scheme=cmux-dev-test&amp;interval=year&amp;cmux_source=app_pricing&amp;cmux_client=mac&amp;cmux_placement=app_pricing",
     );
     expect(html).toContain('role="radiogroup"');
     expect(html).toContain('<button type="button" role="radio" aria-checked="true"');

--- a/web/tests/billing-checkout-route.test.ts
+++ b/web/tests/billing-checkout-route.test.ts
@@ -487,6 +487,9 @@ describe("billing checkout route", () => {
       subject: { scope: "user", stackUserId: ANONYMOUS_USER_ID },
       plan: "pro",
       billingInterval: "month",
+      attribution: expect.objectContaining({ source: "unknown", client: "web" }),
+      signedIn: false,
+      existingStripeCustomer: false,
     });
   });
 
@@ -556,15 +559,32 @@ describe("billing checkout route", () => {
     userResponses = [signedInUser];
 
     await GET(
-      new NextRequest("https://cmux.test/api/billing/checkout?interval=year"),
+      new NextRequest(
+        "https://cmux.test/api/billing/checkout?interval=year" +
+          "&cmux_source=mac_sidebar_badge&cmux_placement=Hero&cmux_client=mac" +
+          "&cmux_channel=nightly&cmux_app_version=0.65.1&cmux_app_build=2026090101" +
+          "&utm_source=newsletter",
+        { headers: { referer: "https://cmux.test/app-pricing?cmux_app=1" } },
+      ),
     );
 
     expect(resolveProPrice).toHaveBeenCalledWith("year");
+    const attributionMetadata = {
+      cmuxSource: "mac_sidebar_badge",
+      cmuxPlacement: "hero",
+      cmuxClient: "mac",
+      cmuxChannel: "nightly",
+      cmuxAppVersion: "0.65.1",
+      cmuxAppBuild: "2026090101",
+      cmuxReferrerHost: "cmux.test",
+      cmuxReferrerPath: "/app-pricing",
+      utmSource: "newsletter",
+    };
     expect(createdStripeSessions[0]).toMatchObject({
       customer_email: "signed@example.com",
       line_items: [{ price: "price_year", quantity: 1 }],
-      metadata: { billingInterval: "year" },
-      subscription_data: { metadata: { billingInterval: "year" } },
+      metadata: { billingInterval: "year", ...attributionMetadata },
+      subscription_data: { metadata: { billingInterval: "year", ...attributionMetadata } },
       cancel_url: "https://cmux.test/pricing?billing=cancelled&interval=year",
     });
     expect(captureBillingCheckoutStarted).toHaveBeenCalledTimes(1);
@@ -573,6 +593,23 @@ describe("billing checkout route", () => {
       subject: { scope: "user", stackUserId: SIGNED_IN_USER_ID },
       plan: "pro",
       billingInterval: "year",
+      attribution: {
+        source: "mac_sidebar_badge",
+        placement: "hero",
+        client: "mac",
+        channel: "nightly",
+        appVersion: "0.65.1",
+        appBuild: "2026090101",
+        referrerHost: "cmux.test",
+        referrerPath: "/app-pricing",
+        utmSource: "newsletter",
+        utmMedium: null,
+        utmCampaign: null,
+        utmContent: null,
+        utmTerm: null,
+      },
+      signedIn: true,
+      existingStripeCustomer: false,
     });
   });
 
@@ -694,6 +731,9 @@ describe("billing checkout route", () => {
       subject: { scope: "team", stackTeamId: TEAM_ID },
       plan: "team",
       billingInterval: "month",
+      attribution: expect.objectContaining({ source: "unknown", client: "web" }),
+      signedIn: true,
+      existingStripeCustomer: false,
     });
   });
 

--- a/web/tests/billing-links.test.ts
+++ b/web/tests/billing-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  appPricingCheckoutRelayURL,
   appPricingCheckoutURL,
   withCheckoutInterval,
   withCheckoutExternalBrowserIntent,
@@ -61,6 +62,32 @@ describe("billing links", () => {
     ).toBe(
       "http://localhost:9210/api/billing/checkout?plan=team&cmux_external_browser=1&cmux_scheme=cmux-dev-test&interval=year",
     );
+  });
+
+  test("relay forwards attribution unsigned next to the signed plan and scheme", () => {
+    const previous = process.env.CMUX_APP_PRICING_CHECKOUT_URL;
+    process.env.CMUX_APP_PRICING_CHECKOUT_URL = "https://billing.example/checkout";
+    try {
+      const relay = appPricingCheckoutRelayURL(
+        new URL(
+          "http://localhost:9210/api/billing/checkout?plan=pro&interval=year&cmux_app_checkout=1" +
+            "&cmux_source=mac_help_menu&cmux_client=mac&cmux_channel=dev&cmux_app_version=0.65.1",
+        ),
+        { plan: "pro", interval: "year", cmuxScheme: "cmux" },
+      );
+      expect(relay?.origin).toBe("https://billing.example");
+      expect(relay?.searchParams.get("cmux_source")).toBe("mac_help_menu");
+      expect(relay?.searchParams.get("cmux_client")).toBe("mac");
+      expect(relay?.searchParams.get("cmux_channel")).toBe("dev");
+      expect(relay?.searchParams.get("cmux_app_version")).toBe("0.65.1");
+      expect(relay?.searchParams.get("plan")).toBe("pro");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CMUX_APP_PRICING_CHECKOUT_URL;
+      } else {
+        process.env.CMUX_APP_PRICING_CHECKOUT_URL = previous;
+      }
+    }
   });
 
   test("app pricing checkout relays an explicit override through its trusted origin", () => {

--- a/web/tests/checkout-attribution.test.ts
+++ b/web/tests/checkout-attribution.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkoutAttributionFromMetadata,
+  checkoutAttributionFromRequest,
+  checkoutAttributionMetadata,
+  checkoutAttributionProperties,
+  forwardCheckoutAttribution,
+  withCheckoutAttribution,
+} from "../services/analytics/checkoutAttribution";
+
+describe("checkout attribution", () => {
+  test("normalizes request parameters and falls back to unknown/web", () => {
+    const attribution = checkoutAttributionFromRequest({
+      searchParams: new URLSearchParams(
+        "cmux_source=Mac_Sidebar_Badge&cmux_placement=<script>&cmux_client=MAC" +
+          "&cmux_channel=beta&cmux_app_version=0.65.1&cmux_app_build=x y&utm_source=" +
+          "%20Newsletter%20",
+      ),
+      referer: "https://cmux.com/app-pricing?cmux_app=1&secret=1",
+    });
+
+    expect(attribution).toEqual({
+      source: "mac_sidebar_badge",
+      placement: null,
+      client: "mac",
+      channel: null,
+      appVersion: "0.65.1",
+      appBuild: null,
+      referrerHost: "cmux.com",
+      referrerPath: "/app-pricing",
+      utmSource: "Newsletter",
+      utmMedium: null,
+      utmCampaign: null,
+      utmContent: null,
+      utmTerm: null,
+    });
+  });
+
+  test("defaults an untagged request to an unknown web checkout with no referrer", () => {
+    const attribution = checkoutAttributionFromRequest({
+      searchParams: new URLSearchParams("plan=pro"),
+      referer: "javascript:alert(1)",
+    });
+    expect(attribution.source).toBe("unknown");
+    expect(attribution.client).toBe("web");
+    expect(attribution.referrerHost).toBeNull();
+    expect(attribution.referrerPath).toBeNull();
+  });
+
+  test("round-trips through Stripe metadata", () => {
+    const attribution = checkoutAttributionFromRequest({
+      searchParams: new URLSearchParams(
+        "cmux_source=pricing_page&cmux_placement=hero&cmux_client=web&utm_campaign=launch",
+      ),
+      referer: "https://cmux.com/pricing",
+    });
+    const metadata = checkoutAttributionMetadata(attribution);
+    expect(metadata).toEqual({
+      cmuxSource: "pricing_page",
+      cmuxPlacement: "hero",
+      cmuxClient: "web",
+      cmuxReferrerHost: "cmux.com",
+      cmuxReferrerPath: "/pricing",
+      utmCampaign: "launch",
+    });
+    expect(checkoutAttributionFromMetadata(metadata)).toEqual(attribution);
+    expect(Object.keys(checkoutAttributionProperties(attribution))).toEqual([
+      "checkout_source",
+      "checkout_placement",
+      "checkout_client",
+      "checkout_channel",
+      "checkout_app_version",
+      "checkout_app_build",
+      "checkout_referrer_host",
+      "checkout_referrer_path",
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_content",
+      "utm_term",
+    ]);
+  });
+
+  test("reads sessions created before attribution existed as unknown", () => {
+    const attribution = checkoutAttributionFromMetadata({ plan: "pro", app: "cmux" });
+    expect(attribution.source).toBe("unknown");
+    expect(attribution.client).toBe("web");
+    expect(attribution.channel).toBeNull();
+  });
+
+  test("appends attribution to a link and keeps the hash", () => {
+    expect(
+      withCheckoutAttribution("/api/billing/checkout?plan=pro#top", {
+        cmux_source: "dashboard_billing",
+        cmux_placement: null,
+        utm_source: undefined,
+      }),
+    ).toBe("/api/billing/checkout?plan=pro&cmux_source=dashboard_billing#top");
+  });
+
+  test("forwards only attribution parameters onto a relay target", () => {
+    const target = new URL("https://checkout.cmux.test/api/billing/checkout?plan=pro");
+    forwardCheckoutAttribution(
+      new URLSearchParams("cmux_source=mac_help_menu&cmux_channel=nightly&cmux_scheme=cmux&plan=team"),
+      target,
+    );
+    expect(target.searchParams.get("cmux_source")).toBe("mac_help_menu");
+    expect(target.searchParams.get("cmux_channel")).toBe("nightly");
+    expect(target.searchParams.get("plan")).toBe("pro");
+    expect(target.searchParams.has("cmux_scheme")).toBe(false);
+  });
+});

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -102,10 +102,10 @@ describe("dashboard billing page", () => {
       "Upgrade when you need cloud agents.",
     );
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=month"',
+      'href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=dashboard_billing&amp;interval=month&amp;cmux_placement=dashboard_billing"',
     );
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=month"',
+      'href="/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_source=dashboard_billing&amp;interval=month&amp;cmux_placement=dashboard_billing"',
     );
     expect(html).toContain("Get Pro");
     expect(html).toContain("Get Teams");
@@ -133,10 +133,10 @@ describe("dashboard billing page", () => {
     expect(html).not.toContain("$24");
     expect(html).not.toContain("$28");
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=year"',
+      'href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=dashboard_billing&amp;interval=year&amp;cmux_placement=dashboard_billing"',
     );
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=year"',
+      'href="/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_source=dashboard_billing&amp;interval=year&amp;cmux_placement=dashboard_billing"',
     );
   });
 

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -158,16 +158,16 @@ describe("localized pricing page", () => {
     expect(html).not.toContain("/mo.");
     expect(html).toContain("$48/user/mo");
     expect(html).toContain(
-      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=year",
+      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=year&amp;cmux_placement=pricing_page",
     );
     expect(html).toContain(
-      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=year",
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=year&amp;cmux_placement=pricing_page",
     );
     expect(html).toMatch(
-      /href="\/api\/billing\/checkout\?plan=pro[^"]*interval=year"[^>]*class="[^"]*min-h-12 px-5 py-3 text-\[15px\][^"]*"[^>]*><span>Get Pro/,
+      /href="\/api\/billing\/checkout\?plan=pro[^"]*interval=year[^"]*"[^>]*class="[^"]*min-h-12 px-5 py-3 text-\[15px\][^"]*"[^>]*><span>Get Pro/,
     );
     expect(html).toMatch(
-      /href="\/api\/billing\/checkout\?plan=team[^"]*interval=year"[^>]*class="[^"]*min-h-12 px-5 py-3 text-\[15px\][^"]*"[^>]*><span>Get Teams/,
+      /href="\/api\/billing\/checkout\?plan=team[^"]*interval=year[^"]*"[^>]*class="[^"]*min-h-12 px-5 py-3 text-\[15px\][^"]*"[^>]*><span>Get Teams/,
     );
     expect(html).toContain('<p class="mt-5 text-sm font-medium">Includes:</p>');
     expect(html).not.toContain('style="min-height:4rem"');
@@ -232,15 +232,34 @@ describe("localized pricing page", () => {
     expect(html).not.toContain("$24");
     expect(html).not.toContain("$28");
     expect(html).toContain(
-      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=year",
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=year&amp;cmux_placement=pricing_page",
     );
     expect(html).toContain(
-      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=year",
+      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=year&amp;cmux_placement=pricing_page",
     );
     expect(html).toContain('role="radiogroup"');
     expect(html).toContain('<button type="button" role="radio" aria-checked="true"');
     expect(html).not.toContain('href="?interval=');
     expect(html).toContain("mx-auto mt-6 flex w-fit");
+  });
+
+  test("forwards an inbound source and campaign tags to checkout", async () => {
+    const element = await PricingPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({
+        interval: "month",
+        cmux_source: "cli_free_access_expiry",
+        cmux_client: "cli",
+        utm_source: "newsletter",
+        utm_campaign: "sept",
+      }),
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain(
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=cli_free_access_expiry&amp;cmux_client=cli&amp;utm_source=newsletter&amp;utm_campaign=sept&amp;interval=month&amp;cmux_placement=pricing_page",
+    );
+    expect(html).not.toContain("cmux_source=pricing_page");
   });
 
   test("honors an explicit monthly billing interval", async () => {
@@ -258,10 +277,10 @@ describe("localized pricing page", () => {
     expect(html).toContain("Unlimited workspaces");
     expect(html).not.toContain("Unlimited active Cloud VMs");
     expect(html).toContain(
-      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=month",
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=month&amp;cmux_placement=pricing_page",
     );
     expect(html).toContain(
-      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=month",
+      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;cmux_source=pricing_page&amp;interval=month&amp;cmux_placement=pricing_page",
     );
     expect(html).toContain(
       '<button type="button" role="radio" aria-checked="true" tabindex="0" class="bg-foreground px-3 py-1.5 font-medium text-background">Monthly</button>',

--- a/web/tests/pro-cta-link.test.tsx
+++ b/web/tests/pro-cta-link.test.tsx
@@ -30,7 +30,7 @@ describe("Pro pricing CTA", () => {
     );
 
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=pro&amp;interval=month"',
+      'href="/api/billing/checkout?plan=pro&amp;interval=month&amp;cmux_placement=pricing_page"',
     );
     expect(html).not.toContain("interval=year");
     expect(html).not.toContain('href="/download/confirmation?dl=1"');
@@ -51,7 +51,7 @@ describe("Pro pricing CTA", () => {
     );
 
     expect(html).toContain(
-      'href="/api/billing/checkout?plan=pro&amp;interval=year"',
+      'href="/api/billing/checkout?plan=pro&amp;interval=year&amp;cmux_placement=pricing_page"',
     );
     expect(html).not.toContain("interval=month");
   });

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -5,6 +5,14 @@ import {
   captureBillingCheckoutStarted,
   captureStripeBillingEvent,
 } from "../services/analytics/stripeBilling";
+import {
+  checkoutAttributionFromRequest,
+} from "../services/analytics/checkoutAttribution";
+
+const WEB_ATTRIBUTION = checkoutAttributionFromRequest({
+  searchParams: new URLSearchParams("cmux_source=pricing_page&cmux_placement=hero"),
+  referer: "https://cmux.com/pricing?interval=year",
+});
 
 describe("Stripe billing analytics", () => {
   test("does not use the real transport in a test process", async () => {
@@ -20,6 +28,9 @@ describe("Stripe billing analytics", () => {
         subject: { scope: "user", stackUserId: "stack-user-test" },
         plan: "pro",
         billingInterval: "month",
+        attribution: WEB_ATTRIBUTION,
+        signedIn: false,
+        existingStripeCustomer: false,
       });
     } finally {
       globalThis.fetch = originalFetch;
@@ -155,6 +166,9 @@ describe("Stripe billing analytics", () => {
       subject: { scope: "user", stackUserId: "stack-user-1" },
       plan: "pro",
       billingInterval: "year",
+      attribution: WEB_ATTRIBUTION,
+      signedIn: true,
+      existingStripeCustomer: false,
     }, (async (_input, init) => {
       payload = JSON.parse(String(init?.body));
       return new Response(null, { status: 200 });
@@ -167,9 +181,120 @@ describe("Stripe billing analytics", () => {
         $insert_id: "checkout-started:cs_started",
         plan: "pro",
         billing_interval: "year",
+        signed_in: true,
+        existing_stripe_customer: false,
+        checkout_source: "pricing_page",
+        checkout_placement: "hero",
+        checkout_client: "web",
+        checkout_channel: null,
+        checkout_referrer_host: "cmux.com",
+        checkout_referrer_path: "/pricing",
       },
     });
     expect(JSON.stringify(payload)).not.toContain("email");
+  });
+
+  test("carries app attribution from Stripe metadata onto paid events", async () => {
+    let payload: Record<string, unknown> = {};
+    const event = {
+      id: "evt_checkout_mac",
+      type: "checkout.session.completed",
+      created: 1_800_000_600,
+      data: {
+        object: {
+          id: "cs_mac",
+          created: 1_800_000_000,
+          amount_total: 5000,
+          currency: "usd",
+          payment_status: "paid",
+          payment_method_types: ["card", "link"],
+          customer: "cus_mac",
+          subscription: "sub_mac",
+          customer_details: { address: { country: "US" } },
+          total_details: { amount_discount: 500 },
+          metadata: {
+            plan: "pro",
+            billingInterval: "year",
+            cmuxSource: "mac_sidebar_badge",
+            cmuxClient: "mac",
+            cmuxChannel: "nightly",
+            cmuxAppVersion: "0.65.1",
+            cmuxAppBuild: "2026090101",
+          },
+        },
+      },
+    } as unknown as Stripe.Event;
+
+    await captureStripeBillingEvent(
+      event,
+      { scope: "user", stackUserId: "stack-user-mac", isActive: true, status: "active" },
+      (async (_input, init) => {
+        payload = JSON.parse(String(init?.body));
+        return new Response(null, { status: 200 });
+      }) as typeof fetch,
+    );
+
+    expect(payload).toMatchObject({
+      event: "cmux_billing_checkout_completed",
+      properties: {
+        checkout_source: "mac_sidebar_badge",
+        checkout_client: "mac",
+        checkout_channel: "nightly",
+        checkout_app_version: "0.65.1",
+        checkout_app_build: "2026090101",
+        checkout_placement: null,
+        payment_method_types: ["card", "link"],
+        customer_country: "US",
+        amount_discount: 500,
+        promotion_applied: true,
+        checkout_duration_seconds: 600,
+        $set: { billing_plan: "pro", billing_customer_type: "user" },
+        $set_once: {
+          first_paid_checkout_source: "mac_sidebar_badge",
+          first_paid_checkout_client: "mac",
+          first_paid_checkout_channel: "nightly",
+          first_paid_checkout_at: new Date(1_800_000_600 * 1000).toISOString(),
+        },
+      },
+    });
+  });
+
+  test("reads pre-attribution sessions as unknown web checkouts", async () => {
+    let payload: Record<string, unknown> = {};
+    const event = {
+      id: "evt_expired",
+      type: "checkout.session.expired",
+      created: 1_800_000_600,
+      data: {
+        object: {
+          id: "cs_old",
+          amount_total: 5000,
+          currency: "usd",
+          customer: null,
+          metadata: { plan: "pro", billingInterval: "month", app: "cmux" },
+        },
+      },
+    } as unknown as Stripe.Event;
+
+    await captureStripeBillingEvent(
+      event,
+      { scope: "user", stackUserId: "stack-user-old", isActive: false, status: "expired" },
+      (async (_input, init) => {
+        payload = JSON.parse(String(init?.body));
+        return new Response(null, { status: 200 });
+      }) as typeof fetch,
+    );
+
+    expect(payload).toMatchObject({
+      event: "cmux_billing_checkout_expired",
+      properties: {
+        distinct_id: "stack-user-old",
+        checkout_source: "unknown",
+        checkout_client: "web",
+        checkout_channel: null,
+        stripe_checkout_session_id: "cs_old",
+      },
+    });
   });
 
   test("captures refunds without payment method details", async () => {


### PR DESCRIPTION
Answers "how did this paying customer reach Stripe?": cmux.com/pricing vs an in-app Upgrade button (and which one), Mac vs web vs CLI, stable vs NIGHTLY vs DEV, and campaign tags.

Every checkout entrypoint tags its link with `cmux_source`, `cmux_placement`, `cmux_client`, `cmux_channel`, `cmux_app_version`, `cmux_app_build` (plus `utm_*`). `/api/billing/checkout` normalizes them (`web/services/analytics/checkoutAttribution.ts`), stores them as Stripe Checkout Session and Subscription metadata, and PostHog gets them on `cmux_billing_checkout_started`, `cmux_billing_checkout_completed`, the `cmux_billing_subscription_*` events, and as `first_paid_checkout_*` person properties. Untagged or pre-contract sessions read as `unknown` / `web`, never fail checkout. New `cmux_billing_checkout_expired` maps Stripe `checkout.session.expired` (analytics only) so the funnel has a denominator; that event type must be enabled on the production webhook endpoint after merge.

Web: `/pricing`, `/app-pricing` and dashboard billing set their source, the pricing button appends its placement, `/pricing` and `/app-pricing` forward an inbound source and utm tags, the app relay forwards attribution unsigned. Completed events also carry payment method types, country, discount, promo flag and Stripe form time; started events carry `signed_in` and `existing_stripe_customer`.

Mac: `ProUpgradePresenter.present(source:)` now requires a `ProUpgradeSource`, so all 12 upgrade surfaces name themselves (`mac_sidebar_badge`, `mac_help_menu`, `mac_command_palette`, `mac_machines_panel_*`, ...). `CheckoutAttribution` builds the query, `cmux_upgrade_entrypoint_opened` records the click, and every Mac PostHog event carries `channel`. The CLI free-access notice and the `vm_requires_pro` error link are tagged too.

Contract and event catalog: `docs/posthog/billing-attribution.md`. Dashboard: https://us.posthog.com/project/244066/dashboard/2075133 (built by cmuxterm-hq `scripts/posthog-billing-dashboard.py`).

`processStripeEvent` was split into per-event helpers to pass the complexity gate; its baseline entry is removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791446780&installation_model_id=21920&pr_number=12118&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12118&signature=7e7ac07cd9f9349898bc766dfdae29af32b4a13a86bddea1793b3400e508d2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Stripe checkout route and webhook analytics path (payment-adjacent), but attribution is explicitly analytics-only and malformed tags normalize rather than block checkout.
> 
> **Overview**
> Adds end-to-end **billing attribution** so paid conversions can be tied to the button, app, and release channel that started checkout.
> 
> **Mac, CLI, and hard-coded links** now append `cmux_source`, `cmux_client`, `cmux_channel`, and related params. `ProUpgradePresenter.present(source:)` requires a `ProUpgradeSource` for every upgrade surface; clicks emit `cmux_upgrade_entrypoint_opened`, and pricing/checkout URLs are built via `CheckoutAttribution`.
> 
> **Web** introduces `checkoutAttribution.ts`: pricing, app-pricing, and dashboard billing tag checkout links (including `cmux_placement` on CTAs). `/api/billing/checkout` reads and normalizes params, writes them to Stripe session/subscription metadata, and passes them into PostHog on `cmux_billing_checkout_started` (plus `signed_in` / `existing_stripe_customer`). Webhook billing analytics gain attribution on completed/subscription events, richer completed-checkout fields, `first_paid_checkout_*` person properties, and a new **`cmux_billing_checkout_expired`** path for `checkout.session.expired`. The Stripe webhook handler is split into helpers (complexity baseline removed).
> 
> **Docs/tests:** `docs/posthog/billing-attribution.md` catalogs the contract; Mac and web tests cover query building and relay forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caa50b3cc75bac04fadb1196fa43be3d0581412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes paid checkouts to the surface, client, and channel that opened them. Every checkout entrypoint tags its link with `cmux_source`, `cmux_placement`, `cmux_client`, `cmux_channel`, `cmux_app_version`, `cmux_app_build`, and UTM params; `/api/billing/checkout` normalizes them, stores them as Stripe metadata, and PostHog receives them on billing events and as `first_paid_checkout_*` person properties. Untagged or pre-contract sessions read as `unknown`/`web` and never fail checkout.

The Mac app now requires every upgrade surface to name itself via a `ProUpgradeSource` (the Settings account card is bridged through `AccountFlow`), and the CLI and VM error links are tagged. A new `cmux_billing_checkout_expired` event maps Stripe's `checkout.session.expired` to give the funnel a denominator.

**Migration**
- After merge, enable the `checkout.session.expired` event type on the production webhook endpoint (`https://cmux.com/api/stripe/webhook`). The route ignores unknown event types, so enabling it early is safe.

<sup>Written for commit 4b225a8f74fb5572fe306b89b92e297b55d631cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgrade flows from settings, menus, command palette, sidebar, and Cloud VM prompts now retain their entry-point context.
  - Pricing and checkout links preserve relevant app, campaign, placement, and build-channel information.
  - Checkout and billing records include richer purchase context, including abandoned checkouts and customer status.

- **Bug Fixes**
  - Cloud VM Pro upgrade links now include updated pricing information and context.

- **Documentation**
  - Added documentation describing billing attribution and checkout event tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->