### PR TITLE
coderouter: one account read for every store

### DIFF
--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -5,8 +5,6 @@ import { redirect } from "next/navigation";
 import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
-import { hostedSubrouterCutoverReadyForTeam } from "@/services/subrouter/cutover";
-import { createHostedSubrouterClient } from "@/services/subrouter/hostedClient";
 import {
   authorizedSubrouterTeams,
 } from "@/services/subrouter/routeHelpers";
@@ -24,14 +22,17 @@ import { loadMachineUsage, MachineUsageSection } from "./machine-usage";
 import {
   coderouterOrganizationFromCookieHeader,
 } from "@/services/coderouter/organizationScope";
-import { listClaudeAccounts } from "@/services/coderouter/claudeUpstream";
 import {
   CoderouterAccountsSection,
   type ClaudeAccountsState,
   type NativeAccountsState,
   type SharedAccountsState,
 } from "../components/coderouter-accounts";
-import { listAccounts as listNativeAccounts } from "@/services/coderouter/repository";
+import {
+  listTeamAccounts,
+  type TeamAccount,
+  type TeamAccountSourceStatus,
+} from "@/services/coderouter/teamAccounts";
 import { CoderouterPageHeader } from "../components/dashboard-page-headers";
 import { withPrioritySpan } from "@/services/telemetry";
 import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
@@ -111,9 +112,13 @@ type CoderouterAuthorizationResult =
 export async function CoderouterOverviewContent({
   locale,
   team,
+  // Injectable so a render test does not have to reach through the account
+  // stores; production always uses the one team-account read.
+  loadAccounts = listTeamAccounts,
 }: {
   locale: string;
   team?: string;
+  loadAccounts?: typeof listTeamAccounts;
 }) {
   // Authorization and the access token are resolved for every request. There
   // is no private page cache here, so a prefetched response cannot outlive a
@@ -136,31 +141,34 @@ export async function CoderouterOverviewContent({
   }
 
   const { selectedTeam, accessToken } = authorization.value;
-  const [tPage, sharedAccounts, metrics, claudeAccounts, nativeAccounts, machineUsage] = await Promise.all([
+  const [tPage, accounts, metrics, machineUsage] = await Promise.all([
     getTranslations({ locale, namespace: "dashboard.coderouter" }),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.accounts",
       { "cmux.team_scope": "selected" },
-      () => loadSharedAccounts(selectedTeam, accessToken),
+      // One read for all three account stores; it fans out concurrently and
+      // reports each store's status separately.
+      () =>
+        loadAccounts({
+          teamId: selectedTeam.id,
+          vault: {
+            kind: "session",
+            accessToken,
+            team: {
+              teamId: selectedTeam.id,
+              teamName: selectedTeam.name,
+              use: selectedTeam.use,
+              manageAccounts: selectedTeam.manageAccounts,
+            },
+          },
+        }),
     ),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.team_metrics",
       { "cmux.team_scope": "selected" },
       () => loadCoderouterTeamMetrics(selectedTeam.id),
-    ),
-    withPrioritySpan(
-      "cmux-coderouter-dashboard",
-      "cmux.coderouter.claude_upstream",
-      { "cmux.team_scope": "selected" },
-      () => loadClaudeAccounts(selectedTeam.id),
-    ),
-    withPrioritySpan(
-      "cmux-coderouter-dashboard",
-      "cmux.coderouter.native_accounts",
-      { "cmux.team_scope": "selected" },
-      () => loadNativeAccounts(selectedTeam.id),
     ),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
@@ -182,9 +190,9 @@ export async function CoderouterOverviewContent({
         key={selectedTeam.id}
         teamId={selectedTeam.id}
         canManage={selectedTeam.manageAccounts}
-        claude={claudeAccounts}
-        native={nativeAccounts}
-        shared={sharedAccounts}
+        claude={claudeState(accounts)}
+        native={nativeState(accounts)}
+        shared={sharedState(accounts)}
       />
 
       <MachineUsageSection
@@ -478,43 +486,47 @@ function selectTeam(
   return teams[0];
 }
 
-async function loadSharedAccounts(
-  team: DashboardTeam,
-  accessToken: string,
-): Promise<SharedAccountsState> {
-  try {
-    if (!await hostedSubrouterCutoverReadyForTeam(team.id)) {
-      return { kind: "migrationPending" };
-    }
-    const client = createHostedSubrouterClient();
-    if (!client.tenantControlConfigured) {
-      return { kind: "notConfigured" };
-    }
-    const tenant = await client.exchangeTeam(accessToken, {
-      teamId: team.id,
-      teamName: team.name,
-      use: team.use,
-      manageAccounts: team.manageAccounts,
-    });
-    const accounts = await client.listAccounts(tenant.tenantKey);
-    return { kind: "ok", accounts };
-  } catch {
-    return { kind: "error" };
-  }
+/**
+ * The section renders one block per store, so the single result is split back
+ * into those three views here. Nothing re-reads: the narrowing is on `source`.
+ */
+function nativeState(result: TeamAccountsView): NativeAccountsState {
+  if (result.sources.native.kind !== "ok") return { kind: "error" };
+  return {
+    kind: "ok",
+    accounts: result.accounts.flatMap((account) =>
+      account.source === "native" ? [account.native] : []
+    ),
+  };
 }
 
-async function loadNativeAccounts(teamId: string): Promise<NativeAccountsState> {
-  try {
-    return { kind: "ok", accounts: await listNativeAccounts(teamId) };
-  } catch {
-    return { kind: "error" };
-  }
+function claudeState(result: TeamAccountsView): ClaudeAccountsState {
+  if (result.sources.claude.kind !== "ok") return { kind: "error" };
+  return {
+    kind: "ok",
+    accounts: result.accounts.flatMap((account) =>
+      account.source === "claude" ? [account.claude] : []
+    ),
+  };
 }
 
-async function loadClaudeAccounts(teamId: string): Promise<ClaudeAccountsState> {
-  try {
-    return { kind: "ok", accounts: await listClaudeAccounts(teamId) };
-  } catch {
-    return { kind: "error" };
+function sharedState(result: TeamAccountsView): SharedAccountsState {
+  const status = result.sources.shared;
+  if (status.kind === "error") return { kind: "error" };
+  if (status.kind === "unavailable") {
+    return status.reason === "migration_pending"
+      ? { kind: "migrationPending" }
+      : { kind: "notConfigured" };
   }
+  return {
+    kind: "ok",
+    accounts: result.accounts.flatMap((account) =>
+      account.source === "shared" ? [account.shared] : []
+    ),
+  };
 }
+
+type TeamAccountsView = {
+  readonly accounts: readonly TeamAccount[];
+  readonly sources: Readonly<Record<"native" | "claude" | "shared", TeamAccountSourceStatus>>;
+};

--- a/web/app/api/coderouter/accounts/[accountId]/route.ts
+++ b/web/app/api/coderouter/accounts/[accountId]/route.ts
@@ -1,5 +1,13 @@
 import { coderouterControlRoute } from "@/services/coderouter/requestTelemetry";
 import { removeAccount } from "../../../../../services/coderouter/accounts";
+import { removeClaudeAccount } from "../../../../../services/coderouter/claudeUpstream";
+import {
+  isTeamAccountId,
+  removeTeamAccount,
+  type TeamAccountRemoval,
+} from "../../../../../services/coderouter/teamAccounts";
+import { vaultAccessFromStackHeaders } from "../../../../../services/coderouter/vaultAccess";
+import { normalizeAccountId } from "../../../../../services/subrouter/routeHelpers";
 import { resolveCodeRouterRequestContext } from "../../../../../services/coderouter/requestContext";
 import { captureCoderouterEvent } from "../../../../../services/coderouter/analytics";
 import {
@@ -8,15 +16,13 @@ import {
 } from "../../../../../services/coderouter/observability";
 
 
-const UUID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export function createDeleteAccountHandler(dependencies: {
   readonly resolve: typeof resolveCodeRouterRequestContext;
   readonly remove: (input: {
     readonly teamId: string;
     readonly accountId: string;
-  }) => ReturnType<typeof removeAccount>;
+    readonly request: Request;
+  }) => Promise<TeamAccountRemoval>;
 }) {
   return async (
     request: Request,
@@ -24,8 +30,9 @@ export function createDeleteAccountHandler(dependencies: {
   ): Promise<Response> => {
     const resolved = await dependencies.resolve(request);
     if (!resolved.ok) return resolved.response;
-    const { accountId } = await context.params;
-    if (!UUID.test(accountId)) {
+    const { accountId: rawAccountId } = await context.params;
+    const accountId = normalizeAccountId(rawAccountId);
+    if (!accountId || !isTeamAccountId(accountId)) {
       return Response.json({ error: "invalid_request" }, { status: 400 });
     }
     let result;
@@ -33,6 +40,7 @@ export function createDeleteAccountHandler(dependencies: {
       result = await dependencies.remove({
         teamId: resolved.value.team.teamId,
         accountId,
+        request,
       });
     } catch (error) {
       reportCoderouterFailure("rds", error, { operation: "remove_account" });
@@ -66,11 +74,13 @@ export function createDeleteAccountHandler(dependencies: {
       teamId: resolved.value.team.teamId,
       properties: {
         source: "native_api",
+        account_source: result.source,
         last_account: result.lastAccount,
         legacy_cleanup_pending: result.legacyCleanupPending,
       },
     });
     addCoderouterBreadcrumb("account", "Provider account removed", {
+      account_source: result.source,
       last_account: result.lastAccount,
       legacy_cleanup_pending: result.legacyCleanupPending,
     });
@@ -82,6 +92,14 @@ export function createDeleteAccountHandler(dependencies: {
 
 export const DELETE = coderouterControlRoute("accounts", "/api/coderouter/accounts/[accountId]", createDeleteAccountHandler({
   resolve: resolveCodeRouterRequestContext,
-  remove: async ({ teamId, accountId }) =>
-    await removeAccount(teamId, accountId),
+  // One removal path for every store, so a client that read one account list
+  // does not have to know which store answered for each row.
+  remove: async ({ teamId, accountId, request }) =>
+    await removeTeamAccount({
+      teamId,
+      accountId,
+      vault: await vaultAccessFromStackHeaders(request, teamId),
+      removeNative: removeAccount,
+      removeClaude: removeClaudeAccount,
+    }),
 }));

--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -7,7 +7,8 @@ import {
   resolveCoderouterUsageTeam,
   resolveCodeRouterRequestContext,
 } from "../../../../services/coderouter/requestContext";
-import { accountsWithUsage } from "../../../../services/coderouter/usage";
+import { listTeamAccounts } from "../../../../services/coderouter/teamAccounts";
+import { vaultAccessFromStackHeaders } from "../../../../services/coderouter/vaultAccess";
 import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
 import {
   addCoderouterBreadcrumb,
@@ -17,19 +18,44 @@ import {
 
 const MAX_BODY_BYTES = 128 * 1_024;
 
-export const GET = coderouterControlRoute("accounts", "/api/coderouter/accounts", handleGet);
+export type AccountsGetDependencies = {
+  readonly resolveTeam: typeof resolveCoderouterUsageTeam;
+  readonly vaultAccess: typeof vaultAccessFromStackHeaders;
+  readonly list: typeof listTeamAccounts;
+};
 
-async function handleGet(request: Request): Promise<Response> {
+const defaultAccountsGetDependencies: AccountsGetDependencies = {
+  resolveTeam: resolveCoderouterUsageTeam,
+  vaultAccess: vaultAccessFromStackHeaders,
+  list: listTeamAccounts,
+};
+
+export const GET = coderouterControlRoute(
+  "accounts",
+  "/api/coderouter/accounts",
+  makeCoderouterAccountsGetHandler(),
+);
+
+export function makeCoderouterAccountsGetHandler(
+  dependencies: AccountsGetDependencies = defaultAccountsGetDependencies,
+) {
+  return async function GET(request: Request): Promise<Response> {
   const startedAt = performance.now();
   const authStartedAt = performance.now();
-  const resolved = await resolveCoderouterUsageTeam(request);
+  const resolved = await dependencies.resolveTeam(request);
   if (!resolved.ok) return resolved.response;
   const authMs = performance.now() - authStartedAt;
-  const result = await accountsWithUsage(resolved.teamId);
+  // The vault check needs the caller's Stack session, and it is only useful
+  // once the team is known, so it cannot start before authorization resolves.
+  const result = await dependencies.list({
+    teamId: resolved.teamId,
+    vault: await dependencies.vaultAccess(request, resolved.teamId),
+  });
   const serializeStartedAt = performance.now();
   const body = JSON.stringify({
     teamId: resolved.teamId,
     accounts: result.accounts,
+    sources: result.sources,
     usageAsOf: result.usageAsOf,
     usageAgeSeconds: Math.max(
       0,
@@ -42,6 +68,7 @@ async function handleGet(request: Request): Promise<Response> {
     timing("auth", authMs),
     timing("rds", result.timing.rdsMs),
     timing("provider", result.timing.providerMs),
+    timing("vault", result.timing.vaultMs),
     timing("serialize", serializeMs),
     timing("total", performance.now() - startedAt),
   ].join(", ");
@@ -71,6 +98,7 @@ async function handleGet(request: Request): Promise<Response> {
       "x-coderouter-server-timing": serverTiming,
     },
   });
+  };
 }
 
 type AccountsPostDependencies = {

--- a/web/services/coderouter/teamAccounts.ts
+++ b/web/services/coderouter/teamAccounts.ts
@@ -14,6 +14,7 @@
  */
 import {
   createHostedSubrouterClient,
+  HostedSubrouterError,
   type HostedTeam,
 } from "../subrouter/hostedClient";
 import type { SubrouterAccount } from "../subrouter/types";
@@ -363,7 +364,17 @@ async function removeSharedAccount(
   const client = vaultClient();
   if (!client.tenantControlConfigured) return { removed: false };
   const tenant = await client.exchangeTeam(vault.accessToken, vault.team);
-  await client.deleteAccount(tenant.tenantKey, accountId);
+  try {
+    await client.deleteAccount(tenant.tenantKey, accountId);
+  } catch (error) {
+    // An id the vault does not hold is a miss, the same as a UUID that matches
+    // no row. Letting it escape would answer 503 and report an outage for what
+    // is only a stale id.
+    if (error instanceof HostedSubrouterError && error.status === 404) {
+      return { removed: false };
+    }
+    throw error;
+  }
   return {
     removed: true,
     source: "shared",

--- a/web/services/coderouter/teamAccounts.ts
+++ b/web/services/coderouter/teamAccounts.ts
@@ -1,0 +1,373 @@
+/**
+ * One read for every account a team has.
+ *
+ * A team's accounts live in three stores: the coderouter account table
+ * (Codex and OpenCode, with provider quota), the Claude upstream table, and
+ * the hosted Subrouter vault that the cmux app writes to. Each surface used to
+ * fan out to those stores itself, which is why `cr accounts` listed four
+ * accounts while the dashboard listed nine. Both now call this function, so a
+ * new store is added in one place and every surface gets it.
+ *
+ * The three reads run concurrently and fail independently: a store that is
+ * down, absent, or unreachable with the caller's credentials is reported in
+ * `sources` and never hides the accounts that did load.
+ */
+import {
+  createHostedSubrouterClient,
+  type HostedTeam,
+} from "../subrouter/hostedClient";
+import type { SubrouterAccount } from "../subrouter/types";
+import { hostedSubrouterCutoverReadyForTeam } from "../subrouter/cutover";
+import { listClaudeAccounts, type ClaudeAccountDescription } from "./claudeUpstream";
+import { accountsWithUsage } from "./usage";
+import type { CodeRouterAccountSummary } from "./types";
+
+export type TeamAccountSource = "native" | "claude" | "shared";
+
+/**
+ * Whether the caller can read the hosted vault. The vault authenticates the
+ * end user itself, so a route token alone cannot read it; that is a missing
+ * source, not an error.
+ */
+export type VaultAccess =
+  | { readonly kind: "none" }
+  | {
+    readonly kind: "session";
+    readonly team: HostedTeam;
+    readonly accessToken: string;
+  };
+
+export type TeamAccountSourceStatus =
+  | { readonly kind: "ok"; readonly count: number }
+  | { readonly kind: "error" }
+  | {
+    readonly kind: "unavailable";
+    readonly reason: "no_session" | "not_configured" | "migration_pending";
+  };
+
+/**
+ * One account, normalized across the three stores.
+ *
+ * `usage` is the provider's own quota document, passed through verbatim for
+ * the client to render; nothing here interprets it.
+ */
+type TeamAccountBase = {
+  readonly id: string;
+  readonly label: string;
+  readonly state: "active" | "disabled" | "refreshing" | "expired" | "broken";
+  /** Whether coderouter's data plane can route a request to this account. */
+  readonly routable: boolean;
+  /**
+   * Sessions bound to this account with recent traffic. Only the native store
+   * binds sessions, so the other stores report null rather than a false zero.
+   */
+  readonly activeSessions: number | null;
+};
+
+export type TeamAccount =
+  | (TeamAccountBase & {
+    readonly source: "native";
+    readonly provider: CodeRouterAccountSummary["provider"];
+    readonly native: CodeRouterAccountSummary;
+    readonly usage?: unknown;
+    readonly usageError?: string;
+  })
+  | (TeamAccountBase & {
+    readonly source: "claude";
+    readonly provider: "claude";
+    readonly claude: ClaudeAccountDescription;
+  })
+  | (TeamAccountBase & {
+    readonly source: "shared";
+    // Its own provider name, not the vault account's kind: a client that
+    // groups by provider must not file these under Codex, where they would
+    // read as routing capacity. The kind stays on `shared`.
+    readonly provider: "shared";
+    readonly shared: SubrouterAccount;
+  });
+
+export type TeamAccountsResult = {
+  readonly accounts: readonly TeamAccount[];
+  readonly sources: Readonly<
+    Record<TeamAccountSource, TeamAccountSourceStatus>
+  >;
+  readonly usageAsOf: string;
+  readonly usageGeneratedAtMs: number;
+  readonly cacheMaxAgeSeconds: number;
+  readonly timing: {
+    readonly rdsMs: number;
+    readonly providerMs: number;
+    readonly vaultMs: number;
+  };
+};
+
+export type TeamAccountsDependencies = {
+  readonly nativeAccounts: typeof accountsWithUsage;
+  readonly claudeAccounts: typeof listClaudeAccounts;
+  readonly vaultReady: typeof hostedSubrouterCutoverReadyForTeam;
+  readonly vaultClient: typeof createHostedSubrouterClient;
+};
+
+const defaultDependencies: TeamAccountsDependencies = {
+  nativeAccounts: accountsWithUsage,
+  claudeAccounts: listClaudeAccounts,
+  vaultReady: hostedSubrouterCutoverReadyForTeam,
+  vaultClient: createHostedSubrouterClient,
+};
+
+type NativeRead = {
+  readonly accounts: readonly TeamAccount[];
+  readonly status: TeamAccountSourceStatus;
+  readonly usageAsOf: string;
+  readonly usageGeneratedAtMs: number;
+  readonly cacheMaxAgeSeconds: number;
+  readonly rdsMs: number;
+  readonly providerMs: number;
+};
+
+export async function listTeamAccounts(
+  input: {
+    readonly teamId: string;
+    readonly vault: VaultAccess;
+  },
+  dependencies: TeamAccountsDependencies = defaultDependencies,
+): Promise<TeamAccountsResult> {
+  const vaultStartedAt = performance.now();
+  const [native, claude, shared] = await Promise.all([
+    readNative(input.teamId, dependencies),
+    readClaude(input.teamId, dependencies),
+    readShared(input.vault, dependencies),
+  ]);
+  return {
+    accounts: [...native.accounts, ...claude.accounts, ...shared.accounts],
+    sources: {
+      native: native.status,
+      claude: claude.status,
+      shared: shared.status,
+    },
+    usageAsOf: native.usageAsOf,
+    usageGeneratedAtMs: native.usageGeneratedAtMs,
+    cacheMaxAgeSeconds: native.cacheMaxAgeSeconds,
+    timing: {
+      rdsMs: native.rdsMs,
+      providerMs: native.providerMs,
+      vaultMs: performance.now() - vaultStartedAt,
+    },
+  };
+}
+
+async function readNative(
+  teamId: string,
+  dependencies: TeamAccountsDependencies,
+): Promise<NativeRead> {
+  const now = Date.now();
+  try {
+    const result = await dependencies.nativeAccounts(teamId);
+    const accounts = result.accounts.map((account): TeamAccount => {
+      const { usage, usageError, ...summary } = account as
+        & CodeRouterAccountSummary
+        & { usage?: unknown; usageError?: string };
+      return {
+        source: "native",
+        id: summary.id,
+        provider: summary.provider,
+        label: summary.label,
+        state: summary.state,
+        routable: summary.state === "active",
+        activeSessions: summary.activeSessions,
+        native: summary,
+        ...(usage === undefined ? {} : { usage }),
+        ...(usageError === undefined ? {} : { usageError }),
+      };
+    });
+    return {
+      accounts,
+      status: { kind: "ok", count: accounts.length },
+      usageAsOf: result.usageAsOf,
+      usageGeneratedAtMs: result.usageGeneratedAtMs,
+      cacheMaxAgeSeconds: result.cacheMaxAgeSeconds,
+      rdsMs: result.timing.rdsMs,
+      providerMs: result.timing.providerMs,
+    };
+  } catch {
+    return {
+      accounts: [],
+      status: { kind: "error" },
+      usageAsOf: new Date(now).toISOString(),
+      usageGeneratedAtMs: now,
+      cacheMaxAgeSeconds: 0,
+      rdsMs: 0,
+      providerMs: 0,
+    };
+  }
+}
+
+async function readClaude(
+  teamId: string,
+  dependencies: TeamAccountsDependencies,
+): Promise<{
+  readonly accounts: readonly TeamAccount[];
+  readonly status: TeamAccountSourceStatus;
+}> {
+  try {
+    const accounts = (await dependencies.claudeAccounts(teamId)).map(
+      (account): TeamAccount => ({
+        source: "claude",
+        id: account.id,
+        provider: "claude",
+        label: account.label.trim() || account.identifier,
+        state: account.state,
+        routable: account.state === "active",
+        activeSessions: null,
+        claude: account,
+      }),
+    );
+    return { accounts, status: { kind: "ok", count: accounts.length } };
+  } catch {
+    return { accounts: [], status: { kind: "error" } };
+  }
+}
+
+async function readShared(
+  vault: VaultAccess,
+  dependencies: TeamAccountsDependencies,
+): Promise<{
+  readonly accounts: readonly TeamAccount[];
+  readonly status: TeamAccountSourceStatus;
+}> {
+  if (vault.kind === "none") {
+    return { accounts: [], status: { kind: "unavailable", reason: "no_session" } };
+  }
+  try {
+    if (!await dependencies.vaultReady(vault.team.teamId)) {
+      return {
+        accounts: [],
+        status: { kind: "unavailable", reason: "migration_pending" },
+      };
+    }
+    const client = dependencies.vaultClient();
+    if (!client.tenantControlConfigured) {
+      return {
+        accounts: [],
+        status: { kind: "unavailable", reason: "not_configured" },
+      };
+    }
+    const tenant = await client.exchangeTeam(vault.accessToken, vault.team);
+    const accounts = (await client.listAccounts(tenant.tenantKey)).map(
+      (account): TeamAccount => ({
+        source: "shared",
+        id: account.id,
+        provider: "shared",
+        label: account.label ?? account.id,
+        state: account.health?.ok === false ? "broken" : "active",
+        // The vault serves the cmux app's own proxy. coderouter's data plane
+        // never selects these accounts, so counting them as routable capacity
+        // would overstate what `cr` can use.
+        routable: false,
+        activeSessions: null,
+        shared: account,
+      }),
+    );
+    return { accounts, status: { kind: "ok", count: accounts.length } };
+  } catch {
+    return { accounts: [], status: { kind: "error" } };
+  }
+}
+
+/**
+ * Account ids the removal path will act on. The database stores use UUIDs and
+ * the vault uses the account's own label (an email in practice), so the shape
+ * cannot be pinned further. Path separators, whitespace, and control
+ * characters are rejected: no store issues them, and forwarding them would let
+ * a caller reach for another resource in an upstream path.
+ */
+export function isTeamAccountId(value: string): boolean {
+  return value.length > 0 && value.length <= 200 &&
+    !/[\s/\\]/.test(value) && !/[\u0000-\u001f\u007f]/.test(value) &&
+    !value.includes("..");
+}
+
+/** UUID v1-v5, the id shape of both database-backed stores. */
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type TeamAccountRemoval =
+  | {
+    readonly removed: true;
+    readonly source: TeamAccountSource;
+    readonly lastAccount: boolean;
+    readonly legacyCleanupPending: boolean;
+  }
+  | { readonly removed: false };
+
+/**
+ * Remove one account from whichever store owns its id.
+ *
+ * Callers hold an account id, not a store name: the CLI reads one list and
+ * removes from it. Resolving the store here is what lets there be one removal
+ * endpoint, and it keeps older clients correct, since they send ids from every
+ * store to this one path.
+ */
+export async function removeTeamAccount(input: {
+  readonly teamId: string;
+  readonly accountId: string;
+  readonly vault: VaultAccess;
+  readonly vaultClient?: typeof createHostedSubrouterClient;
+  readonly removeNative: (
+    teamId: string,
+    accountId: string,
+  ) => Promise<{
+    readonly removed: boolean;
+    readonly lastAccount: boolean;
+    readonly legacyCleanupPending: boolean;
+  }>;
+  readonly removeClaude: (
+    teamId: string,
+    accountId: string,
+  ) => Promise<{ readonly removed: boolean }>;
+}): Promise<TeamAccountRemoval> {
+  if (UUID.test(input.accountId)) {
+    const native = await input.removeNative(input.teamId, input.accountId);
+    if (native.removed) {
+      return {
+        removed: true,
+        source: "native",
+        lastAccount: native.lastAccount,
+        legacyCleanupPending: native.legacyCleanupPending,
+      };
+    }
+    const claude = await input.removeClaude(input.teamId, input.accountId);
+    if (claude.removed) {
+      return {
+        removed: true,
+        source: "claude",
+        lastAccount: false,
+        legacyCleanupPending: false,
+      };
+    }
+    return { removed: false };
+  }
+  return await removeSharedAccount(
+    input.accountId,
+    input.vault,
+    input.vaultClient ?? createHostedSubrouterClient,
+  );
+}
+
+async function removeSharedAccount(
+  accountId: string,
+  vault: VaultAccess,
+  vaultClient: typeof createHostedSubrouterClient,
+): Promise<TeamAccountRemoval> {
+  if (vault.kind === "none") return { removed: false };
+  const client = vaultClient();
+  if (!client.tenantControlConfigured) return { removed: false };
+  const tenant = await client.exchangeTeam(vault.accessToken, vault.team);
+  await client.deleteAccount(tenant.tenantKey, accountId);
+  return {
+    removed: true,
+    source: "shared",
+    lastAccount: false,
+    legacyCleanupPending: false,
+  };
+}

--- a/web/services/coderouter/vaultAccess.ts
+++ b/web/services/coderouter/vaultAccess.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve whether a request may read the team's hosted Subrouter vault.
+ *
+ * The vault verifies the end user's Stack session itself, so a route token
+ * cannot reach it. A CLI request authenticates with its route token in
+ * `authorization` and may carry its Stack session in `x-stack-access-token`
+ * plus `x-stack-refresh-token`. When that session is absent or no longer
+ * valid, the vault is simply a source this caller cannot read: the rest of the
+ * account list still answers.
+ */
+import { resolveTeam } from "../subrouter/routeHelpers";
+import {
+  isSubrouterAuthorizationError,
+  verifySubrouterRequest,
+  withSubrouterAuthorizationDeadline,
+} from "../vms/auth";
+import type { VaultAccess } from "./teamAccounts";
+
+export async function vaultAccessFromStackHeaders(
+  request: Request,
+  teamId: string,
+): Promise<VaultAccess> {
+  const accessToken = request.headers.get("x-stack-access-token")?.trim();
+  const refreshToken = request.headers.get("x-stack-refresh-token")?.trim();
+  if (!accessToken || !refreshToken) return { kind: "none" };
+
+  // verifySubrouterRequest reads a native Stack session from `authorization`,
+  // which this request already spent on the route token. Hand it a request
+  // carrying only the Stack session so one vetted code path decides identity.
+  const stackRequest = new Request(request.url, {
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "x-stack-refresh-token": refreshToken,
+      "x-cmux-team-id": teamId,
+    },
+  });
+
+  try {
+    return await withSubrouterAuthorizationDeadline(async (signal) => {
+      const user = await verifySubrouterRequest(stackRequest, signal, {
+        requestedTeamId: teamId,
+        allowCookie: false,
+      });
+      if (!user) return { kind: "none" };
+      const team = resolveTeam(stackRequest, user);
+      if (!team.ok || team.teamId !== teamId) return { kind: "none" };
+      return {
+        kind: "session",
+        accessToken,
+        team: {
+          teamId: team.teamId,
+          teamName: team.teamName,
+          use: team.use,
+          manageAccounts: team.manageAccounts,
+        },
+      };
+    });
+  } catch (error) {
+    if (!isSubrouterAuthorizationError(error)) throw error;
+    return { kind: "none" };
+  }
+}

--- a/web/tests/coderouter-account-removal.test.ts
+++ b/web/tests/coderouter-account-removal.test.ts
@@ -26,6 +26,7 @@ describe("coderouter account removal", () => {
         removed = input;
         return {
           removed: true,
+          source: "native" as const,
           lastAccount: true,
           legacyCleanupPending: false,
         };
@@ -38,9 +39,11 @@ describe("coderouter account removal", () => {
       { params: Promise.resolve({ accountId }) },
     );
     expect(response.status).toBe(200);
-    expect(removed).toEqual({ teamId: "team-1", accountId });
+    expect(removed?.teamId).toBe("team-1");
+    expect(removed?.accountId).toBe(accountId);
     expect(await response.json()).toEqual({
       removed: true,
+      source: "native",
       lastAccount: true,
       legacyCleanupPending: false,
     });
@@ -65,6 +68,7 @@ describe("coderouter account removal", () => {
         called = true;
         return {
           removed: true,
+          source: "native" as const,
           lastAccount: false,
           legacyCleanupPending: false,
         };

--- a/web/tests/coderouter-accounts-route.test.ts
+++ b/web/tests/coderouter-accounts-route.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import { makeCoderouterAccountsPostHandler } from "../app/api/coderouter/accounts/route";
+import {
+  makeCoderouterAccountsGetHandler,
+  makeCoderouterAccountsPostHandler,
+} from "../app/api/coderouter/accounts/route";
 
 // Access is team membership only. There is no connected-account cap and no
 // plan read: a resolved member context goes straight to the account store.
@@ -89,5 +92,76 @@ describe("coderouter account addition", () => {
       error: "account_store_unavailable",
       retryable: true,
     });
+  });
+});
+
+describe("coderouter account listing", () => {
+  const listed = {
+    accounts: [
+      {
+        source: "native" as const,
+        id: "00000000-0000-4000-8000-000000000001",
+        provider: "codex" as const,
+        label: "codex@example.com",
+        state: "active" as const,
+        routable: true,
+        activeSessions: 0,
+        native: {} as never,
+      },
+    ],
+    sources: {
+      native: { kind: "ok" as const, count: 1 },
+      claude: { kind: "ok" as const, count: 0 },
+      shared: { kind: "unavailable" as const, reason: "no_session" as const },
+    },
+    usageAsOf: "2026-09-08T00:00:00.000Z",
+    usageGeneratedAtMs: Date.now(),
+    cacheMaxAgeSeconds: 0,
+    timing: { rdsMs: 1, providerMs: 2, vaultMs: 3 },
+  };
+
+  test("answers a route token with one list and the status of every store", async () => {
+    const handler = makeCoderouterAccountsGetHandler({
+      resolveTeam: async () => ({
+        ok: true as const,
+        teamId: "team_1",
+        stackUserId: "user_1",
+      }),
+      vaultAccess: async () => ({ kind: "none" as const }),
+      list: async () => listed,
+    });
+    const response = await handler(
+      new Request("https://coderouter.dev/api/coderouter/accounts", {
+        headers: { authorization: "Bearer crt_route" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.accounts).toHaveLength(1);
+    expect(body.sources.shared).toEqual({ kind: "unavailable", reason: "no_session" });
+    expect(response.headers.get("server-timing")).toContain("vault;dur=");
+  });
+
+  test("a caller with no Stack session still gets the stores a route token can read", async () => {
+    let vaultAccess: unknown;
+    const handler = makeCoderouterAccountsGetHandler({
+      resolveTeam: async () => ({
+        ok: true as const,
+        teamId: "team_1",
+        stackUserId: "user_1",
+      }),
+      vaultAccess: async () => ({ kind: "none" as const }),
+      list: async (input) => {
+        vaultAccess = input.vault;
+        return listed;
+      },
+    });
+    const response = await handler(
+      new Request("https://coderouter.dev/api/coderouter/accounts", {
+        headers: { authorization: "Bearer crt_route" },
+      }),
+    );
+    expect(vaultAccess).toEqual({ kind: "none" });
+    expect((await response.json()).accounts).toHaveLength(1);
   });
 });

--- a/web/tests/coderouter-team-accounts.test.ts
+++ b/web/tests/coderouter-team-accounts.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  listTeamAccounts,
+  removeTeamAccount,
+  type TeamAccountsDependencies,
+  type VaultAccess,
+} from "../services/coderouter/teamAccounts";
+
+const vault: VaultAccess = {
+  kind: "session",
+  accessToken: "stack-access",
+  team: {
+    teamId: "team_1",
+    teamName: "Team",
+    use: true,
+    manageAccounts: true,
+  },
+};
+
+const nativeAccount = {
+  id: "00000000-0000-4000-8000-000000000001",
+  provider: "codex" as const,
+  providerAccountId: "acct-1",
+  label: "codex@example.com",
+  state: "active" as const,
+  credentialExpiresAt: null,
+  lastFailureCode: null,
+  cooldownUntil: null,
+  activeSessions: 2,
+};
+
+const claudeAccount = {
+  id: "00000000-0000-4000-8000-000000000002",
+  kind: "anthropic_oauth" as const,
+  label: "",
+  identifier: "sk-ant-oat01-...6789",
+  region: null,
+  modelIds: {},
+  state: "active" as const,
+  cooldownUntil: null,
+  lastFailureCode: null,
+  lastUsedAt: null,
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+const sharedAccount = { id: "shared@example.com", kind: "codex", label: "shared@example.com" };
+
+function dependencies(
+  overrides: Partial<TeamAccountsDependencies> = {},
+): TeamAccountsDependencies {
+  return {
+    nativeAccounts: async () => ({
+      accounts: [nativeAccount],
+      usageAsOf: "2026-09-08T00:00:00.000Z",
+      usageGeneratedAtMs: Date.parse("2026-09-08T00:00:00.000Z"),
+      cacheMaxAgeSeconds: 0,
+      timing: { rdsMs: 1, providerMs: 2, totalMs: 3 },
+    }),
+    claudeAccounts: async () => [claudeAccount],
+    vaultReady: async () => true,
+    vaultClient: () =>
+      ({
+        tenantControlConfigured: true,
+        exchangeTeam: async () => ({
+          tenantId: "team_1",
+          tenantName: "Team",
+          tenantKey: "tenant-key",
+          proxyUrl: "https://example.invalid",
+          capabilities: ["use", "manage_accounts"],
+        }),
+        listAccounts: async () => [sharedAccount],
+      }) as never,
+    ...overrides,
+  };
+}
+
+describe("team account listing", () => {
+  test("returns every store's accounts in one read", async () => {
+    const result = await listTeamAccounts({ teamId: "team_1", vault }, dependencies());
+    expect(result.accounts.map((account) => account.source)).toEqual([
+      "native",
+      "claude",
+      "shared",
+    ]);
+    expect(result.accounts.map((account) => account.label)).toEqual([
+      "codex@example.com",
+      "sk-ant-oat01-...6789",
+      "shared@example.com",
+    ]);
+    expect(result.sources).toEqual({
+      native: { kind: "ok", count: 1 },
+      claude: { kind: "ok", count: 1 },
+      shared: { kind: "ok", count: 1 },
+    });
+  });
+
+  test("only accounts the data plane can select are routable", async () => {
+    const result = await listTeamAccounts({ teamId: "team_1", vault }, dependencies());
+    expect(result.accounts.filter((account) => account.routable).length).toBe(2);
+    expect(
+      result.accounts.find((account) => account.source === "shared")?.provider,
+    ).toBe("shared");
+    expect(
+      result.accounts.find((account) => account.source === "shared")?.routable,
+    ).toBe(false);
+  });
+
+  test("reads the three stores concurrently", async () => {
+    // Each read blocks until all three have started. A sequential
+    // implementation never reaches the third and this test times out.
+    let started = 0;
+    let release = () => {};
+    const allStarted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const gate = async () => {
+      started += 1;
+      if (started === 3) release();
+      await allStarted;
+    };
+    const deps = dependencies({
+      nativeAccounts: async () => {
+        await gate();
+        return {
+          accounts: [],
+          usageAsOf: "2026-09-08T00:00:00.000Z",
+          usageGeneratedAtMs: 0,
+          cacheMaxAgeSeconds: 0,
+          timing: { rdsMs: 0, providerMs: 0, totalMs: 0 },
+        };
+      },
+      claudeAccounts: async () => {
+        await gate();
+        return [];
+      },
+      vaultReady: async () => {
+        await gate();
+        return true;
+      },
+    });
+    await listTeamAccounts({ teamId: "team_1", vault }, deps);
+    expect(started).toBe(3);
+  });
+
+  test("one failing store never hides the others", async () => {
+    const result = await listTeamAccounts(
+      { teamId: "team_1", vault },
+      dependencies({
+        claudeAccounts: async () => {
+          throw new Error("claude table unavailable");
+        },
+      }),
+    );
+    expect(result.accounts.map((account) => account.source)).toEqual([
+      "native",
+      "shared",
+    ]);
+    expect(result.sources.claude).toEqual({ kind: "error" });
+  });
+
+  test("a caller without a Stack session reports the vault as unreadable", async () => {
+    const result = await listTeamAccounts(
+      { teamId: "team_1", vault: { kind: "none" } },
+      dependencies(),
+    );
+    expect(result.sources.shared).toEqual({
+      kind: "unavailable",
+      reason: "no_session",
+    });
+    expect(result.accounts.map((account) => account.source)).toEqual([
+      "native",
+      "claude",
+    ]);
+  });
+});
+
+describe("team account removal", () => {
+  const removeNothing = {
+    removeNative: async () => ({
+      removed: false,
+      lastAccount: false,
+      legacyCleanupPending: false,
+    }),
+    removeClaude: async () => ({ removed: false }),
+  };
+
+  test("falls through to the Claude store when the native store has no such id", async () => {
+    const result = await removeTeamAccount({
+      teamId: "team_1",
+      accountId: claudeAccount.id,
+      vault,
+      ...removeNothing,
+      removeClaude: async () => ({ removed: true }),
+    });
+    expect(result).toEqual({
+      removed: true,
+      source: "claude",
+      lastAccount: false,
+      legacyCleanupPending: false,
+    });
+  });
+
+  test("removes a vault account by its non-UUID id without touching the tables", async () => {
+    let deleted: string | undefined;
+    let nativeCalls = 0;
+    const result = await removeTeamAccount({
+      teamId: "team_1",
+      accountId: sharedAccount.id,
+      vault,
+      vaultClient: () =>
+        ({
+          tenantControlConfigured: true,
+          exchangeTeam: async () => ({
+            tenantId: "team_1",
+            tenantName: "Team",
+            tenantKey: "tenant-key",
+            proxyUrl: "https://example.invalid",
+            capabilities: ["use", "manage_accounts"],
+          }),
+          deleteAccount: async (_tenantKey: string, accountId: string) => {
+            deleted = accountId;
+          },
+        }) as never,
+      removeNative: async () => {
+        nativeCalls += 1;
+        return { removed: false, lastAccount: false, legacyCleanupPending: false };
+      },
+      removeClaude: async () => ({ removed: false }),
+    });
+    expect(deleted).toBe(sharedAccount.id);
+    expect(nativeCalls).toBe(0);
+    expect(result).toEqual({
+      removed: true,
+      source: "shared",
+      lastAccount: false,
+      legacyCleanupPending: false,
+    });
+  });
+
+  test("reports a miss instead of guessing a store", async () => {
+    const result = await removeTeamAccount({
+      teamId: "team_1",
+      accountId: "00000000-0000-4000-8000-000000000009",
+      vault,
+      ...removeNothing,
+    });
+    expect(result).toEqual({ removed: false });
+  });
+});

--- a/web/tests/coderouter-team-accounts.test.ts
+++ b/web/tests/coderouter-team-accounts.test.ts
@@ -249,3 +249,35 @@ describe("team account removal", () => {
     expect(result).toEqual({ removed: false });
   });
 });
+
+describe("team account removal misses", () => {
+  test("an id the vault does not hold is a miss, not an outage", async () => {
+    const { HostedSubrouterError } = await import("../services/subrouter/hostedClient");
+    const result = await removeTeamAccount({
+      teamId: "team_1",
+      accountId: "gone@example.com",
+      vault,
+      vaultClient: () =>
+        ({
+          tenantControlConfigured: true,
+          exchangeTeam: async () => ({
+            tenantId: "team_1",
+            tenantName: "Team",
+            tenantKey: "tenant-key",
+            proxyUrl: "https://example.invalid",
+            capabilities: ["use", "manage_accounts"],
+          }),
+          deleteAccount: async () => {
+            throw new HostedSubrouterError("account not found", 404);
+          },
+        }) as never,
+      removeNative: async () => ({
+        removed: false,
+        lastAccount: false,
+        legacyCleanupPending: false,
+      }),
+      removeClaude: async () => ({ removed: false }),
+    });
+    expect(result).toEqual({ removed: false });
+  });
+});

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import enMessages from "../messages/en.json";
 
+import type { TeamAccountsResult } from "../services/coderouter/teamAccounts";
+
 const authorizationFailure = new Error("Stack authorization deadline exceeded");
 const pendingAuthorization = new Promise<never>(() => {});
 let authorizationAvailable = false;
@@ -251,11 +253,48 @@ mock.module("../services/coderouter/claudeUpstream", () => ({
 
 mock.module("../services/coderouter/repository", () => ({
   listAccounts: async () => [],
+  // The account read is injected below, but the page still imports the
+  // service that reads these stores.
+  listEncryptedCredentials: async () => [],
+  markAccountCooldown: async () => {},
+  encryptedCredentialForAccount: async () => null,
+  replaceAccountCredential: async () => {},
+  claimRefreshLease: async () => null,
+  completeRefreshLease: async () => {},
+  releaseRefreshLease: async () => {},
+  failRefreshLease: async () => {},
+  withVaultLease: async () => {},
 }));
+
+
 
 const { default: CoderouterOverviewPage, CoderouterOverviewContent } = await import(
   "../app/[locale]/dashboard/coderouter/page"
 );
+
+// The page takes its account read as a prop, so these renders supply the
+// result directly instead of reaching through the account stores. The service
+// itself is covered in coderouter-team-accounts.test.ts.
+const loadAccounts = async (): Promise<TeamAccountsResult> => {
+  const shared = !cutoverReady
+    ? ({ kind: "unavailable", reason: "migration_pending" } as const)
+    : !hostedControlConfigured
+    ? ({ kind: "unavailable", reason: "not_configured" } as const)
+    : ({ kind: "ok", count: 0 } as const);
+  if (cutoverReady && hostedControlConfigured) hostedExchangeCalls += 1;
+  return {
+    accounts: [],
+    sources: {
+      native: { kind: "ok", count: 0 },
+      claude: { kind: "ok", count: 0 },
+      shared,
+    },
+    usageAsOf: "2026-09-08T00:00:00.000Z",
+    usageGeneratedAtMs: Date.parse("2026-09-08T00:00:00.000Z"),
+    cacheMaxAgeSeconds: 0,
+    timing: { rdsMs: 0, providerMs: 0, vaultMs: 0 },
+  };
+};
 
 describe("coderouter dashboard", () => {
   beforeEach(() => {
@@ -295,6 +334,7 @@ describe("coderouter dashboard", () => {
   test("renders recovery UI when Stack authorization is unavailable", async () => {
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
     const html = renderToStaticMarkup(page);
 
@@ -313,6 +353,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
     const html = renderToStaticMarkup(page);
 
@@ -328,6 +369,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
     const html = renderToStaticMarkup(page);
 
@@ -344,6 +386,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
     const html = renderToStaticMarkup(page);
 
@@ -356,6 +399,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
       team: "team-1",
     });
     const html = renderToStaticMarkup(page);
@@ -378,7 +422,7 @@ describe("coderouter dashboard", () => {
       { teamId: "team-2", teamName: "Team Two", use: true, manageAccounts: false },
     ];
 
-    const page = await CoderouterOverviewContent({ locale: "en", team: "team-2" });
+    const page = await CoderouterOverviewContent({ locale: "en", team: "team-2", loadAccounts });
     const html = renderToStaticMarkup(page);
 
     expect(html.match(/data-testid="coderouter-accounts"/g)).toHaveLength(1);
@@ -393,6 +437,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
       team: "team-1",
     });
     const html = renderToStaticMarkup(page);
@@ -412,6 +457,7 @@ describe("coderouter dashboard", () => {
 
     const page = await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
       team: "team-1",
     });
     const html = renderToStaticMarkup(page);
@@ -440,6 +486,7 @@ describe("coderouter dashboard", () => {
 
     await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
 
     expect(metricsTeamIds).toEqual(["team-2"]);
@@ -466,6 +513,7 @@ describe("coderouter dashboard", () => {
 
     await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
 
     expect(metricsTeamIds).toEqual(["team-2"]);
@@ -493,6 +541,7 @@ describe("coderouter dashboard", () => {
 
     await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
 
     expect(metricsTeamIds).toEqual(["user-1"]);
@@ -520,6 +569,7 @@ describe("coderouter dashboard", () => {
 
     await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
     });
 
     expect(metricsTeamIds).toEqual(["user-1"]);
@@ -530,6 +580,7 @@ describe("coderouter dashboard", () => {
 
     await CoderouterOverviewContent({
       locale: "en",
+      loadAccounts,
       team: "team-1",
     });
     expect(authorizationCalls).toBe(1);


### PR DESCRIPTION
A team's accounts live in three stores: the coderouter account table, the Claude upstream table, and the hosted Subrouter vault the cmux app writes to. Every surface fanned out to them itself, so they disagreed. For team cmux the dashboard listed 9 accounts and `cr accounts` listed 4.

`listTeamAccounts` is now the one read. It queries the three stores concurrently, normalizes them into one discriminated union (`source` discriminates; each row keeps its store-specific record), and reports each store's status separately so a store that is down, absent, or unreadable with the caller's credentials never hides the accounts that did load. The dashboard and `GET /api/coderouter/accounts` both call it.

- The route takes the CLI's Stack session from `x-stack-access-token` for the vault leg. The vault authenticates the end user itself, so a route token cannot read it; that is a reported missing source, not a failure. A machine with only a route token still gets the two stores it can read.
- Vault accounts are marked `routable: false`. coderouter's data plane never selects them (`codexProxy`/`claudeProxy`/`opencodeProxy` read only the two tables), so counting them as capacity overstates what `cr` can use.
- `DELETE /api/coderouter/accounts/{id}` resolves the store that owns the id instead of assuming the native table. One list, one removal path, and older clients that send a Claude or vault id here stop getting a 404.

The dashboard renders exactly as before; it derives its three section states from the single result.

Tests: 10 new (`coderouter-team-accounts`, GET route), including a deterministic proof the three reads overlap and that one failing store never hides the others. `bun run typecheck`, `bun run lint:complexity`, and the coderouter/dashboard/subrouter suite pass with the same pre-existing failure set as main (31 cross-file mock-order failures, identical on both).

https://claude.ai/code/session_01YKkrYsprvw78ot1WGn6fG5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791448795&installation_model_id=21920&pr_number=12124&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12124&signature=cc2e5ab829be5629e90cca56f61046605754c1f59a9c4eb1d72a0717ee0e0f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account listing, deletion, and vault/session auth across API and dashboard; behavior changes for DELETE on non-native ids and expanded account lists, but failures are isolated per store.
> 
> **Overview**
> Introduces **`listTeamAccounts`** as the single read path for a team’s accounts across the native table, Claude upstream, and hosted Subrouter vault. The dashboard and **`GET /api/coderouter/accounts`** now call it instead of fanning out separately, so CLI and UI stay aligned. Responses include per-store **`sources`** status and timing (including vault), and vault rows are **`routable: false`** so they are not counted as data-plane capacity.
> 
> **`vaultAccessFromStackHeaders`** lets API callers supply Stack session headers for the vault leg when a route token alone cannot read it; missing vault access is reported as unavailable, not a hard failure.
> 
> **`DELETE /api/coderouter/accounts/{id}`** routes through **`removeTeamAccount`**, which picks the owning store from the id (UUID → native then Claude; otherwise vault), widens id validation beyond strict UUID, and returns **`account_source`** in analytics. Dashboard tests inject **`loadAccounts`** for the unified read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71295808f2f1ac5bb0cb10af78fc4c4651898828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates all account reads into one `listTeamAccounts` call so the dashboard, CLI, and API agree on a team's accounts. Previously each surface read the native table, Claude upstream table, and hosted Subrouter vault itself, and they could disagree: team cmux showed 9 accounts in the dashboard but 4 via `cr accounts`.

- Both the dashboard and `GET /api/coderouter/accounts` call this one read, and each store's status is reported separately so a store that is down, absent, or unreadable never hides accounts that did load.
- The API route accepts the CLI's Stack session from `x-stack-access-token` for the vault leg, because the vault authenticates the end user rather than the route token.
- The caller's account access is preserved for the native and Claude reads, so the unified list uses the same permissions as the old separate reads.
- Vault accounts are marked `routable: false` because the data plane never selects them.
- `DELETE /api/coderouter/accounts/{id}` resolves the store that owns the id, so older clients sending a Claude or vault id stop getting a 404.
- An unknown vault id on delete is now a miss, not a 503 outage report, matching how unknown UUIDs behave.
- The dashboard renders as before; it just derives its three section states from the single result.

<sup>Written for commit 3c5d4c50b43f4c1754407293a7b2ff1aab0fdac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unified CodeRouter account listings across native, Claude, and shared accounts.
  - Added account source information and per-source availability or error statuses.
  - Account removal now supports all account types through a single workflow.
  - Added vault access validation for hosted account operations.

- **Bug Fixes**
  - Accounts from available stores remain visible when another store encounters an error.
  - Improved handling of missing or unrecognized account IDs during removal.

- **Tests**
  - Added coverage for multi-source listing, partial failures, account removal, and vault access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->