### PR TITLE
Fix sidebar Sign In button and account avatar not rendering on Intel Macs

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
@@ -103,6 +103,7 @@ public final class CmuxResolvedIconImageView: NSView {
         private let tint: NSColor?
         private let fallbackTint: NSColor?
         private let symbolWeight: CGFloat
+        private let symbolPointSize: CGFloat?
         private let appearanceName: NSAppearance.Name
         private let appearanceIdentity: ObjectIdentifier
 
@@ -119,6 +120,7 @@ public final class CmuxResolvedIconImageView: NSView {
             self.tint = request.tintColor
             self.fallbackTint = request.fallbackTintColor
             self.symbolWeight = request.symbolWeight.rawValue
+            self.symbolPointSize = request.symbolPointSize
             self.appearanceName = appearance.name
             self.appearanceIdentity = ObjectIdentifier(appearance)
         }
@@ -133,6 +135,7 @@ public final class CmuxResolvedIconImageView: NSView {
                 width == other.width &&
                 height == other.height &&
                 symbolWeight == other.symbolWeight &&
+                symbolPointSize == other.symbolPointSize &&
                 appearanceName == other.appearanceName &&
                 appearanceIdentity == other.appearanceIdentity &&
                 Self.colorsEqual(tint, other.tint) &&

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderer.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderer.swift
@@ -66,7 +66,11 @@ public final class CmuxResolvedIconRenderer {
                 NSRect(origin: .zero, size: imageSize).fill()
                 NSGraphicsContext.current?.imageInterpolation = .high
 
-                let drawRect = drawingRect(for: sourceImage.size, in: imageSize)
+                let drawRect = drawingRect(
+                    for: sourceImage.size,
+                    in: imageSize,
+                    preservesNaturalSize: request.drawsSymbolAtNaturalSize(candidate.source)
+                )
                 sourceImage.draw(
                     in: drawRect,
                     from: .zero,
@@ -127,7 +131,7 @@ public final class CmuxResolvedIconRenderer {
             ) else {
                 return nil
             }
-            let pointSize = max(1, min(request.size.width, request.size.height))
+            let pointSize = max(1, request.symbolPointSize ?? min(request.size.width, request.size.height))
             let configuration = NSImage.SymbolConfiguration(
                 pointSize: pointSize,
                 weight: request.symbolWeight
@@ -193,14 +197,24 @@ public final class CmuxResolvedIconRenderer {
         return NSSize(width: ceil(size.width), height: ceil(size.height))
     }
 
-    private func drawingRect(for sourceSize: NSSize, in targetSize: NSSize) -> NSRect {
+    /// Fits `sourceSize` into `targetSize`. With `preservesNaturalSize`, the
+    /// source keeps its own size (centered) unless it overflows the target,
+    /// matching how a configured SF Symbol lays out at its point size.
+    private func drawingRect(
+        for sourceSize: NSSize,
+        in targetSize: NSSize,
+        preservesNaturalSize: Bool = false
+    ) -> NSRect {
         guard sourceSize.width.isFinite,
               sourceSize.height.isFinite,
               sourceSize.width > 0,
               sourceSize.height > 0 else {
             return NSRect(origin: .zero, size: targetSize)
         }
-        let scale = min(targetSize.width / sourceSize.width, targetSize.height / sourceSize.height)
+        var scale = min(targetSize.width / sourceSize.width, targetSize.height / sourceSize.height)
+        if preservesNaturalSize {
+            scale = min(scale, 1)
+        }
         let width = sourceSize.width * scale
         let height = sourceSize.height * scale
         return NSRect(

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRequest.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRequest.swift
@@ -16,6 +16,9 @@ public struct CmuxResolvedIconRequest {
     public let fallbackTintColor: NSColor?
     /// SF Symbol weight used only for ``CmuxResolvedIconSource/systemSymbol(name:accessibilityDescription:)``.
     public let symbolWeight: NSFont.Weight
+    /// Optional explicit SF Symbol configuration point size. When `nil`, the
+    /// symbol is configured from the smaller ``size`` dimension.
+    public let symbolPointSize: CGFloat?
     /// Optional accessibility label for the rendered image view.
     public let accessibilityDescription: String?
 
@@ -29,6 +32,9 @@ public struct CmuxResolvedIconRequest {
     ///     when omitted, ``tintColor`` is reused.
     ///   - symbolWeight: SF Symbol weight for symbol sources.
     ///   - accessibilityDescription: Optional accessibility label for image views.
+    ///   - symbolPointSize: Explicit SF Symbol point size for symbol sources.
+    ///     Pass the configured symbol's natural size as ``size`` to draw the
+    ///     glyph at the same scale AppKit uses for that point size.
     public init(
         source: CmuxResolvedIconSource,
         size: NSSize,
@@ -36,7 +42,8 @@ public struct CmuxResolvedIconRequest {
         symbolWeight: NSFont.Weight = .regular,
         accessibilityDescription: String? = nil,
         fallbackSource: CmuxResolvedIconSource? = nil,
-        fallbackTintColor: NSColor? = nil
+        fallbackTintColor: NSColor? = nil,
+        symbolPointSize: CGFloat? = nil
     ) {
         self.source = source
         self.fallbackSource = fallbackSource
@@ -44,6 +51,15 @@ public struct CmuxResolvedIconRequest {
         self.tintColor = tintColor
         self.fallbackTintColor = fallbackTintColor
         self.symbolWeight = symbolWeight
+        self.symbolPointSize = symbolPointSize
         self.accessibilityDescription = accessibilityDescription
+    }
+
+    /// Symbol sources with an explicit point size draw at the configured
+    /// symbol's natural size instead of being scaled to fill ``size``.
+    func drawsSymbolAtNaturalSize(_ source: CmuxResolvedIconSource) -> Bool {
+        guard symbolPointSize != nil else { return false }
+        if case .systemSymbol = source { return true }
+        return false
     }
 }

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconSymbolPointSizeTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconSymbolPointSizeTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import Testing
+
+@testable import CmuxAppKitSupportUI
+
+/// The hosted renderer must be able to draw an SF Symbol at an explicit
+/// configuration point size inside a larger natural-size slot, so hosted
+/// symbols match the geometry of `NSImage.SymbolConfiguration(pointSize:)`.
+@MainActor
+@Suite struct CmuxResolvedIconSymbolPointSizeTests {
+    @Test func explicitSymbolPointSizeDrawsSmallerGlyphThanSizeDerivedDefault() throws {
+        let renderer = CmuxResolvedIconRenderer()
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let slot = NSSize(width: 32, height: 32)
+
+        let sizeDerived = try #require(renderer.image(
+            for: CmuxResolvedIconRequest(
+                source: .systemSymbol(name: "circle.fill", accessibilityDescription: nil),
+                size: slot,
+                tintColor: .labelColor
+            ),
+            appearance: appearance
+        ))
+        let explicit = try #require(renderer.image(
+            for: CmuxResolvedIconRequest(
+                source: .systemSymbol(name: "circle.fill", accessibilityDescription: nil),
+                size: slot,
+                tintColor: .labelColor,
+                symbolPointSize: 8
+            ),
+            appearance: appearance
+        ))
+
+        let defaultPixels = visiblePixelCount(in: sizeDerived)
+        let explicitPixels = visiblePixelCount(in: explicit)
+        #expect(explicitPixels > 0)
+        #expect(explicitPixels * 2 < defaultPixels)
+        #expect(explicit.size == slot)
+    }
+
+    @Test func explicitSymbolPointSizeMatchesAppKitConfiguredSymbolCoverage() throws {
+        let systemName = "person.crop.circle"
+        let pointSize: CGFloat = 14
+        let base = try #require(NSImage(systemSymbolName: systemName, accessibilityDescription: nil))
+        let configuration = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
+        let configured = try #require(base.withSymbolConfiguration(configuration))
+        let naturalSize = configured.size
+        #expect(naturalSize.width > pointSize)
+
+        let renderer = CmuxResolvedIconRenderer()
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let hosted = try #require(renderer.image(
+            for: CmuxResolvedIconRequest(
+                source: .systemSymbol(name: systemName, accessibilityDescription: nil),
+                size: naturalSize,
+                tintColor: .labelColor,
+                symbolWeight: .regular,
+                symbolPointSize: pointSize
+            ),
+            appearance: appearance
+        ))
+        #expect(hosted.size == naturalSize)
+
+        let expected = try #require(directDraw(configured, size: naturalSize))
+        let expectedPixels = visiblePixelCount(in: expected)
+        let hostedPixels = visiblePixelCount(in: hosted)
+        #expect(expectedPixels > 0)
+        #expect(abs(hostedPixels - expectedPixels) <= expectedPixels / 10)
+    }
+
+    @Test func imageViewRerendersWhenSymbolPointSizeChanges() throws {
+        let view = CmuxResolvedIconImageView(frame: NSRect(x: 0, y: 0, width: 32, height: 32))
+        view.appearance = NSAppearance(named: .aqua)
+        let slot = NSSize(width: 32, height: 32)
+        view.apply(CmuxResolvedIconRequest(
+            source: .systemSymbol(name: "circle.fill", accessibilityDescription: nil),
+            size: slot,
+            tintColor: .labelColor,
+            symbolPointSize: 8
+        ))
+        let small = try #require(renderedImage(in: view))
+        view.apply(CmuxResolvedIconRequest(
+            source: .systemSymbol(name: "circle.fill", accessibilityDescription: nil),
+            size: slot,
+            tintColor: .labelColor,
+            symbolPointSize: 24
+        ))
+        let large = try #require(renderedImage(in: view))
+
+        #expect(large !== small)
+        #expect(visiblePixelCount(in: large) > visiblePixelCount(in: small))
+    }
+
+    private func renderedImage(in view: CmuxResolvedIconImageView) -> NSImage? {
+        view.subviews.compactMap { $0 as? NSImageView }.first?.image
+    }
+
+    private func directDraw(_ image: NSImage, size: NSSize) -> NSImage? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(ceil(size.width * 2)),
+            pixelsHigh: Int(ceil(size.height * 2)),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        bitmap.size = size
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmap)
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        let rendered = NSImage(size: size)
+        rendered.addRepresentation(bitmap)
+        return rendered
+    }
+
+    private func visiblePixelCount(in image: NSImage) -> Int {
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff) else {
+            return 0
+        }
+        var count = 0
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                if let color = bitmap.colorAt(x: x, y: y), color.alphaComponent > 0.01 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+}

--- a/Sources/Auth/StackAccountAvatarImageLoader.swift
+++ b/Sources/Auth/StackAccountAvatarImageLoader.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Foundation
+
+/// Loads a Stack profile picture and normalizes it into a square bitmap that
+/// the AppKit-hosted icon renderer draws as an aspect-fill avatar.
+///
+/// `AsyncImage` hands its result to SwiftUI as a raster `Image`, which draws
+/// nothing on Intel Macs running macOS 15. Decoding here and drawing through
+/// `CmuxResolvedIconImage` keeps the real profile picture visible everywhere.
+@MainActor
+enum StackAccountAvatarImageLoader {
+    /// Fetches `url` through the shared URL cache and returns a square avatar
+    /// bitmap sized for `pointSize`, or `nil` when the download or decode fails.
+    static func load(
+        from url: URL,
+        pointSize: CGFloat,
+        session: URLSession = .shared
+    ) async -> NSImage? {
+        guard let (data, _) = try? await session.data(from: url) else {
+            return nil
+        }
+        return squareImage(from: data, pointSize: pointSize)
+    }
+
+    /// Decodes `data`, center-crops it to a square, and rasterizes it at
+    /// `scale` pixels per point so a square image view fills the avatar circle.
+    static func squareImage(from data: Data, pointSize: CGFloat, scale: CGFloat = 2) -> NSImage? {
+        guard pointSize.isFinite, pointSize > 0,
+              scale.isFinite, scale > 0,
+              let source = NSImage(data: data),
+              source.size.width > 0,
+              source.size.height > 0 else {
+            return nil
+        }
+        let pixels = max(1, Int((pointSize * scale).rounded(.up)))
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixels,
+            pixelsHigh: pixels,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        let targetSize = NSSize(width: pointSize, height: pointSize)
+        bitmap.size = targetSize
+        guard let graphicsContext = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            return nil
+        }
+
+        let side = min(source.size.width, source.size.height)
+        let cropRect = NSRect(
+            x: (source.size.width - side) / 2,
+            y: (source.size.height - side) / 2,
+            width: side,
+            height: side
+        )
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        graphicsContext.imageInterpolation = .high
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: targetSize).fill()
+        source.draw(
+            in: NSRect(origin: .zero, size: targetSize),
+            from: cropRect,
+            operation: .sourceOver,
+            fraction: 1,
+            respectFlipped: true,
+            hints: nil
+        )
+        NSGraphicsContext.restoreGraphicsState()
+
+        let image = NSImage(size: targetSize)
+        image.addRepresentation(bitmap)
+        image.cacheMode = .never
+        return image
+    }
+}

--- a/Sources/Auth/StackAccountAvatarView.swift
+++ b/Sources/Auth/StackAccountAvatarView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxAppKitSupportUI
 import SwiftUI
 
 /// Displays the Stack profile image with an initial-based fallback.
@@ -9,22 +10,38 @@ struct StackAccountAvatarView: View {
     let size: CGFloat
     var loadingSystemName: String? = nil
 
+    @State private var loadedAvatar: LoadedAvatar?
+
+    /// The last completed load, keyed by URL so a changed URL shows the
+    /// loading state again instead of a stale picture.
+    private struct LoadedAvatar {
+        let url: URL
+        let image: NSImage?
+    }
+
     var body: some View {
         Group {
             if let avatarURL {
-                AsyncImage(url: avatarURL) { phase in
-                    if let image = phase.image {
-                        image.resizable().scaledToFill()
-                    } else if phase.error == nil, let loadingSystemName {
-                        CmuxSystemSymbolImage(
-                            systemName: loadingSystemName,
-                            pointSize: size,
-                            weight: .regular
-                        )
-                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                if let loadedAvatar, loadedAvatar.url == avatarURL {
+                    if let image = loadedAvatar.image {
+                        // The hosted AppKit renderer draws the picture; SwiftUI
+                        // raster images are blank on Intel Macs running macOS 15.
+                        CmuxResolvedIconImage(request: CmuxResolvedIconRequest(
+                            source: .image(image),
+                            size: NSSize(width: size, height: size)
+                        ))
                     } else {
                         fallback
                     }
+                } else if let loadingSystemName {
+                    CmuxSystemSymbolImage(
+                        systemName: loadingSystemName,
+                        pointSize: size,
+                        weight: .regular
+                    )
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                } else {
+                    fallback
                 }
             } else {
                 fallback
@@ -34,6 +51,12 @@ struct StackAccountAvatarView: View {
         .clipShape(Circle())
         .overlay(Circle().stroke(Color.primary.opacity(0.12), lineWidth: 0.5))
         .accessibilityHidden(true)
+        .task(id: avatarURL) {
+            guard let avatarURL else { return }
+            let image = await StackAccountAvatarImageLoader.load(from: avatarURL, pointSize: size)
+            guard !Task.isCancelled else { return }
+            loadedAvatar = LoadedAvatar(url: avatarURL, image: image)
+        }
     }
 
     private var fallback: some View {

--- a/Sources/CmuxHostedSystemSymbolImage.swift
+++ b/Sources/CmuxHostedSystemSymbolImage.swift
@@ -1,0 +1,57 @@
+import AppKit
+import CmuxAppKitSupportUI
+import SwiftUI
+
+/// Draws an SF Symbol through the AppKit-hosted icon renderer while keeping
+/// SwiftUI foreground-style tinting.
+///
+/// SwiftUI raster images (`Image(nsImage:)`, `Image(decorative:)`,
+/// `AsyncImage`) draw nothing on Intel Macs running macOS 15, while AppKit
+/// image views hosted in SwiftUI draw normally. Masking a `.foreground`
+/// filled rectangle with the hosted symbol keeps every caller's
+/// `.foregroundStyle` / `.foregroundColor` semantics and the exact glyph
+/// geometry of `NSImage.SymbolConfiguration(pointSize:weight:)`.
+struct CmuxHostedSystemSymbolImage: View {
+    let systemName: String
+    /// SF Symbol configuration point size.
+    let pointSize: CGFloat
+    /// Layout size of the configured symbol; the glyph draws 1:1 inside it.
+    let imageSize: NSSize
+    let weight: NSFont.Weight
+    /// Size of the slot the glyph is centered in, matching the SwiftUI
+    /// `Image(nsImage:)` frame this view replaces.
+    let slotSize: CGFloat
+    var alignment: Alignment = .center
+
+    /// Builds the renderer request for a hosted symbol.
+    static func iconRequest(
+        systemName: String,
+        pointSize: CGFloat,
+        imageSize: NSSize,
+        weight: NSFont.Weight
+    ) -> CmuxResolvedIconRequest {
+        CmuxResolvedIconRequest(
+            source: .systemSymbol(name: systemName, accessibilityDescription: nil),
+            size: imageSize,
+            symbolWeight: weight,
+            symbolPointSize: pointSize
+        )
+    }
+
+    var body: some View {
+        Rectangle()
+            .fill(.foreground)
+            .frame(width: imageSize.width, height: imageSize.height)
+            .mask(
+                CmuxResolvedIconImage(request: Self.iconRequest(
+                    systemName: systemName,
+                    pointSize: pointSize,
+                    imageSize: imageSize,
+                    weight: weight
+                ))
+                .frame(width: imageSize.width, height: imageSize.height)
+            )
+            .frame(width: slotSize, height: slotSize, alignment: alignment)
+            .accessibilityHidden(true)
+    }
+}

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -456,34 +456,33 @@ struct CmuxSystemSymbolImage: View {
             globalFontPercent: globalFontPercent,
             appliesGlobalFontMagnification: appliesGlobalFontMagnification
         )
+        // SwiftUI raster images draw blank on Intel Macs running macOS 15, so
+        // the AppKit-hosted renderer owns every symbol draw. The materialized
+        // image only supplies the configured symbol's natural layout size.
         if let image = RenderableSystemSymbol.configuredAppKitImage(
             systemName: systemName,
             pointSize: rasterSize,
             weight: weight
         ) {
-            Image(nsImage: image)
-                .renderingMode(.template)
-                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+            CmuxHostedSystemSymbolImage(
+                systemName: systemName,
+                pointSize: rasterSize,
+                imageSize: image.size,
+                weight: RenderableSystemSymbol.nsFontWeight(for: weight),
+                slotSize: rasterSize,
+                alignment: alignment
+            )
         } else if RenderableSystemSymbol.isRenderable(systemName) {
             // A transient blank materialization gets the same AppKit lifecycle
-            // owner and forced-appearance retry instead of a lazy SwiftUI provider.
-            // The mask keeps the caller's foreground color/style semantics while
-            // the AppKit view remains the only symbol lifecycle owner.
-            Rectangle()
-                .fill(.foreground)
-                .frame(width: rasterSize, height: rasterSize)
-                .mask(
-                    CmuxResolvedIconImage(request: CmuxResolvedIconRequest(
-                        source: .systemSymbol(
-                            name: systemName,
-                            accessibilityDescription: nil
-                        ),
-                        size: NSSize(width: rasterSize, height: rasterSize),
-                        symbolWeight: RenderableSystemSymbol.nsFontWeight(for: weight)
-                    ))
-                    .frame(width: rasterSize, height: rasterSize)
-                )
-                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+            // owner and forced-appearance retry through the hosted renderer.
+            CmuxHostedSystemSymbolImage(
+                systemName: systemName,
+                pointSize: rasterSize,
+                imageSize: NSSize(width: rasterSize, height: rasterSize),
+                weight: RenderableSystemSymbol.nsFontWeight(for: weight),
+                slotSize: rasterSize,
+                alignment: alignment
+            )
         } else {
             Color.clear
                 .frame(width: rasterSize, height: rasterSize, alignment: alignment)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
+		A11C00010000000000000001 /* CmuxHostedSystemSymbolImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00010000000000000002 /* CmuxHostedSystemSymbolImage.swift */; };
 		A11C00040000000000000001 /* CmuxHostedSystemSymbolImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		1A0B0C0D0E0F101112132013 /* CmuxIrohTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */; };
@@ -2571,6 +2572,7 @@
 		FCB4880428BE4BB3990BCD51 /* SSHRemoteCommandCLIIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6498DB903042C8B9EB34C5 /* SSHRemoteCommandCLIIntegrationTests.swift */; };
 		EF70B7123200D1FB6F03DB26 /* SSHStartupManualReconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */; };
 		F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */; };
+		A11C00020000000000000001 /* StackAccountAvatarImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00020000000000000002 /* StackAccountAvatarImageLoader.swift */; };
 		A11C00030000000000000001 /* StackAccountAvatarImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */; };
 		A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C017000000000000000006 /* StackAccountAvatarView.swift */; };
 		F20F85FC5900550685FA33AD /* StackAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A8BD195031FC4B82B4354297 /* StackAuth */; };
@@ -4263,6 +4265,7 @@
 		A117FF000000000000000004 /* CmuxFeatureFlagSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxFeatureFlagSource.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
+		A11C00010000000000000002 /* CmuxHostedSystemSymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImage.swift; sourceTree = "<group>"; };
 		A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImageTests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
@@ -5825,6 +5828,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		BB6498DB903042C8B9EB34C5 /* SSHRemoteCommandCLIIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHRemoteCommandCLIIntegrationTests.swift; sourceTree = "<group>"; };
 		4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupManualReconnectTests.swift; sourceTree = "<group>"; };
 		F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupSignalLifecycleTests.swift; sourceTree = "<group>"; };
+		A11C00020000000000000002 /* StackAccountAvatarImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarImageLoader.swift; sourceTree = "<group>"; };
 		A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarImageLoaderTests.swift; sourceTree = "<group>"; };
 		A5C017000000000000000006 /* StackAccountAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarView.swift; sourceTree = "<group>"; };
 		C0DE70500000000000000001 /* start-cmux-profiling */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/start-cmux-profiling"; sourceTree = SOURCE_ROOT; };
@@ -6737,6 +6741,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
 				A5C017000000000000000006 /* StackAccountAvatarView.swift */,
+				A11C00020000000000000002 /* StackAccountAvatarImageLoader.swift */,
 			);
 			name = Auth;
 			path = Auth;
@@ -7372,6 +7377,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C9A57302C9A57302C9A57302 /* SidebarWorkspaceGroupHeaderMetrics.swift */,
 				C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */,
 				D5037010000000000000002 /* RenderableSystemSymbol.swift */,
+				A11C00010000000000000002 /* CmuxHostedSystemSymbolImage.swift */,
 				C9A57212C9A57212C9A57212 /* SidebarWorkspaceRenderItemID.swift */,
 				C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */,
 				C9A5760EC9A5760EC9A5760E /* SidebarWorkspaceReorderDropOverlay.swift */,
@@ -11030,6 +11036,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A117FF000000000000000003 /* CmuxFeatureFlagSource.swift in Sources */,
 				C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */,
 				C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */,
+				A11C00010000000000000001 /* CmuxHostedSystemSymbolImage.swift in Sources */,
 				C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */,
 				E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */,
 				2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */,
@@ -12087,6 +12094,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					A6AC72060000000000000001 /* SpinnerGalleryRootView.swift in Sources */,
 					A6AC72070000000000000001 /* SpinnerSpec.swift in Sources */,
 					E30780000000000000000012 /* SSHPTYAttachStartupCommandBuilder.swift in Sources */,
+				A11C00020000000000000001 /* StackAccountAvatarImageLoader.swift in Sources */,
 				A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */,
 				D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */,
 				D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
+		A11C00040000000000000001 /* CmuxHostedSystemSymbolImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		1A0B0C0D0E0F101112132013 /* CmuxIrohTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */; };
 		1A0B0C0D0E0F101112132014 /* CmuxIrohTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */; };
@@ -2570,6 +2571,7 @@
 		FCB4880428BE4BB3990BCD51 /* SSHRemoteCommandCLIIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6498DB903042C8B9EB34C5 /* SSHRemoteCommandCLIIntegrationTests.swift */; };
 		EF70B7123200D1FB6F03DB26 /* SSHStartupManualReconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */; };
 		F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */; };
+		A11C00030000000000000001 /* StackAccountAvatarImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */; };
 		A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C017000000000000000006 /* StackAccountAvatarView.swift */; };
 		F20F85FC5900550685FA33AD /* StackAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A8BD195031FC4B82B4354297 /* StackAuth */; };
 		C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70500000000000000001 /* start-cmux-profiling */; };
@@ -4261,6 +4263,7 @@
 		A117FF000000000000000004 /* CmuxFeatureFlagSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxFeatureFlagSource.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
+		A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImageTests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
@@ -5822,6 +5825,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		BB6498DB903042C8B9EB34C5 /* SSHRemoteCommandCLIIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHRemoteCommandCLIIntegrationTests.swift; sourceTree = "<group>"; };
 		4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupManualReconnectTests.swift; sourceTree = "<group>"; };
 		F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupSignalLifecycleTests.swift; sourceTree = "<group>"; };
+		A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarImageLoaderTests.swift; sourceTree = "<group>"; };
 		A5C017000000000000000006 /* StackAccountAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarView.swift; sourceTree = "<group>"; };
 		C0DE70500000000000000001 /* start-cmux-profiling */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/start-cmux-profiling"; sourceTree = SOURCE_ROOT; };
 		D35B71010000000000000002 /* StartupBreadcrumbLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/StartupBreadcrumbLog.swift; sourceTree = "<group>"; };
@@ -9202,6 +9206,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
+				A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */,
+				A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
 				859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
@@ -13116,6 +13122,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5FB1205 /* CmuxConfigWorkspaceActionTests.swift in Sources */,
 				C54860040000000000000001 /* CmuxDurableDeepLinkRestoreTests.swift in Sources */,
 				E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */,
+				A11C00040000000000000001 /* CmuxHostedSystemSymbolImageTests.swift in Sources */,
 				D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */,
 					D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */,
 					C54860030000000000000001 /* CmuxNavigationTargetResolverTests.swift in Sources */,
@@ -13538,6 +13545,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				FCB4880428BE4BB3990BCD51 /* SSHRemoteCommandCLIIntegrationTests.swift in Sources */,
 				EF70B7123200D1FB6F03DB26 /* SSHStartupManualReconnectTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
+				A11C00030000000000000001 /* StackAccountAvatarImageLoaderTests.swift in Sources */,
 				5873A6BE37C34CC1082864E2 /* SurfaceCatalogTests.swift in Sources */,
 				560A57B0605EC30E23A20456 /* SurfacePaneFactoryFocusTests.swift in Sources */,
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,

--- a/cmuxTests/CmuxHostedSystemSymbolImageTests.swift
+++ b/cmuxTests/CmuxHostedSystemSymbolImageTests.swift
@@ -1,0 +1,79 @@
+import AppKit
+import CmuxAppKitSupportUI
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Hosted symbols must request the configured symbol's natural layout size
+/// with an explicit point size, so the AppKit renderer draws the same glyph
+/// geometry the SwiftUI symbol image used before.
+@Suite("Hosted system symbol image")
+struct CmuxHostedSystemSymbolImageTests {
+    @Test @MainActor func iconRequestPreservesConfiguredSymbolGeometry() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let materialized = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "person.crop.circle",
+            pointSize: 14,
+            weight: .regular
+        ))
+        let request = CmuxHostedSystemSymbolImage.iconRequest(
+            systemName: "person.crop.circle",
+            pointSize: 14,
+            imageSize: materialized.size,
+            weight: .regular
+        )
+
+        #expect(request.size == materialized.size)
+        #expect(request.symbolPointSize == 14)
+        #expect(request.symbolWeight == .regular)
+        #expect(request.tintColor == nil)
+        guard case .systemSymbol(let name, _) = request.source else {
+            Issue.record("expected a system symbol source")
+            return
+        }
+        #expect(name == "person.crop.circle")
+    }
+
+    @Test @MainActor func hostedRendererDrawsRequestedSymbolAtNaturalSize() throws {
+        let materialized = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "questionmark.circle",
+            pointSize: 14,
+            weight: .regular
+        ))
+        let request = CmuxHostedSystemSymbolImage.iconRequest(
+            systemName: "questionmark.circle",
+            pointSize: 14,
+            imageSize: materialized.size,
+            weight: .regular
+        )
+        let appearance = try #require(NSAppearance(named: .darkAqua))
+        let rendered = try #require(CmuxResolvedIconRenderer().image(for: request, appearance: appearance))
+
+        #expect(rendered.size == materialized.size)
+        let renderedBitmap = try #require(rendered.representations.first as? NSBitmapImageRep)
+        let materializedBitmap = try #require(materialized.representations
+            .compactMap { $0 as? NSBitmapImageRep }
+            .first { $0.pixelsWide == renderedBitmap.pixelsWide })
+        let renderedPixels = Self.visiblePixelCount(in: renderedBitmap)
+        let materializedPixels = Self.visiblePixelCount(in: materializedBitmap)
+        #expect(renderedPixels > 0)
+        #expect(abs(renderedPixels - materializedPixels) <= materializedPixels / 10)
+    }
+
+    private static func visiblePixelCount(in bitmap: NSBitmapImageRep) -> Int {
+        var count = 0
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                if let color = bitmap.colorAt(x: x, y: y), color.alphaComponent > 0.01 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+}

--- a/cmuxTests/StackAccountAvatarImageLoaderTests.swift
+++ b/cmuxTests/StackAccountAvatarImageLoaderTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// The avatar loader must hand the hosted renderer a square bitmap that
+/// keeps the center of the profile picture, since the renderer draws its
+/// sources aspect-fit and the avatar is clipped to a circle.
+@Suite("Stack account avatar image loader")
+struct StackAccountAvatarImageLoaderTests {
+    @Test @MainActor func squareImageCenterCropsWideSourceAtRequestedScale() throws {
+        // 40x20 source: red | green | blue columns, 10/20/10 wide.
+        let data = try #require(Self.pngData(width: 40, height: 20) { x, _ in
+            x < 10 ? .red : (x < 30 ? .green : .blue)
+        })
+        let image = try #require(StackAccountAvatarImageLoader.squareImage(from: data, pointSize: 10, scale: 2))
+        let bitmap = try #require(image.representations.first as? NSBitmapImageRep)
+
+        #expect(image.size == NSSize(width: 10, height: 10))
+        #expect(bitmap.pixelsWide == 20)
+        #expect(bitmap.pixelsHigh == 20)
+        // Only the green center band survives the crop.
+        for x in [1, 10, 18] {
+            let color = try #require(bitmap.colorAt(x: x, y: 10)?.usingColorSpace(.deviceRGB))
+            #expect(color.greenComponent > 0.8, "x=\(x)")
+            #expect(color.redComponent < 0.2, "x=\(x)")
+            #expect(color.blueComponent < 0.2, "x=\(x)")
+        }
+    }
+
+    @Test @MainActor func squareImageCenterCropsTallSource() throws {
+        // 20x40 source: red top band, green middle, blue bottom band.
+        let data = try #require(Self.pngData(width: 20, height: 40) { _, y in
+            y < 10 ? .red : (y < 30 ? .green : .blue)
+        })
+        let image = try #require(StackAccountAvatarImageLoader.squareImage(from: data, pointSize: 8, scale: 1))
+        let bitmap = try #require(image.representations.first as? NSBitmapImageRep)
+
+        #expect(bitmap.pixelsWide == 8)
+        #expect(bitmap.pixelsHigh == 8)
+        for y in [0, 4, 7] {
+            let color = try #require(bitmap.colorAt(x: 4, y: y)?.usingColorSpace(.deviceRGB))
+            #expect(color.greenComponent > 0.8, "y=\(y)")
+        }
+    }
+
+    @Test @MainActor func squareImageRejectsUndecodableDataAndInvalidSizes() throws {
+        let garbage = Data([0x00, 0x01, 0x02, 0x03])
+        #expect(StackAccountAvatarImageLoader.squareImage(from: garbage, pointSize: 10) == nil)
+
+        let data = try #require(Self.pngData(width: 4, height: 4) { _, _ in .green })
+        #expect(StackAccountAvatarImageLoader.squareImage(from: data, pointSize: 0) == nil)
+        #expect(StackAccountAvatarImageLoader.squareImage(from: data, pointSize: .nan) == nil)
+    }
+
+    private static func pngData(width: Int, height: Int, color: (Int, Int) -> NSColor) -> Data? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        for y in 0..<height {
+            for x in 0..<width {
+                bitmap.setColor(color(x, y).usingColorSpace(.deviceRGB) ?? .black, atX: x, y: y)
+            }
+        }
+        return bitmap.representation(using: .png, properties: [:])
+    }
+}


### PR DESCRIPTION
## Summary

On Intel Macs running macOS 15, SwiftUI draws nothing for raster images (`Image(nsImage:)`, `Image(decorative:)` from a `CGImage`, and `AsyncImage` results), while SwiftUI's own vector symbols and AppKit image views hosted in SwiftUI paint normally. Sidebar footer controls (Sign In, Help, the profile picture, sidebar top-bar icons) all went through `CmuxSystemSymbolImage`, whose primary branch handed a rasterized template `NSImage` to SwiftUI, so they disappeared. The signed-in avatar disappeared for the same reason inside `AsyncImage`.

- `CmuxSystemSymbolImage` now always draws through the AppKit-hosted `CmuxResolvedIconImage`, masking a `.foreground` fill so callers keep their `.foregroundStyle` tinting. The materialized bitmap only supplies the configured symbol's natural layout size.
- `CmuxResolvedIconRequest` gains an explicit `symbolPointSize`; the shared renderer draws such symbols at their natural size inside the slot, matching `NSImage.SymbolConfiguration(pointSize:weight:)` geometry on every platform.
- `StackAccountAvatarView` replaces `AsyncImage` with `StackAccountAvatarImageLoader`, which fetches through the shared URL cache, center-crops the picture to a square bitmap, and draws it through the hosted renderer. Initial/person fallbacks are unchanged.

Two-commit regression-first history:

1. `26be5ec1ba` — failing tests only (`CmuxResolvedIconSymbolPointSizeTests`, `CmuxHostedSystemSymbolImageTests`, `StackAccountAvatarImageLoaderTests` + pbxproj wiring)
2. `064b36fb3a` — production fix

No user-facing strings, shortcuts, settings, or localization catalogs changed.

## Testing

- Ran `swift test --filter CmuxResolvedIconSymbolPointSizeTests` from `Packages/macOS/CmuxAppKitSupportUI` on this Intel Mac (macOS 15, x86_64). All 3 tests passed.
- `CmuxHostedSystemSymbolImageTests` and `StackAccountAvatarImageLoaderTests` are wired into `cmux-unit` but were not executed locally: this machine has Command Line Tools only (`xcode-select` → `/Library/Developer/CommandLineTools`), no `Xcode.app`, and no `zig`, so `./scripts/reload.sh --tag intel-sidebar-icons` cannot run here. CI `tests` job is the gate for those suites.
- Left the uncommitted DEBUG `SymbolProbeVariantsView` out of the PR.

## Demo Video

- Video URL or attachment: not attached. Remaining dogfood check is a visual confirm on this Intel Mac that the sidebar Sign In / Help glyphs and the signed-in account avatar paint after a tagged build from a machine with Xcode.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791449507&installation_model_id=21920&pr_number=12126&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12126&signature=443e3c3ecc483fbbf5ac6bb426b66755f94fe40750c017e5aad9e3513e045d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared sidebar/auth rendering (`CmuxSystemSymbolImage`, icon renderer) used broadly; behavior change is intentional for one platform bug but affects all Macs’ symbol draw path.
> 
> **Overview**
> Fixes **blank sidebar controls and account avatars** on Intel Macs running macOS 15, where SwiftUI raster images (`Image(nsImage:)`, `AsyncImage`) paint nothing while AppKit-hosted image views still work.
> 
> **`CmuxSystemSymbolImage`** no longer displays a materialized `NSImage` through SwiftUI. It always routes drawing through **`CmuxHostedSystemSymbolImage`**, which masks a `.foreground` rectangle with **`CmuxResolvedIconImage`** so callers keep `.foregroundStyle` tinting. The shared icon pipeline gains optional **`symbolPointSize`** on **`CmuxResolvedIconRequest`**; when set, SF Symbols render at AppKit’s natural configured geometry inside the layout slot instead of scaling to fill the frame.
> 
> **`StackAccountAvatarView`** drops **`AsyncImage`** for **`StackAccountAvatarImageLoader`** (URL fetch, center-crop to a square bitmap) and displays the result via **`CmuxResolvedIconImage`**. Initial/person fallbacks are unchanged.
> 
> Regression tests cover symbol point size, hosted symbol geometry, and avatar cropping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064b36fb3a7db7bdc7e7bfdebe5407ddc4ce017d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cached asynchronous loading for account avatar images, including square cropping and requested-size rendering.
  - Added hosted SF Symbol rendering with configurable point size, weight, image size, slot size, alignment, and tinting.
  - Updated system symbol display to use consistent hosted rendering across supported states.
  - SF Symbols can now preserve their natural size when appropriate.

- **Bug Fixes**
  - Symbol images now re-render correctly when their configured point size changes.
  - Avatar updates prevent stale or cancelled image loads from replacing current content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->