### PR TITLE
Promote devbox images baked from main

### DIFF
--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -3972,7 +3972,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -3980,7 +3980,7 @@
         "storageMb": 16384,
         "freestyleBase": "freestyle/ubuntu-sm"
       },
-      "defaultForLocalDev": true
+      "defaultForLocalDev": false
     },
     {
       "provider": "freestyle",
@@ -4003,7 +4003,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -4033,7 +4033,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -4063,7 +4063,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -4092,7 +4092,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -4122,7 +4122,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-13445a4873ea425a92cb233675735eb5, md=sh-3a939dfce4cb4121a5d77a60ecfba5b4, lg=sh-2993e572dc264ff08b697a7cce9cf04f, lgx=sh-ba0b2832af38452d800901bb32f25a7c, xl=sh-043ce3b92d9c434eab1a24c8446c3b43, 2xl=sh-688a90ed35a241efa77b793b253d4e80.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "2xl",
         "cpu": 32,
@@ -4152,7 +4152,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -4182,7 +4182,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -4212,7 +4212,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -4242,7 +4242,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -4271,7 +4271,7 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -4301,6 +4301,365 @@
       "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 71eb616d6f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-fd6425d614b6419fb9a04f5ca0b5e041, md=sh-66ffbc28e3fb4958999d24fe80cc24dd, lg=sh-3bcc29166b854838b659084b18d4aa88, lgx=sh-7183d7b86a3b4c37881fb7c9b6e6149e, xl=sh-e5647183fe264913a1f23948c909c8fa, 2xl=sh-0616615fbc1c4ecd93814a3d2c11f678.",
       "cmuxTuiCommit": "71eb616d6f3fb4dcc707b206e08752c297917e02",
       "cmuxTuiSha256": "a6734e022c18a1f67bfd46e613880b0d2e8c956eb6bedb92844780bb7de8c315",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-sm",
+      "imageId": "sh-4b2e52f8a9584e2c9ca878c6e387e734",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      },
+      "defaultForLocalDev": true
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-md",
+      "imageId": "sh-6918a0aa1d024b71980122e9cf13f989",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-lg",
+      "imageId": "sh-19ee07cbed004c42ae044fd274f8e766",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-lgx",
+      "imageId": "sh-e5b39ac381cf4ff1ac5b82498e6eef79",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-xl",
+      "imageId": "sh-2297bc37dfe840d7a39c113a27d28f83",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-082340-2xl",
+      "imageId": "sh-5ba0f452f6b244599e4cd0cede3b7292",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "9cbdb7ca84fb7515cbfeb1b39cd20d6623ec479e",
+      "builtAt": "2026-09-08T08:26:59.672Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-4b2e52f8a9584e2c9ca878c6e387e734, md=sh-6918a0aa1d024b71980122e9cf13f989, lg=sh-19ee07cbed004c42ae044fd274f8e766, lgx=sh-e5b39ac381cf4ff1ac5b82498e6eef79, xl=sh-2297bc37dfe840d7a39c113a27d28f83, 2xl=sh-5ba0f452f6b244599e4cd0cede3b7292.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-sm",
+      "imageId": "sh-b674df20b1534084bccec193e3e4ce18",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-md",
+      "imageId": "sh-d050519689674be88fc0bb673d6822f1",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-lg",
+      "imageId": "sh-3eb2c3cf358343f1afc5882733584297",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-lgx",
+      "imageId": "sh-1802051bab72463b9ad3cffac4320070",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-xl",
+      "imageId": "sh-86cda3f0f9b44985a6963af7ebd50223",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260908-083844-2xl",
+      "imageId": "sh-ec4dccfe491740eab1374f8af6136e84",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "5a16fbb6dc34d058e20715696c604c80f6b2589c",
+      "builtAt": "2026-09-08T08:42:55.552Z",
+      "builderScriptVersion": "310730bd941b1d9051100c5925dcb249ccaf64e7695ed985763a362df1870f3f",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-07-r1 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 398a10fcf7, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-08 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-b674df20b1534084bccec193e3e4ce18, md=sh-d050519689674be88fc0bb673d6822f1, lg=sh-3eb2c3cf358343f1afc5882733584297, lgx=sh-1802051bab72463b9ad3cffac4320070, xl=sh-86cda3f0f9b44985a6963af7ebd50223, 2xl=sh-ec4dccfe491740eab1374f8af6136e84.",
+      "cmuxTuiCommit": "398a10fcf705ecbda08fdcf121d4049a99e29e79",
+      "cmuxTuiSha256": "222567deaf105c6c8bc53f5a447cccdc056e19d6f584873d9eaba34e80ee390e",
       "defaultForKind": true,
       "size": {
         "name": "2xl",


### PR DESCRIPTION
Rebakes both ladders so the image source that has been sitting on main finally reaches machines: the Option+Backspace word-delete fix (#12099) and the Dockerfile change that preceded it. The previous defaults were baked from `39bfc41fad`, a commit that exists only on `feat-vm-guest-trust-dead-code` and never landed on main.

| ladder | baked from | master snapshot |
| --- | --- | --- |
| base | `9cbdb7ca84` | `sh-4b2e52f8a9584e2c9ca878c6e387e734` |
| desktop | `5a16fbb6dc` | `sh-b674df20b1534084bccec193e3e4ce18` |

The two sit on different commits because main moved during the run and the stale-checkout guard refused the second bake until the tree was updated. That commit touched no image inputs, so both ladders are content-current; kinds are promoted separately by design.

Every entry is verified: promotion boots a machine from the master snapshot and checks it, and the size derive boots and checks each derived snapshot before recording its id.

**Agent pins are unchanged** across this rebake (claude-code 2.1.252, codex 0.151.0, opencode 1.18.25, pi 0.84.4, agent-browser 0.35.2), so it carries no agent upgrade to review. That is the field worth reading on any future promotion, since a bake resolves those at build time.

Measured while producing this, on the base ladder: 784s end to end, of which bake 199s, verify 131s, and six serial size derives 453s. The config file drops that made this promotion necessary are under three seconds of that.

One known gap: the derive could not move the human-facing slugs (`cmux-devbox-lg` and friends still point at the old snapshots) because that needs `--replace-slug`. Production boots the immutable ids in this manifest, so machines are unaffected, but the convenience pointers are now stale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791449626&installation_model_id=21920&pr_number=12127&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12127&signature=d9f4950c07da72838f27777a4b0e3d5169119397c43401d504438061ed05d8ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebakes the base and desktop devbox images from main so the Option+Backspace word-delete fix and preceding Dockerfile change reach machines; the old defaults were baked from a commit that never landed on main.

**Migration**
- The human-facing slugs (`cmux-devbox-lg` and friends) still point at the old snapshots and need a `--replace-slug` run; production machines are unaffected because they boot the immutable image ids.
- Agent pins are unchanged across this rebake, so there is no agent upgrade to review.

<sup>Written for commit e02060ae7eb76b4708029e3bac79c653f97b9fba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default development environment images to the latest base and desktop image versions.
  * Previous development environment images are no longer selected by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->