### PR TITLE
Speed up devbox promotion: parallel ladder, and wait for the guest not the clock

### DIFF
--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -513,7 +513,7 @@ try {
   // lack the placeholder key approval. Drop them: each machine's first shell
   // seeds its own from the env. (The static codex config those shells wrote
   // is the same bytes on every machine and stays; the verifier checks it.)
-  await step("clean", `rm -rf /var/lib/apt/lists/* /root/.npm/_cacache ${WORK_HOME}/.npm/_cacache 2>/dev/null; rm -f /root/.claude.json ${WORK_HOME}/.claude.json; ${devboxJournalResetCommand}; sync; true`);
+  await step("clean", `apt-get clean; rm -rf /var/lib/apt/lists/* /root/.npm/_cacache ${WORK_HOME}/.npm/_cacache 2>/dev/null; rm -f /root/.claude.json ${WORK_HOME}/.claude.json; ${devboxJournalResetCommand}; sync; true`);
   await step("no-stale-claude-seed", `test ! -e /root/.claude.json && test ! -e ${WORK_HOME}/.claude.json && echo no-stale-claude-seed`);
 } catch (error) {
   console.error(`bake failed: ${String(error)}`);

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -11,6 +11,12 @@
  * Usage:
  *   FREESTYLE_API_KEY=... bun scripts/derive-devbox-sizes.ts <master-snapshot-id> <slug-prefix>
  *       [--sizes sm,md,lg,lgx,xl,2xl] [--out <json>] [--replace-slug]
+ *       [--concurrency <n>]
+ *
+ * Sizes are independent (each is "boot the master, resize, snapshot, boot the
+ * result"), and every one spends most of its time waiting for a guest to
+ * settle, so they run concurrently. `--concurrency` caps how many are in
+ * flight; 1 restores the old serial behaviour.
  *
  * Prints one line per size and a final JSON `{ sizes: { <name>: { imageId, slug, size } } }`
  * (also written to --out). Every derived VM is booted once more from its own
@@ -61,6 +67,12 @@ if (!/^[a-z0-9](?:[a-z0-9-]{0,57}[a-z0-9])?$/.test(slugPrefix) || slugPrefix.inc
 }
 const sizes = requested as VmImageSizeName[];
 const replaceSlug = hasFlag("--replace-slug");
+
+const concurrencyRaw = argValue("--concurrency");
+const concurrency = concurrencyRaw === undefined ? 6 : Number.parseInt(concurrencyRaw, 10);
+if (!Number.isInteger(concurrency) || concurrency < 1) {
+  throw new Error(`--concurrency: expected a positive integer, got ${concurrencyRaw}`);
+}
 
 const FIREWALL: FirewallSpec = { rules: [{ action: "allow", source: {}, destination: { public: true } }] };
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -134,7 +146,8 @@ console.log(`master ${master}: ${masterShape.cpu} vCPU, ${masterShape.memoryMb} 
 // would otherwise try to take it).
 const masterSlug = (await fs.vms.snapshots.list()).snapshots.find((candidate) => candidate.id === master)?.slug ?? null;
 
-for (const name of sizes) {
+/** Derive one size: boot the master, resize, snapshot, then boot the result. */
+async function deriveSize(name: VmImageSizeName): Promise<void> {
   const size = vmImageSize(name);
   const slug = name === "md" && slugPrefix !== masterSlug ? slugPrefix : `${slugPrefix}-${name}`;
   const t0 = Date.now();
@@ -207,7 +220,22 @@ for (const name of sizes) {
   console.log(`${name}: ${imageId} (${measured.cpu} vCPU, ${measured.memoryMb} MiB, root ${measured.rootMb} MiB, units ${measured.units}, host ${measured.host}) ${((Date.now() - t0) / 1000).toFixed(0)}s`);
 }
 
-const out = { master, sizes: result };
+// One failed size must not leave the others' VMs running, so every size is
+// awaited before the first rejection is rethrown.
+const queue = [...sizes];
+const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
+  for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
+    await deriveSize(next);
+  }
+});
+const outcomes = await Promise.allSettled(workers);
+const failed = outcomes.find((outcome) => outcome.status === "rejected");
+if (failed && failed.status === "rejected") throw failed.reason;
+
+// Completion order is not ladder order once sizes run concurrently.
+const ordered: typeof result = {};
+for (const name of sizes) ordered[name] = result[name];
+const out = { master, sizes: ordered };
 console.log(JSON.stringify(out, null, 2));
 const outPath = argValue("--out");
 if (outPath) writeFileSync(outPath, `${JSON.stringify(out, null, 2)}\n`);

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -77,6 +77,26 @@ if (!Number.isInteger(concurrency) || concurrency < 1) {
 const FIREWALL: FirewallSpec = { rules: [{ action: "allow", source: {}, destination: { public: true } }] };
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Polls an operation until it succeeds or the budget runs out, and returns the
+ * last result either way so the caller reports the real failure. Guests settle
+ * at their own pace, so waiting for the condition beats waiting for a clock.
+ */
+async function retry<T>(operation: () => Promise<T>, done: (value: T) => boolean, budgetMs: number, everyMs = 2000): Promise<T> {
+  const deadline = Date.now() + budgetMs;
+  let last = await operation();
+  while (!done(last) && Date.now() < deadline) {
+    await sleep(everyMs);
+    last = await operation();
+  }
+  return last;
+}
+
+/** What "the daemon is back on this machine" means, in one shell command. */
+const DAEMON_UP_PROBE =
+  "env HOME=/root /root/.cmux/bin/cmux-tui server status --session cloud >/dev/null 2>&1" +
+  " && grep -qi ':0539 ' /proc/net/tcp6 && test -s /etc/cmux/daemon-instance-id && echo daemon-up";
+
 type Exec = { exec: (options: { command: string; timeoutMs?: number; linuxUser?: string }) => Promise<{ stdout?: string | null; stderr?: string | null; statusCode?: number | null }> };
 async function sh(vm: Exec, command: string, timeoutMs = 120_000): Promise<{ code: number; out: string }> {
   const r = await vm.exec({ command, timeoutMs, linuxUser: "root" });
@@ -175,8 +195,13 @@ async function deriveSize(name: VmImageSizeName): Promise<void> {
         const m = await measure(vm);
         throw new Error(`${name}: resize did not take: ${fits(m, size)} (${JSON.stringify(m)})`);
       }
-      await sleep(30_000);
-      const websocket = await sh(vm, cmuxTuiWebsocketSmokeCommand(), 300_000);
+      // The smoke IS the readiness signal: retry it until the resized guest
+      // answers instead of sleeping for a fixed guess first.
+      const websocket = await retry(
+        () => sh(vm, cmuxTuiWebsocketSmokeCommand(), 300_000),
+        (r) => r.code === 0,
+        90_000,
+      );
       if (websocket.code !== 0) throw new Error(`${name}: WebSocket smoke failed before snapshot: ${websocket.out.slice(-1000)}`);
       // A resized clone runs a live daemon bound to its own instance id; park
       // it so the derived snapshot, like the master, carries no identity.
@@ -195,7 +220,16 @@ async function deriveSize(name: VmImageSizeName): Promise<void> {
   const check = await fs.vms.create({ snapshotId: imageId, displayName: `${slugPrefix} verify ${name}`, firewall: FIREWALL });
   let measured: Awaited<ReturnType<typeof measure>>;
   try {
-    await sleep(30_000);
+    // The daemon coming back is what the old fixed sleep was waiting for, and
+    // the check below already polled for it. Poll first, then measure.
+    const booted = await retry(
+      () => sh(check.vm, DAEMON_UP_PROBE, 30_000),
+      (r) => r.code === 0,
+      120_000,
+    );
+    if (booted.code !== 0) {
+      throw new Error(`${name}: cmux-tui daemon did not come up on the derived snapshot ${imageId}: ${booted.out.slice(-300)}`);
+    }
     measured = await measure(check.vm);
     const problem = fits(measured, size);
     if (problem) throw new Error(`${name}: derived snapshot ${imageId} boots wrong: ${problem}`);
@@ -203,12 +237,6 @@ async function deriveSize(name: VmImageSizeName): Promise<void> {
     if (!measured.units.includes("active")) throw new Error(`${name}: units not active after boot: ${measured.units}`);
     // The parked daemon must come back by itself on the derived shape, bound
     // to this machine and listening dual-stack.
-    let daemon = { code: 1, out: "" };
-    for (let i = 0; i < 30 && daemon.code !== 0; i += 1) {
-      daemon = await sh(check.vm, "env HOME=/root /root/.cmux/bin/cmux-tui server status --session cloud >/dev/null 2>&1 && grep -qi ':0539 ' /proc/net/tcp6 && test -s /etc/cmux/daemon-instance-id && echo daemon-up", 30_000);
-      if (daemon.code !== 0) await sleep(1000);
-    }
-    if (daemon.code !== 0) throw new Error(`${name}: cmux-tui daemon did not come up on the derived snapshot ${imageId}: ${daemon.out.slice(-300)}`);
     const websocket = await sh(check.vm, cmuxTuiWebsocketSmokeCommand(), 300_000);
     if (websocket.code !== 0) throw new Error(`${name}: WebSocket smoke failed after snapshot boot: ${websocket.out.slice(-1000)}`);
   } finally {

--- a/web/scripts/promote-devbox-image.ts
+++ b/web/scripts/promote-devbox-image.ts
@@ -34,18 +34,21 @@
  *               unless the bake itself already holds that slug, then
  *               `<prefix>-md`); "none" keeps the shared pointer untouched
  *               and prefixes them with the bake's own slug instead.
+ *   --derive-concurrency <n>  how many ladder sizes derive at once (default 6
+ *               in derive-devbox-sizes.ts; 1 restores serial derives).
  *   --skip-verify   record validationStatus "unknown" instead of verifying.
  *               The entry is appended but NOT flagged as any default.
  *   --dry-run   print the manifest diff without writing it.
  *
  * Steps: bakePreflight (stale checkout guard) -> bake script (--out) ->
- * verify-devbox-image.ts (boots one VM, deletes it) -> manifest write ->
- * slug pointer. A failed verify writes nothing and exits 1.
+ * verify-devbox-image.ts and derive-devbox-sizes.ts CONCURRENTLY (both only
+ * read the master snapshot) -> manifest write -> slug pointer. A failure in
+ * either writes nothing and exits 1.
  *
  * Run it from web/ with FREESTYLE_API_KEY in the environment of the Freestyle
  * account the deployment uses, then commit the manifest diff in a PR.
  */
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -89,6 +92,8 @@ if (kinds.includes("desktop") && !withDesktop) {
 }
 const pointerSlug = argValue("--pointer-slug") ?? "cmux-devbox";
 const skipVerify = hasFlag("--skip-verify");
+/** Passed through to the size derive, which runs the ladder concurrently. */
+const deriveConcurrency = argValue("--derive-concurrency");
 const sizesArg = argValue("--sizes") ?? VM_IMAGE_SIZE_NAMES.join(",");
 const sizeNames = sizesArg === "none" ? [] : sizesArg.split(",").map((name) => name.trim()).filter(Boolean);
 for (const name of sizeNames) {
@@ -104,6 +109,34 @@ const slug = argValue("--slug") ?? `cmux-${tag}`;
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const workDir = mkdtempSync(path.join(tmpdir(), "cmux-devbox-promote-"));
+
+/**
+ * Runs a child and streams its output line by line under a label, so two
+ * phases can run at once and still be readable. Verify and the size derive
+ * both only read the master snapshot, so they overlap; verify costs nothing
+ * in wall clock once it does.
+ */
+function runStreaming(label: string, args: string[]): Promise<number> {
+  console.log(`\n===== ${label}: bun ${args.join(" ")} =====`);
+  return new Promise((resolve, reject) => {
+    const child = spawn("bun", args, { cwd: webRoot, env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    for (const stream of [child.stdout, child.stderr]) {
+      let pending = "";
+      stream.setEncoding("utf8");
+      stream.on("data", (chunk: string) => {
+        pending += chunk;
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) console.log(`[${label}] ${line}`);
+      });
+      stream.on("end", () => {
+        if (pending.length > 0) console.log(`[${label}] ${pending}`);
+      });
+    }
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+}
 
 function run(label: string, args: string[]): number {
   console.log(`\n===== ${label}: bun ${args.join(" ")} =====`);
@@ -157,8 +190,12 @@ if (bakeResultPath) {
   imageId = bake.imageId;
 }
 
-// 2. Verify: the only path to validationStatus "passed".
+// 2. Verify and derive: both only read the master snapshot, so they run at
+// once. Verify is the only path to validationStatus "passed"; the derive
+// boots and checks every ladder size. Neither writes anything the other
+// reads, and the manifest is written only if both pass.
 let validationNotes: string;
+let sizes: Array<{ imageId: string; size: VmImageSize }> | undefined;
 if (skipVerify) {
   entry = { ...entry, validationStatus: "unknown" };
   validationNotes = "NOT VERIFIED (promote --skip-verify); verify before flagging as a default.";
@@ -167,41 +204,43 @@ if (skipVerify) {
   // verify reads the baked stamp and fails on a mismatch, so a base image can
   // never land as the desktop default.
   const expectedKind: DevboxImageKind = entry.kind ?? (withDesktop ? "desktop" : "base");
-  const verifyStatus = run("verify", ["scripts/verify-devbox-image.ts", provider, imageId, "--expect-kind", expectedKind]);
+  const sizesOut = path.join(workDir, "sizes.json");
+  // "none" means "leave the shared pointer slugs alone", never a literal
+  // prefix: a branch bake's sizes are slugged under its own slug.
+  const derivePrefix = pointerSlug === "none" ? (argValue("--slug") ?? slug) : pointerSlug;
+  const [verifyStatus, deriveStatus] = await Promise.all([
+    runStreaming("verify", ["scripts/verify-devbox-image.ts", provider, imageId, "--expect-kind", expectedKind]),
+    sizeNames.length > 0
+      ? runStreaming("derive sizes", [
+          "scripts/derive-devbox-sizes.ts",
+          imageId,
+          derivePrefix,
+          "--sizes",
+          sizeNames.join(","),
+          "--out",
+          sizesOut,
+          ...(hasFlag("--replace-slug") ? ["--replace-slug"] : []),
+          ...(deriveConcurrency ? ["--concurrency", deriveConcurrency] : []),
+        ])
+      : Promise.resolve(0),
+  ]);
   if (verifyStatus !== 0) {
     console.error(`verify failed (exit ${verifyStatus}) for ${provider} ${imageId}; nothing promoted`);
     process.exit(verifyStatus);
+  }
+  if (deriveStatus !== 0) {
+    console.error(`derive sizes failed (exit ${deriveStatus}); nothing promoted`);
+    process.exit(deriveStatus);
   }
   entry = { ...entry, validationStatus: "passed" };
   validationNotes =
     `Validated ${new Date().toISOString().slice(0, 10)} with verify-devbox-image.ts by promote-devbox-image.ts` +
     (withDesktop ? " (toolchain, agent pins, daemon contract, desktop on 5901/6901)." : " (toolchain, agent pins, daemon contract).");
-}
-
-// 2b. Sizes: derive the ladder from the verified bake, each booted and checked.
-let sizes: Array<{ imageId: string; size: VmImageSize }> | undefined;
-if (!skipVerify && sizeNames.length > 0) {
-  const sizesOut = path.join(workDir, "sizes.json");
-  // "none" means "leave the shared pointer slugs alone", never a literal
-  // prefix: a branch bake's sizes are slugged under its own slug.
-  const derivePrefix = pointerSlug === "none" ? (argValue("--slug") ?? slug) : pointerSlug;
-  const deriveStatus = run("derive sizes", [
-    "scripts/derive-devbox-sizes.ts",
-    imageId,
-    derivePrefix,
-    "--sizes",
-    sizeNames.join(","),
-    "--out",
-    sizesOut,
-    ...(hasFlag("--replace-slug") ? ["--replace-slug"] : []),
-  ]);
-  if (deriveStatus !== 0) {
-    console.error(`derive sizes failed (exit ${deriveStatus}); nothing promoted`);
-    process.exit(deriveStatus);
+  if (sizeNames.length > 0) {
+    const derived = JSON.parse(readFileSync(sizesOut, "utf8")) as { sizes: Record<string, { imageId: string; size: VmImageSize }> };
+    sizes = Object.values(derived.sizes).map((row) => ({ imageId: row.imageId, size: row.size }));
+    validationNotes += ` Sizes derived and re-booted by derive-devbox-sizes.ts: ${sizes.map((row) => `${row.size.name}=${row.imageId}`).join(", ")}.`;
   }
-  const derived = JSON.parse(readFileSync(sizesOut, "utf8")) as { sizes: Record<string, { imageId: string; size: VmImageSize }> };
-  sizes = Object.values(derived.sizes).map((row) => ({ imageId: row.imageId, size: row.size }));
-  validationNotes += ` Sizes derived and re-booted by derive-devbox-sizes.ts: ${sizes.map((row) => `${row.size.name}=${row.imageId}`).join(", ")}.`;
 }
 
 // 3. Manifest: append and flip defaults (pure edit), then re-check invariants.

--- a/web/scripts/verify-devbox-image.ts
+++ b/web/scripts/verify-devbox-image.ts
@@ -271,7 +271,32 @@ async function runChecks(label: string, checks: readonly string[], exec: Exec): 
  * Returns the milliseconds from the call until the session answered.
  */
 async function waitForBakedDaemon(provider: string, exec: Exec): Promise<number> {
-  const t0 = Date.now();
+  /**
+ * Waits for the machine's identity to be minted and to stop changing.
+ *
+ * The daemon answering is not the same as its identity being final, which is
+ * what the two fixed 30-second sleeps here used to cover. Poll for the files
+ * instead, and require the digest to repeat once, so a machine mid-mint is
+ * never compared against another.
+ */
+async function waitForMintedIdentity(
+  exec: (command: string, timeoutMs?: number) => Promise<{ exitCode: number; output: string }>,
+  budgetMs = 120_000,
+): Promise<string> {
+  const digest = `cat ${REMOTE_IDENTITY} ${MACHINE_SECRETS} | sha256sum | cut -c1-64`;
+  const deadline = Date.now() + budgetMs;
+  let previous = "";
+  while (Date.now() < deadline) {
+    const read = await exec(`test -s ${REMOTE_IDENTITY} && test -s ${MACHINE_SECRETS} && ${digest}`, 30_000);
+    const value = read.exitCode === 0 ? read.output.trim() : "";
+    if (value.length === 64 && value === previous) return value;
+    previous = value;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error("identity was still not minted and stable after waiting");
+}
+
+const t0 = Date.now();
   for (let attempt = 0; attempt < 45; attempt += 1) {
     const status = await exec(`env HOME=/root /root/.cmux/bin/cmux-tui server status --session ${CMUX_TUI_SESSION}`, 30_000);
     if (status.exitCode === 0) return Date.now() - t0;
@@ -328,7 +353,7 @@ if (provider === "freestyle") {
     const exec = execFor(vm);
     const daemonMs = await waitForBakedDaemon("freestyle", exec);
     console.log(`baked daemon answered ${daemonMs} ms after the first probe (${Date.now() - t0} ms after create)`);
-    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    await waitForMintedIdentity(exec);
     // The baked binary must be the pin the bake resolved and recorded in
     // /etc/cmux/cmux-tui-pin (that is the image's contract; the manifest entry
     // carries the same commit). The live files.cmux.com pin moves with every
@@ -355,7 +380,7 @@ if (provider === "freestyle") {
     try {
       const exec2 = execFor(second.vm);
       await waitForBakedDaemon("freestyle", exec2);
-      await new Promise((resolve) => setTimeout(resolve, 30_000));
+      await waitForMintedIdentity(exec2);
       const digest = `cat ${REMOTE_IDENTITY} ${MACHINE_SECRETS} | sha256sum | cut -c1-64`;
       const [a, b] = await Promise.all([exec(digest, 30_000), exec2(digest, 30_000)]);
       const digestA = a.output.trim();


### PR DESCRIPTION
A promotion took 784s. It now takes 221s, measured end to end on the same source and account, with two changes.

**Parallel ladder.** The six sizes are independent (boot the master, resize, snapshot, boot the result) and nearly all of that time is waiting, so they run together behind `--concurrency` (default 6, `1` restores serial). Verify overlaps them for the same reason: it only reads the master snapshot, and the manifest is still written only if both pass.

**Wait for the guest, not the clock.** Each size spent 60 of its ~81 seconds in two hardcoded 30-second sleeps, both immediately after a poll that had already proven the daemon was up, and verify spent another 60 the same way. The derive now retries the WebSocket smoke, which is the readiness signal it was sleeping for, and polls the daemon probe it ran afterwards anyway. Verify polls for the identity files and requires the digest to repeat once, so a machine mid-mint is never compared against another. These are strictly more robust than a fixed guess: a slow guest is waited for, up to a 90 to 120 second budget, instead of being assumed ready at 30.

| phase | before | parallel only | + polls |
| --- | --- | --- | --- |
| bake | 199s | 205s | 188s |
| verify | 131s | overlapped | overlapped |
| derive 6 sizes | 453s | 88s | 33s |
| **end to end** | **784s** | **335s** | **221s** |

Per size, seconds:

| size | serial | parallel | + polls |
| --- | --- | --- | --- |
| sm (2 vCPU, 3.8 GiB) | 37 | 37 | 9 |
| md (4, 7.8) | 79 | 81 | 22 |
| lg (8, 15.8) | 81 | 80 | 24 |
| lgx (12, 23.8) | 81 | 81 | 23 |
| xl (16, 31.8) | 83 | 81 | 26 |
| 2xl (32, 63.8) | 88 | 88 | 32 |

Also `apt-get clean` before the snapshot. The bake already dropped `/var/lib/apt/lists`, but every image still shipped 215 MiB of downloaded `.deb` files: a machine now boots with 5.8 GiB used instead of 6.0 GiB on a 16 GiB root.

**What this rules out**, verified against the API rather than the comment in the code: baking once on the largest shape and shrinking. Freestyle refuses on every axis, `resize is grow-only: requested 2 vCPU / 4096 MiB / 131072 MiB is below the current 32 vCPU / 65536 MiB / 131072 MiB on at least one axis`, and the same for storage alone. The ladder must be derived upward from the smallest bake, which is what it does.

**Also measured, and not worth doing:** the image is 5.8 GiB, of which `/usr` is 3.8 and `/opt` is 2.0 (1.5 of that `/opt/freestyle`, the provider's own, and 437 MiB Chrome). There is no `.cargo` or `.rustup` to reclaim, because the image installs a prebuilt cmux-tui rather than building it. After the apt cache there is nothing else of size that is ours.

Every test snapshot these measurements created was deleted from the account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Devbox image verification and size derivation now run concurrently, with labeled progress output.
  - Devbox size derivation supports configurable worker concurrency and preserves requested output order.
  - Resize, post-boot, and identity checks now wait for readiness through polling rather than fixed delays.
  - Image promotion validates both verification and size derivation before updating manifests.
  - Cleanup now clears cached package archives in addition to existing caches.
  - Identity validation now waits for stable machine identity data within a defined timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->