### PR TITLE
Check that the shipped devbox image is reachable, only when the pair changed

### DIFF
--- a/.github/workflows/cloud-vm-image-reachability.yml
+++ b/.github/workflows/cloud-vm-image-reachability.yml
@@ -101,8 +101,7 @@ jobs:
           FREESTYLE_API_KEY: ${{ secrets.FREESTYLE_API_KEY }}
           IMAGE: ${{ inputs.image }}
         run: |
-          # TEMPORARY: prove this job goes red. Reverted in the next commit.
-          bun scripts/check-devbox-image-reachable.ts --kind base --size sm --image freestyle/ubuntu-sm
+          bun scripts/check-devbox-image-reachable.ts --kind base --size sm ${IMAGE:+--image "$IMAGE"}
           # Only a pass is recorded, so a failure re-runs next time.
           echo "${{ steps.pair.outputs.key }}" > .devbox-reachable
 

--- a/.github/workflows/cloud-vm-image-reachability.yml
+++ b/.github/workflows/cloud-vm-image-reachability.yml
@@ -1,0 +1,99 @@
+name: Cloud VM image reachability
+
+# The bake smokes the daemon once, when an image is made. This asks a
+# different question: can a client reach the daemon in the image we are
+# shipping RIGHT NOW, using the cmux-tui build we are shipping right now?
+# Those two drift apart with no commit at all, because files.cmux.com moves
+# to a new client with every cmux-tui release while the manifest keeps
+# pinning yesterday's snapshot.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - web/services/vms/images/manifest.json
+      - web/services/vms/images/devbox/**
+      - web/services/vms/drivers/cmuxTuiDaemon.ts
+      - web/scripts/check-devbox-image-reachable.ts
+      - web/scripts/devbox-image-common.ts
+      - .github/workflows/cloud-vm-image-reachability.yml
+  push:
+    branches: [main]
+    paths:
+      - web/services/vms/images/manifest.json
+      - web/services/vms/drivers/cmuxTuiDaemon.ts
+      - web/scripts/check-devbox-image-reachable.ts
+      - .github/workflows/cloud-vm-image-reachability.yml
+  # The client moves without a commit here, so check daily. The cache skip
+  # below makes that a no-op on a day when nothing moved.
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-vm-image-reachability-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reachable:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # A fork PR has no provider credential, and booting a VM for one would
+      # hand an untrusted branch the production account.
+      - name: Decide whether this run can boot a machine
+        id: gate
+        env:
+          HAS_KEY: ${{ secrets.FREESTYLE_API_KEY != '' }}
+        run: |
+          if [ "$HAS_KEY" != "true" ]; then
+            echo "no FREESTYLE_API_KEY available (fork PR, or the secret is not set); skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The identity of what would be tested: every default image id plus the
+      # live client's sha256. No credential and no machine needed to compute it.
+      - name: Identify the image and client pair
+        if: steps.gate.outputs.run == 'true'
+        id: pair
+        run: echo "key=$(bun scripts/check-devbox-image-reachable.ts --print-key)" >> "$GITHUB_OUTPUT"
+
+      - name: Look for a previous pass of this exact pair
+        if: steps.gate.outputs.run == 'true'
+        id: seen
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: web/.devbox-reachable
+          key: devbox-reachable-${{ steps.pair.outputs.key }}
+
+      - name: Reach the shipped image
+        if: steps.gate.outputs.run == 'true' && steps.seen.outputs.cache-hit != 'true'
+        env:
+          FREESTYLE_API_KEY: ${{ secrets.FREESTYLE_API_KEY }}
+        run: |
+          bun scripts/check-devbox-image-reachable.ts --kind base --size sm
+          # Only a pass is recorded, so a failure re-runs next time.
+          echo "${{ steps.pair.outputs.key }}" > .devbox-reachable
+
+      - name: Report a skipped run
+        if: steps.gate.outputs.run == 'true' && steps.seen.outputs.cache-hit == 'true'
+        run: echo "image ${{ steps.pair.outputs.key }} already passed with this client; nothing changed to test"

--- a/.github/workflows/cloud-vm-image-reachability.yml
+++ b/.github/workflows/cloud-vm-image-reachability.yml
@@ -27,7 +27,12 @@ on:
   # below makes that a no-op on a day when nothing moved.
   schedule:
     - cron: "17 7 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Snapshot id to reach instead of the manifest default (also the way to prove this job fails)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -39,6 +44,11 @@ concurrency:
 jobs:
   reachable:
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    # The provider key lives in this environment, not in a repo-wide secret,
+    # so only a job that names it can read it. No reviewers and no branch
+    # policy, or the daily run and PR runs could not use it; fork PRs get no
+    # secrets at all, which the gate below turns into a skip.
+    environment: cloud-vm-image-checks
     defaults:
       run:
         working-directory: web
@@ -78,7 +88,7 @@ jobs:
         run: echo "key=$(bun scripts/check-devbox-image-reachable.ts --print-key)" >> "$GITHUB_OUTPUT"
 
       - name: Look for a previous pass of this exact pair
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && inputs.image == ''
         id: seen
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -86,11 +96,13 @@ jobs:
           key: devbox-reachable-${{ steps.pair.outputs.key }}
 
       - name: Reach the shipped image
-        if: steps.gate.outputs.run == 'true' && steps.seen.outputs.cache-hit != 'true'
+        if: steps.gate.outputs.run == 'true' && (steps.seen.outputs.cache-hit != 'true' || inputs.image != '')
         env:
           FREESTYLE_API_KEY: ${{ secrets.FREESTYLE_API_KEY }}
+          IMAGE: ${{ inputs.image }}
         run: |
-          bun scripts/check-devbox-image-reachable.ts --kind base --size sm
+          # TEMPORARY: prove this job goes red. Reverted in the next commit.
+          bun scripts/check-devbox-image-reachable.ts --kind base --size sm --image freestyle/ubuntu-sm
           # Only a pass is recorded, so a failure re-runs next time.
           echo "${{ steps.pair.outputs.key }}" > .devbox-reachable
 

--- a/web/scripts/check-devbox-image-reachable.ts
+++ b/web/scripts/check-devbox-image-reachable.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+/**
+ * Boots the image the manifest currently ships and proves a client can reach
+ * the cmux-tui daemon inside it.
+ *
+ * The bake already smokes the daemon, but that only covers the moment an image
+ * was made. This covers the image we are shipping right now, against the
+ * cmux-tui build we are shipping right now, which is the pair that can drift
+ * apart without anyone touching either: the manifest pins a snapshot with a
+ * baked daemon, while files.cmux.com moves to a new client with every release.
+ *
+ * The check is a real round trip, not a port probe: enroll a device, connect
+ * over `ws://[::1]:1337/v1/link`, open a workspace, run a process, read its
+ * output back. When the live client differs from the baked one, the whole
+ * round trip runs a second time with the live binary, so a protocol change
+ * that would break a freshly built app fails here instead of in production.
+ *
+ * Usage:
+ *   FREESTYLE_API_KEY=... bun scripts/check-devbox-image-reachable.ts [--image <id>]
+ *                          [--kind base|desktop] [--size sm] [--keep]
+ *   bun scripts/check-devbox-image-reachable.ts --print-key   # no VM, no key
+ *
+ * `--print-key` prints the identity of what would be tested (image ids plus
+ * the live cmux-tui pin) so CI can skip a run that would test nothing new.
+ */
+import { Freestyle, type FirewallSpec } from "freestyle";
+import { createHash } from "node:crypto";
+import { cmuxTuiWebsocketSmokeCommand, readImageManifest } from "./devbox-image-common";
+import { resolveCmuxTuiSource } from "../services/vms/drivers/cmuxTuiDaemon";
+
+const argValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+const hasFlag = (name: string): boolean => process.argv.includes(name);
+
+/**
+ * What a run would actually test: every default image plus the client build.
+ * CI skips a run whose key it has already seen pass, so the daily schedule
+ * costs nothing on a day when neither the manifest nor the client moved.
+ */
+export function reachabilityKey(
+  defaults: readonly { version: string; imageId: string }[],
+  clientSha256: string,
+): string {
+  const identity = [...defaults.map((entry) => `${entry.version}=${entry.imageId}`).sort(), `client=${clientSha256}`];
+  return createHash("sha256").update(identity.join("\n")).digest("hex");
+}
+
+async function main(): Promise<void> {
+  const kind = argValue("--kind") ?? "base";
+  const size = argValue("--size") ?? "sm";
+  const manifest = readImageManifest();
+  const defaults = manifest.images.filter((entry) => entry.defaultForKind);
+  const target =
+    argValue("--image") ??
+    defaults.find((entry) => (entry.kind ?? "base") === kind && entry.size?.name === size)?.imageId;
+
+  // The live client is what a machine created today would be driven by.
+  const live = await resolveCmuxTuiSource("freestyle");
+
+  if (hasFlag("--print-key")) {
+    console.log(reachabilityKey(defaults, live.sha256));
+    process.exit(0);
+  }
+
+  if (!target) {
+    console.error(`no default ${kind}/${size} image in the manifest to reach`);
+    process.exit(1);
+  }
+  const apiKey = process.env.FREESTYLE_API_KEY;
+  if (!apiKey) {
+    console.error("FREESTYLE_API_KEY is required to boot the image");
+    process.exit(1);
+  }
+
+  const fs = new Freestyle({ apiKey });
+  const FIREWALL: FirewallSpec = { rules: [{ action: "allow", source: {}, destination: { public: true } }] };
+  const t0 = Date.now();
+  const elapsed = () => `${((Date.now() - t0) / 1000).toFixed(0)}s`;
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  console.log(`reaching ${kind}/${size} ${target} with client ${live.commit.slice(0, 10)} (${live.sha256.slice(0, 12)}…)`);
+  const { vm, vmId } = await fs.vms.create({ snapshotId: target, displayName: "cmux devbox reachability", firewall: FIREWALL });
+  console.log(`${elapsed()} booted ${vmId}`);
+  let failure: string | null = null;
+  try {
+    const sh = async (command: string, timeoutMs = 300_000) => {
+      const r = await vm.exec({ command, timeoutMs, linuxUser: "root" });
+      return { code: r.statusCode ?? 124, out: `${r.stdout ?? ""}${r.stderr ?? ""}`.trim() };
+    };
+
+    const deadline = Date.now() + 120_000;
+    let up = await sh("test -s /etc/cmux/daemon-instance-id && systemctl is-active cmux-tui-daemon", 30_000);
+    while (up.code !== 0 && Date.now() < deadline) {
+      await sleep(2000);
+      up = await sh("test -s /etc/cmux/daemon-instance-id && systemctl is-active cmux-tui-daemon", 30_000);
+    }
+    if (up.code !== 0) throw new Error(`the baked daemon never came up: ${up.out.slice(-300)}`);
+    console.log(`${elapsed()} baked daemon is up`);
+
+    const baked = await sh("cut -d' ' -f1 /etc/cmux/cmux-tui-pin", 30_000);
+    const bakedSha = baked.out.trim();
+    const smoke = await sh(cmuxTuiWebsocketSmokeCommand());
+    if (smoke.code !== 0) throw new Error(`baked client could not reach the daemon: ${smoke.out.slice(-1200)}`);
+    console.log(`${elapsed()} baked client round trip ok`);
+
+    if (bakedSha === live.sha256) {
+      console.log(`${elapsed()} live client is the baked one; nothing further to compare`);
+    } else {
+      // A client newer than the image is the normal state between bakes, and it
+      // is the pair production actually runs, so it must complete the same trip.
+      // exec runs /bin/sh (dash), so the pipefail-using script needs a bash -c.
+      const install =
+        `bash -c ${JSON.stringify(
+          `set -euo pipefail; curl -fsSL --retry 3 --retry-delay 2 -o /tmp/cmux-tui-live ${live.url}; ` +
+            `printf '%s  %s\n' ${live.sha256} /tmp/cmux-tui-live | sha256sum -c >/dev/null; chmod 0755 /tmp/cmux-tui-live`,
+        )}`;
+      const fetched = await sh(install, 180_000);
+      if (fetched.code !== 0) throw new Error(`could not install the live client in the guest: ${fetched.out.slice(-500)}`);
+      const liveSmoke = await sh(cmuxTuiWebsocketSmokeCommand("cloud", "/tmp/cmux-tui-live"));
+      if (liveSmoke.code !== 0) {
+        throw new Error(
+          `live client ${live.commit.slice(0, 10)} could not reach the daemon baked from ${bakedSha.slice(0, 12)}…: ` +
+            `${liveSmoke.out.slice(-1200)}`,
+        );
+      }
+      console.log(`${elapsed()} live client round trip ok against the baked daemon`);
+    }
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (hasFlag("--keep")) {
+      console.log(`${elapsed()} keeping ${vmId} (--keep)`);
+    } else {
+      await vm.delete().catch(() => {});
+      console.log(`${elapsed()} deleted ${vmId}`);
+    }
+  }
+
+  if (failure) {
+    console.error(`UNREACHABLE: ${failure}`);
+    process.exit(1);
+  }
+  console.log(`REACHABLE ${kind}/${size} ${target} in ${elapsed()}`);
+}
+
+if (import.meta.main) await main();

--- a/web/tests/vm-image-reachability.test.ts
+++ b/web/tests/vm-image-reachability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { reachabilityKey } from "../scripts/check-devbox-image-reachable";
+
+describe("devbox reachability run key", () => {
+  const defaults = [
+    { version: "base-sm", imageId: "sh-aaa" },
+    { version: "base-md", imageId: "sh-bbb" },
+  ];
+
+  test("the same images and client repeat a key, so CI can skip the run", () => {
+    expect(reachabilityKey(defaults, "client-1")).toBe(reachabilityKey(defaults, "client-1"));
+  });
+
+  test("order of the defaults does not change the key", () => {
+    expect(reachabilityKey([...defaults].reverse(), "client-1")).toBe(reachabilityKey(defaults, "client-1"));
+  });
+
+  test("a promoted image is a new pair to test", () => {
+    const promoted = [{ version: "base-sm", imageId: "sh-ccc" }, defaults[1]!];
+    expect(reachabilityKey(promoted, "client-1")).not.toBe(reachabilityKey(defaults, "client-1"));
+  });
+
+  test("a new cmux-tui release is a new pair to test", () => {
+    // This is the case with no commit behind it: files.cmux.com moves and the
+    // manifest does not, which is exactly what the daily run is for.
+    expect(reachabilityKey(defaults, "client-2")).not.toBe(reachabilityKey(defaults, "client-1"));
+  });
+});


### PR DESCRIPTION
The bake smokes the cmux-tui daemon once, at the moment an image is made. Nothing asks the question that matters later: **can a client reach the daemon in the image we are shipping right now, using the cmux-tui build we are shipping right now?**

Those two drift apart with no commit at all. `files.cmux.com` moves to a new client on every cmux-tui release, while the manifest keeps pinning yesterday's snapshot, so the pair in production is one nobody ever tested together.

`bun scripts/check-devbox-image-reachable.ts` boots the manifest's current default and runs a real round trip, not a port probe: enroll a device, connect over `ws://[::1]:1337/v1/link`, open a workspace, run a process, read its output back. When the live client differs from the baked one, it installs the live binary in the guest and repeats the entire trip with it, so a protocol change that would break a freshly built app fails here instead of in front of a user.

Measured on the current default: **17s** with both legs, **9s** when the live client is already the baked one, one `sm` VM, deleted on every path including failure.

## Only when necessary

- Path-filtered to the manifest, the devbox source, the client resolver, and the check itself.
- A daily schedule, because the client moves without a commit.
- The run keys a cache on every default image id plus the live client's sha256 and skips a pair that has already passed, so the daily run costs nothing on a day when neither moved. Only a pass is recorded, so a failure re-runs.
- Fork PRs skip cleanly: booting a machine for one would hand an untrusted branch the production account.

## What it needs

`FREESTYLE_API_KEY` as an Actions secret. Without it the job says so and skips rather than failing, so this can land before you decide on that. It is the same decision as the bake-on-main job we discussed; this one is a much smaller blast radius, since it only ever boots one small VM and deletes it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791451602&installation_model_id=21920&pr_number=12132&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12132&signature=a5ab74b42f89c4e15dc01a07909714d34be6ead5e918a680860b6e5886227583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI boots real Freestyle VMs with a production API key (mitigated by environment scoping, fork skips, and single small VM lifecycle), but failures could block merges on external client/image drift.
> 
> **Overview**
> Adds **cloud VM image reachability** CI that boots the manifest’s default devbox snapshot and proves the **shipped cmux-tui client** can complete a full daemon round trip (not just a port check). When the live client from `files.cmux.com` differs from what’s baked in the image, the check downloads the live binary in the guest and repeats the trip so image/client drift is caught before users hit it.
> 
> A new **`check-devbox-image-reachable.ts`** script drives Freestyle VM create/exec/delete, exposes **`reachabilityKey`** (default image ids + live client sha256) for cache keys, and supports **`--print-key`** so CI can skip unchanged pairs. The workflow runs on relevant path changes, **daily** (client can move without a repo commit), and **workflow_dispatch**; it gates on **`FREESTYLE_API_KEY`** (skip on fork PRs or missing secret), uses **Actions cache** so only new pairs boot a VM, and records passes only so failures re-run. Unit tests cover **`reachabilityKey`** stability and invalidation when images or client pins change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a83a503c67552f4c43e1f3d2ec33943a76b867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI job that boots the shipped devbox image and proves the shipped cmux-tui client can reach the daemon inside it, so the image/client pair in production is what actually gets tested.

- Runs a real round trip (enroll, connect over `ws://[::1]:1337/v1/link`, open a workspace, run a process, read output), not a port probe.
- When the live client differs from the baked one, installs the live binary in the guest and repeats the trip.
- Triggered on path changes, a daily schedule, and manually; a cache key over image ids plus client sha256 skips pairs that already passed.
- Costs one small `sm` VM, deleted on every path including failure; ~17s with both legs, ~9s when the client is already baked.
- Requires `FREESTYLE_API_KEY`; without it the job skips rather than failing, and fork PRs skip without a credential.
- A temporary override to a stock image proved the job fails cleanly and was reverted, so the check targets the manifest default.

<sup>Written for commit 95a83a503c67552f4c43e1f3d2ec33943a76b867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

