### PR TITLE
surfaces: resolve projection liveness by pane identity

### DIFF
--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -1023,13 +1023,21 @@ final class SurfaceCatalog {
             cancelCompletedMaterialization(key, waiterID: waiterID)
             throw SurfaceCatalogError.unknownResource(id)
         }
-        guard projections.contains(result.projection) else {
+        // A pane's identity is its resource and panel, not the whole projection value.
+        // Remote coordinates and the local workspace are mutable fields: a concurrent
+        // `attachRemoteView` or pane move rewrites the recorded value in place while
+        // this caller is still resuming. Whole-value membership would read that live
+        // pane as closed and fail an open that actually succeeded, so resolve the
+        // current value by identity and hand the caller that one.
+        guard let live = projections.first(where: {
+            $0.resource == result.projection.resource && $0.panelID == result.projection.panelID
+        }) else {
             cancelCompletedMaterialization(key, waiterID: waiterID)
             throw SurfaceCatalogError.unavailable(id, reason: "projection closed while opening")
         }
         acknowledgeMaterialization(key, waiterID: waiterID)
-        if result.reused, focus { focusProjection?(result.projection) }
-        return result
+        if result.reused, focus { focusProjection?(live) }
+        return (projection: live, reused: result.reused)
     }
 
     private func acknowledgeMaterialization(_ key: MaterializationKey, waiterID: UUID) {

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -1036,8 +1036,14 @@ final class SurfaceCatalog {
             throw SurfaceCatalogError.unavailable(id, reason: "projection closed while opening")
         }
         acknowledgeMaterialization(key, waiterID: waiterID)
-        if result.reused, focus { focusProjection?(live) }
-        return (projection: live, reused: result.reused)
+        guard result.reused, focus else { return (projection: live, reused: result.reused) }
+        focusProjection?(live)
+        // Focusing a pane can select another tab or move it between workspaces, so
+        // read the pane's value once more rather than returning the pre-focus copy.
+        let focused = projections.first {
+            $0.resource == live.resource && $0.panelID == live.panelID
+        }
+        return (projection: focused ?? live, reused: result.reused)
     }
 
     private func acknowledgeMaterialization(_ key: MaterializationKey, waiterID: UUID) {

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -544,6 +544,10 @@ struct SurfaceCatalogTests {
         for result in results {
             #expect(result.projection.panelID == live.panelID)
         }
+        // Every caller that focused the pane sees where the pane actually is.
+        for result in results where result.reused {
+            #expect(result.projection.workspaceID == movedWorkspaceID)
+        }
     }
 
     @Test func `An adopted projection wins a materialization race`() async throws {

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -192,6 +192,12 @@ struct SurfaceCatalogTests {
         }
     }
 
+    /// One-shot latch for the focus hook, so the first finishing caller rewrites the
+    /// recorded projection exactly once.
+    private final class MoveOnce {
+        var pending = false
+    }
+
     private final class FakeProvider: SurfaceProvider {
         let machine: SurfaceMachineID
         var info: SurfaceMachineInfo
@@ -488,6 +494,56 @@ struct SurfaceCatalogTests {
         #expect(secondResult.reused)
         #expect(firstResult.projection == secondResult.projection)
         #expect(catalog.projections(of: term.id).count == 1)
+    }
+
+    /// A pane's identity is its resource and panel. While coalesced callers are still
+    /// finishing, focus handling (or a tab drag) can rewrite the recorded projection's
+    /// workspace in place. That pane is open, so no caller may be told it closed.
+    @Test func `Coalesced callers accept a projection whose value changed while opening`() async throws {
+        let catalog = SurfaceCatalog()
+        let provider = FakeProvider(machine: .cloud("vivid-newt"))
+        let gate = MaterializeGate()
+        provider.materializeGate = gate
+        catalog.register(provider)
+        let term = terminal(.cloud("vivid-newt"), "term_1")
+        catalog.replaceResources([term], on: .cloud("vivid-newt"))
+        let destination = SurfaceDestination.workspace(id: UUID(), placement: .split)
+        let movedWorkspaceID = UUID()
+        let moveOnce = MoveOnce()
+        catalog.focusProjection = { [weak catalog] projection in
+            guard !moveOnce.pending else { return }
+            moveOnce.pending = true
+            catalog?.moveProjections(panelID: projection.panelID, to: movedWorkspaceID)
+        }
+
+        let first = Task { try await catalog.project(term.id, into: destination) }
+        await gate.waitUntilEntered()
+
+        var joined: [Task<(projection: SurfaceProjection, reused: Bool), any Error>] = []
+        for _ in 0..<2 {
+            let (started, startedContinuation) = AsyncStream<Void>.makeStream(
+                bufferingPolicy: .bufferingNewest(1)
+            )
+            joined.append(Task { @MainActor in
+                startedContinuation.yield(())
+                startedContinuation.finish()
+                return try await catalog.project(term.id, into: destination)
+            })
+            _ = try await awaitFirst(started)
+        }
+        #expect(provider.materialized.count == 1)
+
+        gate.release()
+        var results = [try await first.value]
+        for task in joined { results.append(try await task.value) }
+
+        #expect(moveOnce.pending)
+        #expect(catalog.projections(of: term.id).count == 1)
+        let live = try #require(catalog.projections(of: term.id).first)
+        #expect(live.workspaceID == movedWorkspaceID)
+        for result in results {
+            #expect(result.projection.panelID == live.panelID)
+        }
     }
 
     @Test func `An adopted projection wins a materialization race`() async throws {


### PR DESCRIPTION
Opening a Cloud terminal quickly could fail with `vm-.../terminal/term_... is unavailable: projection closed while opening` even though the pane opened.

`SurfaceCatalog.project` coalesces concurrent opens of the same resource. When the provider result lands, every waiting caller finishes by checking that its projection is still recorded. That check used whole-value set membership, but `SurfaceProjection` carries mutable fields (`workspaceID`, `remoteWorkspaceID`, `remoteTabID`). `attachRemoteView` and `moveProjections` remove the old value and insert an updated one, so a pane that is alive and visible reads as closed to a caller that is still finishing, and the Cloud sidebar shows the failure.

A pane's identity is `(resource, panelID)`, which is what `cleanupRecordedMaterialization` already uses. The finish path now resolves the current projection by that identity and returns it, so callers also get the up-to-date remote coordinates instead of a stale snapshot. A genuinely closed pane still fails with the same error.

Commit 1 adds the failing test (three coalesced callers, the first to finish rewrites the pane's workspace through the focus hook), commit 2 the fix.

Test: `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/SurfaceCatalogTests test` on a fleet mini.

https://claude.ai/code/session_01EqDJPhu37D3MrtRCCb2Z9x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791452623&installation_model_id=21920&pr_number=12136&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12136&signature=d944fa98a90f63ff119eef81538dc8425704622c3e7e9bdd432377e802761077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the coalesced materialization finish path in `SurfaceCatalog`, which gates successful cloud terminal opens; behavior change is narrow but concurrency-sensitive.
> 
> **Overview**
> Fixes spurious **projection closed while opening** failures when several concurrent `project` calls share one in-flight materialization and the pane is still open.
> 
> **`finalizeMaterializationWaiter`** no longer treats `Set` membership of the exact `SurfaceProjection` snapshot as “still open.” It looks up the current row by **resource + `panelID`**, returns that live value (including updated workspace/remote fields), and passes it to **`focusProjection`**. A pane that was actually torn down still fails with the same unavailable error.
> 
> Adds a regression test where coalesced waiters finish while the focus hook **`moveProjections`** rewrites the recorded projection in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f20f92d52ef0924e4bf08a3eced1eb84f8121f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in `SurfaceCatalog.project` that could fail a successful Cloud terminal open with "projection closed while opening".

- Liveness is now checked by pane identity (`resource` + `panelID`) instead of whole projection value.
- The open path returns the live projection, and re-reads it after focusing, so callers get post-focus coordinates.
- Adds a test with three coalesced callers where the first rewrites the pane's workspace via the focus hook.

<sup>Written for commit 7e3ee242a9c7ce7e442b17251d328de618288448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved surface reuse during concurrent updates so the latest projection is correctly resolved and focused.
  - Ensured coalesced opening requests receive the current projection when focus changes during opening.
  - Prevented duplicate materialization while preserving the projection after it moves.
  - Improved reliability when workspace or remote surface details change while a surface is opening.
  - Ensured reopened surfaces remain correctly tracked after focus or placement changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->