### PR TITLE
Fix sidebar footer icons that go blank and never re-render

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
@@ -9,6 +9,15 @@ public final class CmuxResolvedIconImageView: NSView {
     private var renderKey: RenderKey?
     private var lastVisibleRenderKey: RenderKey?
     private var blankRenderKey: RenderKey?
+    /// Layout passes a blank draw may use to recover before the view gives
+    /// up until its window or effective appearance changes. A transparent
+    /// first raster is a transient AppKit state (the symbol provider resolved
+    /// before the effective appearance did); by the time AppKit lays the view
+    /// out inside its window the appearance is resolved, so the next layout
+    /// pass is the readiness signal. A source that stays blank stops after
+    /// this many passes.
+    static let blankRecoveryLayoutPasses = 3
+    private(set) var blankRecoveryPassesUsed = 0
 
     /// Creates the resolved icon view.
     public override init(frame frameRect: NSRect) {
@@ -49,6 +58,20 @@ public final class CmuxResolvedIconImageView: NSView {
         renderIfNeeded(force: false)
     }
 
+    public override func layout() {
+        super.layout()
+        recoverBlankRenderIfNeeded()
+    }
+
+    /// Re-renders a blank draw during a layout pass, when the view is inside
+    /// its window and AppKit has resolved the effective appearance.
+    private func recoverBlankRenderIfNeeded() {
+        guard blankRenderKey != nil,
+              blankRecoveryPassesUsed < Self.blankRecoveryLayoutPasses else { return }
+        blankRecoveryPassesUsed += 1
+        renderIfNeeded(force: true)
+    }
+
     private func renderIfNeeded(force: Bool) {
         guard let request else {
             renderKey = nil
@@ -60,24 +83,34 @@ public final class CmuxResolvedIconImageView: NSView {
         let nextKey = RenderKey(request: request, appearance: effectiveAppearance)
         guard force || renderKey != nextKey else { return }
         guard force || blankRenderKey?.shouldSkipBlankRetry(for: nextKey) != true else { return }
+        if blankRenderKey?.matchesRequestAndAppearance(nextKey) != true {
+            // A different request or appearance gets a fresh recovery budget.
+            blankRecoveryPassesUsed = 0
+        }
         switch renderer.render(for: request, appearance: effectiveAppearance) {
         case .success(let image):
             renderKey = nextKey
             lastVisibleRenderKey = nextKey
             blankRenderKey = nil
+            blankRecoveryPassesUsed = 0
             imageView.image = image
         case .failure(.sourceUnavailable):
             renderKey = nextKey
             lastVisibleRenderKey = nil
             blankRenderKey = nil
+            blankRecoveryPassesUsed = 0
             imageView.image = nil
         case .failure(.blankOutput):
             renderKey = nil
             blankRenderKey = nextKey
-            guard lastVisibleRenderKey?.matchesRequestAndAppearance(nextKey) == true else {
+            if lastVisibleRenderKey?.matchesRequestAndAppearance(nextKey) != true {
                 lastVisibleRenderKey = nil
                 imageView.image = nil
-                break
+            }
+            if blankRecoveryPassesUsed < Self.blankRecoveryLayoutPasses {
+                // Ask AppKit for a layout pass; `layout()` retries the draw
+                // once the view is laid out inside its window.
+                needsLayout = true
             }
         }
         imageView.contentTintColor = nil

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconImageViewBlankRetryTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconImageViewBlankRetryTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Testing
+
+@testable import CmuxAppKitSupportUI
+
+/// Blank first draws are transient: a symbol can rasterize to a fully
+/// transparent bitmap while AppKit is still resolving the effective
+/// appearance for a freshly hosted view. The sidebar footer controls
+/// (account, iPhone, Help) showed this as icons that vanished while their
+/// buttons stayed clickable, because the view only re-rendered on a window
+/// or appearance change that never came. The next layout pass, which AppKit
+/// runs once the view sits inside its window, is the recovery signal.
+@MainActor
+@Suite struct CmuxResolvedIconImageViewBlankRetryTests {
+    private let size = NSSize(width: 16, height: 16)
+
+    /// A blank first draw heals on the next layout pass once the source
+    /// draws visible pixels, without a window move or appearance change.
+    @Test func imageViewRecoversBlankRenderOnLayoutPass() throws {
+        let view = CmuxResolvedIconImageView(frame: NSRect(origin: .zero, size: size))
+        view.appearance = NSAppearance(named: .aqua)
+        let representation = transparentBitmapRepresentation(pixels: 16)
+        let sourceImage = NSImage(size: size)
+        sourceImage.addRepresentation(representation)
+
+        view.apply(CmuxResolvedIconRequest(source: .image(sourceImage), size: size))
+        #expect(renderedImage(in: view) == nil)
+
+        fill(representation, color: .systemRed)
+        view.layout()
+
+        let pixel = try #require(renderedImage(in: view).flatMap(centerPixelColor))
+        #expect(pixel.redComponent > pixel.blueComponent)
+    }
+
+    private func renderedImage(in view: CmuxResolvedIconImageView) -> NSImage? {
+        view.subviews.compactMap { ($0 as? NSImageView)?.image }.first
+    }
+
+    private func solidBitmapRepresentation(color: NSColor, pixels: Int) -> NSBitmapImageRep {
+        let representation = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixels,
+            pixelsHigh: pixels,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        )!
+        representation.size = NSSize(width: pixels, height: pixels)
+        fill(representation, color: color, operation: .copy)
+        return representation
+    }
+
+    private func transparentBitmapRepresentation(pixels: Int) -> NSBitmapImageRep {
+        solidBitmapRepresentation(color: .clear, pixels: pixels)
+    }
+
+    private func fill(
+        _ representation: NSBitmapImageRep,
+        color: NSColor,
+        operation: NSCompositingOperation = .sourceOver
+    ) {
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: representation)
+        color.setFill()
+        NSRect(origin: .zero, size: representation.size).fill(using: operation)
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    private func centerPixelColor(in image: NSImage) -> NSColor? {
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff) else { return nil }
+        let x = max(0, min(bitmap.pixelsWide - 1, bitmap.pixelsWide / 2))
+        let y = max(0, min(bitmap.pixelsHigh - 1, bitmap.pixelsHigh / 2))
+        return bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB)
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconImageViewBlankRetryTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconImageViewBlankRetryTests.swift
@@ -33,6 +33,43 @@ import Testing
         #expect(pixel.redComponent > pixel.blueComponent)
     }
 
+    /// A source that stays blank stops re-rendering after the bounded number
+    /// of layout passes, so a permanently empty icon never re-rasterizes on
+    /// every layout.
+    @Test func imageViewStopsRecoveringAfterBoundedLayoutPasses() {
+        let view = CmuxResolvedIconImageView(frame: NSRect(origin: .zero, size: size))
+        view.appearance = NSAppearance(named: .aqua)
+        let sourceImage = NSImage(size: size)
+        sourceImage.addRepresentation(transparentBitmapRepresentation(pixels: 16))
+
+        view.apply(CmuxResolvedIconRequest(source: .image(sourceImage), size: size))
+        for _ in 0..<(CmuxResolvedIconImageView.blankRecoveryLayoutPasses + 2) {
+            view.layout()
+        }
+
+        #expect(renderedImage(in: view) == nil)
+        #expect(view.blankRecoveryPassesUsed == CmuxResolvedIconImageView.blankRecoveryLayoutPasses)
+    }
+
+    /// A new request gets a fresh recovery budget and renders immediately.
+    @Test func imageViewResetsRecoveryBudgetWhenRequestChanges() throws {
+        let view = CmuxResolvedIconImageView(frame: NSRect(origin: .zero, size: size))
+        view.appearance = NSAppearance(named: .aqua)
+        let blankImage = NSImage(size: size)
+        blankImage.addRepresentation(transparentBitmapRepresentation(pixels: 16))
+        view.apply(CmuxResolvedIconRequest(source: .image(blankImage), size: size))
+        view.layout()
+        #expect(view.blankRecoveryPassesUsed == 1)
+
+        let visibleImage = NSImage(size: size)
+        visibleImage.addRepresentation(solidBitmapRepresentation(color: .systemBlue, pixels: 16))
+        view.apply(CmuxResolvedIconRequest(source: .image(visibleImage), size: size))
+
+        #expect(view.blankRecoveryPassesUsed == 0)
+        let pixel = try #require(renderedImage(in: view).flatMap(centerPixelColor))
+        #expect(pixel.blueComponent > pixel.redComponent)
+    }
+
     private func renderedImage(in view: CmuxResolvedIconImageView) -> NSImage? {
         view.subviews.compactMap { ($0 as? NSImageView)?.image }.first
     }


### PR DESCRIPTION
## Summary

Sidebar footer icons (account avatar placeholder, iPhone pairing, Help) could vanish while their buttons stayed laid out and clickable, the symptom tracked in #8352 and #7725 and previously reduced for Vault/sidebar rows in #10764. This makes the shared AppKit icon view recover a blank draw on the next layout pass.

## Root cause

`CmuxResolvedIconImageView` rasterizes each icon through `CmuxResolvedIconRenderer` and rejects a fully transparent bitmap as `.blankOutput`. That transparent first raster is a transient AppKit state: the symbol provider resolves before the effective appearance does, most often on macOS 15 and Intel, typically when the request arrives before the view is laid out inside its window. After a blank result the view only drew again on `viewDidMoveToWindow` or `viewDidChangeEffectiveAppearance`; for a footer control that lives for the whole window, neither fires again, so the icon stayed blank. `CmuxSystemSymbolImage` (the SwiftUI path every previously fixed site uses) falls back to this same view when its own materialization is blank, so it inherited the stuck state.

## Fix

- A blank draw sets `needsLayout`; `layout()` re-renders while the view sits inside its window with a resolved appearance, which is the readiness signal for this state. No timers, no sleeps, no test-only hooks.
- Recovery is bounded to three layout passes per request and appearance (`blankRecoveryLayoutPasses`), so a source that stays blank never re-rasterizes on every layout. A successful draw, a source-unavailable result, or a different request/appearance resets the budget; window moves and appearance changes still force a draw through the existing paths.
- Last-good-image preservation and the "skip identical blank re-render" guard are unchanged.

## Verification

- Two commits: `47578c5c35` adds `imageViewRecoversBlankRenderOnLayoutPass`, which fails on `main` (a layout pass never recovers the blank draw); `ce3d6cf716` adds the fix plus `imageViewStopsRecoveringAfterBoundedLayoutPasses` and `imageViewResetsRecoveryBudgetWhenRequestChanges`.
- `swift test --package-path Packages/macOS/CmuxAppKitSupportUI --filter CmuxResolvedIcon`: 21 tests pass locally (Swift 6.1.2 command line tools); no new warnings in the touched files; `scripts/check-test-determinism.py --strict` reports 0 active findings.
- Full `ci.yml` dispatched on this branch for `swift-package-tests` and the app build; a tagged Xcode 26 dev build (`reload-build.yml`, tag `sidebar-icon-heal`) is linked in the comments.
- Localization audit: no user-facing strings, menus, settings, or docs changed.
- Not reproduced visually on this machine (no Xcode here); the blank state is intermittent by nature (#8352). Dogfood check: the account, iPhone, and Help icons stay visible across a long session and after popovers.

Addresses #8352 and #7725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8Eci7rC11iSuCw4F4DE2g

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit icon rendering retry logic with a hard cap; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **sidebar footer icons** (account, iPhone, Help) that could rasterize as fully transparent and then **never redraw** because `CmuxResolvedIconImageView` only retried on window or appearance changes.
> 
> When `CmuxResolvedIconRenderer` returns **`.blankOutput`**, the view now sets **`needsLayout`** and retries during **`layout()`** (up to **`blankRecoveryLayoutPasses` = 3** per request/appearance). Successful draws, unavailable sources, or a new request/appearance reset the budget; permanently blank sources stop retrying so layout does not loop forever. The **`.blankOutput`** branch also stops clearing the last visible image in a way that blocked recovery while still dropping stale pixels when the request/appearance no longer matches.
> 
> Adds **`CmuxResolvedIconImageViewBlankRetryTests`** for recovery on layout, bounded retries, and budget reset on request change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3d6cf7161e6b474f0c578c3ec53c79be774bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved icon rendering recovery when the initial rasterized output is blank.
  - Icon views now retry rendering across layout passes and stop after a bounded number of attempts.
  - Recovery state resets when a new icon request or appearance is applied.

- **Tests**
  - Added coverage for blank-render recovery, retry limits, and recovery after switching to a new image request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->