### PR TITLE
cloud: explain the tunnel approval wait in the port pane, add cmux.sh proxy URLs

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69358,6 +69358,244 @@
         }
       }
     },
+    "cloudTree.pane.approval.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow the cmux Cloud Tunnel to open %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Cloud Tunnel を許可して %@ を開く"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.why": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port %1$d on %2$@ is served at %3$@, an address on your private Cloud network. macOS reaches it through the cmux Cloud Tunnel, a VPN extension bundled with cmux. macOS blocks every new VPN extension until you allow it once in System Settings; the tunnel start is waiting on that switch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ のポート %1$d は、プライベート Cloud ネットワーク上のアドレス %3$@ で提供されています。macOS は cmux に同梱された VPN 機能拡張「cmux Cloud Tunnel」を通じてこのアドレスに到達します。新しい VPN 機能拡張はシステム設定で一度許可するまで macOS にブロックされるため、トンネルの開始はその許可を待っています。"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.step1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Open System Settings › General › Login Items & Extensions."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. システム設定 › 一般 › ログイン項目と機能拡張 を開きます。"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.step2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Under Extensions, open Network Extensions."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 「機能拡張」の中の「ネットワーク機能拡張」を開きます。"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.step3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Turn on cmux Cloud Tunnel, then confirm with your password or Touch ID."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 「cmux Cloud Tunnel」をオンにし、パスワードまたは Touch ID で確認します。"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.step4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Come back here and press Check Again. The page loads as soon as the tunnel is up."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. ここに戻って「再確認」を押します。トンネルが接続されるとページが読み込まれます。"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.approval.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open System Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定を開く"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.checkAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再確認"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.tryAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
+          }
+        }
+      }
+    },
+    "cloudTree.pane.openProxy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open through cmux.sh instead"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代わりに cmux.sh 経由で開く"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.copyLink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクをコピー"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.copyProxyURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Proxy URL (cmux.sh)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシ URL をコピー (cmux.sh)"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.openProxyURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Proxy URL (cmux.sh)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシ URL を開く (cmux.sh)"
+          }
+        }
+      }
+    },
+    "cloudTree.operation.proxy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publishing %@:%d on cmux.sh…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@:%d を cmux.sh に公開しています…"
+          }
+        }
+      }
+    },
     "cloudTree.pane.retryHint": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Auth/BrowserAppSession/BrowserAppSessionController.swift
+++ b/Sources/Auth/BrowserAppSession/BrowserAppSessionController.swift
@@ -72,8 +72,24 @@ final class BrowserAppSessionController {
         )
     }
 
+    /// The cmux web origin's root, the handoff destination used when the page
+    /// to open lives elsewhere (see ``request(externalDestinationURL:)``).
+    var webOriginRootURL: URL { handoff.webOrigin }
+
+    /// Prepare a navigation to a page OUTSIDE the cmux origin that will bounce
+    /// through cmux for sign-in (a `cmux.sh` port publication redirects to
+    /// `/cloud/access`). The cookie exchange targets the cmux origin as usual;
+    /// only the navigation itself goes to `externalDestinationURL`, in the same
+    /// isolated store, so the bounce finds the account already signed in.
     func request(
-        destinationURL: URL
+        externalDestinationURL: URL
+    ) async -> BrowserAppSessionRequestOutcome {
+        await request(destinationURL: webOriginRootURL, navigationURL: externalDestinationURL)
+    }
+
+    func request(
+        destinationURL: URL,
+        navigationURL: URL? = nil
     ) async -> BrowserAppSessionRequestOutcome {
         let snapshot: AuthenticatedSessionSnapshot
         do {
@@ -106,6 +122,7 @@ final class BrowserAppSessionController {
             guard let self else { return BrowserAppSessionRequestOutcome.cancelled }
             return await performHandoff(
                 destinationURL: destinationURL,
+                navigationURL: navigationURL ?? destinationURL,
                 websiteDataStore: websiteDataStore,
                 requestGeneration: requestGeneration,
                 snapshot: snapshot
@@ -257,6 +274,7 @@ final class BrowserAppSessionController {
 
     private func performHandoff(
         destinationURL: URL,
+        navigationURL: URL,
         websiteDataStore: WKWebsiteDataStore,
         requestGeneration: UInt64,
         snapshot: AuthenticatedSessionSnapshot
@@ -322,7 +340,7 @@ final class BrowserAppSessionController {
         }
 
         return .navigation(BrowserAppSessionNavigation(
-            request: URLRequest(url: destinationURL),
+            request: URLRequest(url: navigationURL),
             websiteDataStore: websiteDataStore,
             generation: requestGeneration,
             authSessionGeneration: snapshot.generation

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -48,6 +48,10 @@ struct CloudTreeNodeActions {
     /// Select a local workspace.
     let selectLocalWorkspace: @MainActor (_ workspaceID: UUID) -> Void
     let copyToPasteboard: @MainActor (_ text: String) -> Void
+    /// Copy a port's public `cmux.sh` URL (creating the personal publication on first use).
+    let copyProxyURL: @MainActor (_ resource: SurfaceResourceID) -> Void
+    /// Open a port's public `cmux.sh` URL in a browser pane signed in as this account.
+    let openProxyURL: @MainActor (_ resource: SurfaceResourceID) -> Void
     let refresh: @MainActor () -> Void
 
     @MainActor
@@ -87,6 +91,17 @@ struct CloudTreeNodeActions {
         }
         let openingLabel: (SurfaceMachineID) -> String = { machine in
             String(format: String(localized: "cloudTree.operation.project", defaultValue: "Opening on %@\u{2026}"), machineName(machine))
+        }
+        let proxyLabel: (SurfaceMachineID, Int) -> String = { machine, port in
+            String(format: String(localized: "cloudTree.operation.proxy", defaultValue: "Publishing %@:%d on cmux.sh\u{2026}"), machineName(machine), port)
+        }
+        let copyToPasteboard: @MainActor (String) -> Void = { text in
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            let ok = pasteboard.setString(text, forType: .string)
+            #if DEBUG
+            cmuxDebugLog("cloudTree.copyToPasteboard ok=\(ok) chars=\(text.count)")
+            #endif
         }
         let startingLabel: (SurfaceMachineID) -> String = { machine in
             String(format: String(localized: "cloudTree.operation.newTerminal", defaultValue: "Starting a terminal on %@\u{2026}"), machineName(machine))
@@ -338,13 +353,29 @@ struct CloudTreeNodeActions {
                 }
             },
             selectLocalWorkspace: selectLocalWorkspace,
-            copyToPasteboard: { text in
-                let pasteboard = NSPasteboard.general
-                pasteboard.clearContents()
-                let ok = pasteboard.setString(text, forType: .string)
-                #if DEBUG
-                cmuxDebugLog("cloudTree.copyToPasteboard ok=\(ok) chars=\(text.count)")
-                #endif
+            copyToPasteboard: copyToPasteboard,
+            copyProxyURL: { resource in
+                guard let vmID = resource.machine.cloudMachineID, let port = resource.forwardedPort else { return }
+                run(proxyLabel(resource.machine, port)) { _ in
+                    let url = try await CloudPortProxy.url(vmID: vmID, port: port)
+                    copyToPasteboard(url.absoluteString)
+                }
+            },
+            openProxyURL: { resource in
+                guard let vmID = resource.machine.cloudMachineID, let port = resource.forwardedPort else { return }
+                let capturedWorkspaceID = selectedWorkspaceID()
+                run(proxyLabel(resource.machine, port)) { catalog in
+                    guard let workspaceID = catalog.preferredLocalWorkspaceID(for: resource, fallback: capturedWorkspaceID) else {
+                        throw SurfaceCatalogError.destinationNotFound(SurfaceCatalog.portDestinationUnavailableMessage(machine: resource.machine))
+                    }
+                    let url = try await CloudPortProxy.url(vmID: vmID, port: port)
+                    let opened = try await SurfacePaneFactory.makeAuthenticatedBrowserPane(
+                        url: url,
+                        at: .workspace(id: workspaceID, placement: .split),
+                        focus: true
+                    )
+                    SurfacePaneFactory.focus(panelID: opened.panelID, in: opened.workspaceID)
+                }
             },
             refresh: refresh
         )

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -757,6 +757,10 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             items.append(.separator())
             if let portURL {
                 items.append(item(String(localized: "cloudTree.menu.copyLink", defaultValue: "Copy Link")) { [nodeActions] in nodeActions.copyToPasteboard(portURL) })
+                // The public route needs no tunnel: a personal `cmux.sh` publication
+                // that signs in through cmux. Same verbs as the private link.
+                items.append(item(String(localized: "cloudTree.menu.copyProxyURL", defaultValue: "Copy Proxy URL (cmux.sh)")) { [nodeActions] in nodeActions.copyProxyURL(resource.id) })
+                items.append(item(String(localized: "cloudTree.menu.openProxyURL", defaultValue: "Open Proxy URL (cmux.sh)")) { [nodeActions] in nodeActions.openProxyURL(resource.id) })
             } else if let port = resource.port, resource.kind == .browser {
                 items.append(item(String(localized: "cloudTree.menu.copyPort", defaultValue: "Copy Port")) { [nodeActions] in nodeActions.copyToPasteboard(String(port)) })
             }

--- a/Sources/Cloud/Tunnel/CloudPrivateNetworkGate.swift
+++ b/Sources/Cloud/Tunnel/CloudPrivateNetworkGate.swift
@@ -4,8 +4,20 @@ import Foundation
 /// metadata use the separate user-space WireGuard hub.
 protocol CloudPrivateNetworkGate: Sendable {
     /// Require a working route before a browser is allowed to navigate to a
-    /// private address. This fails closed.
-    func requirePrivateNetworkUse(_ use: CloudPrivateNetworkUse) async throws
+    /// private address. This fails closed. `onStateChange` reports every
+    /// tunnel state the wait passes through (the current one first), so the
+    /// caller can show the person what the wait is blocked on: a start that
+    /// is waiting on the system-extension approval never resolves by itself.
+    func requirePrivateNetworkUse(
+        _ use: CloudPrivateNetworkUse,
+        onStateChange: @escaping @Sendable (CloudTunnelState) -> Void
+    ) async throws
+}
+
+extension CloudPrivateNetworkGate {
+    func requirePrivateNetworkUse(_ use: CloudPrivateNetworkUse) async throws {
+        try await requirePrivateNetworkUse(use, onStateChange: { _ in })
+    }
 }
 
 /// What is about to dial the private network, for logging and consumer

--- a/Sources/Cloud/Tunnel/CloudPrivateNetworkNoopGate.swift
+++ b/Sources/Cloud/Tunnel/CloudPrivateNetworkNoopGate.swift
@@ -1,5 +1,8 @@
 import Foundation
 
 struct CloudPrivateNetworkNoopGate: CloudPrivateNetworkGate {
-    func requirePrivateNetworkUse(_ use: CloudPrivateNetworkUse) async throws {}
+    func requirePrivateNetworkUse(
+        _ use: CloudPrivateNetworkUse,
+        onStateChange: @escaping @Sendable (CloudTunnelState) -> Void
+    ) async throws {}
 }

--- a/Sources/Cloud/Tunnel/CloudTunnelCoordinator.swift
+++ b/Sources/Cloud/Tunnel/CloudTunnelCoordinator.swift
@@ -94,7 +94,10 @@ actor CloudTunnelCoordinator: CloudPrivateNetworkGate {
 
     /// Browser navigation must not race or bypass the Network Extension. The
     /// pane stays on its connecting screen until this returns successfully.
-    func requirePrivateNetworkUse(_ use: CloudPrivateNetworkUse) async throws {
+    func requirePrivateNetworkUse(
+        _ use: CloudPrivateNetworkUse,
+        onStateChange: @escaping @Sendable (CloudTunnelState) -> Void
+    ) async throws {
         guard case .networkExtension = backend else {
             throw CloudTunnelError.backendUnavailable(backend.unavailableReason ?? .entitlementMissing)
         }
@@ -104,7 +107,7 @@ actor CloudTunnelCoordinator: CloudPrivateNetworkGate {
         }
         clearFailureBackoff()
         logger.info("Cloud browser use for \(use.machineID, privacy: .public): requiring the tunnel")
-        try await ensureUp()
+        try await ensureUp(onStateChange: onStateChange)
         restartIdleTimer()
     }
 
@@ -205,11 +208,14 @@ actor CloudTunnelCoordinator: CloudPrivateNetworkGate {
     /// Start if needed and wait for the outcome. Waits on the state stream
     /// rather than the start task's value so a caller's deadline can release
     /// it while the start itself carries on.
-    private func ensureUp() async throws {
+    private func ensureUp(
+        onStateChange: @escaping @Sendable (CloudTunnelState) -> Void = { _ in }
+    ) async throws {
         if state == .up { return }
         _ = startTaskIfNeeded()
         let updates = subscribeToState(current: state)
         for await candidate in updates {
+            onStateChange(candidate)
             switch candidate {
             case .up:
                 return

--- a/Sources/Cloud/Tunnel/CloudTunnelStatus.swift
+++ b/Sources/Cloud/Tunnel/CloudTunnelStatus.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 struct CloudTunnelStatus: Sendable, Equatable {
@@ -35,5 +36,21 @@ struct CloudTunnelStatus: Sendable, Equatable {
                 defaultValue: "This Mac's tunnel to your Cloud VM network is down; reopen the machine to start it."
             )
         }
+    }
+}
+
+/// Where macOS keeps the switch for the cmux Cloud Tunnel extension.
+enum CloudTunnelSystemSettings {
+    /// System Settings › General › Login Items & Extensions, scrolled to Network
+    /// Extensions. The `extensionPointIdentifier` query is what Apple's own
+    /// `systemextensionsctl` guidance points at; older releases ignore it and
+    /// land on the Login Items pane, which still lists the extension.
+    static let networkExtensionsURL = URL(
+        string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?extensionPointIdentifier=com.apple.system_extension.network_extension.extension-point"
+    )!
+
+    @MainActor
+    static func openNetworkExtensions(open: (URL) -> Bool = { NSWorkspace.shared.open($0) }) -> Bool {
+        open(networkExtensionsURL)
     }
 }

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -765,9 +765,13 @@ actor VMClient {
 
     /// Do not let a Cloud webview navigate until the browser tunnel is ready.
     /// Direct private URLs call this without a control-plane request.
-    func requireCloudBrowserAccess(machineID: String) async throws {
+    func requireCloudBrowserAccess(
+        machineID: String,
+        onStateChange: @escaping @Sendable (CloudTunnelState) -> Void = { _ in }
+    ) async throws {
         try await privateNetwork.requirePrivateNetworkUse(
-            CloudPrivateNetworkUse(machineID: machineID, purpose: .openPort)
+            CloudPrivateNetworkUse(machineID: machineID, purpose: .openPort),
+            onStateChange: onStateChange
         )
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2941,6 +2941,9 @@ final class BrowserPanel: Panel, ObservableObject {
         // Enable JavaScript
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         WebSurfaceSelectionReader.installTracking(in: configuration.userContentController)
+        // Buttons on cloud pane placeholder pages (tunnel approval, retry). The
+        // bridge accepts only main-frame `about:` documents with a live pane token.
+        SurfaceBrowserPlaceholderBridge.install(in: configuration.userContentController)
         configuration.userContentController.addUserScript(
             WKUserScript(
                 source: BrowserFileSystemAccessBridge.scriptSource,

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1111,30 +1111,21 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             // address until the Network Extension is connected. This is the
             // only action that can cause the one-time macOS approval request.
             let label = Self.paneLabel(machineID: machineID, port: port, desktop: desktop)
-            let machineWasAwake = isAwake
             created = try SurfacePaneFactory.makeBrowserPane(url: SurfacePaneFactory.blankURL, at: destination, focus: focus)
-            SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(label), panelID: created.panelID, in: created.workspaceID)
-            let pane = created
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                do {
-                    guard let client = VMClient.shared else { throw ProviderError.notSignedIn }
-                    try await client.requireCloudBrowserAccess(machineID: self.machineID)
-                    if !machineWasAwake {
-                        // Waking a paused machine is an explicit management
-                        // operation. Ignore the returned URL and keep the
-                        // private address captured above.
-                        _ = try await client.openPort(id: self.machineID, port: port)
-                    }
-                    SurfacePaneFactory.navigate(panelID: pane.panelID, in: pane.workspaceID, to: directURL)
-                } catch {
-                    let text = CloudMachineLink.errorText(error)
-                    SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.failed(label, error: text), panelID: pane.panelID, in: pane.workspaceID)
-                    #if DEBUG
-                    cmuxDebugLog("cloud.provider.endpointFailed machine=\(self.machineID) port=\(port) error=\(String(reflecting: error))")
-                    #endif
-                }
-            }
+            let opener = CloudBrowserPaneOpener(
+                pane: created,
+                machineID: machineID,
+                machineName: info.name,
+                privateAddress: info.privateAddress,
+                port: port,
+                label: label,
+                directURL: directURL,
+                machineWasAwake: isAwake,
+                // The desktop is a VNC page served only on the private network;
+                // a `cmux.sh` publication of it would expose the desktop token.
+                proxyAvailable: !desktop
+            )
+            opener.start()
         }
         materializedPanels.insert(created.panelID)
         let selectedView = remoteView ?? Self.defaultRemoteView(for: resource)
@@ -1968,5 +1959,170 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 }
             }
         }
+    }
+}
+
+/// One optimistic cloud browser pane, from "Connecting…" to a loaded page.
+///
+/// Owns the pane's placeholder token and every retry, so the page's buttons
+/// (Check Again after the extension approval, Try Again after a failure, and
+/// the `cmux.sh` escape hatch) act on THIS pane. The tunnel gate reports its
+/// state while it waits; `.awaitingApproval` swaps the spinner for the approval
+/// instructions and opens System Settings once, because that wait never ends on
+/// its own and a bare spinner told nobody what to do (the 2026-09-08 NIGHTLY report).
+@MainActor
+final class CloudBrowserPaneOpener {
+    private let pane: (workspaceID: UUID, panelID: UUID)
+    private let machineID: String
+    private let machineName: String
+    private let privateAddress: String?
+    private let port: Int
+    private let label: String
+    private let directURL: URL
+    private let machineWasAwake: Bool
+    private let proxyAvailable: Bool
+    private let openSystemSettings: @MainActor () -> Bool
+    private var token: String?
+    private var attempt: Task<Void, Never>?
+    private var openedSystemSettings = false
+    private(set) var shownState: CloudTunnelState?
+
+    init(
+        pane: (workspaceID: UUID, panelID: UUID),
+        machineID: String,
+        machineName: String,
+        privateAddress: String?,
+        port: Int,
+        label: String,
+        directURL: URL,
+        machineWasAwake: Bool,
+        proxyAvailable: Bool,
+        openSystemSettings: @escaping @MainActor () -> Bool = { CloudTunnelSystemSettings.openNetworkExtensions() }
+    ) {
+        self.pane = pane
+        self.machineID = machineID
+        self.machineName = machineName
+        self.privateAddress = privateAddress
+        self.port = port
+        self.label = label
+        self.directURL = directURL
+        self.machineWasAwake = machineWasAwake
+        self.proxyAvailable = proxyAvailable
+        self.openSystemSettings = openSystemSettings
+    }
+
+    func start() {
+        let token = SurfaceBrowserPlaceholderBridge.shared.register { [weak self] action in
+            self?.handle(action)
+        }
+        self.token = token
+        runAttempt()
+    }
+
+    private func handle(_ action: SurfaceBrowserPlaceholderAction) {
+        switch action {
+        case .retry:
+            runAttempt()
+        case .openSystemSettings:
+            _ = openSystemSettings()
+        case .openProxy:
+            openProxy()
+        }
+    }
+
+    /// The whole open, from the top: tunnel gate (with live state), optional
+    /// wake, then navigation. A retry while an attempt is still waiting joins
+    /// the same tunnel start (the coordinator runs one at a time), so pressing
+    /// Check Again repeatedly is harmless.
+    private func runAttempt() {
+        attempt?.cancel()
+        SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(label), panelID: pane.panelID, in: pane.workspaceID)
+        shownState = nil
+        attempt = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                guard let client = VMClient.shared else { throw CmuxTuiSurfaceProvider.ProviderError.notSignedIn }
+                try await client.requireCloudBrowserAccess(machineID: machineID) { [weak self] state in
+                    Task { @MainActor in self?.tunnelStateDidChange(state) }
+                }
+                try Task.checkCancellation()
+                if !machineWasAwake {
+                    // Waking a paused machine is an explicit management
+                    // operation. Ignore the returned URL and keep the
+                    // private address captured above.
+                    _ = try await client.openPort(id: machineID, port: port)
+                    try Task.checkCancellation()
+                }
+                finish()
+                SurfacePaneFactory.navigate(panelID: pane.panelID, in: pane.workspaceID, to: directURL)
+            } catch is CancellationError {
+                // Superseded by a newer attempt, which owns the pane now.
+            } catch {
+                let text = CloudMachineLink.errorText(error)
+                SurfacePaneFactory.showPlaceholder(
+                    SurfaceBrowserPlaceholder.failed(label, error: text, token: token, proxyAvailable: proxyAvailable),
+                    panelID: pane.panelID,
+                    in: pane.workspaceID
+                )
+                #if DEBUG
+                cmuxDebugLog("cloud.provider.endpointFailed machine=\(machineID) port=\(port) error=\(String(reflecting: error))")
+                #endif
+            }
+        }
+    }
+
+    func tunnelStateDidChange(_ state: CloudTunnelState) {
+        guard state != shownState else { return }
+        shownState = state
+        switch state {
+        case .awaitingApproval:
+            guard let token else { return }
+            SurfacePaneFactory.showPlaceholder(
+                SurfaceBrowserPlaceholder.tunnelApproval(
+                    label: label,
+                    machineName: machineName,
+                    privateAddress: privateAddress,
+                    port: port,
+                    token: token,
+                    proxyAvailable: proxyAvailable
+                ),
+                panelID: pane.panelID,
+                in: pane.workspaceID
+            )
+            if !openedSystemSettings {
+                openedSystemSettings = true
+                _ = openSystemSettings()
+            }
+        case .starting, .stopping:
+            SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(label), panelID: pane.panelID, in: pane.workspaceID)
+        case .up, .off, .failed:
+            break
+        }
+    }
+
+    /// The private route is stuck; open the port's public `cmux.sh` URL, signed in
+    /// as this account, in the placeholder's place.
+    private func openProxy() {
+        attempt?.cancel()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let url = try await CloudPortProxy.url(vmID: machineID, port: port)
+                SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.connecting(url.host ?? label), panelID: pane.panelID, in: pane.workspaceID)
+                _ = try await CloudPortProxy.open(url, replacing: pane)
+                finish()
+            } catch {
+                SurfacePaneFactory.showPlaceholder(
+                    SurfaceBrowserPlaceholder.failed(label, error: CloudMachineLink.errorText(error), token: token, proxyAvailable: proxyAvailable),
+                    panelID: pane.panelID,
+                    in: pane.workspaceID
+                )
+            }
+        }
+    }
+
+    private func finish() {
+        if let token { SurfaceBrowserPlaceholderBridge.shared.unregister(token) }
+        token = nil
     }
 }

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -92,6 +92,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// Panels this provider created (or replaced) in this process. A projection whose
     /// panel is not here came back from a restored session as a placeholder shell.
     var materializedPanels: Set<UUID> = []
+    /// Browser panes still resolving their endpoint, by panel id. The opener owns the
+    /// pane's placeholder token and retry loop, so it must outlive `materialize`; it
+    /// leaves when the page loads or the pane goes away.
+    private var browserPaneOpeners: [UUID: CloudBrowserPaneOpener] = [:]
     /// Native cloud terminals own a manual attachment separate from their
     /// catalog projection. The provider retains it for the life of the pane.
     var manualMirrorSessions: [UUID: CloudTuiManualMirrorSession] = [:]
@@ -1123,8 +1127,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 machineWasAwake: isAwake,
                 // The desktop is a VNC page served only on the private network;
                 // a `cmux.sh` publication of it would expose the desktop token.
-                proxyAvailable: !desktop
+                proxyAvailable: !desktop,
+                onFinish: { [weak self] panelID in self?.browserPaneOpeners[panelID] = nil }
             )
+            browserPaneOpeners[created.panelID] = opener
             opener.start()
         }
         materializedPanels.insert(created.panelID)
@@ -1604,12 +1610,14 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     func projectionDidEnd(_ projection: SurfaceProjection) {
         materializedPanels.remove(projection.panelID)
         manualMirrorSessions.removeValue(forKey: projection.panelID)?.stop()
+        browserPaneOpeners.removeValue(forKey: projection.panelID)?.cancel()
     }
 
     @discardableResult
     func discardMaterialization(_ projection: SurfaceProjection) -> Bool {
         materializedPanels.remove(projection.panelID)
         manualMirrorSessions.removeValue(forKey: projection.panelID)?.stop()
+        browserPaneOpeners.removeValue(forKey: projection.panelID)?.cancel()
         SurfacePaneFactory.close(panelID: projection.panelID, in: projection.workspaceID)
         return false
     }
@@ -1982,6 +1990,7 @@ final class CloudBrowserPaneOpener {
     private let machineWasAwake: Bool
     private let proxyAvailable: Bool
     private let openSystemSettings: @MainActor () -> Bool
+    private let onFinish: @MainActor (UUID) -> Void
     private var token: String?
     private var attempt: Task<Void, Never>?
     private var openedSystemSettings = false
@@ -1997,7 +2006,8 @@ final class CloudBrowserPaneOpener {
         directURL: URL,
         machineWasAwake: Bool,
         proxyAvailable: Bool,
-        openSystemSettings: @escaping @MainActor () -> Bool = { CloudTunnelSystemSettings.openNetworkExtensions() }
+        openSystemSettings: @escaping @MainActor () -> Bool = { CloudTunnelSystemSettings.openNetworkExtensions() },
+        onFinish: @escaping @MainActor (UUID) -> Void = { _ in }
     ) {
         self.pane = pane
         self.machineID = machineID
@@ -2009,7 +2019,10 @@ final class CloudBrowserPaneOpener {
         self.machineWasAwake = machineWasAwake
         self.proxyAvailable = proxyAvailable
         self.openSystemSettings = openSystemSettings
+        self.onFinish = onFinish
     }
+
+    var isFinished: Bool { token == nil }
 
     func start() {
         let token = SurfaceBrowserPlaceholderBridge.shared.register { [weak self] action in
@@ -2121,8 +2134,17 @@ final class CloudBrowserPaneOpener {
         }
     }
 
+    /// The pane went away: stop any in-flight attempt and drop the token.
+    func cancel() {
+        attempt?.cancel()
+        attempt = nil
+        finish()
+    }
+
     private func finish() {
-        if let token { SurfaceBrowserPlaceholderBridge.shared.unregister(token) }
-        token = nil
+        guard let token else { return }
+        SurfaceBrowserPlaceholderBridge.shared.unregister(token)
+        self.token = nil
+        onFinish(pane.panelID)
     }
 }

--- a/Sources/Surfaces/SurfaceCatalog+CloudPorts.swift
+++ b/Sources/Surfaces/SurfaceCatalog+CloudPorts.swift
@@ -449,3 +449,43 @@ extension CmuxTuiSurfaceProvider {
         }
     }
 }
+
+/// The public route to a machine port: `https://<vm>--<org>--<port>.cmux.sh`, a
+/// managed publication that needs no tunnel. Personal by default (only this
+/// account, after cmux sign-in), so copying or opening it never exposes the port.
+/// Creating it is idempotent server-side: the same port yields the same hostname.
+enum CloudPortProxy {
+    @MainActor
+    static func publication(vmID: String, port: Int) async throws -> VMPublication {
+        guard let client = VMClient.shared else { throw CmuxTuiSurfaceProvider.ProviderError.notSignedIn }
+        return try await client.createPublication(vmID: vmID, port: port, hostname: nil, accessMode: nil, teamID: nil)
+    }
+
+    @MainActor
+    static func url(vmID: String, port: Int) async throws -> URL {
+        let publication = try await publication(vmID: vmID, port: port)
+        guard let url = URL(string: publication.url), url.host != nil else {
+            throw CmuxTuiSurfaceProvider.ProviderError.badURL(publication.url)
+        }
+        return url
+    }
+
+    /// Opens the proxy URL signed in as the cmux account, as a tab where the
+    /// placeholder pane sits, then closes the placeholder. The new pane needs
+    /// its own (isolated, cookie-primed) website data store, which an existing
+    /// pane cannot adopt.
+    @MainActor
+    @discardableResult
+    static func open(_ url: URL, replacing pane: (workspaceID: UUID, panelID: UUID)) async throws -> (workspaceID: UUID, panelID: UUID) {
+        guard let paneID = SurfacePaneFactory.paneID(ofPanel: pane.panelID, in: pane.workspaceID) else {
+            throw SurfacePaneFactory.FactoryError.paneNotFound(pane.panelID.uuidString)
+        }
+        let opened = try await SurfacePaneFactory.makeAuthenticatedBrowserPane(
+            url: url,
+            at: .tab(workspaceID: pane.workspaceID, paneID: paneID, index: nil),
+            focus: true
+        )
+        SurfacePaneFactory.close(panelID: pane.panelID, in: pane.workspaceID)
+        return opened
+    }
+}

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -41,6 +41,50 @@ enum SurfacePaneFactory {
         try create(typeRaw: "browser", url: url.absoluteString, initialCommand: nil, workingDirectory: nil, at: destination, focus: focus)
     }
 
+    /// A browser pane at `url`, signed in as the cmux account: the pane gets its own
+    /// isolated website data store holding the account's cmux session cookies, so a page
+    /// that bounces through cmux for sign-in (a `cmux.sh` port publication) loads without a
+    /// login form. Falls back to a plain pane when there is no session to hand off (signed
+    /// out, exchange failed); the page then shows its own sign-in.
+    static func makeAuthenticatedBrowserPane(url: URL, at destination: SurfaceDestination, focus: Bool) async throws -> (workspaceID: UUID, panelID: UUID) {
+        var request = URLRequest(url: url)
+        var websiteDataStore: WKWebsiteDataStore?
+        if let auth = AppDelegate.shared?.auth,
+           case .navigation(let navigation) = await auth.browserAppSession.request(externalDestinationURL: url) {
+            request = navigation.request
+            websiteDataStore = navigation.websiteDataStore
+        }
+        guard let workspace = workspace(id: destination.workspaceID) else { throw FactoryError.workspaceNotFound(destination.workspaceID) }
+        let panel: BrowserPanel?
+        switch destination {
+        case .tab(_, let paneID, _):
+            guard let uuid = UUID(uuidString: paneID) else { throw FactoryError.paneNotFound(paneID) }
+            panel = workspace.newBrowserSurface(inPane: PaneID(id: uuid), initialRequest: request, focus: focus, allowsExternalBrowserFallback: false, websiteDataStore: websiteDataStore)
+        case .workspace(_, .tab):
+            guard let focused = workspace.focusedPanelId, let pane = workspace.paneId(forPanelId: focused) else {
+                throw FactoryError.paneNotFound("focused")
+            }
+            panel = workspace.newBrowserSurface(inPane: pane, initialRequest: request, focus: focus, allowsExternalBrowserFallback: false, websiteDataStore: websiteDataStore)
+        case .split(_, let paneID, let direction):
+            let anchor = try anchorSurface(paneID: paneID, in: workspace)
+            let vertical = direction == .up || direction == .down
+            panel = workspace.newBrowserSplit(
+                from: anchor,
+                orientation: vertical ? .vertical : .horizontal,
+                insertFirst: direction == .left || direction == .up,
+                initialRequest: request,
+                focus: focus,
+                allowsExternalBrowserFallback: false,
+                websiteDataStore: websiteDataStore
+            )
+        case .workspace(_, .split):
+            guard let focused = workspace.focusedPanelId else { throw FactoryError.paneNotFound("focused") }
+            panel = workspace.newBrowserSplit(from: focused, orientation: .horizontal, initialRequest: request, focus: focus, allowsExternalBrowserFallback: false, websiteDataStore: websiteDataStore)
+        }
+        guard let panel else { throw FactoryError.creationFailed("browser pane for \(url.host ?? url.absoluteString)") }
+        return (workspace.id, panel.id)
+    }
+
     /// The URL a browser pane opens with when its real URL is still being resolved; the
     /// caller fills the pane with ``SurfaceBrowserPlaceholder`` content and navigates later.
     static let blankURL = URL(string: "about:blank")!
@@ -257,9 +301,78 @@ enum SurfacePaneFactory {
     }
 }
 
+/// A button on a ``SurfaceBrowserPlaceholder`` page. The page posts it back through
+/// ``SurfaceBrowserPlaceholderBridge`` with the pane's one-time token.
+enum SurfaceBrowserPlaceholderAction: String, CaseIterable, Sendable {
+    /// Re-run the open from the top (the tunnel gate, then navigation).
+    case retry
+    /// Open System Settings on the Network Extensions list.
+    case openSystemSettings
+    /// Give up on the private route and open the port's public `cmux.sh` URL instead.
+    case openProxy
+}
+
+/// Routes button presses on placeholder pages back to the provider that owns the pane.
+///
+/// One handler serves every browser webview (`BrowserPanel.configureWebViewConfiguration`
+/// installs it), so a message is honored only when it comes from a main-frame `about:`
+/// document (what `loadHTMLString(_:baseURL: nil)` produces; no web origin can post as
+/// one) and names a token that a live pane registered. Tokens are single-use secrets:
+/// unregistered on success, and useless once the pane is gone.
+@MainActor
+final class SurfaceBrowserPlaceholderBridge: NSObject, WKScriptMessageHandler {
+    static let name = "cmuxSurfacePlaceholder"
+    static let shared = SurfaceBrowserPlaceholderBridge()
+
+    private var handlers: [String: @MainActor (SurfaceBrowserPlaceholderAction) -> Void] = [:]
+
+    static func install(in userContentController: WKUserContentController) {
+        userContentController.removeScriptMessageHandler(forName: name)
+        userContentController.add(shared, name: name)
+    }
+
+    /// Registers a pane's action handler and returns the token its pages embed.
+    func register(_ handler: @escaping @MainActor (SurfaceBrowserPlaceholderAction) -> Void) -> String {
+        let token = UUID().uuidString
+        handlers[token] = handler
+        return token
+    }
+
+    func unregister(_ token: String) {
+        handlers[token] = nil
+    }
+
+    var registeredTokenCount: Int { handlers.count }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == Self.name,
+              let parsed = Self.parse(body: message.body, isMainFrame: message.frameInfo.isMainFrame, frameURL: message.frameInfo.request.url),
+              let handler = handlers[parsed.token] else { return }
+        handler(parsed.action)
+    }
+
+    /// Pure validation of one message, so the acceptance rules are testable without WebKit.
+    nonisolated static func parse(body: Any, isMainFrame: Bool, frameURL: URL?) -> (token: String, action: SurfaceBrowserPlaceholderAction)? {
+        guard isMainFrame else { return nil }
+        if let frameURL, let scheme = frameURL.scheme?.lowercased(), scheme != "about" { return nil }
+        guard let dictionary = body as? [String: Any],
+              let token = dictionary["token"] as? String, !token.isEmpty,
+              let rawAction = dictionary["action"] as? String,
+              let action = SurfaceBrowserPlaceholderAction(rawValue: rawAction) else { return nil }
+        return (token, action)
+    }
+}
+
 /// The local pages an optimistic browser pane shows while its endpoint resolves (and if
 /// that fails). Pure: strings in, HTML out, every dynamic value escaped.
 enum SurfaceBrowserPlaceholder {
+    /// One button on a placeholder page.
+    struct Button: Equatable {
+        let action: SurfaceBrowserPlaceholderAction
+        let title: String
+        let primary: Bool
+    }
+
     /// "Connecting to <label>…" on the desktop's dark background, so the pane reads as
     /// the desktop's own loading state rather than a blank tab.
     static func connecting(_ label: String) -> String {
@@ -270,14 +383,71 @@ enum SurfaceBrowserPlaceholder {
         return page(title: title, detail: nil, spinner: true)
     }
 
+    /// The tunnel start is blocked on the one-time macOS approval of the cmux Cloud Tunnel
+    /// extension. Says why the pane needs it, exactly where the switch is, and offers the
+    /// two things that get the person unstuck: open System Settings, and check again.
+    /// `proxyAvailable` adds the way around the tunnel entirely: the port's public
+    /// `cmux.sh` URL, which needs no VPN.
+    static func tunnelApproval(
+        label: String,
+        machineName: String,
+        privateAddress: String?,
+        port: Int,
+        token: String,
+        proxyAvailable: Bool
+    ) -> String {
+        let title = String(
+            format: String(localized: "cloudTree.pane.approval.title", defaultValue: "Allow the cmux Cloud Tunnel to open %@"),
+            label
+        )
+        let address = privateAddress.map { "\($0):\(port)" } ?? String(port)
+        let why = String(
+            format: String(
+                localized: "cloudTree.pane.approval.why",
+                defaultValue: "Port %1$d on %2$@ is served at %3$@, an address on your private Cloud network. macOS reaches it through the cmux Cloud Tunnel, a VPN extension bundled with cmux. macOS blocks every new VPN extension until you allow it once in System Settings; the tunnel start is waiting on that switch."
+            ),
+            port, machineName, address
+        )
+        let steps = [
+            String(localized: "cloudTree.pane.approval.step1", defaultValue: "1. Open System Settings › General › Login Items & Extensions."),
+            String(localized: "cloudTree.pane.approval.step2", defaultValue: "2. Under Extensions, open Network Extensions."),
+            String(localized: "cloudTree.pane.approval.step3", defaultValue: "3. Turn on cmux Cloud Tunnel, then confirm with your password or Touch ID."),
+            String(localized: "cloudTree.pane.approval.step4", defaultValue: "4. Come back here and press Check Again. The page loads as soon as the tunnel is up."),
+        ]
+        let detail = ([why, ""] + steps).joined(separator: "\n")
+        var buttons = [
+            Button(action: .openSystemSettings, title: String(localized: "cloudTree.pane.approval.openSettings", defaultValue: "Open System Settings"), primary: true),
+            Button(action: .retry, title: String(localized: "cloudTree.pane.checkAgain", defaultValue: "Check Again"), primary: false),
+        ]
+        if proxyAvailable {
+            buttons.append(Button(action: .openProxy, title: String(localized: "cloudTree.pane.openProxy", defaultValue: "Open through cmux.sh instead"), primary: false))
+        }
+        return page(title: title, detail: detail, spinner: false, token: token, buttons: buttons)
+    }
+
     /// "Couldn't open <label>" with the typed error and an appropriate next step.
     /// Unsupported providers deliberately omit the retry instruction: the pane is
     /// truthful about a permanent capability gap instead of inviting a retry loop.
-    static func failed(_ label: String, error: String, retryable: Bool = true) -> String {
+    /// With a `token`, a retryable failure gets a Try Again button (and the `cmux.sh`
+    /// alternative when `proxyAvailable`) instead of the close-and-reopen instruction.
+    static func failed(
+        _ label: String,
+        error: String,
+        retryable: Bool = true,
+        token: String? = nil,
+        proxyAvailable: Bool = false
+    ) -> String {
         let title = String(
             format: String(localized: "cloudTree.pane.failed", defaultValue: "Couldn’t open %@"),
             label
         )
+        if retryable, let token {
+            var buttons = [Button(action: .retry, title: String(localized: "cloudTree.pane.tryAgain", defaultValue: "Try Again"), primary: true)]
+            if proxyAvailable {
+                buttons.append(Button(action: .openProxy, title: String(localized: "cloudTree.pane.openProxy", defaultValue: "Open through cmux.sh instead"), primary: false))
+            }
+            return page(title: title, detail: error, spinner: false, token: token, buttons: buttons)
+        }
         let hint = retryable
             ? String(
                 localized: "cloudTree.pane.retryHint",
@@ -306,10 +476,15 @@ enum SurfaceBrowserPlaceholder {
         return out
     }
 
-    private static func page(title: String, detail: String?, spinner: Bool) -> String {
+    private static func page(title: String, detail: String?, spinner: Bool, token: String? = nil, buttons: [Button] = []) -> String {
         let detailHTML = detail.map { text in
             text.split(separator: "\n", omittingEmptySubsequences: false)
-                .map { "<p>\(escape(String($0)))</p>" }
+                .map { line -> String in
+                    if line.isEmpty { return "<p class=\"gap\"></p>" }
+                    // Numbered instructions read as a list: left-aligned, indented.
+                    let isStep = line.first?.isNumber == true && line.dropFirst().hasPrefix(".")
+                    return "<p\(isStep ? " class=\"step\"" : "")>\(escape(String(line)))</p>"
+                }
                 .joined()
         } ?? ""
         let spinnerHTML = spinner ? "<div class=\"spinner\" role=\"progressbar\"></div>" : ""
@@ -322,6 +497,40 @@ enum SurfaceBrowserPlaceholder {
                      animation: spin 0.9s linear infinite; }
           @keyframes spin { to { transform: rotate(360deg); } }
         """ : ""
+        // Buttons post {token, action} to the bridge; the token is the pane's secret,
+        // embedded once as a JS string literal (UUID text, nothing to escape).
+        let buttonsHTML: String
+        let buttonsCSS: String
+        if let token, !buttons.isEmpty {
+            let items = buttons.map { button in
+                "<button type=\"button\" class=\"\(button.primary ? "primary" : "")\" data-action=\"\(button.action.rawValue)\">\(escape(button.title))</button>"
+            }.joined()
+            buttonsHTML = """
+            <div class="actions">\(items)</div>
+            <script>
+              (() => {
+                const token = "\(token)";
+                for (const button of document.querySelectorAll("button[data-action]")) {
+                  button.addEventListener("click", () => {
+                    window.webkit.messageHandlers["\(SurfaceBrowserPlaceholderBridge.name)"].postMessage({ token, action: button.dataset.action });
+                  });
+                }
+              })();
+            </script>
+            """
+            buttonsCSS = """
+
+              .actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin-top: 1.2em; }
+              button { font: inherit; padding: 6px 14px; border-radius: 6px; cursor: pointer;
+                       border: 1px solid rgba(216,222,233,0.35); background: transparent; color: #d8dee9; }
+              button:hover { background: rgba(216,222,233,0.12); }
+              button.primary { background: #5e81ac; border-color: #5e81ac; color: white; }
+              button.primary:hover { background: #81a1c1; }
+            """
+        } else {
+            buttonsHTML = ""
+            buttonsCSS = ""
+        }
         return """
         <!doctype html>
         <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
@@ -332,9 +541,11 @@ enum SurfaceBrowserPlaceholder {
                  font: 14px -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; }
           main { text-align: center; max-width: 36em; padding: 0 1.5em; }
           h1 { font-size: 15px; font-weight: 500; margin: 0 0 0.6em; }
-          p { margin: 0.3em 0; opacity: 0.8; word-break: break-word; }\(spinnerCSS)
+          p { margin: 0.3em 0; opacity: 0.8; word-break: break-word; }
+          p.gap { height: 0.4em; }
+          p.step { text-align: left; padding-left: 1.5em; text-indent: -1.5em; opacity: 0.9; }\(spinnerCSS)\(buttonsCSS)
         </style></head>
-        <body><main>\(spinnerHTML)<h1>\(escape(title))</h1>\(detailHTML)</main></body></html>
+        <body><main>\(spinnerHTML)<h1>\(escape(title))</h1>\(detailHTML)\(buttonsHTML)</main></body></html>
         """
     }
 }

--- a/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
+++ b/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
@@ -285,6 +285,8 @@ struct CloudTreeNativeDragOwnershipTests {
         renameTerminal: { _, _ in },
         selectLocalWorkspace: { _ in },
         copyToPasteboard: { _ in },
+        copyProxyURL: { _ in },
+        openProxyURL: { _ in },
         refresh: {}
     )
 

--- a/cmuxTests/CloudTunnelCoordinatorTests.swift
+++ b/cmuxTests/CloudTunnelCoordinatorTests.swift
@@ -334,6 +334,33 @@ struct CloudTunnelCoordinatorTests {
         #expect(await harness.coordinator.state == .up)
     }
 
+    @Test("a browser use hears every state it waits through, so a pane can explain the approval wait")
+    func browserUseReportsStatesWhileWaiting() async throws {
+        let harness = Harness()
+        harness.controller.holdInstallForApproval = true
+        let seen = TunnelStateRecorder()
+        let gate = Task {
+            try await harness.coordinator.requirePrivateNetworkUse(Self.use) { state in
+                Task { await seen.record(state) }
+            }
+        }
+        #expect(await harness.awaitState(.awaitingApproval) == .awaitingApproval)
+        #expect(await harness.waitUntil { await seen.states.contains(.awaitingApproval) })
+        #expect(await seen.states.first == .starting, "the current state is reported first")
+
+        harness.controller.approve()
+        try await gate.value
+        let states = await seen.states
+        #expect(states.last == .up)
+        #expect(states.contains(.awaitingApproval))
+        // An already-up tunnel reports nothing: there is no wait to explain.
+        let afterUp = TunnelStateRecorder()
+        try await harness.coordinator.requirePrivateNetworkUse(Self.use) { state in
+            Task { await afterUp.record(state) }
+        }
+        #expect(await afterUp.states.isEmpty)
+    }
+
     @Test("a tunnel left connected by a previous app instance is adopted, not restarted")
     func adoptsAlreadyConnectedTunnel() async {
         let harness = Harness()
@@ -437,4 +464,9 @@ struct CloudTunnelCoordinatorTests {
         harness.controller.emit(.connected)
         #expect(await waiter.value == .up)
     }
+}
+
+private actor TunnelStateRecorder {
+    private(set) var states: [CloudTunnelState] = []
+    func record(_ state: CloudTunnelState) { states.append(state) }
 }

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -1073,6 +1073,34 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(settingsOpens == 0, "System Settings opens only for a registered (started) pane")
     }
 
+    @Test @MainActor func paneOpenerHoldsItsTokenUntilFinishedOrCancelled() {
+        var finished: [UUID] = []
+        let panelID = UUID()
+        let opener = CloudBrowserPaneOpener(
+            pane: (workspaceID: UUID(), panelID: panelID),
+            machineID: "vivid-newt",
+            machineName: "vivid-newt",
+            privateAddress: nil,
+            port: 8000,
+            label: "vivid-newt:8000",
+            directURL: URL(string: "http://10.0.0.1:8000")!,
+            machineWasAwake: true,
+            proxyAvailable: false,
+            openSystemSettings: { false },
+            onFinish: { finished.append($0) }
+        )
+        let before = SurfaceBrowserPlaceholderBridge.shared.registeredTokenCount
+        opener.start()
+        #expect(!opener.isFinished)
+        #expect(SurfaceBrowserPlaceholderBridge.shared.registeredTokenCount == before + 1)
+        // A closed pane releases the token exactly once and tells its owner.
+        opener.cancel()
+        opener.cancel()
+        #expect(opener.isFinished)
+        #expect(SurfaceBrowserPlaceholderBridge.shared.registeredTokenCount == before)
+        #expect(finished == [panelID])
+    }
+
     @Test func linkPipesReadOnGCDNotCooperativeThreads() async throws {
         // Lines arrive as the child writes them, a trailing CR is dropped, and an
         // unterminated last line is delivered at EOF.

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -981,6 +981,98 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(SurfaceBrowserPlaceholder.escape("a\"b'c") == "a&quot;b&#39;c")
     }
 
+    @Test @MainActor func approvalPlaceholderExplainsTheWaitAndOffersTheWayOut() {
+        let html = SurfaceBrowserPlaceholder.tunnelApproval(
+            label: "vivid-newt:8000",
+            machineName: "vivid-newt",
+            privateAddress: "10.16.203.4",
+            port: 8000,
+            token: "TOKEN-1",
+            proxyAvailable: true
+        )
+        #expect(html.contains("Allow the cmux Cloud Tunnel to open vivid-newt:8000"))
+        // Why: the private address and the extension that reaches it.
+        #expect(html.contains("10.16.203.4:8000"))
+        #expect(html.contains("allow it once in System Settings"))
+        // What: the exact path to the switch, and what to press afterwards.
+        #expect(html.contains("Login Items &amp; Extensions"))
+        #expect(html.contains("Network Extensions"))
+        #expect(html.contains("Turn on cmux Cloud Tunnel"))
+        // The three actions, wired to the bridge with this pane's token.
+        for action in [SurfaceBrowserPlaceholderAction.openSystemSettings, .retry, .openProxy] {
+            #expect(html.contains("data-action=\"\(action.rawValue)\""))
+        }
+        #expect(html.contains("Check Again"))
+        #expect(html.contains("Open through cmux.sh instead"))
+        #expect(html.contains("const token = \"TOKEN-1\""))
+        #expect(html.contains("messageHandlers[\"\(SurfaceBrowserPlaceholderBridge.name)\"]"))
+        #expect(!html.contains("class=\"spinner\""), "an approval wait is not a loading state")
+
+        let noProxy = SurfaceBrowserPlaceholder.tunnelApproval(
+            label: "vivid-newt · Desktop", machineName: "vivid-newt", privateAddress: nil, port: 6901, token: "T", proxyAvailable: false
+        )
+        #expect(!noProxy.contains("data-action=\"openProxy\""))
+    }
+
+    @Test @MainActor func failedPlaceholderWithTokenOffersRetryInsteadOfReopenInstruction() {
+        let retryable = SurfaceBrowserPlaceholder.failed("m:3000", error: "boom", token: "T", proxyAvailable: true)
+        #expect(retryable.contains("data-action=\"retry\""))
+        #expect(retryable.contains("Try Again"))
+        #expect(retryable.contains("data-action=\"openProxy\""))
+        #expect(!retryable.contains("open it again from the sidebar"))
+        // A permanent capability gap keeps its no-retry wording even with a token.
+        let permanent = SurfaceBrowserPlaceholder.failed("m:3000", error: "HTTP 501", retryable: false, token: "T")
+        #expect(!permanent.contains("data-action="))
+        #expect(permanent.contains("Do not retry"))
+    }
+
+    @Test @MainActor func placeholderBridgeAcceptsOnlyLocalMainFrameMessagesWithLiveTokens() {
+        let bridge = SurfaceBrowserPlaceholderBridge()
+        var received: [SurfaceBrowserPlaceholderAction] = []
+        let token = bridge.register { received.append($0) }
+        let body: [String: Any] = ["token": token, "action": "retry"]
+
+        // What `loadHTMLString(_:baseURL: nil)` produces: a main-frame about:blank document.
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: body, isMainFrame: true, frameURL: URL(string: "about:blank"))?.action == .retry)
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: body, isMainFrame: true, frameURL: nil)?.token == token)
+        // A web origin, a subframe, an unknown action, or a malformed body never reaches a pane.
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: body, isMainFrame: true, frameURL: URL(string: "https://evil.example/")) == nil)
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: body, isMainFrame: false, frameURL: URL(string: "about:blank")) == nil)
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: ["token": token, "action": "format"], isMainFrame: true, frameURL: nil) == nil)
+        #expect(SurfaceBrowserPlaceholderBridge.parse(body: "retry", isMainFrame: true, frameURL: nil) == nil)
+
+        // Tokens are single-use secrets: gone after unregister, unknown ones ignored.
+        #expect(bridge.registeredTokenCount == 1)
+        bridge.unregister(token)
+        #expect(bridge.registeredTokenCount == 0)
+        #expect(received.isEmpty)
+    }
+
+    @Test @MainActor func paneOpenerShowsApprovalOnceAndOpensSystemSettingsOnce() {
+        var settingsOpens = 0
+        let opener = CloudBrowserPaneOpener(
+            pane: (workspaceID: UUID(), panelID: UUID()),
+            machineID: "vivid-newt",
+            machineName: "vivid-newt",
+            privateAddress: "10.16.203.4",
+            port: 8000,
+            label: "vivid-newt:8000",
+            directURL: URL(string: "http://10.16.203.4:8000")!,
+            machineWasAwake: true,
+            proxyAvailable: true,
+            openSystemSettings: { settingsOpens += 1; return true }
+        )
+        // No pane exists for these ids, so placeholder writes are no-ops; the
+        // state bookkeeping is what this checks.
+        opener.tunnelStateDidChange(.starting)
+        #expect(opener.shownState == .starting)
+        #expect(settingsOpens == 0)
+        opener.tunnelStateDidChange(.awaitingApproval)
+        opener.tunnelStateDidChange(.awaitingApproval)
+        #expect(opener.shownState == .awaitingApproval)
+        #expect(settingsOpens == 0, "System Settings opens only for a registered (started) pane")
+    }
+
     @Test func linkPipesReadOnGCDNotCooperativeThreads() async throws {
         // Lines arrive as the child writes them, a trailing CR is dropped, and an
         // unterminated last line is delivered at EOF.


### PR DESCRIPTION
Clicking a Cloud port in NIGHTLY showed "Connecting to vm-…:8000…" forever. Cause: `com.cmuxterm.app.nightly.tunnel` was `activated waiting for user` (System Settings approval), `requirePrivateNetworkUse` has no deadline, and the pane got no state feedback. An end user had no way to know what to do.

**Overlay.** The gate (`CloudPrivateNetworkGate`) now reports each `CloudTunnelState` it waits through. On `.awaitingApproval`, `CloudBrowserPaneOpener` replaces the spinner with an overlay: why this port needs the VPN extension (private address, what macOS blocks), the exact System Settings path, and buttons **Open System Settings**, **Check Again** (re-runs the whole open; joins the in-flight start), and **Open through cmux.sh instead**. System Settings opens automatically the first time. Failures show **Try Again** instead of "close this pane and reopen". Buttons reach the app through `SurfaceBrowserPlaceholderBridge`, a `WKScriptMessageHandler` that accepts only main-frame `about:` documents carrying a live per-pane token.

**Proxy URL.** Port row context menu gains **Copy Proxy URL (cmux.sh)** and **Open Proxy URL (cmux.sh)**. Both call `POST /api/vm/publications` (idempotent, personal access mode) and use `<vm>--<org>--<port>.cmux.sh`.

**Auto sign-in.** `BrowserAppSessionController.request(externalDestinationURL:)` reuses the native→web cookie handoff but navigates the primed isolated store to the publication URL, so the forward-auth bounce to `/cloud/access` finds the account signed in and returns to the page. Falls back to a plain pane when there is no session.

Tests: `CloudTunnelCoordinatorTests` (state callback), `CmuxTuiSurfaceProviderTests` (overlay content, retry page, bridge acceptance rules, opener bookkeeping).

Verification limits: DEV builds have no NetworkExtension entitlement, so in a tagged DEV build the port click lands on the failure page with Try Again + cmux.sh button (bridge path proven); the approval overlay itself renders from the same page builder (screenshot in PR). Dev backend has no `CMUX_VM_PUBLICATION_FORWARD_AUTH_SECRET`, so publication creation there returns `forward_auth_not_configured`; the proxy and auto sign-in path needs NIGHTLY/prod dogfood.

https://claude.ai/code/session_01QBFjuF4W1uQ9p4XVy8BiyF

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791457738&installation_model_id=21920&pr_number=12148&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12148&signature=b81a471f721aff666f66c8fb4559f0a6fe0f1ef5428aed3371556302ff52b29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VPN gating, WebKit message handling, and auth cookie handoff for external URLs; mistakes could affect tunnel UX or session isolation, but changes are scoped to cloud browser flows with tests.
> 
> **Overview**
> Cloud port panes no longer sit on **Connecting…** indefinitely when the VPN extension is waiting on a one-time macOS approval. The private-network gate streams **tunnel state** while it waits; **`CloudBrowserPaneOpener`** swaps in an approval overlay (why the tunnel is needed, System Settings steps, **Open System Settings**, **Check Again**, optional **Open through cmux.sh instead**) and wires actions through **`SurfaceBrowserPlaceholderBridge`** (main-frame `about:` + per-pane token). Failures with a live opener get **Try Again** / proxy instead of “close and reopen.”
> 
> Port rows gain **Copy/Open Proxy URL (cmux.sh)** via idempotent personal publications (`CloudPortProxy`). **`makeAuthenticatedBrowserPane`** and **`request(externalDestinationURL:)`** prime an isolated WebKit store with cmux cookies but navigate to the publication URL so forward-auth works without a login form. Desktop/VNC keeps proxy disabled so tokens are not exposed on the public route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce1eb4f1aef6ac0252e7338f6b160c1c84b0821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud port pane getting stuck on a forever "Connecting" spinner when the macOS VPN extension approval is pending. The pane now shows an overlay that explains why the tunnel is blocked, gives the exact System Settings path, and offers Open System Settings, Check Again, and "Open through cmux.sh instead" actions.

**Bug Fixes**
- Tunnel gate now reports each waiting state, so the pane can react to `.awaitingApproval` with instructions instead of a silent spinner.
- System Settings opens automatically the first time the approval overlay appears; failures show Try Again instead of "close and reopen".
- Pane openers are retained by the provider until the page loads or the pane closes, so the retry loop and bridge token survive past pane creation.

**New Features**
- Port row context menu gains Copy Proxy URL (cmux.sh) and Open Proxy URL (cmux.sh) actions.
- Proxy URLs are personal publications (`<vm>--<org>--<port>.cmux.sh`) that need no tunnel and are created idempotently.
- Opening a proxy URL signs in automatically via the existing cmux session handoff, so the sign-in bounce completes without a login form.

<sup>Written for commit 39fb894849596848bd91e8551f5b09b46deca966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided Cloud Tunnel approval screen with setup steps, retry controls, and a direct link to the relevant System Settings.
  - Added options to copy or open authenticated proxy URLs for forwarded ports.
  - Added proxy-based fallback access when direct Cloud browser connections are unavailable.
  - Cloud browser panes now display tunnel connection progress and actionable approval or retry states.
  - Added authenticated browser navigation for external Cloud destinations.
  - Added English and Japanese translations for new Cloud Tunnel and proxy actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->