### PR TITLE
Route Antigravity hooks to the launching cmux so agy sessions restore and auto-resume (#5473)

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -380,7 +380,8 @@ extension CMUXCLI {
         // session started from one cmux build (stable, nightly, a tagged dev
         // build) is never reported to whichever build last ran `hooks setup`.
         // The pinned install remains the fallback for sanitized hook
-        // environments and for terminals whose app has since exited.
+        // environments, and for a stale socket node left by an exited app: the
+        // ambient invocation must succeed, otherwise the pinned chain runs.
         // https://github.com/manaflow-ai/cmux/issues/5473
         let ambientGuard = pinnedHookAmbientDispatchGuard
         let ambientInvocation = pinnedHookAmbientInvocation(routedArguments: routedArguments)
@@ -392,9 +393,9 @@ extension CMUXCLI {
                 routedArguments: routedArguments,
                 socketPath: socketPath
             )
-            dispatch = "if \(ambientGuard); then \(ambientInvocation); elif [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
+            dispatch = "if \(ambientGuard) && \(ambientInvocation); then :; elif [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
         } else {
-            dispatch = "if \(ambientGuard); then \(ambientInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
+            dispatch = "if \(ambientGuard) && \(ambientInvocation); then :; elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
         }
         return ": \(marker); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); \(noOpSnippet); } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
     }

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -375,6 +375,15 @@ extension CMUXCLI {
             routedArguments: routedArguments,
             socketPath: socketPath
         )
+        // The terminal that launched the agent owns the surface. When the agent
+        // preserved that terminal's cmux environment, dispatch there first so a
+        // session started from one cmux build (stable, nightly, a tagged dev
+        // build) is never reported to whichever build last ran `hooks setup`.
+        // The pinned install remains the fallback for sanitized hook
+        // environments and for terminals whose app has since exited.
+        // https://github.com/manaflow-ai/cmux/issues/5473
+        let ambientGuard = pinnedHookAmbientDispatchGuard
+        let ambientInvocation = pinnedHookAmbientInvocation(routedArguments: routedArguments)
         let dispatch: String
         if let cliPath = pinnedAgentHookCLIPath() {
             let quotedCLIPath = shellSingleQuote(cliPath)
@@ -383,11 +392,22 @@ extension CMUXCLI {
                 routedArguments: routedArguments,
                 socketPath: socketPath
             )
-            dispatch = "if [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
+            dispatch = "if \(ambientGuard); then \(ambientInvocation); elif [ -x \(quotedCLIPath) ]; then \(primaryInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
         } else {
-            dispatch = "command -v cmux >/dev/null 2>&1 && \(fallbackInvocation) || \(noOpSnippet)"
+            dispatch = "if \(ambientGuard); then \(ambientInvocation); elif command -v cmux >/dev/null 2>&1; then \(fallbackInvocation); else \(noOpSnippet); fi"
         }
         return ": \(marker); \(shellTraceStart); printenv \(def.disableEnvVar) | grep -qx 1 && { \(shellTraceDisabled); \(noOpSnippet); } || { \(dispatch); cmux_hook_status=$?; \(shellTraceExit); exit $cmux_hook_status; }"
+    }
+
+    /// Shell test that is true only when the hook inherited a live cmux terminal
+    /// environment: a socket that exists plus an executable bundled CLI file.
+    /// `-f` matters because a directory also satisfies `-x`.
+    static let pinnedHookAmbientDispatchGuard =
+        "[ -n \"${CMUX_SOCKET_PATH:-}\" ] && [ -S \"$CMUX_SOCKET_PATH\" ] && [ -f \"${CMUX_BUNDLED_CLI_PATH:-}\" ] && [ -x \"$CMUX_BUNDLED_CLI_PATH\" ]"
+
+    /// Dispatches through the launching terminal's own cmux build and socket.
+    static func pinnedHookAmbientInvocation(routedArguments: String) -> String {
+        "\"$CMUX_BUNDLED_CLI_PATH\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments)"
     }
 
     private static func pinnedHookInvocation(

--- a/Sources/CachedAgentProcessIdentityValidator.swift
+++ b/Sources/CachedAgentProcessIdentityValidator.swift
@@ -101,12 +101,18 @@ struct CachedAgentProcessIdentityValidator: Sendable {
             let observedSessionID: String?
             switch registration.sessionIdSource {
             case .argvOption(let option):
-                guard let observedSessionID = nonOptionValue(after: option, in: arguments) else {
-                    // An argv-keyed registration cannot prove ownership when
-                    // its identity option is absent. Preserve the historical
-                    // fail-closed behavior instead of treating any matching
-                    // executable as this session.
-                    return false
+                guard let observedSessionID = nonOptionValue(after: option, in: arguments)
+                    ?? authoritativeEnvironmentSessionID else {
+                    // The identity option only appears on explicit resumes. A
+                    // fresh launch has none: Antigravity mints its conversation
+                    // id in-process and reports it through its hooks, so the
+                    // record behind this snapshot was written by the very
+                    // process generation that already matched on pid identity,
+                    // cmux scope, and executable above. A bare argv cannot
+                    // contradict that record. Failing closed here marked every
+                    // fresh Antigravity session exited and retired its binding
+                    // on the next autosave (#5473).
+                    return true
                 }
                 return ManagedAgentSessionIdentity.sessionIDsMatch(
                     kind: snapshot.kind.rawValue,

--- a/Sources/CachedAgentProcessIdentityValidator.swift
+++ b/Sources/CachedAgentProcessIdentityValidator.swift
@@ -2,6 +2,9 @@ import CMUXAgentLaunch
 import Foundation
 
 struct CachedAgentProcessIdentityValidator: Sendable {
+    /// Which evidence backs the snapshot's session id when the live process
+    /// cannot state its own (a bare Hermes argv, or an argv-keyed
+    /// registration launched without its identity option).
     enum HermesSessionValidation: Sendable {
         /// A cached snapshot can outlive a conversation switch in the same process.
         case cachedSnapshot
@@ -46,7 +49,11 @@ struct CachedAgentProcessIdentityValidator: Sendable {
         guard currentProcessExecutable(process.arguments, environment: process.environment, matches: snapshot) else {
             return false
         }
-        return currentProcessSession(process, matches: snapshot)
+        return currentProcessSession(
+            process,
+            matches: snapshot,
+            hermesSessionValidation: hermesSessionValidation
+        )
     }
 
     private func currentProcessExecutable(
@@ -91,7 +98,8 @@ struct CachedAgentProcessIdentityValidator: Sendable {
 
     private func currentProcessSession(
         _ process: CmuxTopProcessArguments,
-        matches snapshot: SessionRestorableAgentSnapshot
+        matches snapshot: SessionRestorableAgentSnapshot,
+        hermesSessionValidation: HermesSessionValidation
     ) -> Bool {
         let arguments = process.arguments
         let authoritativeEnvironmentSessionID = normalizedProcessValue(
@@ -105,14 +113,16 @@ struct CachedAgentProcessIdentityValidator: Sendable {
                     ?? authoritativeEnvironmentSessionID else {
                     // The identity option only appears on explicit resumes. A
                     // fresh launch has none: Antigravity mints its conversation
-                    // id in-process and reports it through its hooks, so the
-                    // record behind this snapshot was written by the very
-                    // process generation that already matched on pid identity,
-                    // cmux scope, and executable above. A bare argv cannot
-                    // contradict that record. Failing closed here marked every
-                    // fresh Antigravity session exited and retired its binding
-                    // on the next autosave (#5473).
-                    return true
+                    // id in-process and reports it through its hooks. When the
+                    // current hook record is the evidence, it was written by
+                    // the very process generation that already matched on pid
+                    // identity, cmux scope, and executable above, so a bare
+                    // argv cannot contradict it; failing closed there marked
+                    // every fresh Antigravity session exited and retired its
+                    // binding on the next autosave (#5473). A cached snapshot
+                    // cannot rule out an in-process conversation switch, so it
+                    // keeps failing closed, as for Hermes.
+                    return hermesSessionValidation == .currentHookRecord
                 }
                 return ManagedAgentSessionIdentity.sessionIDsMatch(
                     kind: snapshot.kind.rawValue,

--- a/Sources/DockSplitStore+AttentionRouting.swift
+++ b/Sources/DockSplitStore+AttentionRouting.swift
@@ -64,6 +64,9 @@ extension DockSplitStore {
                   mountedTerminal === terminal else {
                 return
             }
+            // The user (or a socket client) took over the pane: never replay a
+            // lost restore selector into a line they are typing.
+            self.restoredAgentLifecycle.clearStartupInput(panelId: terminal.id)
             ownerTabManager?.dismissNotificationOnTerminalInteraction(
                 tabId: self.workspaceId,
                 surfaceId: terminal.id

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -39,6 +39,9 @@ extension DockSplitStore {
         switch (state, restoredAgentLifecycle.resumeStatesByPanelId[panelId]) {
         case (.commandRunning, .some(.awaitingAutoResumeCommand)):
             restoredAgentLifecycle.setResumeState(.autoResumeCommandRunning, panelId: panelId)
+            restoredAgentLifecycle.clearStartupInput(panelId: panelId)
+        case (.promptIdle, .some(.awaitingAutoResumeCommand)):
+            scheduleRestoredStartupInputResend(panelId: panelId)
         case (.commandRunning, .some(.manualResumeAvailable)):
             restoredAgentLifecycle.setSnapshot(nil, panelId: panelId)
             restoredAgentLifecycle.setResumeState(nil, panelId: panelId)
@@ -198,6 +201,40 @@ extension DockSplitStore {
             )
         }
         return true
+    }
+
+    /// Dock twin of `Workspace.scheduleRestoredStartupInputResend(panelId:)`: a
+    /// login shell that discarded Ghostty's typeahead reports an idle prompt while
+    /// the launch still awaits its startup input, so replay it once after the
+    /// shared grace period (https://github.com/manaflow-ai/cmux/issues/5473).
+    func scheduleRestoredStartupInputResend(panelId: UUID) {
+        guard restoredAgentLifecycle.armStartupInputResend(panelId: panelId) else { return }
+        let grace = Workspace.restoredStartupInputResendGrace
+        DispatchQueue.main.asyncAfter(deadline: .now() + grace) { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.resendRestoredStartupInputIfStillIdle(panelId: panelId)
+            }
+        }
+    }
+
+    func resendRestoredStartupInputIfStillIdle(panelId: UUID) {
+        guard let terminal = panels[panelId] as? TerminalPanel,
+              let input = restoredAgentLifecycle.takeStartupInputForResend(
+                  panelId: panelId,
+                  shellState: terminal.shellActivity.state
+              ) else {
+            return
+        }
+        // The idle prompt came from a live runtime; never queue the selector
+        // for some future shell of this pane.
+        guard terminal.surface.surface != nil else { return }
+        let result = terminal.sendInputResult(input)
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.startupInput.resend dock=\(workspaceId.uuidString.prefix(5)) " +
+            "panel=\(panelId.uuidString.prefix(5)) result=\(result) bytes=\(input.utf8.count)"
+        )
+#endif
     }
 
     private func retireAgentHookResumeBinding(
@@ -680,10 +717,13 @@ extension DockSplitStore {
                 .awaitingAutoResumeCommand,
                 panelId: panelId
             )
+            let admittedInput = restore.remoteResumeCommandEmbedded ? nil : startupInput
+            restoredAgentLifecycle.registerStartupInput(admittedInput, panelId: panelId)
             let admitted = terminal.surface.admitStartupRestoreRuntime(
-                initialInput: restore.remoteResumeCommandEmbedded ? nil : startupInput
+                initialInput: admittedInput
             )
             if !admitted {
+                restoredAgentLifecycle.clearStartupInput(panelId: panelId)
                 if let ownedClaim {
                     AgentResumeLaunchGuard.shared.releaseResumeLaunch(
                         kind: ownedClaim.kind,

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -141,6 +141,12 @@ extension DockSplitStore {
             resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory,
             startupInput: detached.restoredStartupInput
         )
+        // Dock twin of `Workspace.rearmTransferredStartupInputResend(from:)`:
+        // the idle prompt was reported to the previous owner and never repeats
+        // here, so arm the replay for a launch still awaiting its selector.
+        if detached.shellActivityState == .promptIdle {
+            scheduleRestoredStartupInputResend(panelId: detached.panelId)
+        }
         managedAgentResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
         if let resumeBinding = detached.resumeBinding {
             if surfaceResumeBindingMutationAllowed(resumeBinding, panelId: detached.panelId) {

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -496,12 +496,25 @@ extension DockSplitStore {
         deferredAgentResumeRestoresByPanelId[panelId] = restore
         guard deferredAgentResumeIndexTask == nil else { return }
         deferredAgentResumeIndexTask = Task { @MainActor [weak self] in
-            let index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            let refreshed = await SharedLiveAgentIndex.shared.indexRefreshingNow()
             guard !Task.isCancelled else { return }
             guard let self else { return }
             self.deferredAgentResumeIndexTask = nil
+            // Same rule as Workspace.deferAgentResumeRestore: a refresh that
+            // could not settle is not a reason to abandon every restore.
+            let index = Workspace.deferredResumeIndex(
+                refreshed: refreshed,
+                lastKnown: SharedLiveAgentIndex.shared.index
+            )
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.deferred.index dock=\(self.workspaceId.uuidString.prefix(5)) " +
+                "settled=\(refreshed == nil ? 0 : 1) available=\(index == nil ? 0 : 1) " +
+                "pending=\(self.deferredAgentResumeRestoresByPanelId.count)"
+            )
+#endif
             guard let index else {
-                self.clearDeferredAgentResumeRestores()
+                self.clearDeferredAgentResumeRestores(retireBindings: false)
                 return
             }
             self.resolveDeferredAgentResumeRestores(using: index)
@@ -827,7 +840,8 @@ extension DockSplitStore {
     func cancelDeferredAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore,
-        startRuntime: Bool = true
+        startRuntime: Bool = true,
+        retireBinding: Bool = true
     ) {
         // A cancelled launch must never have its selector replayed later.
         restoredAgentLifecycle.clearStartupInput(panelId: panelId)
@@ -838,7 +852,7 @@ extension DockSplitStore {
             restoredAgentLifecycle.clearSessionRestore(panelId: panelId)
         }
         removeDeferredAgentResumeRestore(panelId: panelId)
-        if startRuntime, restore.restorableAgent == nil {
+        if startRuntime, retireBinding, restore.restorableAgent == nil {
             if let binding = restore.resumeBinding {
                 retireAgentHookResumeBinding(panelId: panelId, matching: binding)
             }
@@ -912,7 +926,7 @@ extension DockSplitStore {
         retireAgentHookResumeBinding(panelId: panelId)
     }
 
-    func clearDeferredAgentResumeRestores(startRuntime: Bool = true) {
+    func clearDeferredAgentResumeRestores(startRuntime: Bool = true, retireBindings: Bool = true) {
         deferredAgentResumeIndexTask?.cancel()
         deferredAgentResumeIndexTask = nil
         let panelIds = Set(
@@ -924,7 +938,8 @@ extension DockSplitStore {
                 cancelDeferredAgentResumeRestore(
                     panelId: panelId,
                     restore: restore,
-                    startRuntime: startRuntime
+                    startRuntime: startRuntime,
+                    retireBinding: retireBindings
                 )
             } else {
                 if startRuntime {

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -828,6 +828,8 @@ extension DockSplitStore {
         restore: DeferredAgentResumeRestore,
         startRuntime: Bool = true
     ) {
+        // A cancelled launch must never have its selector replayed later.
+        restoredAgentLifecycle.clearStartupInput(panelId: panelId)
         if startRuntime {
             (panels[panelId] as? TerminalPanel)?.surface.cancelStartupRestoreAdmission()
         } else {

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -138,7 +138,8 @@ extension DockSplitStore {
             snapshot: detached.restorableAgent,
             resumeState: detached.restorableAgentResumeState,
             completedGeneration: detached.restoredAgentCompletedGeneration,
-            resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory
+            resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory,
+            startupInput: detached.restoredStartupInput
         )
         managedAgentResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
         if let resumeBinding = detached.resumeBinding {

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -502,6 +502,11 @@ extension DockSplitStore {
             panelId: terminal.id,
             internallySeededInput: initialInput
         )
+        if willRunAgentInput {
+            // Keep the typed resume selector so the shell-state handler can
+            // replay it if the login shell drops the typeahead.
+            restoredAgentLifecycle.registerStartupInput(initialInput, panelId: terminal.id)
+        }
         if let stableSurfaceId = snapshot.stableSurfaceId,
            !excludingStableIdentities.contains(stableSurfaceId) {
             terminal.adoptStableSurfaceId(stableSurfaceId)

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -374,6 +374,7 @@ extension DockSplitStore {
             shellActivityState: transferredShellActivityState,
             restoredPanelTitleBoundary: transferredRestoredPanelTitleBoundary,
             restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectory,
+            restoredStartupInput: restoredAgentLifecycle.startupInput(panelId: panelId),
             resumeBinding: resumeBinding,
             deferredAgentResumeRestore: deferredAgentResumeRestore,
             managedAgentResumeBinding: managedResumeBinding,

--- a/Sources/RestoredAgentLifecycleCoordinator.swift
+++ b/Sources/RestoredAgentLifecycleCoordinator.swift
@@ -208,6 +208,11 @@ final class RestoredAgentLifecycleCoordinator {
         armedStartupInputResendPanelIds.remove(panelId)
     }
 
+    /// The retained startup input, so a pane transfer can carry it to the new owner.
+    func startupInput(panelId: UUID) -> String? {
+        pendingStartupInputsByPanelId[panelId]
+    }
+
     /// Whether a restored launch is still waiting for its typed startup input to run.
     func awaitsStartupInput(panelId: UUID) -> Bool {
         resumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand &&
@@ -325,8 +330,15 @@ final class RestoredAgentLifecycleCoordinator {
         snapshot: SessionRestorableAgentSnapshot?,
         resumeState: Workspace.RestoredAgentResumeState?,
         completedGeneration: RestoredAgentCompletedGeneration?,
-        resumeWorkingDirectory: String?
+        resumeWorkingDirectory: String?,
+        startupInput: String? = nil
     ) {
+        // A launch still awaiting its typed selector keeps the replay safety
+        // net across a Workspace/Dock move; any other phase has nothing to replay.
+        registerStartupInput(
+            resumeState == .awaitingAutoResumeCommand ? startupInput : nil,
+            panelId: panelId
+        )
         replaceQueuedRestoreSnapshot(
             Self.retainsStartupRestoreIdentity(resumeState) ? snapshot : nil,
             panelId: panelId

--- a/Sources/RestoredAgentLifecycleCoordinator.swift
+++ b/Sources/RestoredAgentLifecycleCoordinator.swift
@@ -24,6 +24,14 @@ final class RestoredAgentLifecycleCoordinator {
 
     private var completedGenerationsByPanelId: [UUID: RestoredAgentCompletedGeneration] = [:]
 
+    /// Startup input a restored launch types into its shell, retained until shell
+    /// integration reports the command running. Ghostty writes that input as soon
+    /// as the PTY exists, and a slow login shell can discard the typeahead while it
+    /// initializes, which leaves the pane at an idle prompt with nothing typed.
+    /// The owner replays the retained input once when that happens (#5473).
+    private var pendingStartupInputsByPanelId: [UUID: String] = [:]
+    private var armedStartupInputResendPanelIds: Set<UUID> = []
+
     /// Replaces one panel's mutable snapshot while preserving an in-flight restore target.
     func setSnapshot(_ snapshot: SessionRestorableAgentSnapshot?, panelId: UUID) {
         let resolvedSnapshot: SessionRestorableAgentSnapshot?
@@ -182,6 +190,57 @@ final class RestoredAgentLifecycleCoordinator {
         invalidatedFingerprintsByPanelId.removeValue(forKey: panelId)
     }
 
+    /// Retains the startup input a restored launch will type into its shell.
+    /// Passing `nil` or an empty string forgets any earlier registration.
+    func registerStartupInput(_ input: String?, panelId: UUID) {
+        armedStartupInputResendPanelIds.remove(panelId)
+        guard let input, !input.isEmpty else {
+            pendingStartupInputsByPanelId.removeValue(forKey: panelId)
+            return
+        }
+        pendingStartupInputsByPanelId[panelId] = input
+    }
+
+    /// Forgets retained startup input once the shell ran it, the user took over
+    /// the pane, or the launch was abandoned.
+    func clearStartupInput(panelId: UUID) {
+        pendingStartupInputsByPanelId.removeValue(forKey: panelId)
+        armedStartupInputResendPanelIds.remove(panelId)
+    }
+
+    /// Whether a restored launch is still waiting for its typed startup input to run.
+    func awaitsStartupInput(panelId: UUID) -> Bool {
+        resumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand &&
+            pendingStartupInputsByPanelId[panelId] != nil
+    }
+
+    /// Arms one grace-period replay for a launch whose shell reported an idle
+    /// prompt while the launch still awaits its startup input. Returns `false`
+    /// when nothing is pending or a replay is already armed.
+    func armStartupInputResend(panelId: UUID) -> Bool {
+        guard awaitsStartupInput(panelId: panelId),
+              !armedStartupInputResendPanelIds.contains(panelId) else {
+            return false
+        }
+        armedStartupInputResendPanelIds.insert(panelId)
+        return true
+    }
+
+    /// Consumes the retained startup input when the shell is still idle after
+    /// the grace period and the launch never entered its command phase. A
+    /// prompt-then-command sequence that settled into `.autoResumeCommandRunning`
+    /// yields `nil`, and only one replay is ever handed out per restored launch.
+    func takeStartupInputForResend(
+        panelId: UUID,
+        shellState: PanelShellActivityState
+    ) -> String? {
+        armedStartupInputResendPanelIds.remove(panelId)
+        guard shellState == .promptIdle, awaitsStartupInput(panelId: panelId) else {
+            return nil
+        }
+        return pendingStartupInputsByPanelId.removeValue(forKey: panelId)
+    }
+
     /// Removes continuation metadata without discarding an invalidation fingerprint.
     func clearSessionRestore(panelId: UUID) {
         queuedRestoreSnapshotsByPanelId.removeValue(forKey: panelId)
@@ -189,6 +248,7 @@ final class RestoredAgentLifecycleCoordinator {
         snapshotsByPanelId.removeValue(forKey: panelId)
         resumeWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
         completedGenerationsByPanelId.removeValue(forKey: panelId)
+        clearStartupInput(panelId: panelId)
     }
 
     /// Resets every restored-session lifecycle collection.
@@ -199,6 +259,8 @@ final class RestoredAgentLifecycleCoordinator {
         invalidatedFingerprintsByPanelId.removeAll(keepingCapacity: false)
         resumeWorkingDirectoriesByPanelId.removeAll(keepingCapacity: false)
         completedGenerationsByPanelId.removeAll(keepingCapacity: false)
+        pendingStartupInputsByPanelId.removeAll(keepingCapacity: false)
+        armedStartupInputResendPanelIds.removeAll(keepingCapacity: false)
     }
 
     /// Shell integration has observed the restored launch enter its command

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -312,6 +312,7 @@ extension Workspace {
             switch restoredAgentResumeStatesByPanelId[panelId] {
             case .some(.awaitingAutoResumeCommand):
                 restoredAgentLifecycle.setResumeState(.autoResumeCommandRunning, panelId: panelId)
+                restoredAgentLifecycle.clearStartupInput(panelId: panelId)
             case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning),
                  .some(.completedAgentExit):
                 break
@@ -324,7 +325,9 @@ extension Workspace {
                 markRestoredAgentCompleted(panelId: panelId, snapshot: restoredAgent)
                 restoredResumeSessionWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
                 retireAgentHookResumeBinding(panelId: panelId, matching: restoredAgent)
-            case .some(.awaitingAutoResumeCommand), .some(.manualResumeAvailable), .some(.completedAgentExit), nil:
+            case .some(.awaitingAutoResumeCommand):
+                scheduleRestoredStartupInputResend(panelId: panelId)
+            case .some(.manualResumeAvailable), .some(.completedAgentExit), nil:
                 break
             }
         case .unknown:
@@ -339,6 +342,9 @@ extension Workspace {
         switch (shellState, restoredAgentResumeStatesByPanelId[panelId]) {
         case (.commandRunning, .some(.awaitingAutoResumeCommand)):
             restoredAgentLifecycle.setResumeState(.autoResumeCommandRunning, panelId: panelId)
+            restoredAgentLifecycle.clearStartupInput(panelId: panelId)
+        case (.promptIdle, .some(.awaitingAutoResumeCommand)):
+            scheduleRestoredStartupInputResend(panelId: panelId)
         case (.promptIdle, .some(.autoResumeCommandRunning)),
              (.promptIdle, .some(.observedAgentCommandRunning)):
             restoredAgentLifecycle.setResumeState(nil, panelId: panelId)
@@ -347,6 +353,48 @@ extension Workspace {
         default:
             break
         }
+    }
+
+    /// Grace period between a restored launch's shell settling at an idle prompt
+    /// and replaying its startup input. Long enough for a prompt-then-command
+    /// sequence to report `commandRunning`, short enough that a lost restore
+    /// still resumes before the user notices an empty shell.
+    static var restoredStartupInputResendGrace: TimeInterval = 2
+
+    /// Ghostty types a restored launch's startup input as soon as the PTY exists,
+    /// and a slow login shell can discard that typeahead while it initializes.
+    /// When shell integration then reports an idle prompt while the launch is
+    /// still `.awaitingAutoResumeCommand`, replay the retained input once after
+    /// the grace period (https://github.com/manaflow-ai/cmux/issues/5473).
+    func scheduleRestoredStartupInputResend(panelId: UUID) {
+        guard restoredAgentLifecycle.armStartupInputResend(panelId: panelId) else { return }
+        let grace = Self.restoredStartupInputResendGrace
+        DispatchQueue.main.asyncAfter(deadline: .now() + grace) { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.resendRestoredStartupInputIfStillIdle(panelId: panelId)
+            }
+        }
+    }
+
+    func resendRestoredStartupInputIfStillIdle(panelId: UUID) {
+        guard !isRetiredFromOwningTabManager,
+              let terminal = panels[panelId] as? TerminalPanel,
+              let input = restoredAgentLifecycle.takeStartupInputForResend(
+                  panelId: panelId,
+                  shellState: panelShellActivityStates[panelId] ?? .unknown
+              ) else {
+            return
+        }
+        // The idle prompt came from a live runtime; never queue the selector
+        // for some future shell of this pane.
+        guard terminal.surface.surface != nil else { return }
+        let result = terminal.sendInputResult(input)
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.startupInput.resend panel=\(panelId.uuidString.prefix(5)) " +
+            "result=\(result) bytes=\(input.utf8.count)"
+        )
+#endif
     }
 
     private func invalidateRestoredAgentSnapshot(
@@ -839,10 +887,13 @@ extension Workspace {
                 .awaitingAutoResumeCommand,
                 panelId: panelId
             )
+            let admittedInput = restore.remoteResumeCommandEmbedded ? nil : startupInput
+            restoredAgentLifecycle.registerStartupInput(admittedInput, panelId: panelId)
             let admitted = terminal.surface.admitStartupRestoreRuntime(
-                initialInput: restore.remoteResumeCommandEmbedded ? nil : startupInput
+                initialInput: admittedInput
             )
             if !admitted {
+                restoredAgentLifecycle.clearStartupInput(panelId: panelId)
                 if let ownedClaim {
                     AgentResumeLaunchGuard.shared.releaseResumeLaunch(
                         kind: ownedClaim.kind,

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -692,16 +692,45 @@ extension Workspace {
         deferredAgentResumeRestoresByPanelId[panelId] = restore
         guard deferredAgentResumeIndexTask == nil else { return }
         deferredAgentResumeIndexTask = Task { @MainActor [weak self] in
-            let index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            let refreshed = await SharedLiveAgentIndex.shared.indexRefreshingNow()
             guard !Task.isCancelled else { return }
             guard let self else { return }
             self.deferredAgentResumeIndexTask = nil
+            // The settled refresh gives up after its bounded passes whenever
+            // hook stores keep changing, which is the steady state on a Mac
+            // running several agents. The most recent completed load is still
+            // current to within seconds and its process evidence is
+            // revalidated during resolution, so resolve against it instead of
+            // cancelling every restore: a cancel starts a plain shell, and the
+            // next relaunch then sees no running agent to resume (#5473).
+            let index = Self.deferredResumeIndex(
+                refreshed: refreshed,
+                lastKnown: SharedLiveAgentIndex.shared.index
+            )
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.deferred.index workspace=\(self.id.uuidString.prefix(5)) " +
+                "settled=\(refreshed == nil ? 0 : 1) available=\(index == nil ? 0 : 1) " +
+                "pending=\(self.deferredAgentResumeRestoresByPanelId.count)"
+            )
+#endif
             guard let index else {
-                self.clearDeferredAgentResumeRestores()
+                // No index has ever loaded. Start plain shells, but keep the
+                // bindings auto-resumable: this says nothing about the sessions.
+                self.clearDeferredAgentResumeRestores(retireBindings: false)
                 return
             }
             self.resolveDeferredAgentResumeRestores(using: index)
         }
+    }
+
+    /// The index a deferred restore resolves against: the settled refresh when
+    /// it completed, otherwise the most recent completed load.
+    nonisolated static func deferredResumeIndex(
+        refreshed: RestorableAgentSessionIndex?,
+        lastKnown: RestorableAgentSessionIndex?
+    ) -> RestorableAgentSessionIndex? {
+        refreshed ?? lastKnown
     }
 
     private func resolveDeferredAgentResumeRestores(
@@ -979,12 +1008,13 @@ extension Workspace {
         panelId: UUID,
         restore: DeferredAgentResumeRestore,
         startRuntime: Bool = true,
+        retireBinding: Bool = true,
         callerLine: Int = #line
     ) {
 #if DEBUG
         cmuxDebugLog(
             "session.restore.deferred.cancel panel=\(panelId.uuidString.prefix(5)) " +
-            "startRuntime=\(startRuntime ? 1 : 0) line=\(callerLine) " +
+            "startRuntime=\(startRuntime ? 1 : 0) retireBinding=\(retireBinding ? 1 : 0) line=\(callerLine) " +
             "session=\((restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId ?? "-").prefix(8))"
         )
 #endif
@@ -997,7 +1027,7 @@ extension Workspace {
             restoredAgentLifecycle.clearSessionRestore(panelId: panelId)
         }
         removeDeferredAgentResumeRestore(panelId: panelId)
-        if startRuntime, restore.restorableAgent == nil {
+        if startRuntime, retireBinding, restore.restorableAgent == nil {
             if let binding = restore.resumeBinding {
                 retireAgentHookResumeBinding(panelId: panelId, matching: binding)
             }
@@ -1071,7 +1101,7 @@ extension Workspace {
         retireAgentHookResumeBinding(panelId: panelId)
     }
 
-    func clearDeferredAgentResumeRestores(startRuntime: Bool = true) {
+    func clearDeferredAgentResumeRestores(startRuntime: Bool = true, retireBindings: Bool = true) {
         deferredAgentResumeIndexTask?.cancel()
         deferredAgentResumeIndexTask = nil
         let panelIds = Set(
@@ -1083,7 +1113,8 @@ extension Workspace {
                 cancelDeferredAgentResumeRestore(
                     panelId: panelId,
                     restore: restore,
-                    startRuntime: startRuntime
+                    startRuntime: startRuntime,
+                    retireBinding: retireBindings
                 )
             } else {
                 if startRuntime {

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -597,7 +597,8 @@ extension Workspace {
             snapshot: detached.restorableAgent,
             resumeState: detached.restorableAgentResumeState,
             completedGeneration: detached.restoredAgentCompletedGeneration,
-            resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory
+            resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory,
+            startupInput: detached.restoredStartupInput
         )
         if let deferredRestore = detached.deferredAgentResumeRestore {
             let adoptedRemoteContext = surfaceResumeBindingsByPanelId[detached.panelId]?

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -607,6 +607,7 @@ extension Workspace {
             resumeWorkingDirectory: detached.restoredResumeSessionWorkingDirectory,
             startupInput: detached.restoredStartupInput
         )
+        rearmTransferredStartupInputResend(from: detached)
         if let deferredRestore = detached.deferredAgentResumeRestore {
             let adoptedRemoteContext = surfaceResumeBindingsByPanelId[detached.panelId]?
                 .launchFlavor.remoteContext
@@ -616,6 +617,15 @@ extension Workspace {
             )
         }
         invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: detached.panelId)
+    }
+
+    /// The shell reported its idle prompt to the pane's previous owner, and
+    /// that transition never repeats after a Workspace/Dock move (same-state
+    /// reports return early), so a launch still awaiting its typed selector
+    /// needs the new owner to arm the grace-period replay itself (#5473).
+    func rearmTransferredStartupInputResend(from detached: DetachedSurfaceTransfer) {
+        guard detached.shellActivityState == .promptIdle else { return }
+        scheduleRestoredStartupInputResend(panelId: detached.panelId)
     }
 
     func setAgentLifecycle(

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -573,13 +573,20 @@ extension Workspace {
         ) != true else {
             return false
         }
-        let liveEntry = liveIndex.entryForStablePanel(
+        // Only an index entry for this very session can say it exited. A panel
+        // with no entry, or entries for other sessions only, means the scan has
+        // not caught up with a hook record written after it (routine on a busy
+        // Mac, where the next autosave used to retire a binding that was
+        // published seconds earlier, #5473). Treat that as unknown and keep it.
+        guard let sessionEntry = liveIndex.entryForStablePanel(
             workspaceId: id,
             panelId: panelId,
             revalidateProcessEvidence: false
-        )
+        )?.matchingAgentSession(kind: kind, sessionId: checkpointId) else {
+            return false
+        }
         return !AgentResumeLiveness.hasLiveProcess(
-            for: liveEntry,
+            for: sessionEntry,
             kind: kind,
             sessionId: checkpointId
         )

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -367,7 +367,19 @@ extension Workspace {
     /// still `.awaitingAutoResumeCommand`, replay the retained input once after
     /// the grace period (https://github.com/manaflow-ai/cmux/issues/5473).
     func scheduleRestoredStartupInputResend(panelId: UUID) {
-        guard restoredAgentLifecycle.armStartupInputResend(panelId: panelId) else { return }
+        guard restoredAgentLifecycle.armStartupInputResend(panelId: panelId) else {
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.startupInput.resend.skip panel=\(panelId.uuidString.prefix(5)) " +
+                "state=\(String(describing: restoredAgentResumeStatesByPanelId[panelId])) " +
+                "awaits=\(restoredAgentLifecycle.awaitsStartupInput(panelId: panelId) ? 1 : 0)"
+            )
+#endif
+            return
+        }
+#if DEBUG
+        cmuxDebugLog("session.restore.startupInput.resend.armed panel=\(panelId.uuidString.prefix(5))")
+#endif
         let grace = Self.restoredStartupInputResendGrace
         DispatchQueue.main.asyncAfter(deadline: .now() + grace) { [weak self] in
             Task { @MainActor [weak self] in
@@ -377,17 +389,30 @@ extension Workspace {
     }
 
     func resendRestoredStartupInputIfStillIdle(panelId: UUID) {
+        let shellState = panelShellActivityStates[panelId] ?? .unknown
         guard !isRetiredFromOwningTabManager,
               let terminal = panels[panelId] as? TerminalPanel,
               let input = restoredAgentLifecycle.takeStartupInputForResend(
                   panelId: panelId,
-                  shellState: panelShellActivityStates[panelId] ?? .unknown
+                  shellState: shellState
               ) else {
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.startupInput.resend.declined panel=\(panelId.uuidString.prefix(5)) " +
+                "shell=\(shellState.rawValue) " +
+                "state=\(String(describing: restoredAgentResumeStatesByPanelId[panelId]))"
+            )
+#endif
             return
         }
         // The idle prompt came from a live runtime; never queue the selector
         // for some future shell of this pane.
-        guard terminal.surface.surface != nil else { return }
+        guard terminal.surface.surface != nil else {
+#if DEBUG
+            cmuxDebugLog("session.restore.startupInput.resend.noRuntime panel=\(panelId.uuidString.prefix(5))")
+#endif
+            return
+        }
         let result = terminal.sendInputResult(input)
 #if DEBUG
         cmuxDebugLog(
@@ -752,6 +777,13 @@ extension Workspace {
                 nil
             }
             if let liveSessionOwner {
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.deferred.liveOwner panel=\(panelId.uuidString.prefix(5)) " +
+                    "session=\(liveSessionOwner.sessionID.prefix(8)) pid=\(liveSessionOwner.processID)"
+                )
+#endif
+                restoredAgentLifecycle.clearStartupInput(panelId: panelId)
                 let noticeInput = AgentRestoreLiveOwnerNotice(
                     processID: liveSessionOwner.processID
                 ).startupInput(
@@ -892,6 +924,12 @@ extension Workspace {
             let admitted = terminal.surface.admitStartupRestoreRuntime(
                 initialInput: admittedInput
             )
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.deferred.admit panel=\(panelId.uuidString.prefix(5)) " +
+                "admitted=\(admitted ? 1 : 0) inputBytes=\(admittedInput?.utf8.count ?? 0)"
+            )
+#endif
             if !admitted {
                 restoredAgentLifecycle.clearStartupInput(panelId: panelId)
                 if let ownedClaim {
@@ -939,8 +977,18 @@ extension Workspace {
     func cancelDeferredAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore,
-        startRuntime: Bool = true
+        startRuntime: Bool = true,
+        callerLine: Int = #line
     ) {
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.deferred.cancel panel=\(panelId.uuidString.prefix(5)) " +
+            "startRuntime=\(startRuntime ? 1 : 0) line=\(callerLine) " +
+            "session=\((restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId ?? "-").prefix(8))"
+        )
+#endif
+        // A cancelled launch must never have its selector replayed later.
+        restoredAgentLifecycle.clearStartupInput(panelId: panelId)
         if startRuntime {
             (panels[panelId] as? TerminalPanel)?.surface.cancelStartupRestoreAdmission()
         } else {

--- a/Sources/Workspace+AttentionFlashRouting.swift
+++ b/Sources/Workspace+AttentionFlashRouting.swift
@@ -9,6 +9,9 @@ extension Workspace {
     func installTerminalVisualBellRouting(for terminalPanel: TerminalPanel) {
         terminalPanel.surface.onExplicitInput = { [weak self, weak terminalPanel] in
             guard let self, let terminalPanel else { return }
+            // The user (or a socket client) took over the pane: never replay a
+            // lost restore selector into a line they are typing.
+            self.restoredAgentLifecycle.clearStartupInput(panelId: terminalPanel.id)
             self.owningTabManager?.dismissNotificationOnTerminalInteraction(
                 tabId: self.id,
                 surfaceId: terminalPanel.id

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -111,6 +111,7 @@ extension Workspace {
                 shellActivityState: shellActivityState,
                 restoredPanelTitleBoundary: restoredPanelTitleBoundary,
                 restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectory,
+                restoredStartupInput: restoredStartupInput,
                 resumeBinding: resumeBinding,
                 deferredAgentResumeRestore: deferredAgentResumeRestore,
                 managedAgentResumeBinding: managedAgentResumeBinding,

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -50,6 +50,9 @@ extension Workspace {
         let shellActivityState: PanelShellActivityState?
         var restoredPanelTitleBoundary: RestoredPanelTitleBoundary? = nil
         let restoredResumeSessionWorkingDirectory: String?
+        /// Typed restore selector still awaiting its shell, carried so the
+        /// idle-prompt replay survives a Workspace/Dock move.
+        var restoredStartupInput: String? = nil
         let resumeBinding: SurfaceResumeBindingSnapshot?
         /// Deferred ownership resolution carried across a Workspace/Dock transfer.
         var deferredAgentResumeRestore: DeferredAgentResumeRestore? = nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2181,6 +2181,16 @@ extension Workspace {
                 panelId: terminalPanel.id,
                 internallySeededInput: restoredStartupInput
             )
+            if restoredAgentWillRunStartupInput,
+               restoredRemotePTYAttachCommand == nil,
+               !restoresRemoteWorkspaceTerminalSnapshot {
+                // Keep the typed local resume selector so the shell-state
+                // handler can replay it if the login shell drops the typeahead.
+                restoredAgentLifecycle.registerStartupInput(
+                    restoredStartupInput,
+                    panelId: terminalPanel.id
+                )
+            }
             return terminalPanel.id
         case .browser:
             if deferBrowserPanelsDuringSessionRestore,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -14131,6 +14131,7 @@ extension Workspace: BonsplitDelegate {
                 shellActivityState: panelShellActivityStates[panelId],
                 restoredPanelTitleBoundary: restoredPanelTitleBoundariesByPanelId[panelId],
                 restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectoriesByPanelId[panelId],
+                restoredStartupInput: restoredAgentLifecycle.startupInput(panelId: panelId),
                 resumeBinding: resumeBinding,
                 deferredAgentResumeRestore: deferredAgentResumeRestoresByPanelId.removeValue(
                     forKey: panelId

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2190,6 +2190,12 @@ extension Workspace {
                     restoredStartupInput,
                     panelId: terminalPanel.id
                 )
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.startupInput.registered panel=\(terminalPanel.id.uuidString.prefix(5)) " +
+                    "bytes=\(restoredStartupInput?.utf8.count ?? 0) deferred=\(deferredAgentResumeAdmission ? 1 : 0)"
+                )
+#endif
             }
             return terminalPanel.id
         case .browser:
@@ -6009,7 +6015,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 #if DEBUG
         cmuxDebugLog(
             "surface.shellState workspace=\(id.uuidString.prefix(5)) " +
-            "panel=\(panelId.uuidString.prefix(5)) from=\(previousState.rawValue) to=\(state.rawValue)"
+            "panel=\(panelId.uuidString.prefix(5)) from=\(previousState.rawValue) to=\(state.rawValue) " +
+            "restore=\(restoredAgentResumeStatesByPanelId[panelId].map { String(describing: $0) } ?? "none") " +
+            "awaitsInput=\(restoredAgentLifecycle.awaitsStartupInput(panelId: panelId) ? 1 : 0)"
         )
 #endif
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1979,6 +1979,7 @@
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
 		A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */; };
 		A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000003 /* RestoredStartupInputResendTests.swift */; };
+		A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
@@ -5289,6 +5290,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
 		A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityHookSessionSnapshotRestoreTests.swift; sourceTree = "<group>"; };
 		A54730000000000000000003 /* RestoredStartupInputResendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredStartupInputResendTests.swift; sourceTree = "<group>"; };
+		A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredAgentResumeIndexFallbackTests.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
@@ -9225,6 +9227,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			children = (
 				A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */,
 				A54730000000000000000003 /* RestoredStartupInputResendTests.swift */,
+				A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */,
 				C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */,
 				9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */,
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
@@ -13548,6 +13551,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 				A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */,
 				A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */,
+				A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1977,6 +1977,7 @@
 		8672F0018672F0018672F001 /* PiFeedOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0028672F0028672F002 /* PiFeedOwnershipTests.swift */; };
 		8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
+		A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
@@ -5285,6 +5286,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8672F0028672F0028672F002 /* PiFeedOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedOwnershipTests.swift; sourceTree = "<group>"; };
 		8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedV2CallResultBox.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
+		A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityHookSessionSnapshotRestoreTests.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
@@ -9219,6 +9221,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		F1000003A1B2C3D4E5F60718 /* cmuxTests */ = {
 			isa = PBXGroup;
 			children = (
+				A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */,
 				C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */,
 				9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */,
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
@@ -13539,7 +13542,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8672FA028672FA028672FA02 /* PiFeedLegacyOwnershipTests.swift in Sources */,
 				8672F0018672F0018672F001 /* PiFeedOwnershipTests.swift in Sources */,
 				8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */,
-					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
+				B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
+				A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1978,6 +1978,7 @@
 		8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
 		A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */; };
+		A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000003 /* RestoredStartupInputResendTests.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
@@ -5287,6 +5288,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedV2CallResultBox.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
 		A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityHookSessionSnapshotRestoreTests.swift; sourceTree = "<group>"; };
+		A54730000000000000000003 /* RestoredStartupInputResendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredStartupInputResendTests.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
@@ -9222,6 +9224,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			isa = PBXGroup;
 			children = (
 				A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */,
+				A54730000000000000000003 /* RestoredStartupInputResendTests.swift */,
 				C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */,
 				9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */,
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
@@ -13544,6 +13547,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */,
 				B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 				A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */,
+				A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,

--- a/cmuxTests/AgentRestoreLiveOwnerAdmissionTests.swift
+++ b/cmuxTests/AgentRestoreLiveOwnerAdmissionTests.swift
@@ -140,15 +140,21 @@ struct AgentRestoreLiveOwnerAdmissionTests {
         )
 
         // agy mints the conversation id in-process and reports it through its
-        // hooks, so the record behind this snapshot came from this very process.
-        // Rejecting the bare argv retired every fresh binding on the next
-        // autosave (https://github.com/manaflow-ai/cmux/issues/5473).
-        #expect(validator.currentProcess(freshLaunch, matches: snapshot))
+        // hooks, so the current hook record behind this snapshot came from this
+        // very process. Rejecting the bare argv retired every fresh binding on
+        // the next autosave (https://github.com/manaflow-ai/cmux/issues/5473).
         #expect(validator.currentProcess(
             freshLaunch,
             matches: snapshot,
             hermesSessionValidation: .currentHookRecord
         ))
+        // A cached snapshot cannot rule out an in-process conversation switch.
+        #expect(!validator.currentProcess(
+            freshLaunch,
+            matches: snapshot,
+            hermesSessionValidation: .cachedSnapshot
+        ))
+        #expect(!validator.currentProcess(freshLaunch, matches: snapshot))
         // An explicit selector still has to name this session.
         #expect(validator.currentProcess(
             CmuxTopProcessArguments(arguments: ["agy", "--conversation", sessionID], environment: [:]),
@@ -159,7 +165,8 @@ struct AgentRestoreLiveOwnerAdmissionTests {
                 arguments: ["agy", "--conversation", "11111111-2222-3333-4444-555555555555"],
                 environment: [:]
             ),
-            matches: snapshot
+            matches: snapshot,
+            hermesSessionValidation: .currentHookRecord
         ))
         // So does an exported process identity.
         #expect(!validator.currentProcess(
@@ -167,7 +174,8 @@ struct AgentRestoreLiveOwnerAdmissionTests {
                 arguments: ["agy"],
                 environment: ["CMUX_AGENT_SESSION_ID": "11111111-2222-3333-4444-555555555555"]
             ),
-            matches: snapshot
+            matches: snapshot,
+            hermesSessionValidation: .currentHookRecord
         ))
     }
 

--- a/cmuxTests/AgentRestoreLiveOwnerAdmissionTests.swift
+++ b/cmuxTests/AgentRestoreLiveOwnerAdmissionTests.swift
@@ -116,6 +116,61 @@ struct AgentRestoreLiveOwnerAdmissionTests {
         )
     }
 
+    @Test("A fresh Antigravity launch without --conversation still owns the session its hooks recorded")
+    func antigravityFreshLaunchOwnsHookRecordedSession() {
+        let sessionID = "58057d57-0ce6-4008-99ec-77f1b7e2c470"
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .antigravity,
+            sessionId: sessionID,
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "antigravity",
+                executablePath: "agy",
+                arguments: ["agy", "--dangerously-skip-permissions"],
+                workingDirectory: nil,
+                capturedAt: nil,
+                source: "process"
+            ),
+            registration: .builtInAntigravity
+        )
+        let validator = CachedAgentProcessIdentityValidator()
+        let freshLaunch = CmuxTopProcessArguments(
+            arguments: ["agy", "--dangerously-skip-permissions"],
+            environment: [:]
+        )
+
+        // agy mints the conversation id in-process and reports it through its
+        // hooks, so the record behind this snapshot came from this very process.
+        // Rejecting the bare argv retired every fresh binding on the next
+        // autosave (https://github.com/manaflow-ai/cmux/issues/5473).
+        #expect(validator.currentProcess(freshLaunch, matches: snapshot))
+        #expect(validator.currentProcess(
+            freshLaunch,
+            matches: snapshot,
+            hermesSessionValidation: .currentHookRecord
+        ))
+        // An explicit selector still has to name this session.
+        #expect(validator.currentProcess(
+            CmuxTopProcessArguments(arguments: ["agy", "--conversation", sessionID], environment: [:]),
+            matches: snapshot
+        ))
+        #expect(!validator.currentProcess(
+            CmuxTopProcessArguments(
+                arguments: ["agy", "--conversation", "11111111-2222-3333-4444-555555555555"],
+                environment: [:]
+            ),
+            matches: snapshot
+        ))
+        // So does an exported process identity.
+        #expect(!validator.currentProcess(
+            CmuxTopProcessArguments(
+                arguments: ["agy"],
+                environment: ["CMUX_AGENT_SESSION_ID": "11111111-2222-3333-4444-555555555555"]
+            ),
+            matches: snapshot
+        ))
+    }
+
     @Test("A reused Claude PID with another session id is not an owner")
     func claudeSessionArgumentMustMatch() {
         let expectedSessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/cmuxTests/AntigravityHookSessionSnapshotRestoreTests.swift
+++ b/cmuxTests/AntigravityHookSessionSnapshotRestoreTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Antigravity hook session restore")
+struct AntigravityHookSessionSnapshotRestoreTests {
+    @Test("Attaches an agy hook session to the persisted terminal snapshot")
+    func attachesHookSessionToSessionSnapshot() throws {
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-antigravity-hook-restore-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: homeDirectory) }
+
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let panelID = try #require(source.focusedPanelId)
+        let sessionID = "antigravity-conversation-5473"
+        let stateDirectory = homeDirectory.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+
+        let record: [String: Any] = [
+            "sessionId": sessionID,
+            "workspaceId": source.id.uuidString,
+            "surfaceId": panelID.uuidString,
+            "cwd": "/tmp/antigravity-5473",
+            "launchCommand": [
+                "launcher": "antigravity",
+                "executablePath": "agy",
+                "arguments": ["agy", "-c", "--dangerously-skip-permissions"],
+                "workingDirectory": "/tmp/antigravity-5473",
+                "source": "agent-hook",
+            ],
+            "isRestorable": true,
+            "updatedAt": 1_780_000_000.0,
+        ]
+        let store = try JSONSerialization.data(
+            withJSONObject: ["version": 1, "sessions": [sessionID: record]],
+            options: .sortedKeys
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("antigravity-hook-sessions.json"),
+            options: .atomic
+        )
+
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: homeDirectory.path,
+            fileManager: fileManager,
+            processArgumentsProvider: { _ in nil }
+        )
+        let snapshot = try #require(
+            source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: index,
+                currentAgentProcessIdentity: { _ in nil },
+                agentProcessPresence: { _ in .absent }
+            ).panels.first(where: { $0.id == panelID })?.terminal?.agent
+        )
+
+        #expect(snapshot.kind == .custom("antigravity"))
+        #expect(snapshot.sessionId == sessionID)
+        #expect(snapshot.registration?.id == "antigravity")
+        #expect(
+            snapshot.resumeCommand ==
+                "cd -- '/tmp/antigravity-5473' 2>/dev/null || [ ! -d '/tmp/antigravity-5473' ] && 'agy' '--conversation' 'antigravity-conversation-5473'"
+        )
+    }
+}

--- a/cmuxTests/AntigravityHookSessionSnapshotRestoreTests.swift
+++ b/cmuxTests/AntigravityHookSessionSnapshotRestoreTests.swift
@@ -52,6 +52,11 @@ struct AntigravityHookSessionSnapshotRestoreTests {
         let index = RestorableAgentSessionIndex.load(
             homeDirectory: homeDirectory.path,
             fileManager: fileManager,
+            registry: CmuxVaultAgentRegistry.load(
+                homeDirectory: homeDirectory.path,
+                fileManager: fileManager
+            ),
+            detectedSnapshots: [:],
             processArgumentsProvider: { _ in nil }
         )
         let snapshot = try #require(
@@ -66,9 +71,12 @@ struct AntigravityHookSessionSnapshotRestoreTests {
         #expect(snapshot.kind == .custom("antigravity"))
         #expect(snapshot.sessionId == sessionID)
         #expect(snapshot.registration?.id == "antigravity")
+        // `-c` (continue) is a launch-only flag and must not replay; the
+        // permission flag must survive so the restored session keeps the mode
+        // the user launched with (https://github.com/manaflow-ai/cmux/issues/5473).
         #expect(
             snapshot.resumeCommand ==
-                "cd -- '/tmp/antigravity-5473' 2>/dev/null || [ ! -d '/tmp/antigravity-5473' ] && 'agy' '--conversation' 'antigravity-conversation-5473'"
+                "cd -- '/tmp/antigravity-5473' 2>/dev/null || [ ! -d '/tmp/antigravity-5473' ] && 'agy' '--conversation' 'antigravity-conversation-5473' '--dangerously-skip-permissions'"
         )
     }
 }

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1940,6 +1940,101 @@ extension CLINotifyProcessIntegrationRegressionTests {
         }
     }
 
+    /// A socket node can outlive the app that owned it. When the ambient
+    /// invocation fails, the hook must fall through to the pinned build instead
+    /// of dropping the event and the session record with it.
+    func testAntigravityHookFallsBackToPinnedBuildWhenAmbientDispatchFails() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agy-fb-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let callLogPath = root.appendingPathComponent("calls.log").path
+
+        func writeFakeCLI(_ name: String, exitCode: Int32) throws -> String {
+            let path = root.appendingPathComponent(name).path
+            let script = "#!/bin/sh\nprintf '%s %s\\n' '\(name)' \"$*\" >> '\(callLogPath)'\necho '{}'\nexit \(exitCode)\n"
+            try script.write(toFile: path, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+            return path
+        }
+        let pinnedCLI = try writeFakeCLI("pinned-cmux", exitCode: 0)
+        let ambientCLI = try writeFakeCLI("ambient-cmux", exitCode: 7)
+        let pinnedSocketPath = root.appendingPathComponent("pinned.sock").path
+
+        let install = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "agy", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_BUNDLED_CLI_PATH": pinnedCLI,
+                "CMUX_SOCKET_PATH": pinnedSocketPath,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            timeout: 5
+        )
+        XCTAssertFalse(install.timedOut, install.stderr)
+        XCTAssertEqual(install.status, 0, install.stderr)
+
+        let hookURL = root
+            .appendingPathComponent(".gemini", isDirectory: true)
+            .appendingPathComponent("config", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: hookURL)) as? [String: Any])
+        let cmuxGroup = try XCTUnwrap(json["cmux"] as? [String: Any])
+        let sessionStart = try XCTUnwrap(cmuxGroup["SessionStart"] as? [[String: Any]])
+        let command = try XCTUnwrap(sessionStart.first?["command"] as? String)
+
+        // A socket node that was bound once and is no longer served.
+        let staleSocketPath = root.appendingPathComponent("stale.sock").path
+        let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(socketFD, 0)
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(staleSocketPath.utf8CString)
+        XCTAssertLessThan(pathBytes.count, MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            for (index, byte) in pathBytes.enumerated() {
+                buffer[index] = UInt8(bitPattern: byte)
+            }
+        }
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.bind(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        XCTAssertEqual(bindResult, 0, String(cString: strerror(errno)))
+        close(socketFD)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: staleSocketPath))
+
+        let run = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", command],
+            environment: [
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_BUNDLED_CLI_PATH": ambientCLI,
+                "CMUX_SOCKET_PATH": staleSocketPath,
+            ],
+            timeout: 10
+        )
+        XCTAssertFalse(run.timedOut, run.stderr)
+        XCTAssertEqual(run.status, 0, run.stderr)
+
+        let calls = try String(contentsOfFile: callLogPath, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        XCTAssertEqual(calls.count, 2, "expected the ambient attempt and then the pinned fallback, saw \(calls)")
+        XCTAssertEqual(
+            calls.first,
+            "ambient-cmux --socket \(staleSocketPath) hooks antigravity session-start"
+        )
+        XCTAssertEqual(
+            calls.last,
+            "pinned-cmux --socket \(pinnedSocketPath) hooks antigravity session-start"
+        )
+    }
+
     func testKiroHookInstallUsesAgentConfigShapeAndPreservesDenyExit() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1870,6 +1870,76 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertNotNil(cmuxGroup["Notification"])
     }
 
+    /// `agy` preserves the launch environment, so a hook must report to the cmux
+    /// build that owns the terminal it runs in. Without this, `cmux hooks setup`
+    /// from any other build (nightly, a tagged dev build) silently redirects every
+    /// Antigravity session to that build's socket and restore never sees the
+    /// session. https://github.com/manaflow-ai/cmux/issues/5473
+    func testAntigravityHookInstallPrefersLaunchingTerminalSocket() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-antigravity-hook-ambient-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pinnedSocketPath = root.appendingPathComponent("cmux-pinned.sock").path
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "agy", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_BUNDLED_CLI_PATH": cliPath,
+                "CMUX_SOCKET_PATH": pinnedSocketPath,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            timeout: 5
+        )
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let hookURL = root
+            .appendingPathComponent(".gemini", isDirectory: true)
+            .appendingPathComponent("config", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: hookURL)) as? [String: Any])
+        let cmuxGroup = try XCTUnwrap(json["cmux"] as? [String: Any])
+        let commands = cmuxGroup.values
+            .compactMap { $0 as? [[String: Any]] }
+            .flatMap { entries in entries.compactMap { $0["command"] as? String } }
+        XCTAssertFalse(commands.isEmpty)
+
+        let ambientInvocation = #""$CMUX_BUNDLED_CLI_PATH" --socket "$CMUX_SOCKET_PATH" hooks antigravity"#
+        let pinnedInvocation = "--socket '\(pinnedSocketPath)' hooks antigravity"
+        for command in commands {
+            let ambientRange = command.range(of: ambientInvocation)
+            let pinnedRange = command.range(of: pinnedInvocation)
+            XCTAssertNotNil(
+                ambientRange,
+                "Antigravity hooks must dispatch through the launching terminal's cmux first, saw \(command)"
+            )
+            XCTAssertNotNil(
+                pinnedRange,
+                "Antigravity hooks must keep the pinned install as a fallback, saw \(command)"
+            )
+            if let ambientRange, let pinnedRange {
+                XCTAssertLessThan(
+                    ambientRange.lowerBound,
+                    pinnedRange.lowerBound,
+                    "The terminal's own socket must win over the pinned socket, saw \(command)"
+                )
+            }
+            XCTAssertTrue(
+                command.contains(#"[ -S "$CMUX_SOCKET_PATH" ]"#),
+                "Ambient dispatch must require a live socket so an exited app falls back to the pinned build, saw \(command)"
+            )
+            XCTAssertTrue(
+                command.contains(#"[ -f "${CMUX_BUNDLED_CLI_PATH:-}" ]"#),
+                "Ambient dispatch must require a bundled CLI file, not a directory, saw \(command)"
+            )
+        }
+    }
+
     func testKiroHookInstallUsesAgentConfigShapeAndPreservesDenyExit() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/cmuxTests/DeferredAgentResumeIndexFallbackTests.swift
+++ b/cmuxTests/DeferredAgentResumeIndexFallbackTests.swift
@@ -66,6 +66,89 @@ struct DeferredAgentResumeIndexFallbackTests {
         #expect(workspace.surfaceResumeBindingsByPanelId[panelId]?.autoResume == true)
     }
 
+    @Test("An index that has not caught up with a fresh hook record does not make its binding stale")
+    func missingIndexEntryIsUnknownNotStale() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = agentHookBinding(checkpoint: "fbce5061-b13a-4c00-8000-000000000002")
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        // The scan finished before the hook wrote this session: no entry at all.
+        #expect(
+            !workspace.isStaleAgentHookBinding(
+                binding,
+                panelId: panelId,
+                restorableAgentIndex: .empty
+            )
+        )
+    }
+
+    @Test("An index entry for the session with no live process still marks the binding stale")
+    func exitedIndexEntryIsStale() throws {
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-stale-binding-\(UUID().uuidString)", isDirectory: true)
+        let stateDirectory = homeDirectory.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: homeDirectory) }
+
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let sessionId = "9836696c-cf40-4d00-8000-000000000003"
+        let binding = agentHookBinding(checkpoint: sessionId)
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        // A hook record for this session that never carried a live PID.
+        let store = try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "sessions": [
+                    sessionId: [
+                        "sessionId": sessionId,
+                        "workspaceId": workspace.id.uuidString,
+                        "surfaceId": panelId.uuidString,
+                        "cwd": "/tmp",
+                        "launchCommand": [
+                            "launcher": "antigravity",
+                            "executablePath": "agy",
+                            "arguments": ["agy", "--dangerously-skip-permissions"],
+                            "workingDirectory": "/tmp",
+                            "source": "agent-hook",
+                        ],
+                        "isRestorable": true,
+                        "updatedAt": 1_788_868_000.0,
+                    ],
+                ],
+            ],
+            options: .sortedKeys
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("antigravity-hook-sessions.json"),
+            options: .atomic
+        )
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: homeDirectory.path,
+            fileManager: fileManager,
+            registry: CmuxVaultAgentRegistry.load(
+                homeDirectory: homeDirectory.path,
+                fileManager: fileManager
+            ),
+            detectedSnapshots: [:],
+            processArgumentsProvider: { _ in nil }
+        )
+        #expect(index.entryForStablePanel(workspaceId: workspace.id, panelId: panelId) != nil)
+
+        #expect(
+            workspace.isStaleAgentHookBinding(
+                binding,
+                panelId: panelId,
+                restorableAgentIndex: index
+            )
+        )
+    }
+
     @Test("A positive ownership decision still retires the binding")
     func ownershipCancelRetiresBinding() throws {
         let workspace = Workspace()

--- a/cmuxTests/DeferredAgentResumeIndexFallbackTests.swift
+++ b/cmuxTests/DeferredAgentResumeIndexFallbackTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// At relaunch the live-agent index is loaded off-main, so every agent restore
+/// is deferred until it settles. On a Mac running several agents the hook
+/// stores never stop changing, the settled refresh gives up, and the deferred
+/// restores used to be cancelled into plain shells with retired bindings, which
+/// is the "resumes once, never again" report in
+/// https://github.com/manaflow-ai/cmux/issues/5473.
+@MainActor
+@Suite("Deferred agent resume without a settled index")
+struct DeferredAgentResumeIndexFallbackTests {
+    private func agentHookBinding(checkpoint: String) -> SurfaceResumeBindingSnapshot {
+        SurfaceResumeBindingSnapshot(
+            name: "Antigravity",
+            kind: "antigravity",
+            command: "cd -- '/tmp' 2>/dev/null || [ ! -d '/tmp' ] && 'agy' '--conversation' '\(checkpoint)'",
+            cwd: "/tmp",
+            checkpointId: checkpoint,
+            source: "agent-hook",
+            environment: nil,
+            launchCommand: nil,
+            permissionMode: nil,
+            autoResume: true,
+            resumeEvidenceProvenance: nil,
+            updatedAt: 1_788_868_000
+        )
+    }
+
+    @Test("A refresh that could not settle resolves against the most recent completed load")
+    func unsettledRefreshFallsBackToLastKnownIndex() {
+        let lastKnown = RestorableAgentSessionIndex.empty
+        #expect(Workspace.deferredResumeIndex(refreshed: nil, lastKnown: lastKnown) != nil)
+        #expect(Workspace.deferredResumeIndex(refreshed: nil, lastKnown: nil) == nil)
+        let refreshed = RestorableAgentSessionIndex.empty
+        #expect(Workspace.deferredResumeIndex(refreshed: refreshed, lastKnown: nil) != nil)
+    }
+
+    @Test("Cancelling for index unavailability keeps the binding auto-resumable")
+    func indexUnavailabilityDoesNotRetireBindings() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = agentHookBinding(checkpoint: "6e8458c7-7970-41e0-8d3e-00beda48097b")
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+        workspace.deferredAgentResumeRestoresByPanelId[panelId] = DeferredAgentResumeRestore(
+            stablePanelID: panelId,
+            restorableAgent: nil,
+            resumeBinding: binding,
+            restoresRemoteWorkspaceTerminalSnapshot: false,
+            workingDirectory: "/tmp",
+            resumeWorkingDirectory: "/tmp"
+        )
+
+        workspace.clearDeferredAgentResumeRestores(retireBindings: false)
+
+        #expect(workspace.deferredAgentResumeRestoresByPanelId[panelId] == nil)
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .manualResumeAvailable)
+        // The next relaunch may still auto-resume this session.
+        #expect(workspace.surfaceResumeBindingsByPanelId[panelId]?.autoResume == true)
+    }
+
+    @Test("A positive ownership decision still retires the binding")
+    func ownershipCancelRetiresBinding() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = agentHookBinding(checkpoint: "312c5284-0000-4000-8000-000000000001")
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+        workspace.deferredAgentResumeRestoresByPanelId[panelId] = DeferredAgentResumeRestore(
+            stablePanelID: panelId,
+            restorableAgent: nil,
+            resumeBinding: binding,
+            restoresRemoteWorkspaceTerminalSnapshot: false,
+            workingDirectory: "/tmp",
+            resumeWorkingDirectory: "/tmp"
+        )
+
+        workspace.clearDeferredAgentResumeRestores()
+
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .manualResumeAvailable)
+        #expect(workspace.surfaceResumeBindingsByPanelId[panelId]?.autoResume == false)
+    }
+}

--- a/cmuxTests/RestoredStartupInputResendTests.swift
+++ b/cmuxTests/RestoredStartupInputResendTests.swift
@@ -94,6 +94,37 @@ struct RestoredStartupInputResendTests {
         #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == nil)
     }
 
+    @Test("A Workspace/Dock transfer carries the retained input only while the launch still awaits it")
+    func transferCarriesInputWhileAwaiting() {
+        let panelId = UUID()
+        let source = awaitingCoordinator(panelId: panelId)
+        let destination = RestoredAgentLifecycleCoordinator(dateProvider: { 1_788_868_000 })
+
+        destination.seedTransferredState(
+            panelId: panelId,
+            snapshot: nil,
+            resumeState: .awaitingAutoResumeCommand,
+            completedGeneration: nil,
+            resumeWorkingDirectory: nil,
+            startupInput: source.startupInput(panelId: panelId)
+        )
+        #expect(destination.awaitsStartupInput(panelId: panelId))
+        #expect(destination.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == selector)
+
+        // Once the command ran before the move, nothing may be replayed after it.
+        let settled = RestoredAgentLifecycleCoordinator(dateProvider: { 1_788_868_000 })
+        settled.seedTransferredState(
+            panelId: panelId,
+            snapshot: nil,
+            resumeState: .autoResumeCommandRunning,
+            completedGeneration: nil,
+            resumeWorkingDirectory: nil,
+            startupInput: selector
+        )
+        #expect(!settled.awaitsStartupInput(panelId: panelId))
+        #expect(settled.startupInput(panelId: panelId) == nil)
+    }
+
     @Test("Tearing down the restore forgets the retained input")
     func clearSessionRestoreForgetsInput() {
         let panelId = UUID()
@@ -126,7 +157,11 @@ struct RestoredStartupInputResendTests {
         // The grace period keeps a prompt-then-command sequence from double-typing.
         #expect(workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
 
-        try await Task.sleep(for: .milliseconds(400))
+        let deadline = ContinuousClock.now + .seconds(5)
+        while workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId),
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
         #expect(!workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
         #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand)
     }

--- a/cmuxTests/RestoredStartupInputResendTests.swift
+++ b/cmuxTests/RestoredStartupInputResendTests.swift
@@ -1,4 +1,5 @@
 import CmuxWorkspaces
+import Combine
 import Foundation
 import Testing
 
@@ -186,4 +187,170 @@ struct RestoredStartupInputResendTests {
         #expect(!workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
         #expect(!workspace.restoredAgentLifecycle.armStartupInputResend(panelId: panelId))
     }
+
+    // MARK: - Workspace/Dock transfers
+
+    /// A transfer for a launch whose typed selector is still outstanding. The
+    /// default shell state models the case that matters: the shell settled at
+    /// an idle prompt before the move, so the destination never sees that
+    /// transition itself.
+    private func awaitingTransfer(
+        panel: any Panel,
+        sourceWorkspaceId: UUID,
+        shellActivityState: PanelShellActivityState? = .promptIdle
+    ) -> Workspace.DetachedSurfaceTransfer {
+        Workspace.DetachedSurfaceTransfer(
+            sourceWorkspaceId: sourceWorkspaceId,
+            sessionRestoreSourceWorkspaceId: nil,
+            panelId: panel.id,
+            panel: panel,
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            iconImageData: nil,
+            kind: "terminal",
+            isLoading: false,
+            isPinned: false,
+            directory: nil,
+            directoryIsTrustedRemoteReport: false,
+            directoryDisplayLabel: nil,
+            ttyName: nil,
+            cachedTitle: nil,
+            customTitle: nil,
+            customTitleSource: nil,
+            manuallyUnread: false,
+            restoredUnreadIndicator: nil,
+            restorableAgent: nil,
+            restorableAgentResumeState: .awaitingAutoResumeCommand,
+            restoredAgentCompletedGeneration: nil,
+            shellActivityState: shellActivityState,
+            restoredResumeSessionWorkingDirectory: nil,
+            restoredStartupInput: selector,
+            resumeBinding: nil,
+            managedAgentResumeBinding: nil,
+            agentRuntime: nil,
+            isRemoteTerminal: false,
+            remoteRelayPort: nil,
+            remotePTYSessionID: nil,
+            remoteCleanupConfiguration: nil
+        )
+    }
+
+    private func waitForReplay(
+        _ coordinator: RestoredAgentLifecycleCoordinator,
+        panelId: UUID
+    ) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while coordinator.awaitsStartupInput(panelId: panelId),
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    @Test("Re-stamping a transfer's remote cleanup configuration keeps the retained selector")
+    func remoteCleanupCopyKeepsStartupInput() {
+        let panel = RestoredStartupInputTransferTestPanel()
+        let transfer = awaitingTransfer(panel: panel, sourceWorkspaceId: UUID())
+
+        let copied = transfer.withRemoteCleanupConfiguration(nil)
+
+        #expect(copied.restoredStartupInput == selector)
+        #expect(copied.restorableAgentResumeState == .awaitingAutoResumeCommand)
+        #expect(copied.shellActivityState == .promptIdle)
+    }
+
+    @Test("A workspace that adopts a pane whose shell already idled replays the selector itself")
+    func workspaceReplaysAfterAdoptingIdleTransfer() async throws {
+        let previousGrace = Workspace.restoredStartupInputResendGrace
+        Workspace.restoredStartupInputResendGrace = 0.05
+        defer { Workspace.restoredStartupInputResendGrace = previousGrace }
+
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let panel = try #require(workspace.panels[panelId])
+
+        workspace.seedDetachedRestoredAgentState(
+            from: awaitingTransfer(panel: panel, sourceWorkspaceId: UUID())
+        )
+
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand)
+        #expect(workspace.panelShellActivityStates[panelId] == .promptIdle)
+        #expect(workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
+        // The idle prompt was reported to the previous owner and never repeats
+        // here, so adoption itself must have armed the replay.
+        #expect(!workspace.restoredAgentLifecycle.armStartupInputResend(panelId: panelId))
+
+        try await waitForReplay(workspace.restoredAgentLifecycle, panelId: panelId)
+        #expect(!workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand)
+    }
+
+    @Test("A Dock that adopts a pane whose shell already idled replays the selector itself")
+    func dockReplaysAfterAdoptingIdleTransfer() async throws {
+        let previousGrace = Workspace.restoredStartupInputResendGrace
+        Workspace.restoredStartupInputResendGrace = 0.05
+        defer { Workspace.restoredStartupInputResendGrace = previousGrace }
+
+        let sourceWorkspaceId = UUID()
+        let panel = TerminalPanel(workspaceId: sourceWorkspaceId)
+        let store = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+
+        let attached = store.attachDetachedSurface(
+            awaitingTransfer(panel: panel, sourceWorkspaceId: sourceWorkspaceId),
+            inPane: rootPane,
+            focus: false
+        )
+
+        #expect(attached == panel.id)
+        #expect(panel.shellActivity.state == .promptIdle)
+        #expect(store.restoredAgentLifecycle.awaitsStartupInput(panelId: panel.id))
+        #expect(!store.restoredAgentLifecycle.armStartupInputResend(panelId: panel.id))
+
+        try await waitForReplay(store.restoredAgentLifecycle, panelId: panel.id)
+        #expect(!store.restoredAgentLifecycle.awaitsStartupInput(panelId: panel.id))
+        #expect(store.restoredAgentLifecycle.resumeStatesByPanelId[panel.id] == .awaitingAutoResumeCommand)
+    }
+
+    @Test("Detaching from a Dock carries the retained selector to the next owner")
+    func dockDetachCarriesStartupInput() throws {
+        let sourceWorkspaceId = UUID()
+        let panel = TerminalPanel(workspaceId: sourceWorkspaceId)
+        let store = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        _ = store.attachDetachedSurface(
+            awaitingTransfer(
+                panel: panel,
+                sourceWorkspaceId: sourceWorkspaceId,
+                shellActivityState: nil
+            ),
+            inPane: rootPane,
+            focus: false
+        )
+        #expect(store.restoredAgentLifecycle.awaitsStartupInput(panelId: panel.id))
+
+        let detached = try #require(store.detachSurface(panelId: panel.id))
+        defer { panel.close() }
+
+        #expect(detached.restorableAgentResumeState == .awaitingAutoResumeCommand)
+        #expect(detached.restoredStartupInput == selector)
+    }
+}
+
+@MainActor
+private final class RestoredStartupInputTransferTestPanel: Panel {
+    let objectWillChange = ObservableObjectPublisher()
+    let id = UUID()
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    let panelType: PanelType = .terminal
+    var displayTitle = "Restored"
+    let displayIcon: String? = "terminal.fill"
+    let isDirty = false
+
+    func close() {}
+    func focus() {}
+    func unfocus() {}
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {}
 }

--- a/cmuxTests/RestoredStartupInputResendTests.swift
+++ b/cmuxTests/RestoredStartupInputResendTests.swift
@@ -1,0 +1,154 @@
+import CmuxWorkspaces
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Ghostty types a restored agent's `cmux restore` selector as soon as the PTY
+/// exists. A slow login shell can discard that typeahead while it initializes,
+/// leaving the pane at an empty prompt (https://github.com/manaflow-ai/cmux/issues/5473).
+/// The lifecycle coordinator retains the input so the owner can replay it once.
+@MainActor
+@Suite("Restored startup input resend")
+struct RestoredStartupInputResendTests {
+    private let selector = " cmux restore antigravity 6e8458c7-7970-41e0-8d3e-00beda48097b\n"
+
+    private func awaitingCoordinator(panelId: UUID) -> RestoredAgentLifecycleCoordinator {
+        let coordinator = RestoredAgentLifecycleCoordinator(dateProvider: { 1_788_868_000 })
+        coordinator.seedSessionRestore(
+            panelId: panelId,
+            snapshot: nil,
+            manualResumeAvailable: false,
+            willRunStartupCommand: false,
+            willRunStartupInput: true,
+            resumeWorkingDirectory: nil
+        )
+        coordinator.registerStartupInput(selector, panelId: panelId)
+        return coordinator
+    }
+
+    @Test("Replays the retained input once while the launch is still waiting at an idle prompt")
+    func replaysOnceWhilePromptStaysIdle() {
+        let panelId = UUID()
+        let coordinator = awaitingCoordinator(panelId: panelId)
+
+        #expect(coordinator.awaitsStartupInput(panelId: panelId))
+        #expect(coordinator.armStartupInputResend(panelId: panelId))
+        // A second idle-prompt report must not arm a second timer.
+        #expect(!coordinator.armStartupInputResend(panelId: panelId))
+
+        #expect(
+            coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == selector
+        )
+        // Only one replay is ever handed out.
+        #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == nil)
+        #expect(!coordinator.awaitsStartupInput(panelId: panelId))
+    }
+
+    @Test("A prompt-then-command sequence that reached the command phase is not replayed")
+    func doesNotReplayOnceTheCommandStarted() {
+        let panelId = UUID()
+        let coordinator = awaitingCoordinator(panelId: panelId)
+        #expect(coordinator.armStartupInputResend(panelId: panelId))
+
+        // Shell integration reported the command running before the grace period elapsed.
+        coordinator.setResumeState(.autoResumeCommandRunning, panelId: panelId)
+        coordinator.clearStartupInput(panelId: panelId)
+
+        #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == nil)
+        #expect(!coordinator.awaitsStartupInput(panelId: panelId))
+    }
+
+    @Test("A shell that is no longer idle when the grace period ends is left alone")
+    func doesNotReplayIntoARunningCommand() {
+        let panelId = UUID()
+        let coordinator = awaitingCoordinator(panelId: panelId)
+        #expect(coordinator.armStartupInputResend(panelId: panelId))
+
+        #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .commandRunning) == nil)
+        // The input stays retained for a later idle prompt.
+        #expect(coordinator.awaitsStartupInput(panelId: panelId))
+    }
+
+    @Test("Manual and unrestored launches never arm a replay")
+    func onlyAwaitingLaunchesArm() {
+        let panelId = UUID()
+        let coordinator = RestoredAgentLifecycleCoordinator(dateProvider: { 1_788_868_000 })
+        coordinator.registerStartupInput(selector, panelId: panelId)
+        #expect(!coordinator.awaitsStartupInput(panelId: panelId))
+        #expect(!coordinator.armStartupInputResend(panelId: panelId))
+
+        coordinator.seedSessionRestore(
+            panelId: panelId,
+            snapshot: nil,
+            manualResumeAvailable: true,
+            willRunStartupCommand: false,
+            willRunStartupInput: false,
+            resumeWorkingDirectory: nil
+        )
+        #expect(!coordinator.armStartupInputResend(panelId: panelId))
+        #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == nil)
+    }
+
+    @Test("Tearing down the restore forgets the retained input")
+    func clearSessionRestoreForgetsInput() {
+        let panelId = UUID()
+        let coordinator = awaitingCoordinator(panelId: panelId)
+        coordinator.clearSessionRestore(panelId: panelId)
+        #expect(!coordinator.awaitsStartupInput(panelId: panelId))
+        #expect(coordinator.takeStartupInputForResend(panelId: panelId, shellState: .promptIdle) == nil)
+    }
+
+    @Test("A workspace replays the lost selector after its shell settles at an idle prompt")
+    func workspaceReplaysAfterIdlePrompt() async throws {
+        let previousGrace = Workspace.restoredStartupInputResendGrace
+        Workspace.restoredStartupInputResendGrace = 0.05
+        defer { Workspace.restoredStartupInputResendGrace = previousGrace }
+
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        workspace.restoredAgentLifecycle.seedSessionRestore(
+            panelId: panelId,
+            snapshot: nil,
+            manualResumeAvailable: false,
+            willRunStartupCommand: false,
+            willRunStartupInput: true,
+            resumeWorkingDirectory: nil
+        )
+        workspace.restoredAgentLifecycle.registerStartupInput(selector, panelId: panelId)
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)
+        // The grace period keeps a prompt-then-command sequence from double-typing.
+        #expect(workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
+
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(!workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .awaitingAutoResumeCommand)
+    }
+
+    @Test("A workspace whose shell ran the typed selector keeps nothing to replay")
+    func workspaceClearsInputOnceCommandRuns() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        workspace.restoredAgentLifecycle.seedSessionRestore(
+            panelId: panelId,
+            snapshot: nil,
+            manualResumeAvailable: false,
+            willRunStartupCommand: false,
+            willRunStartupInput: true,
+            resumeWorkingDirectory: nil
+        )
+        workspace.restoredAgentLifecycle.registerStartupInput(selector, panelId: panelId)
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .commandRunning)
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning)
+        #expect(!workspace.restoredAgentLifecycle.awaitsStartupInput(panelId: panelId))
+        #expect(!workspace.restoredAgentLifecycle.armStartupInputResend(panelId: panelId))
+    }
+}

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -34,6 +34,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 | Kimi Code | `kimi` | `~/.kimi-code/config.toml` or `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
+| Antigravity | `agy` | `~/.gemini/config/hooks.json` (`cmux` hook group) | `agy --conversation <id>` | none |
 
 OpenCode also supports project-local Feed installation:
 
@@ -155,6 +156,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
 | Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
+| Antigravity | none | `CMUX_ANTIGRAVITY_HOOKS_DISABLED=1` |
 
 Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
 
@@ -167,6 +169,8 @@ Kiro stores hooks inside agent configuration files. The cmux installer creates o
 Kiro Feed verbosity follows **Settings > Automation > Kiro Notification Level** or `automation.kiroNotificationLevel` in `cmux.json`. `minimal` keeps actionable approval cards only, `standard` also keeps mutating tool events, and `verbose` keeps every Kiro tool event.
 
 Kimi ships under two config layouts: Kimi Code CLI reads `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`, and Kimi CLI 1.49 and earlier read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. cmux installs into the file the installed binary reports through `kimi doctor`; when the binary cannot answer, it installs into the first of those two locations that already exists, defaulting to the Kimi Code CLI path. The other location is never emptied by setup: an existing cmux block there is refreshed in place so a second Kimi install keeps working, and a config without a cmux block is left untouched. `cmux hooks uninstall kimi` removes the block from both. Unrelated TOML and third-party hooks are preserved everywhere.
+
+Antigravity (`agy`) hooks are written as the `cmux` group of `~/.gemini/config/hooks.json`. Each hook command first uses the cmux that owns the terminal the session runs in (`CMUX_BUNDLED_CLI_PATH` and `CMUX_SOCKET_PATH` from that terminal's environment), so sessions started from different cmux builds (stable, nightly, tagged dev builds) each report to their own app and restore correctly. When `agy` runs a hook without that environment, the command falls back to the cmux build that installed it. Re-run `cmux hooks agy install --yes` from an up-to-date cmux to refresh that fallback.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #5473

## Summary

Antigravity (`agy`) panes came back after a quit/relaunch as plain shells with no `agent` snapshot and no `resumeBinding`, so cmux never auto-resumed the conversation.

**Root cause.** Antigravity hooks are installed with *pinned* dispatch: every command in the `cmux` group of `~/.gemini/config/hooks.json` embeds the CLI path and socket of whichever cmux build ran `cmux hooks setup` last. `agy` does preserve the launch environment, so a session started in any other build (stable, nightly, a tagged dev build) sends its `SessionStart`/`Stop` to the wrong socket, where the surface does not exist. The hook then exits without writing `~/.cmuxterm/antigravity-hook-sessions.json` or publishing a resume binding, and the pane has nothing to restore from. On this machine the file was pinned to a nightly socket while the user's main app runs from `/Applications/cmux.app`, and later to another agent's tagged dev build.

**Second cause: the typed resume is lost on slow login shells.** Session restore types ` cmux restore antigravity <id>` through Ghostty's initial input, which is written to the PTY as soon as the shell spawns. With a login shell that takes a few seconds to initialize (conda/oh-my-zsh style), that typeahead is discarded before the line editor is ready: the pane comes back at an empty prompt with nothing typed and cmux retires the binding. Five quit/relaunch cycles on this machine lost the selector three times.

**Third cause: deferred restores were cancelled wholesale when the live-agent index could not settle.** At relaunch the index loads off-main, so every agent restore is deferred until `SharedLiveAgentIndex.indexRefreshingNow()` settles. That refresh gives up after two passes whenever hook stores keep changing (the steady state on a Mac running several agents), and the deferred path treated the resulting `nil` as "no index" and cancelled every restore: plain shell, lifecycle set to manual, and the next quit saved `wasAgentRunning: false`, so the session never auto-resumed again. This is the "resumes once, then never" behavior and it affected every restorable agent kind. The instrumented build showed the cancel firing 4 s after restore, inside the 10 s deadline.

**Fourth cause: the live-agent index rejected every fresh `agy` process, so the next autosave retired its binding.** Antigravity's registration keys session identity on the `--conversation` argv option, which only appears on explicit resumes. A freshly started `agy` has none, so `CachedAgentProcessIdentityValidator` failed closed, the index reported the running session as exited, and the autosave reconcile retired the agent-hook binding (`autoResume: false`, policy left at `auto`). Relaunch then cancelled the deferred restore at the auto-resume guard and started a plain shell. On this Mac the flip happened 5–11 s after the hook registered the session, every time (three probes, two quit/relaunch chains). This is why the pane never auto-resumed even once its hooks reached the right cmux.

**Fix 1.** Each generated Antigravity hook command now dispatches through the launching terminal's own `CMUX_BUNDLED_CLI_PATH` and `CMUX_SOCKET_PATH` when that environment is present and the socket is live, and keeps the pinned CLI/socket as the fallback for sanitized hook environments or an exited app. The restore path itself (`agent` snapshot from the hook store, `agent-hook` binding, ` cmux restore antigravity <id>` on relaunch) was verified working once hooks reach the owning app.

## Commits

1. `test: cover Antigravity hook session snapshot restore` — snapshot attaches the hook-store record to the terminal panel.
2. `test: make the Antigravity hook snapshot restore test compile and keep the permission flag` — the test did not compile (wrong `RestorableAgentSessionIndex.load` overload); it now loads the built-in Vault registry and expects `--dangerously-skip-permissions` to survive the rendered resume command.
3. `test: Antigravity hooks must dispatch to the terminal's own cmux first` — **red** without the fix.
4. `Route Antigravity hooks through the launching terminal's cmux before the pinned build` — the fix plus `docs/agent-hooks.md` (Antigravity row in the integrations and environment tables, dispatch order note).
6. `Resolve deferred agent restores against the last completed index instead of cancelling them` — **Fix 3**: the deferred task resolves against the most recent completed load when the settled refresh gives up (process evidence is revalidated during resolution); only when no index has ever loaded does it start plain shells, and then without retiring bindings. `DeferredAgentResumeIndexFallbackTests` covers the fallback and the retire-vs-keep distinction. Also: every cancel path drops the retained replay input, pane transfers carry it, ambient hook dispatch falls back to the pinned build when the ambient call fails, and debug builds log each restore admission decision.
5. `Replay a restored agent's startup input when the login shell drops it` — **Fix 2**: the lifecycle coordinator retains the typed selector while the launch is awaiting its command; when shell integration reports an idle prompt in that state, the Workspace or Dock owner replays it once after a 2 s grace period, unless the command already started, the user or a socket client typed into the pane, or the pane has no live runtime. Applies to every restorable agent kind, not just Antigravity. Tests: `RestoredStartupInputResendTests` (coordinator one-shot contract plus workspace shell-state wiring). This one is a single commit: the tests exercise new coordinator API, so there is no compiling red state before the fix.
7. `test: a pane moved after its shell idled must still replay the selector, and every transfer path must carry it` — **red** without the fix ([hosted lane run](https://github.com/manaflow-ai/cmux/actions/runs/34247817577): the four new `RestoredStartupInputResendTests` fail, the earlier ones pass).
8. `Re-arm the restore selector replay when a pane is adopted after its shell idled; carry the selector through Dock detach and transfer copies` — addresses the CodeRabbit and Cursor Bugbot review findings: adoption arms the replay itself when the transferred shell state is already `promptIdle` (Workspace and Dock), `DockSplitStore.detachSurface` puts the retained selector on its transfer, and `withRemoteCleanupConfiguration(_:)` no longer drops it ([hosted lane run](https://github.com/manaflow-ai/cmux/actions/runs/34247689995): green).
9. `test: a fresh Antigravity launch without --conversation must still validate as the owner of its hook-recorded session` — **red** without the fix (`AgentRestoreLiveOwnerAdmissionTests`, hosted lane link below).
10. `Accept a bare argv for argv-keyed agent registrations once pid identity, scope, and executable match` — **Fix 4**: when the registration's identity option is absent and no `CMUX_AGENT_SESSION_ID` is exported, the process that already matched on pid start-time identity, cmux scope, and executable is accepted as the owner of the hook-recorded session; an explicit selector or exported id still has to name the session. Also applies to the Campfire (`--session`) and Kimi (`--resume`) registrations, which key identity the same way.
11. `Scope the bare-argv fallback to validations against the current hook record` — review follow-up (CodeRabbit): the fallback applies only when the index was built from the current hook record; cached-snapshot revalidation keeps failing closed for every argv-keyed registration, mirroring the Hermes rule.

## Verification

Tagged fleet build `issue-5473-agy-restore` on this Mac with the real `agy` (1.1.27):

- With hooks pinned to this build: `agy --dangerously-skip-permissions` → SessionStart/prompt-submit/Stop resolved to the right workspace/surface; autosave persisted `agent.kind: antigravity`, an `agent-hook` binding with `autoResume: true`, command `agy --conversation <id> --dangerously-skip-permissions`, `wasAgentRunning: true`; quit/relaunch typed the resume and the pane came back running the same conversation. A manual ` cmux restore antigravity <id>` in another pane resumed its conversation too.
- With hooks pinned to a different build (what `cmux hooks setup` from another tagged build did mid-test): the same `agy` session produced no hook record and no binding, reproducing the issue.
- Hosted unit-test lane (`test-e2e.yml`): `DeferredAgentResumeIndexFallbackTests` [red at the test-only commit](https://github.com/manaflow-ai/cmux/actions/runs/34233801591) and [green at the fix](https://github.com/manaflow-ai/cmux/actions/runs/34233790032); `RestoredStartupInputResendTests` [red at the transfer test-only commit](https://github.com/manaflow-ai/cmux/actions/runs/34247817577) and [green at the transfer fix](https://github.com/manaflow-ai/cmux/actions/runs/34247689995).
- Post-fix dogfood on the rebuilt tag at the final commit (`issue-5473-agy-restore`, app relaunched with a clean environment, real `agy` 1.1.27): fresh `agy --dangerously-skip-permissions` in a new workspace, prompt answered, then three consecutive quit → relaunch hops on the same pane. Every hop came back with `agy --conversation <id>` running in the pane, the resumed conversation on screen, and a follow-up prompt answered (history grew 4 → 6 → 8 lines: PINEAPPLE, MANGO, KIWI, PAPAYA); the hook store was updated after each follow-up and the binding stayed `autoResume: true` across all hops. Before Fix 4, on the same build lineage, the binding flipped to `autoResume: false` 5–11 s after registration in every probe and hop 1 came back as an empty shell.
- Hosted lane for Fix 4: `AgentRestoreLiveOwnerAdmissionTests` [red at the test-only commit](https://github.com/manaflow-ai/cmux/actions/runs/34258332543) (only the new test fails) and [green at the fix](https://github.com/manaflow-ai/cmux/actions/runs/34258344047) (9/9); `RestoredStartupInputResendTests` [green at the final commit](https://github.com/manaflow-ai/cmux/actions/runs/34258375281).
- Dogfood caveat worth knowing: a workspace created with `cmux new-workspace --command agy` from inside an agent-launched pane inherits that pane's `CMUX_AGENT_LAUNCH_KIND`/`CMUX_AGENT_LAUNCH_*` environment (the CLI forwards the caller environment). The live-agent index then rejects the `agy` process as a different agent kind and the next autosave retires its binding (`autoResume: false`), so the session never auto-resumes. That is a pre-existing environment-attribution issue outside this PR; the dogfood harness scrubs those variables. A pane where the user types `agy` normally does not carry them.

Localization audit: no user-facing strings changed (generated shell command and docs only).

## Observations for follow-up (not changed here)

- `read-screen` (`surface.read_text` over the socket) can pin the app main thread for minutes when the target pane is a TUI that keeps repainting (the resumed `agy` while it thinks). A `sample` of the stalled app showed the main thread inside `TerminalController.v2SurfaceReadText` for the whole window; hooks, autosaves, and Quit all queued behind it. The dogfood harness now reads the screen only once the agent is idle.
- A resumed `agy --conversation <id>` never sends `SessionStart`, so the hook record keeps the original launch pid; prompt-submit/Stop from the resumed process still update the record. Restore does not depend on it because the process-detected index resolves the session from `--conversation`, but a reader of the hook store should not treat the record pid as the live process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwJZhVvc3cQynztiSzVe3w
