### PR TITLE
chore: make the never-mutated socket payload a let

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8778,7 +8778,7 @@ class TerminalController {
 
                     switch ctx.webView.replayBrowserKeyboardEvent(event, action: action) {
                     case .delivered:
-                        var payload: [String: Any] = [
+                        let payload: [String: Any] = [
                             "workspace_id": ctx.workspaceId.uuidString,
                             "workspace_ref": v2Ref(kind: .workspace, uuid: ctx.workspaceId),
                             "surface_id": ctx.surfaceId.uuidString,


### PR DESCRIPTION
## Summary

Main's full CI currently fails the Swift warning budget in `tests-build-and-lag` with `+1 Sources/TerminalController.swift: variable 'payload' was never mutated; consider changing to 'let' constant` (see https://github.com/manaflow-ai/cmux/actions/runs/34057995765 on main and the same finding on the #12137 branch). The declaration at line 8779 builds a dictionary and returns it unchanged, so this makes it a `let`. No budget file change.

## Verification

- One-line change; full `ci.yml` dispatched on this branch so the `Validate Swift warning budget` step can confirm the count is back under budget (link in the comments).
- No user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8Eci7rC11iSuCw4F4DE2g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791458426&installation_model_id=21920&pr_number=12153&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12153&signature=0a12a001c6ac8b54b14024645d1e6be5435ed42c1225dc5a1a01eeaafaecedd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the `payload` variable in `TerminalController.swift` from `var` to `let` to fix the failing Swift warning budget check. The value is returned unchanged, so there's no behavior change.

<sup>Written for commit 8288d605129ef300b7bbd1a26ed3dad16f30cb5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single declaration change with no logic or API behavior change; only silences an unused-mutation compiler warning.
> 
> **Overview**
> Fixes a **Swift warning budget** failure on main by declaring the success-path response dictionary as **`let`** instead of **`var`** in the browser keyboard replay handler inside `TerminalController.swift`.
> 
> When native keyboard replay **delivers**, the handler still returns the same workspace/surface IDs and v2 refs; nothing in that path mutates the dictionary after it is built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8288d605129ef300b7bbd1a26ed3dad16f30cb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->