### PR TITLE
web: portable entry-point guard for check-devbox-image-reachable (typecheck fix)

### DIFF
--- a/web/scripts/check-devbox-image-reachable.ts
+++ b/web/scripts/check-devbox-image-reachable.ts
@@ -25,6 +25,8 @@
  */
 import { Freestyle, type FirewallSpec } from "freestyle";
 import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { cmuxTuiWebsocketSmokeCommand, readImageManifest } from "./devbox-image-common";
 import { resolveCmuxTuiSource } from "../services/vms/drivers/cmuxTuiDaemon";
 
@@ -145,4 +147,9 @@ async function main(): Promise<void> {
   console.log(`REACHABLE ${kind}/${size} ${target} in ${elapsed()}`);
 }
 
-if (import.meta.main) await main();
+// Bun-only `import.meta.main` is not in TypeScript's ImportMeta type; use the
+// portable entry-point check the sibling devbox scripts already rely on.
+const isEntryPoint =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntryPoint) await main();


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/12147

## Problem

`web/scripts/check-devbox-image-reachable.ts` (added by #12132) ends with `if (import.meta.main) await main();`. `import.meta.main` is Bun-only and not part of TypeScript's `ImportMeta` type, so `bun run typecheck` (`tsgo --noEmit`) fails on main:

```text
scripts/check-devbox-image-reachable.ts(148,17): error TS2339: Property 'main' does not exist on type 'ImportMeta'.
```

`ci.yml` is path-gated for pull requests, so main's own PR checks never ran this job; every PR that touches `ci.yml` (which forces all CI areas) now fails `web-typecheck`, `linux-preflight`, `tests`, and `ci-status` (#12140, #12141, and the #12100 dispatch).

## Fix

Replace the guard with the portable entry-point check the sibling devbox scripts already use (`fileURLToPath(import.meta.url)` compared with `path.resolve(process.argv[1])`). No Bun ambient types are added to the web typecheck config.

## Verification

Run in a sparse clone of current main with this patch, using an installed `web/node_modules`:

```text
$ ./node_modules/.bin/tsgo --noEmit          # clean (was: TS2339 at scripts/check-devbox-image-reachable.ts:148)
$ bun test tests/vm-image-reachability.test.ts
 4 pass / 0 fail                             # importing reachabilityKey does not run main()
$ bun scripts/check-devbox-image-reachable.ts --print-key
dd571d4dbdd25c0fa011260e3304b3441ef8e1a4957b1547476ee68973f8d7a1   # entry-point path still runs main()
```

A manual `ci.yml` dispatch on this branch runs the `web-typecheck` job as CI evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qiy38q5XFYQU3CeccDENty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791458509&installation_model_id=21920&pr_number=12154&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12154&signature=676813ab3697af0ad241c3497c1b99e09fef2d0986def8a4c398a2ced446bbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typecheck-only guard change with no logic or security impact; entry-point behavior is preserved.
> 
> **Overview**
> Fixes **`web` typecheck** by replacing Bun-only **`import.meta.main`** at the bottom of `check-devbox-image-reachable.ts` with a portable **entry-point guard** that compares **`path.resolve(process.argv[1])`** to **`fileURLToPath(import.meta.url)`**, matching the approach used by other devbox scripts.
> 
> Adds **`node:path`** and **`node:url`** imports only to support that guard. **Runtime behavior is unchanged**: direct script execution still runs **`main()`**, while importing the module (e.g. **`reachabilityKey`** in tests) does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de39d891e0ea5dcc95f4dbf2fa955b5ba150ee6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the web typecheck failure by replacing the Bun-only `import.meta.main` guard in `web/scripts/check-devbox-image-reachable.ts` with the portable entry-point check the sibling devbox scripts already use.

`import.meta.main` is not part of TypeScript's `ImportMeta` type, so `bun run typecheck` errored with TS2339. The new check compares `fileURLToPath(import.meta.url)` with `path.resolve(process.argv[1])`; running the script directly still calls `main()`, and importing `reachabilityKey` from tests still does not. Closes #12147.

<sup>Written for commit de39d891e0ea5dcc95f4dbf2fa955b5ba150ee6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

