### PR TITLE
Fix file-explorer-opened tabs that could not be dragged (#12152)

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1354,6 +1354,7 @@
 		FE001105 /* FileExplorerKeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE001005 /* FileExplorerKeyboardShortcuts.swift */; };
 		9860F0029860F0029860F002 /* FileExplorerNativeDragOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9860F0039860F0039860F003 /* FileExplorerNativeDragOwnershipTests.swift */; };
 		FE5996030000000000000002 /* FileExplorerNSOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5996030000000000000001 /* FileExplorerNSOutlineView.swift */; };
+		A2CFBE5869E987D3E306CB7A /* FileExplorerOpenedTabDragSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06880917B87678F2857EC8FB /* FileExplorerOpenedTabDragSourceTests.swift */; };
 		828800020000000000000002 /* FileExplorerPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828800020000000000000001 /* FileExplorerPalette.swift */; };
 		FE002101 /* FileExplorerRootResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002001 /* FileExplorerRootResolverTests.swift */; };
 		9F8A6669D6F54F0EA8E8BEB8 /* FileExplorerRootSyncPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */; };
@@ -4671,6 +4672,7 @@
 		FE001005 /* FileExplorerKeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerKeyboardShortcuts.swift; sourceTree = "<group>"; };
 		9860F0039860F0039860F003 /* FileExplorerNativeDragOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerNativeDragOwnershipTests.swift; sourceTree = "<group>"; };
 		FE5996030000000000000001 /* FileExplorerNSOutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerNSOutlineView.swift; sourceTree = "<group>"; };
+		06880917B87678F2857EC8FB /* FileExplorerOpenedTabDragSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerOpenedTabDragSourceTests.swift; sourceTree = "<group>"; };
 		828800020000000000000001 /* FileExplorerPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerPalette.swift; sourceTree = "<group>"; };
 		FE002001 /* FileExplorerRootResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerRootResolverTests.swift; sourceTree = "<group>"; };
 		120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerRootSyncPolicyTests.swift; sourceTree = "<group>"; };
@@ -9508,6 +9510,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					469200014692000146920002 /* VaultPaneDropRoutingTests.swift */,
 					469200064692000146920002 /* VaultPaneDropTestSupport.swift */,
 					469200044692000146920002 /* VaultPaneTransferLifecycleTests.swift */,
+					06880917B87678F2857EC8FB /* FileExplorerOpenedTabDragSourceTests.swift */,
 					469200054692000146920002 /* VaultNativeDragSourceTests.swift */,
 					D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */,
 				EC010C02 /* TerminalUploadCommandTests.swift */,
@@ -13379,6 +13382,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				FE002110 /* FileExplorerDoubleClickActionTests.swift in Sources */,
 				FE002112 /* FileExplorerGitStatusProviderTests.swift in Sources */,
 				9860F0029860F0029860F002 /* FileExplorerNativeDragOwnershipTests.swift in Sources */,
+				A2CFBE5869E987D3E306CB7A /* FileExplorerOpenedTabDragSourceTests.swift in Sources */,
 				FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 				9F8A6669D6F54F0EA8E8BEB8 /* FileExplorerRootSyncPolicyTests.swift in Sources */,
 				F5996002A1B2C3D4E5F60001 /* FileExplorerShortcutSettingsTests.swift in Sources */,

--- a/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
+++ b/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
@@ -2,6 +2,7 @@ import AppKit
 @testable import Bonsplit
 import CmuxWorkspaces
 import Foundation
+import SwiftUI
 import Testing
 
 #if canImport(cmux_DEV)
@@ -80,5 +81,114 @@ struct FileExplorerOpenedTabDragSourceTests {
             #expect(resolved.tabId == tabId.uuid)
             #expect(resolver.source(for: resolved) == .surface)
         }
+    }
+
+    @Test("The strip arms a native drag for the explorer-opened tab on its first laid-out press")
+    func openedFileTabArmsOnFirstLaidOutPress() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let fixture = try VaultPaneAppFixture()
+            defer { fixture.tearDown() }
+            let workspace = fixture.workspace
+            let controller = workspace.bonsplitController
+            controller.tabShortcutHintsEnabled = false
+            let fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-explorer-open-\(UUID().uuidString)")
+                .appendingPathExtension("yml")
+            try "services:\n  web:\n    image: nginx\n".write(to: fileURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+
+            // Host the workspace's real tab strip: the same BonsplitView the app
+            // renders, driven by the same controller the explorer mutates.
+            let hostingView = NSHostingView(
+                rootView: BonsplitView(controller: controller) { _, _ in Color.clear }
+            )
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 640, height: 360),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try #require(window.contentView)
+            hostingView.frame = contentView.bounds
+            hostingView.autoresizingMask = [.width, .height]
+            contentView.addSubview(hostingView)
+            window.makeKeyAndOrderFront(nil)
+            Self.settle(window, hostingView)
+
+            let paneId = try #require(controller.focusedPaneId ?? controller.allPaneIds.first)
+            let openedPanels = workspace.openFileSurfaces(
+                inPane: paneId,
+                filePaths: [fileURL.path],
+                focus: true,
+                reuseExisting: true,
+                duplicateWhenFocused: true
+            )
+            let panel = try #require(openedPanels.first as? FilePreviewPanel)
+            let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
+            Self.settle(window, hostingView)
+
+            let strip = try #require(
+                Self.descendants(ofType: TabBarDragAndHoverView.TabBarBackgroundNSView.self, in: hostingView).first
+            )
+            let frame = try #require(strip.geometryRegistry?.frame(for: tabId.uuid, in: strip))
+            let pressPoint = NSPoint(x: frame.midX, y: frame.midY)
+            // A press on the laid-out tab is a tab press for the strip
+            // background, so minimal mode never turns it into a window drag.
+            #expect(strip.containsBonsplitTabItemHit(localPoint: pressPoint))
+
+            var armedTabId: UUID?
+            strip.onBeginTabDrag = { armed, _, _, _, _ in
+                armedTabId = armed
+                return true
+            }
+            let windowPoint = strip.convert(pressPoint, to: nil)
+            let mouseDown = try Self.mouseEvent(.leftMouseDown, window: window, at: windowPoint)
+            let mouseDragged = try Self.mouseEvent(
+                .leftMouseDragged,
+                window: window,
+                at: NSPoint(x: windowPoint.x + 12, y: windowPoint.y)
+            )
+            _ = strip.handleTabDragEvent(mouseDown)
+            _ = strip.handleTabDragEvent(mouseDragged)
+            #expect(armedTabId == tabId.uuid)
+        }
+    }
+
+    private static func settle(_ window: NSWindow, _ hostingView: NSView, passes: Int = 8) {
+        for _ in 0..<passes {
+            window.contentView?.layoutSubtreeIfNeeded()
+            hostingView.layoutSubtreeIfNeeded()
+            RunLoop.current.run(mode: .default, before: Date.now.addingTimeInterval(0.02))
+        }
+    }
+
+    private static func descendants<T: NSView>(ofType type: T.Type, in root: NSView) -> [T] {
+        var matches: [T] = []
+        if let match = root as? T {
+            matches.append(match)
+        }
+        for subview in root.subviews {
+            matches.append(contentsOf: descendants(ofType: type, in: subview))
+        }
+        return matches
+    }
+
+    private static func mouseEvent(
+        _ type: NSEvent.EventType,
+        window: NSWindow,
+        at windowPoint: NSPoint
+    ) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: type,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
     }
 }

--- a/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
+++ b/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+@testable import Bonsplit
+import CmuxWorkspaces
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Covers the open-from-explorer path behind cmux issue 12152: every explorer
+/// entrypoint (double-click, Enter, search result, context menu, pane-hosted
+/// explorer) converges on `Workspace.openFileSurfaces` with these arguments,
+/// and the resulting tab must be a live pane-transfer source that every drop
+/// destination resolves as the surface itself.
+@MainActor
+@Suite("File explorer opened tab drag source", .serialized)
+struct FileExplorerOpenedTabDragSourceTests {
+    @Test("A file opened from the explorer is a live surface for pane transfers")
+    func openedFileTabResolvesAsLiveSurface() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let fixture = try VaultPaneAppFixture()
+            defer { fixture.tearDown() }
+            let workspace = fixture.workspace
+            let fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-explorer-open-\(UUID().uuidString)")
+                .appendingPathExtension("yml")
+            try "services:\n  web:\n    image: nginx\n".write(to: fileURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+
+            let paneId = try #require(
+                workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first
+            )
+            let openedPanels = workspace.openFileSurfaces(
+                inPane: paneId,
+                filePaths: [fileURL.path],
+                focus: true,
+                reuseExisting: true,
+                duplicateWhenFocused: true
+            )
+            let panel = try #require(openedPanels.first as? FilePreviewPanel)
+            let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
+            let pane = try #require(workspace.bonsplitController.internalController.paneState(for: paneId))
+            let tab = try #require(pane.tabs.first { $0.id == tabId.uuid })
+            #expect(pane.selectedTabId == tabId.uuid)
+            #expect(tab.kind == SurfaceKind.filePreview.rawValue)
+
+            // The strip drags this tab as a live Bonsplit surface. No synthetic
+            // file-preview registration may shadow it, and every destination
+            // must accept the surface transfer.
+            let resolver = PaneTransferSourceResolver()
+            let transfer = PaneDragTransfer(
+                tabId: tabId.uuid,
+                sourcePaneId: paneId.id,
+                sourceProcessId: Int32(ProcessInfo.processInfo.processIdentifier)
+            )
+            #expect(resolver.registeredSource(id: tabId.uuid) == nil)
+            #expect(resolver.source(for: transfer) == .surface)
+            #expect(workspace.canPerformPortalPaneDrop(transfer, source: .surface))
+
+            // The capability Bonsplit publishes when the drag session begins
+            // resolves back to this tab through cmux's shared registry.
+            let registry = fixture.appDelegate.tabDragTransferRegistry
+            let registration = try #require(registry.register(TabDragTransfer(
+                tab: Tab(from: tab),
+                sourcePaneId: paneId
+            )))
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name(
+                "cmux.test.explorer-open-drag.\(UUID().uuidString)"
+            ))
+            pasteboard.clearContents()
+            defer {
+                registry.end(registration)
+                pasteboard.clearContents()
+            }
+            #expect(registration.write(to: pasteboard))
+            let resolved = try #require(resolver.transfer(from: pasteboard))
+            #expect(resolved.tabId == tabId.uuid)
+            #expect(resolver.source(for: resolved) == .surface)
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/12152

Bonsplit PR: https://github.com/manaflow-ai/bonsplit/pull/235 (branch `issue-12152-file-explorer-tab-drag`, pointer `cb9bcfa`). Expected-red proof of its first commit: https://github.com/manaflow-ai/bonsplit/pull/236 (closed after the run recorded the red state).

## Root cause on `main` (verified)

A pane-tab drag is armed by an AppKit local event monitor in Bonsplit's `TabBarBackgroundNSView.trackTabMouseDown`. That gate judged a press against two SwiftUI-pushed snapshots instead of the live strip: a copied `tabIds` list handed over in `updateNSView`, and the per-strip `TabBarItemGeometryRegistry`, which also vetoed any tab item with an ancestor at alpha 0. Both trail the pane model by a SwiftUI commit. A press that outruns them is silently dropped, and in minimal mode the strip background turns that same press into a window drag because `containsBonsplitTabItemHit` consulted the same snapshot. The file-open path is where this bites: `Workspace.newFilePreviewSurface` creates, focuses, selects and re-titles the tab in one burst, right when the user reaches for it.

Measured on macOS 26.5.1 with the real `BonsplitView` strip driven through the exact `newFilePreviewSurface` ordering: immediately after `createTab` + `selectTab` the strip reports `tabIds=3 containsNew=false frames=3` for the new tab (nothing can arm it); after the commit it reports `tabIds=4 frames=4` and the press arms.

### What did and did not reproduce

- Reproduced: the press gate rejecting a tab the pane model already owns while its geometry snapshot lags (deterministic, red on `main` in `TabBarDragEventRoutingTests`).
- Not reproduced: a persistent steady-state failure of a committed, visible file-preview tab. On macOS 26.5.1 the AppKit hit chain over a tab is SwiftUI's `HostingScrollView` container (no `NSControl`, no editable text view, so `isNativeInteraction` does not veto), making the editable `SavingTextView` first responder does not affect arming, the drop side resolves an explorer-opened tab as a live surface (`PaneTransferSourceResolver.source == .surface`, no `FilePreviewDragRegistry` entry shadows it), and `TabDragTransferRegistry.register` cannot fail for this kind. Hypotheses H2 (drop-side rejection), H3 (native-interaction veto) and H5 (text-drop routing) from the issue are ruled out by these checks; H4 (stale explorer drag state) does not reach the arming path on `main` since #10804.
- 0.64.22 vs `main`: 0.64.22 armed tab drags with SwiftUI `.onDrag` (Bonsplit `e3837a7`, `TabBarView.swift:1300`), which was replaced by the AppKit monitor in Bonsplit #207 and follow-ups. The symptom Austin saw on 0.64.22 therefore came from a different mechanism than the one fixed here; this PR fixes the class that exists on `main`.

## Fix (Bonsplit #235)

- The strip background holds the `PaneState` it renders and resolves tab membership from it at press time.
- Tab frames resolve from the geometry registry first and, when it lags, from the tab item region views AppKit has laid out in the same window (`BonsplitTabItemHitRegionRegistry.laidOutFrames`). A registry miss can no longer drop a press on a visible tab, in fixed, fill and full-width tab modes.
- The strip background's tab-press answer (minimal-mode window-drag decision, cmux window-move suppression, drag-zone deferral) uses the same resolution, so the press is never misrouted to a window drag.
- DEBUG builds log `tab.drag.arm.miss reason=… tabs= registered= laidOut=` for any press inside the strip that does not arm, `tab.drag.arm registryLag` when the laid-out fallback answered, and `tab.drag.begin.miss` when the native session could not start. They reach the cmux debug log, so the next occurrence on a dogfood build names its cause.

No cmux `Sources/` change is needed: cmux's window-move suppression and drag-handle deferral already consult the laid-out region views.

## Trade-offs

- The laid-out fallback iterates the process-wide tab item registry on a press or tab-press query (a few dozen views); it runs only when the per-strip registry has not answered, which in full-width tab mode is every press. Cost is microseconds, on pointer-down paths only.
- The `tabIds` snapshot is gone from `TabBarBackgroundNSView`; tests now hand the strip a `PaneState`, which the strip holds weakly exactly like production.
- The trailing empty-chrome drag zone still receives a pushed `tabIds` copy, but it defers to the laid-out region views first, so it cannot claim a laid-out tab.

## Tests

- Bonsplit commit 1 (red on `main`): `laidOutTabStillArmsWhenGeometryRegistryLagsBehindTheStrip`, `pressOverLaidOutTabIsATabPressWhenGeometryRegistryLagsBehindTheStrip`; plus `TabBarFilePreviewTabDragArmingTests` which drives the real strip through the cmux file-open ordering with an editable text view as first responder (green before and after; pins the verified behavior).
- Bonsplit commit 2: all Swift Testing suites pass on macOS 26.5.1 / Xcode 26.3 (`cmux13s-mac-mini` via `maclease`). The XCTest pasteboard cases fail identically on the untouched base commit in that SSH session (no pasteboard server) and run on Bonsplit CI's GUI runner.
- cmux: `cmuxTests/FileExplorerOpenedTabDragSourceTests` has two tests. `openedFileTabResolvesAsLiveSurface` opens a `.yml` through `Workspace.openFileSurfaces` with the explorer's exact arguments and asserts the tab is selected, is a `filePreview` surface, resolves as a live surface for pane transfers with no synthetic registration shadowing it, is accepted by `canPerformPortalPaneDrop`, and that the capability Bonsplit publishes at drag start resolves back to it through the shared registry. `openedFileTabArmsOnFirstLaidOutPress` (added for CodeRabbit's finding) hosts the workspace's real `BonsplitView`, opens the file the same way, and presses the laid-out tab through the strip's event path, asserting it counts as a tab press and arms a native drag for exactly that tab. Both pass on `main` (the red→green proof lives in the Bonsplit PR); the file is wired into `project.pbxproj` and `lint-pbxproj-test-wiring.sh` passes. A live-pointer XCUITest through cmux's window portals is not cleanly testable in the app-host lane, so window-level routing is not covered here.
- Hosted lanes: `test-e2e.yml` for `cmuxTests/FileExplorerOpenedTabDragSourceTests` and a full `ci.yml` dispatch on the branch head (links in the closeout comment).
- Dogfood build: `reload-cloud.sh --tag issue-12152-file-explorer-tab-drag --launch` was run at Austin's request with `CMUX_DEV_BACKEND_MODE=off` because the remote dev-backend host `cmux-dev-backend-1` did not resolve; the change under test needs no web backend. The first install attempt failed because this Mac's data volume was full (170 MiB free); the sanctioned `cleanup-dev-builds` tool reclaimed one idle tagged build and the install was retried once space returned.

## Localization audit

No user-facing strings changed. The only new strings are DEBUG-only debug-log lines in Bonsplit.

## Checklist

- [x] Failing regression-test commit is separate from the fix commit (Bonsplit #235).
- [x] No Swift warning budget change; no `Sources/` change in cmux.
- [ ] Dogfood by Austin, then merge on explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGgpc86Qe4AMMsUrtso2Tu
