### PR TITLE
Let only a control under the pointer veto a pane tab drag; hit-test window points in the right coordinate space (#12152 follow-up)

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -957,8 +957,7 @@ func shouldSuppressWindowMoveForFolderDrag(window: NSWindow, event: NSEvent) -> 
         return false
     }
 
-    let contentPoint = contentView.convert(event.locationInWindow, from: nil)
-    let hitView = contentView.hitTest(contentPoint)
+    let hitView = contentView.cmuxHitTest(windowPoint: event.locationInWindow)
     return shouldSuppressWindowMoveForFolderDrag(hitView: hitView)
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -19933,8 +19933,7 @@ private extension NSWindow {
         guard let contentView = window.contentView else {
             return nil
         }
-        let pointInContent = contentView.convert(event.locationInWindow, from: nil)
-        return contentView.hitTest(pointInContent)
+        return contentView.cmuxHitTest(windowPoint: event.locationInWindow)
     }
 
     private static func cmuxTopHitViewForEvent(in window: NSWindow, event: NSEvent) -> NSView? {

--- a/Sources/Canvas/CanvasHostedPanelPresentation.swift
+++ b/Sources/Canvas/CanvasHostedPanelPresentation.swift
@@ -41,8 +41,7 @@ final class CanvasHostedPanelPresentation {
               let window = owner.window,
               event.window === window,
               let contentView = window.contentView else { return false }
-        let point = contentView.convert(event.locationInWindow, from: nil)
-        guard let hitView = contentView.hitTest(point) else { return false }
+        guard let hitView = contentView.cmuxHitTest(windowPoint: event.locationInWindow) else { return false }
         return hitView === owner || hitView.isDescendant(of: owner)
     }
 }

--- a/Sources/DetachedFolderDragIcon.swift
+++ b/Sources/DetachedFolderDragIcon.swift
@@ -117,7 +117,9 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        guard bounds.contains(point) else { return nil }
+        // `point` is in the superview's coordinate space (AppKit contract), so
+        // the icon's own frame, not its bounds, decides whether it was hit.
+        guard frame.contains(point) else { return nil }
         let hit = super.hitTest(point)
         #if DEBUG
         let hitDesc = hit.map { String(describing: type(of: $0)) } ?? "nil"

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -238,8 +238,7 @@ final class FileDropOverlayView: NSView {
             // dragged/up event even though its down was delivered underneath.
             // Recover the normal target in that case instead of dropping the
             // event and leaving the underlying selection gesture incomplete.
-            let point = contentView.convert(event.locationInWindow, from: nil)
-            target = contentView.hitTest(point)
+            target = contentView.cmuxHitTest(windowPoint: event.locationInWindow)
         }
 
         guard let target, target !== self else {

--- a/Sources/NSView+WindowPointHitTest.swift
+++ b/Sources/NSView+WindowPointHitTest.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+extension NSView {
+    /// Hit-tests a window-space point through this view the way AppKit does.
+    ///
+    /// `NSView.hitTest(_:)` takes a point in the receiver's *superview*
+    /// coordinate space. The main window's content view is a flipped SwiftUI
+    /// host while the window's frame view is not, so a point converted into
+    /// the content view itself and handed to `hitTest` is mirrored vertically:
+    /// a press near the top of the window is answered by whatever sits near
+    /// the bottom (cmux issue 12152, where the file editor answered for the
+    /// pane tab strip). Every window-space hit-test in the app goes through
+    /// this helper so the coordinate space is decided once.
+    func cmuxHitTest(windowPoint: NSPoint) -> NSView? {
+        let reference = superview ?? self
+        return hitTest(reference.convert(windowPoint, from: nil))
+    }
+}

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4459,8 +4459,7 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             guard let contentView = window.contentView else {
                 return nil
             }
-            let pointInContent = contentView.convert(event.locationInWindow, from: nil)
-            return contentView.hitTest(pointInContent)
+            return contentView.cmuxHitTest(windowPoint: event.locationInWindow)
         }
 
         private func pointerDownBlurIntent(window: NSWindow?) -> Bool {

--- a/Sources/Sidebar/SidebarDividerTrackingView.swift
+++ b/Sources/Sidebar/SidebarDividerTrackingView.swift
@@ -49,8 +49,7 @@ final class SidebarDividerTrackingView: NSView {
         NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { event in
             if let contentView = event.window?.contentView {
                 let location = event.locationInWindow
-                let point = contentView.convert(location, from: nil)
-                let hit = contentView.hitTest(point)
+                let hit = contentView.cmuxHitTest(windowPoint: location)
                 // macOS 26 can deliver events whose window location is
                 // non-finite; `Int(_:)` traps on NaN/infinity and takes the
                 // whole app down from this log line. `%.0f` formats any

--- a/Sources/Sidebar/SidebarWorkspaceDragSourceMonitor.swift
+++ b/Sources/Sidebar/SidebarWorkspaceDragSourceMonitor.swift
@@ -185,9 +185,8 @@ final class SidebarWorkspaceDragSourceMonitor {
         at windowPoint: NSPoint,
         in window: NSWindow
     ) -> Bool {
-        guard let contentView = window.contentView else { return false }
-        let contentPoint = contentView.convert(windowPoint, from: nil)
-        guard var candidate = contentView.hitTest(contentPoint) else { return false }
+        guard let contentView = window.contentView,
+              var candidate = contentView.cmuxHitTest(windowPoint: windowPoint) else { return false }
         while true {
             if candidate is NSTextView
                 || candidate is NSControl

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12797,11 +12797,17 @@ class TerminalController {
     /// shadowing pane-local Bonsplit drop targets.
     private func dragHitChain(_ args: String) -> String {
         let parts = args.split(separator: " ").map(String.init)
-        guard parts.count == 2,
+        guard parts.count == 2 || parts.count == 3,
               let nx = Double(parts[0]), let ny = Double(parts[1]),
-              (0...1).contains(nx), (0...1).contains(ny) else {
-            return "ERROR: Usage: drag_hit_chain <x 0-1> <y 0-1>"
+              (0...1).contains(nx), (0...1).contains(ny),
+              parts.count == 2 || parts[2] == "content" || parts[2] == "theme" else {
+            return "ERROR: Usage: drag_hit_chain <x 0-1> <y 0-1> [theme|content]"
         }
+        // `content` reproduces the traversal Bonsplit's tab-drag veto and the
+        // sidebar-divider diagnostic use (`contentView.hitTest` with a point
+        // converted into the content view), and reports the geometry that
+        // decides whether that traversal agrees with the theme-frame one.
+        let traversesContentView = parts.count == 3 && parts[2] == "content"
 
         var result = "ERROR: No window"
         v2MainSync {
@@ -12823,8 +12829,19 @@ class TerminalController {
             if let overlay { overlay.isHidden = true }
             defer { overlay?.isHidden = false }
 
-            guard let hit = themeFrame.hitTest(pointInTheme) else {
-                result = "none"
+            let geometry = "geometry contentFrame=\(NSStringFromRect(contentView.frame)) " +
+                "contentBounds=\(NSStringFromRect(contentView.bounds)) " +
+                "contentFlipped=\(contentView.isFlipped) themeFlipped=\(themeFrame.isFlipped) " +
+                "currentEvent=\(NSApp.currentEvent.map { String(describing: $0.type) } ?? "nil")"
+            let resolvedHit: NSView?
+            if traversesContentView {
+                let windowPoint = themeFrame.convert(pointInTheme, to: nil)
+                resolvedHit = contentView.hitTest(contentView.convert(windowPoint, from: nil))
+            } else {
+                resolvedHit = themeFrame.hitTest(pointInTheme)
+            }
+            guard let hit = resolvedHit else {
+                result = "none " + geometry
                 return
             }
 
@@ -12836,7 +12853,7 @@ class TerminalController {
                 current = view.superview
                 depth += 1
             }
-            result = chain.joined(separator: "->")
+            result = chain.joined(separator: "->") + " " + geometry
         }
         return result
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -974,7 +974,6 @@
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
 		A11C00010000000000000001 /* CmuxHostedSystemSymbolImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00010000000000000002 /* CmuxHostedSystemSymbolImage.swift */; };
 		A11C00040000000000000001 /* CmuxHostedSystemSymbolImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */; };
-		A11C00050000000000000001 /* StackAccountAvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00050000000000000002 /* StackAccountAvatarViewTests.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		1A0B0C0D0E0F101112132013 /* CmuxIrohTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */; };
 		1A0B0C0D0E0F101112132014 /* CmuxIrohTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */; };
@@ -1923,6 +1922,7 @@
 		D77690000000000000000007 /* NotificationsPopoverResizeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77690000000000000000008 /* NotificationsPopoverResizeHandle.swift */; };
 		D77690000000000000000009 /* NotificationsPopoverResizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7769000000000000000000A /* NotificationsPopoverResizeView.swift */; };
 		C01E00080000000000000001 /* NSTextView+FilePreviewTabWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01E00080000000000000002 /* NSTextView+FilePreviewTabWidth.swift */; };
+		25C58D231850D0F414A62F19 /* NSView+WindowPointHitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFC842F5002FB86145AEF1E /* NSView+WindowPointHitTest.swift */; };
 		D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */; };
 		645645000000000000000002 /* NumberedShortcutSwapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645645000000000000000001 /* NumberedShortcutSwapTests.swift */; };
 		0A1107110000000000000001 /* OllamaAgentDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000002 /* OllamaAgentDetectionTests.swift */; };
@@ -2636,6 +2636,7 @@
 		A11C00020000000000000001 /* StackAccountAvatarImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00020000000000000002 /* StackAccountAvatarImageLoader.swift */; };
 		A11C00030000000000000001 /* StackAccountAvatarImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */; };
 		A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C017000000000000000006 /* StackAccountAvatarView.swift */; };
+		A11C00050000000000000001 /* StackAccountAvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C00050000000000000002 /* StackAccountAvatarViewTests.swift */; };
 		F20F85FC5900550685FA33AD /* StackAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A8BD195031FC4B82B4354297 /* StackAuth */; };
 		C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70500000000000000001 /* start-cmux-profiling */; };
 		D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B71010000000000000002 /* StartupBreadcrumbLog.swift */; };
@@ -3128,6 +3129,7 @@
 		D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */; };
 		313585583035A1E685010A97 /* WindowKeyDownReplayGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B8CFAF8FCA4231C702D16A /* WindowKeyDownReplayGuard.swift */; };
 		8770D0F2D2BB45359D6BE5E3 /* WindowKeyDownReplayGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79482F1ECA54E98BE5C8953 /* WindowKeyDownReplayGuardTests.swift */; };
+		7329AC8BD30AD03864D1E4EC /* WindowPointHitTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1015067C3423D09C2453BB /* WindowPointHitTestTests.swift */; };
 		6042C0056042C0056042C005 /* WindowScopedShortcutHintModifierMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042D0056042D0056042D005 /* WindowScopedShortcutHintModifierMonitor.swift */; };
 		9065A0090000000000000001 /* WindowScreenshotBackendAttempt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9065A0090000000000000002 /* WindowScreenshotBackendAttempt.swift */; };
 		9065A0050000000000000001 /* WindowScreenshotCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9065A0050000000000000002 /* WindowScreenshotCaptureCoordinator.swift */; };
@@ -4366,7 +4368,6 @@
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
 		A11C00010000000000000002 /* CmuxHostedSystemSymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImage.swift; sourceTree = "<group>"; };
 		A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImageTests.swift; sourceTree = "<group>"; };
-		A11C00050000000000000002 /* StackAccountAvatarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarViewTests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
@@ -5257,6 +5258,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D77690000000000000000008 /* NotificationsPopoverResizeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/NotificationsPopoverResizeHandle.swift; sourceTree = "<group>"; };
 		D7769000000000000000000A /* NotificationsPopoverResizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/NotificationsPopoverResizeView.swift; sourceTree = "<group>"; };
 		C01E00080000000000000002 /* NSTextView+FilePreviewTabWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/NSTextView+FilePreviewTabWidth.swift"; sourceTree = "<group>"; };
+		2EFC842F5002FB86145AEF1E /* NSView+WindowPointHitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+WindowPointHitTest.swift"; sourceTree = "<group>"; };
 		D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/NSWindow+CmuxPeerWindow.swift"; sourceTree = "<group>"; };
 		645645000000000000000001 /* NumberedShortcutSwapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberedShortcutSwapTests.swift; sourceTree = "<group>"; };
 		0A1107110000000000000002 /* OllamaAgentDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaAgentDetectionTests.swift; sourceTree = "<group>"; };
@@ -5958,6 +5960,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A11C00020000000000000002 /* StackAccountAvatarImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarImageLoader.swift; sourceTree = "<group>"; };
 		A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarImageLoaderTests.swift; sourceTree = "<group>"; };
 		A5C017000000000000000006 /* StackAccountAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarView.swift; sourceTree = "<group>"; };
+		A11C00050000000000000002 /* StackAccountAvatarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarViewTests.swift; sourceTree = "<group>"; };
 		C0DE70500000000000000001 /* start-cmux-profiling */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/start-cmux-profiling"; sourceTree = SOURCE_ROOT; };
 		D35B71010000000000000002 /* StartupBreadcrumbLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/StartupBreadcrumbLog.swift; sourceTree = "<group>"; };
 		C0DE70530000000000000001 /* submit-cmux-profile */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/submit-cmux-profile"; sourceTree = SOURCE_ROOT; };
@@ -6447,6 +6450,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInputRoutingContext.swift; sourceTree = "<group>"; };
 		81B8CFAF8FCA4231C702D16A /* WindowKeyDownReplayGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WindowKeyDownReplayGuard.swift; sourceTree = "<group>"; };
 		B79482F1ECA54E98BE5C8953 /* WindowKeyDownReplayGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowKeyDownReplayGuardTests.swift; sourceTree = "<group>"; };
+		8F1015067C3423D09C2453BB /* WindowPointHitTestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPointHitTestTests.swift; sourceTree = "<group>"; };
 		6042D0056042D0056042D005 /* WindowScopedShortcutHintModifierMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScopedShortcutHintModifierMonitor.swift; sourceTree = "<group>"; };
 		9065A0090000000000000002 /* WindowScreenshotBackendAttempt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotBackendAttempt.swift; sourceTree = "<group>"; };
 		9065A0050000000000000002 /* WindowScreenshotCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotCaptureCoordinator.swift; sourceTree = "<group>"; };
@@ -7340,6 +7344,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE35010000000000000002 /* SidebarScrim.swift */,
 				D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */,
 				D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */,
+				2EFC842F5002FB86145AEF1E /* NSView+WindowPointHitTest.swift */,
 				C0DE43000000000000000006 /* ContentView+AgentChatCommandPalette.swift */,
 				C0DEA7710000000000000002 /* ContentView+AuthCommandPalette.swift */,
 				C0DEA7710000000000000004 /* ContentView+ProCommandPalette.swift */,
@@ -9570,6 +9575,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					469200014692000146920002 /* VaultPaneDropRoutingTests.swift */,
 					469200064692000146920002 /* VaultPaneDropTestSupport.swift */,
 					469200044692000146920002 /* VaultPaneTransferLifecycleTests.swift */,
+					8F1015067C3423D09C2453BB /* WindowPointHitTestTests.swift */,
 					06880917B87678F2857EC8FB /* FileExplorerOpenedTabDragSourceTests.swift */,
 					469200054692000146920002 /* VaultNativeDragSourceTests.swift */,
 					D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */,
@@ -11864,6 +11870,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D77690000000000000000007 /* NotificationsPopoverResizeHandle.swift in Sources */,
 				D77690000000000000000009 /* NotificationsPopoverResizeView.swift in Sources */,
 				C01E00080000000000000001 /* NSTextView+FilePreviewTabWidth.swift in Sources */,
+				25C58D231850D0F414A62F19 /* NSView+WindowPointHitTest.swift in Sources */,
 				D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */,
 				C67540090000000000000001 /* OmnibarAddressButtonStyle.swift in Sources */,
 				A5001670 /* OneShotTerminalLauncherStore.swift in Sources */,
@@ -13391,7 +13398,6 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C54860040000000000000001 /* CmuxDurableDeepLinkRestoreTests.swift in Sources */,
 				E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */,
 				A11C00040000000000000001 /* CmuxHostedSystemSymbolImageTests.swift in Sources */,
-				A11C00050000000000000001 /* StackAccountAvatarViewTests.swift in Sources */,
 				D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */,
 					D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */,
 					C54860030000000000000001 /* CmuxNavigationTargetResolverTests.swift in Sources */,
@@ -13828,6 +13834,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				EF70B7123200D1FB6F03DB26 /* SSHStartupManualReconnectTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
 				A11C00030000000000000001 /* StackAccountAvatarImageLoaderTests.swift in Sources */,
+				A11C00050000000000000001 /* StackAccountAvatarViewTests.swift in Sources */,
 				5873A6BE37C34CC1082864E2 /* SurfaceCatalogTests.swift in Sources */,
 				560A57B0605EC30E23A20456 /* SurfacePaneFactoryFocusTests.swift in Sources */,
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,
@@ -13930,6 +13937,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D6212D0C00000000000000D1 /* WindowDockLifecycleTests.swift in Sources */,
 				D6212D0C00000000000000D7 /* WindowDockRoutingSocketTests.swift in Sources */,
 				8770D0F2D2BB45359D6BE5E3 /* WindowKeyDownReplayGuardTests.swift in Sources */,
+				7329AC8BD30AD03864D1E4EC /* WindowPointHitTestTests.swift in Sources */,
 				606600010000000000000001 /* WindowTerminalHostViewTitlebarHitTests.swift in Sources */,
 				604500100000000000000003 /* WindowTitleTemplateTests.swift in Sources */,
 				7F0A0E04A8CADC84BB4F1DF7 /* WorkspaceActionDispatcherTests.swift in Sources */,

--- a/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
+++ b/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
@@ -11,6 +11,29 @@ import Testing
 @testable import cmux
 #endif
 
+/// Mirrors the file-preview panel body under a pane: an editable `NSTextView`
+/// that fills the pane, hosted through `NSViewRepresentable`. The real editor
+/// is vertically resizable inside its scroll view and fills the pane the same
+/// way, which is what puts it under the mirror image of a tab-strip press.
+private struct EditableTextEditorHost: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.string = "<!DOCTYPE html>\n<html lang=\"en\">\n"
+        textView.autoresizingMask = [.width, .height]
+        return textView
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {}
+}
+
+/// cmux's main window hosts SwiftUI directly, so its content view is flipped
+/// while the window frame is not.
+private final class FlippedHostContentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
 /// Covers the open-from-explorer path behind cmux issue 12152: every explorer
 /// entrypoint (double-click, Enter, search result, context menu, pane-hosted
 /// explorer) converges on `Workspace.openFileSurfaces` with these arguments,
@@ -143,6 +166,96 @@ struct FileExplorerOpenedTabDragSourceTests {
                 return true
             }
             let windowPoint = strip.convert(pressPoint, to: nil)
+            let mouseDown = try Self.mouseEvent(.leftMouseDown, window: window, at: windowPoint)
+            let mouseDragged = try Self.mouseEvent(
+                .leftMouseDragged,
+                window: window,
+                at: NSPoint(x: windowPoint.x + 12, y: windowPoint.y)
+            )
+            _ = strip.handleTabDragEvent(mouseDown)
+            _ = strip.handleTabDragEvent(mouseDragged)
+            #expect(armedTabId == tabId.uuid)
+        }
+    }
+
+    @Test("The explorer-opened tab still arms inside a flipped host window with its editor focused")
+    func openedFileTabArmsInsideAFlippedHostWindowWithTheEditorFocused() async throws {
+        // The exact shape of the report on issue 12152: the main window's
+        // content view is flipped, the just-opened file's editable text view
+        // sits below the strip and holds first responder, and the press lands
+        // on the new tab. A hit test that mirrors the press vertically answers
+        // the editor and vetoes the drag; the strip must still arm it.
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let fixture = try VaultPaneAppFixture()
+            defer { fixture.tearDown() }
+            let workspace = fixture.workspace
+            let controller = workspace.bonsplitController
+            controller.tabShortcutHintsEnabled = false
+            let fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-explorer-open-\(UUID().uuidString)")
+                .appendingPathExtension("html")
+            try "<!DOCTYPE html>\n<html lang=\"en\">\n".write(to: fileURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+
+            let hostingView = NSHostingView(
+                rootView: BonsplitView(controller: controller) { tab, _ in
+                    if tab.kind == SurfaceKind.filePreview.rawValue {
+                        EditableTextEditorHost()
+                    } else {
+                        Color.clear
+                    }
+                }
+            )
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 640, height: 360),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = FlippedHostContentView(frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+            window.contentView = contentView
+            hostingView.frame = contentView.bounds
+            hostingView.autoresizingMask = [.width, .height]
+            contentView.addSubview(hostingView)
+            window.makeKeyAndOrderFront(nil)
+            Self.settle(window, hostingView)
+
+            let paneId = try #require(controller.focusedPaneId ?? controller.allPaneIds.first)
+            let openedPanels = workspace.openFileSurfaces(
+                inPane: paneId,
+                filePaths: [fileURL.path],
+                focus: true,
+                reuseExisting: true,
+                duplicateWhenFocused: true
+            )
+            let panel = try #require(openedPanels.first as? FilePreviewPanel)
+            let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
+            Self.settle(window, hostingView)
+
+            let editor = try #require(Self.descendants(ofType: NSTextView.self, in: hostingView).first)
+            #expect(window.makeFirstResponder(editor))
+            Self.settle(window, hostingView, passes: 2)
+
+            let strip = try #require(
+                Self.descendants(ofType: TabBarDragAndHoverView.TabBarBackgroundNSView.self, in: hostingView).first
+            )
+            let frame = try #require(strip.geometryRegistry?.frame(for: tabId.uuid, in: strip))
+            let pressPoint = NSPoint(x: frame.midX, y: frame.midY)
+            let windowPoint = strip.convert(pressPoint, to: nil)
+            // Fixture shape check: the press converted into the flipped content
+            // view and handed to `hitTest` (the old traversal) lands on the
+            // editor, while the superview-space traversal does not.
+            let mirroredHit = contentView.hitTest(contentView.convert(windowPoint, from: nil))
+            #expect(mirroredHit === editor || mirroredHit?.isDescendant(of: editor) == true)
+            let hit = contentView.cmuxHitTest(windowPoint: windowPoint)
+            #expect(hit !== editor && hit?.isDescendant(of: editor) != true)
+
+            var armedTabId: UUID?
+            strip.onBeginTabDrag = { armed, _, _, _, _ in
+                armedTabId = armed
+                return true
+            }
             let mouseDown = try Self.mouseEvent(.leftMouseDown, window: window, at: windowPoint)
             let mouseDragged = try Self.mouseEvent(
                 .leftMouseDragged,

--- a/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
+++ b/cmuxTests/FileExplorerOpenedTabDragSourceTests.swift
@@ -137,7 +137,7 @@ struct FileExplorerOpenedTabDragSourceTests {
             hostingView.autoresizingMask = [.width, .height]
             contentView.addSubview(hostingView)
             window.makeKeyAndOrderFront(nil)
-            Self.settle(window, hostingView)
+            Self.settle(window, hostingView) { Self.strip(in: hostingView) != nil }
 
             let paneId = try #require(controller.focusedPaneId ?? controller.allPaneIds.first)
             let openedPanels = workspace.openFileSurfaces(
@@ -149,11 +149,11 @@ struct FileExplorerOpenedTabDragSourceTests {
             )
             let panel = try #require(openedPanels.first as? FilePreviewPanel)
             let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
-            Self.settle(window, hostingView)
+            Self.settle(window, hostingView) {
+                Self.strip(in: hostingView).flatMap { $0.geometryRegistry?.frame(for: tabId.uuid, in: $0) } != nil
+            }
 
-            let strip = try #require(
-                Self.descendants(ofType: TabBarDragAndHoverView.TabBarBackgroundNSView.self, in: hostingView).first
-            )
+            let strip = try #require(Self.strip(in: hostingView))
             let frame = try #require(strip.geometryRegistry?.frame(for: tabId.uuid, in: strip))
             let pressPoint = NSPoint(x: frame.midX, y: frame.midY)
             // A press on the laid-out tab is a tab press for the strip
@@ -219,7 +219,7 @@ struct FileExplorerOpenedTabDragSourceTests {
             hostingView.autoresizingMask = [.width, .height]
             contentView.addSubview(hostingView)
             window.makeKeyAndOrderFront(nil)
-            Self.settle(window, hostingView)
+            Self.settle(window, hostingView) { Self.strip(in: hostingView) != nil }
 
             let paneId = try #require(controller.focusedPaneId ?? controller.allPaneIds.first)
             let openedPanels = workspace.openFileSurfaces(
@@ -231,15 +231,16 @@ struct FileExplorerOpenedTabDragSourceTests {
             )
             let panel = try #require(openedPanels.first as? FilePreviewPanel)
             let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
-            Self.settle(window, hostingView)
+            Self.settle(window, hostingView) {
+                Self.descendants(ofType: NSTextView.self, in: hostingView).first?.window === window
+                    && Self.strip(in: hostingView).flatMap { $0.geometryRegistry?.frame(for: tabId.uuid, in: $0) } != nil
+            }
 
             let editor = try #require(Self.descendants(ofType: NSTextView.self, in: hostingView).first)
             #expect(window.makeFirstResponder(editor))
-            Self.settle(window, hostingView, passes: 2)
+            Self.settle(window, hostingView) { window.firstResponder === editor }
 
-            let strip = try #require(
-                Self.descendants(ofType: TabBarDragAndHoverView.TabBarBackgroundNSView.self, in: hostingView).first
-            )
+            let strip = try #require(Self.strip(in: hostingView))
             let frame = try #require(strip.geometryRegistry?.frame(for: tabId.uuid, in: strip))
             let pressPoint = NSPoint(x: frame.midX, y: frame.midY)
             let windowPoint = strip.convert(pressPoint, to: nil)
@@ -268,12 +269,29 @@ struct FileExplorerOpenedTabDragSourceTests {
         }
     }
 
-    private static func settle(_ window: NSWindow, _ hostingView: NSView, passes: Int = 8) {
-        for _ in 0..<passes {
+    /// Pumps layout and the run loop until `predicate` holds or the deadline
+    /// passes. Layout under a loaded CI host can lag a fixed number of run-loop
+    /// turns, so every lookup that depends on SwiftUI having committed waits on
+    /// the state it needs rather than on a duration.
+    @discardableResult
+    private static func settle(
+        _ window: NSWindow,
+        _ hostingView: NSView,
+        timeout: TimeInterval = 5,
+        until predicate: () -> Bool
+    ) -> Bool {
+        let deadline = Date.now.addingTimeInterval(timeout)
+        repeat {
             window.contentView?.layoutSubtreeIfNeeded()
             hostingView.layoutSubtreeIfNeeded()
             RunLoop.current.run(mode: .default, before: Date.now.addingTimeInterval(0.02))
-        }
+            if predicate() { return true }
+        } while Date.now < deadline
+        return false
+    }
+
+    private static func strip(in hostingView: NSView) -> TabBarDragAndHoverView.TabBarBackgroundNSView? {
+        descendants(ofType: TabBarDragAndHoverView.TabBarBackgroundNSView.self, in: hostingView).first
     }
 
     private static func descendants<T: NSView>(ofType type: T.Type, in root: NSView) -> [T] {

--- a/cmuxTests/WindowPointHitTestTests.swift
+++ b/cmuxTests/WindowPointHitTestTests.swift
@@ -1,0 +1,88 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// cmux's main window hosts SwiftUI directly, so its content view is flipped
+/// while the window frame is not. `NSView.hitTest(_:)` takes a point in the
+/// receiver's superview space; a window point converted into the flipped
+/// content view and handed to `hitTest` is mirrored vertically (issue 12152:
+/// the file editor at the bottom answered for presses on the tab strip at
+/// the top). Every window-space hit-test goes through `cmuxHitTest`.
+@MainActor
+@Suite("Window-point hit testing")
+struct WindowPointHitTestTests {
+    private final class FlippedContentView: NSView {
+        override var isFlipped: Bool { true }
+    }
+
+    @Test("A flipped content view answers the view under the window point, not its mirror image")
+    func flippedContentViewAnswersTheViewUnderThePoint() throws {
+        let window = try Self.makeWindow()
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        // Flipped coordinates: y grows downward, so `top` is at the top of the window.
+        let top = NSView(frame: NSRect(x: 0, y: 0, width: 240, height: 40))
+        let bottom = NSView(frame: NSRect(x: 0, y: 40, width: 240, height: 160))
+        contentView.addSubview(top)
+        contentView.addSubview(bottom)
+        window.makeKeyAndOrderFront(nil)
+
+        let topPoint = top.convert(NSPoint(x: 120, y: 20), to: nil)
+        let bottomPoint = bottom.convert(NSPoint(x: 120, y: 80), to: nil)
+        #expect(contentView.cmuxHitTest(windowPoint: topPoint) === top)
+        #expect(contentView.cmuxHitTest(windowPoint: bottomPoint) === bottom)
+    }
+
+    @Test("Folder-drag window-move suppression sees the folder icon under the press, not its mirror image")
+    func folderDragSuppressionUsesTheViewUnderThePress() throws {
+        let window = try Self.makeWindow()
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let folder = DraggableFolderNSView(directory: NSTemporaryDirectory())
+        folder.frame = NSRect(x: 20, y: 0, width: 40, height: 40)
+        let filler = NSView(frame: NSRect(x: 0, y: 40, width: 240, height: 160))
+        contentView.addSubview(folder)
+        contentView.addSubview(filler)
+        window.isMovable = true
+        window.makeKeyAndOrderFront(nil)
+
+        // Press in the icon's right half: its frame starts at x = 20, so a
+        // superview-space point there lies outside the icon's own bounds and
+        // exposes a hit test that compares the wrong coordinate space.
+        let folderPress = try Self.mouseDown(window: window, at: folder.convert(NSPoint(x: 30, y: 20), to: nil))
+        let fillerPress = try Self.mouseDown(window: window, at: filler.convert(NSPoint(x: 40, y: 80), to: nil))
+        #expect(shouldSuppressWindowMoveForFolderDrag(window: window, event: folderPress))
+        #expect(!shouldSuppressWindowMoveForFolderDrag(window: window, event: fillerPress))
+    }
+
+    private static func makeWindow() throws -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = FlippedContentView(frame: NSRect(x: 0, y: 0, width: 240, height: 200))
+        return window
+    }
+
+    private static func mouseDown(window: NSWindow, at windowPoint: NSPoint) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+}


### PR DESCRIPTION
Follow-up to #12164 for https://github.com/manaflow-ai/cmux/issues/12152. Austin dogfooded the #12164 build and still could not drag a tab opened from the file explorer (an `.html` file this time). The DEBUG build of #12164 logged why.

## Verified root cause

The tab strip's press gate vetoes a drag when the AppKit view under the press is an enabled native control or an editable text view (`isNativeInteraction`, so a tab's close button or rename field keeps its press). Two things were wrong with how it asked AppKit that question:

1. **Wrong coordinate space.** `NSView.hitTest(_:)` takes a point in the receiver's *superview* space. The veto converted the window point into the content view itself and handed that to `contentView.hitTest`. cmux's main window hosts SwiftUI directly, so its content view is flipped while the window's frame view is not; the converted point is mirrored vertically, and a press on the strip at the top of the window was hit-tested at the bottom of the window. That is where the just-opened file editor (an editable `NSTextView`) lives while its own tab is selected, so the veto fired only for the tab that had just been opened. With a terminal tab selected nothing editable sits there, so those tabs dragged fine. Measured on the live window through the extended debug probe: `contentFlipped=true themeFlipped=false`, theme-frame traversal → the tab strip, content-view traversal → `SavingTextView`. Debug log at the press: `tab.drag.arm.miss reason=nativeInteraction tabs=2 registered=2 laidOut=2`.
2. **No containment.** Even a correct hit-test answer was allowed to veto the press regardless of whether the pointer was inside that control.

The same mirrored traversal pattern (`contentView.hitTest(contentView.convert(p, from: nil))`) existed in seven more places in the app, plus a sibling in `DraggableFolderNSView.hitTest`, which compared a superview-space point against its own `bounds`.

## Fix

- Bonsplit (https://github.com/manaflow-ai/bonsplit/pull/237, pointer `d967a86`): `isNativeInteraction` hit-tests through the content view's superview space, and a control vetoes only when the press lies inside the control's own frame and that frame lies inside the strip. DEBUG builds log the full hit chain behind any veto (`tab.drag.arm.veto …`).
- cmux: `NSView.cmuxHitTest(windowPoint:)` (`Sources/NSView+WindowPointHitTest.swift`) decides the coordinate space once; every window-space hit-test now goes through it: the sidebar workspace drag veto, folder-drag window-move suppression, the file-drop overlay's forwarding target, the browser panel's pointer-blur target, the Canvas pointer-entry check, the first-responder guard fallback, and the sidebar-divider diagnostic. `DraggableFolderNSView.hitTest` checks its `frame`. Behavior is unchanged where the content view is not flipped or the icon sits at its host's origin (its `NSViewRepresentable` host, today).
- Debug probe: `drag_hit_chain <x> <y> [theme|content]` reports the geometry and can reproduce either traversal.

## Tests (red → green, separate commits)

- Bonsplit: `editableTextViewOutsideTheStripNeverVetoesATabPress` (host whose hit-test answers a view the pointer is not in) and `flippedHostContentViewStillArmsAndStillYieldsToTheTabsOwnControl` (cmux's window shape: flipped content view, editor at the bottom, close button inside the tab; the tab body arms, the close button still owns its press).
- cmux `cmuxTests/WindowPointHitTestTests`: a flipped content view answers the view under the point rather than its mirror image, and folder-drag window-move suppression sees the folder icon under the press when the icon's frame origin is nonzero (red on the old `bounds` check).
- cmux `cmuxTests/FileExplorerOpenedTabDragSourceTests`: the two tests from #12164 plus `openedFileTabArmsInsideAFlippedHostWindowWithTheEditorFocused`, which reproduces the report's exact window shape in the app host: a flipped host content view, the file opened through `Workspace.openFileSurfaces` with the explorer's arguments, an editable text view filling the pane and holding first responder, and a press on the new tab. The test first proves the fixture's geometry (the press converted into the flipped content view lands on the editor; the superview-space traversal does not), then asserts the strip arms the drag. It is green with the Bonsplit pointer in this PR; the red proof for the veto lives in Bonsplit #237.
- Bonsplit suites: 20 tests in 6 suites pass on macOS 26.5.1 / Xcode 26.3 (pasteboard-server suites are environmental over SSH, as in #235).

## CI

Required checks are green, and both dispatched hosted lanes pass on this head: `cmuxTests/WindowPointHitTestTests` and `cmuxTests/FileExplorerOpenedTabDragSourceTests` (3 tests). The dispatched full `ci.yml` has two red jobs that fail identically on `main`'s latest run (34221588627) and are fixed by #12168: `swift-package-tests` (`FakeTerminalEngine.swift: cannot find type 'UUID'`) and `tests-build-and-lag` (Swift warning budget: six new buckets in `AppDelegate+PaneMemoryGuardrail.swift`, `SessionIndexTableController.swift`, `CmuxTuiSnapshotParser.swift`, `SurfaceCatalogModel.swift`, and `TerminalController.swift` line 8781, none from this diff). This PR adds no warnings and no TSV changes. The app-host lane's shard 6 fails in `ClaudeHookLifecycleCleanupTests` (Claude hook `clear_notifications` routing), which this diff does not touch and which also fails on `main`'s latest run (shard 3 there, inside a wider app-host storm). The shards that contain this PR's suites pass.

## Trade-offs stated

- The containment guard in Bonsplit is redundant once the coordinate space is correct; it stays as defense in depth for hosts whose hit-test answers a view the pointer is not in, and costs one `contains` per press.
- `cmuxHitTest` uses `superview ?? self` as the reference; for a view with no superview it degrades to the receiver's own space, which is the only space available.
- The `drag_hit_chain … content` mode intentionally reproduces the wrong traversal for diagnosis; it is DEBUG-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGgpc86Qe4AMMsUrtso2Tu
