### PR TITLE
fix: open repo-relative terminal links from any subdirectory

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -57,6 +57,7 @@ public struct BrowserURLResolver: Sendable {
         if BrowserAppWebOrigin.isLoopbackHost(bareHost) {
             return URL(string: "http://\(trimmed)")
         }
+        guard hasNavigableHostLabels(bareHost) else { return nil }
 
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
             if scheme == "file", url.isFileURL, url.path.hasPrefix("/") {
@@ -210,6 +211,19 @@ public struct BrowserURLResolver: Sendable {
             components.query != nil ||
             components.fragment != nil
         return hasPathQueryOrFragment || components.port != nil
+    }
+
+    /// Whether a scheme-less host candidate could name a host at all.
+    ///
+    /// A dotted label sequence with an empty label (`.agents/x`, `a..b`,
+    /// `foo.`) is never a hostname; such text is a relative file path or a
+    /// sentence fragment, and promoting it to `https://` only produces a
+    /// navigation error. Bracketed IPv6 literals and the empty candidate
+    /// (which later branches already reject) are passed through unchanged.
+    private func hasNavigableHostLabels(_ bareHost: String) -> Bool {
+        guard !bareHost.isEmpty, !bareHost.hasPrefix("[") else { return true }
+        return !bareHost.split(separator: ".", omittingEmptySubsequences: false)
+            .contains(where: \.isEmpty)
     }
 
     private func bareHostCandidate(_ lowercasedInput: String) -> String {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -17,6 +17,23 @@ import Testing
         #expect(try #require(resolver.navigableURL(from: wrapped)).absoluteString == expected)
     }
 
+    @Test(arguments: [
+        ".agents/skills/fix-lint/references/set-state-in-render.md",
+        ".config/cmux/cmux.json",
+        "a..b/path",
+        "trailing./path",
+    ])
+    func doesNotPromoteTextWithAnEmptyHostLabelToHTTPS(input: String) {
+        #expect(resolver.navigableURL(from: input) == nil)
+    }
+
+    @Test func stillPromotesBareDomainWithPathToHTTPS() throws {
+        #expect(
+            try #require(resolver.navigableURL(from: "example.com/docs/guide.md")).absoluteString
+                == "https://example.com/docs/guide.md"
+        )
+    }
+
     @Test func preparesWrappedPasteBeforeSingleLineFieldRewritesIt() {
         let expected = "https://example.com/callback?scope=openid%20profile&state=abc123"
         let wrapped = expected.replacingOccurrences(of: "&state=", with: "&\tstate=")

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -31,8 +31,9 @@ public struct TerminalPathResolver: Sendable {
     ///
     /// Candidates are derived from the raw text (as-is, shell-unescaped,
     /// shell-unquoted, and trailing-punctuation-trimmed variants), expanded
-    /// for `~`, resolved against `cwd` when relative, standardized, and probed
-    /// in order. The first existing path wins.
+    /// for `~`, resolved against `cwd` and then each ancestor up to the
+    /// enclosing repository root when relative, standardized, and probed in
+    /// order. The first existing path wins.
     ///
     /// - Parameters:
     ///   - rawText: The raw text under the cursor or selection.
@@ -48,22 +49,51 @@ public struct TerminalPathResolver: Sendable {
             guard !normalizedToken.isEmpty else { continue }
 
             let expandedToken = (normalizedToken as NSString).expandingTildeInPath
-            let candidatePath: String
+            let candidatePaths: [String]
             if expandedToken.hasPrefix("/") {
-                candidatePath = expandedToken
+                candidatePaths = [expandedToken]
             } else {
                 guard let cwd, !cwd.isEmpty else { continue }
-                candidatePath = (cwd as NSString).appendingPathComponent(expandedToken)
+                candidatePaths = relativeResolutionBases(cwd: cwd).map { base in
+                    (base as NSString).appendingPathComponent(expandedToken)
+                }
             }
 
-            let standardizedPath = (candidatePath as NSString).standardizingPath
-            guard seenPaths.insert(standardizedPath).inserted else { continue }
-            if fileExists(standardizedPath) {
-                return standardizedPath
+            for candidatePath in candidatePaths {
+                let standardizedPath = (candidatePath as NSString).standardizingPath
+                guard seenPaths.insert(standardizedPath).inserted else { continue }
+                if fileExists(standardizedPath) {
+                    return standardizedPath
+                }
             }
         }
 
         return nil
+    }
+
+    /// Directories a relative candidate is resolved against, nearest first.
+    ///
+    /// Tools print paths relative to the repository root regardless of the
+    /// shell's working directory (a linter run from `frontend/` names
+    /// `.agents/skills/x.md`), so after `cwd` every ancestor up to and
+    /// including the repository root is probed. The walk stops at the first
+    /// directory that contains a `.git` entry (a directory in a primary
+    /// checkout, a file in a worktree); outside any repository only `cwd`
+    /// is used, so a stray `src/main.swift` never resolves against an
+    /// unrelated project higher up the tree.
+    private func relativeResolutionBases(cwd: String) -> [String] {
+        var bases: [String] = []
+        var directory = (cwd as NSString).standardizingPath
+        while true {
+            bases.append(directory)
+            if fileExists((directory as NSString).appendingPathComponent(".git")) {
+                return bases
+            }
+            let parent = (directory as NSString).deletingLastPathComponent
+            guard parent != directory, !parent.isEmpty else { break }
+            directory = parent
+        }
+        return [bases[0]]
     }
 
     /// Resolves the path token under a column of a visible terminal line.

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -239,3 +239,49 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 }
+
+@Suite struct TerminalRepoRelativePathResolutionTests {
+    private let repoRoot = "/Users/dev/project"
+    private let subdirectory = "/Users/dev/project/frontend"
+    private let repoRelativeFile = "/Users/dev/project/.agents/skills/fix-lint/references/set-state-in-render.md"
+
+    @Test func resolvesRepoRootRelativePathFromSubdirectory() {
+        let resolver = TerminalPathResolver(fileExists: existsIn([repoRelativeFile, "\(repoRoot)/.git"]))
+        #expect(
+            resolver.resolveQuicklookPath(
+                ".agents/skills/fix-lint/references/set-state-in-render.md",
+                cwd: subdirectory
+            ) == repoRelativeFile
+        )
+    }
+
+    @Test func resolvesRepoRootRelativePathFromWorktreeWhoseGitEntryIsAFile() {
+        // A worktree's `.git` is a file pointing at the primary checkout; the
+        // walk must stop there just as it does at a `.git` directory.
+        let worktreeRoot = "/Users/dev/project/.worktrees/feature"
+        let file = "\(worktreeRoot)/.agents/guide.md"
+        let resolver = TerminalPathResolver(fileExists: existsIn([file, "\(worktreeRoot)/.git", "\(repoRoot)/.git"]))
+        #expect(
+            resolver.resolveQuicklookPath(".agents/guide.md", cwd: "\(worktreeRoot)/frontend") == file
+        )
+    }
+
+    @Test func prefersTheNearestDirectoryWhenSeveralAncestorsMatch() {
+        let nearer = "\(subdirectory)/README.md"
+        let farther = "\(repoRoot)/README.md"
+        let resolver = TerminalPathResolver(fileExists: existsIn([nearer, farther, "\(repoRoot)/.git"]))
+        #expect(resolver.resolveQuicklookPath("README.md", cwd: subdirectory) == nearer)
+    }
+
+    @Test func doesNotLookAboveTheRepositoryRoot() {
+        let outside = "/Users/dev/README.md"
+        let resolver = TerminalPathResolver(fileExists: existsIn([outside, "\(repoRoot)/.git"]))
+        #expect(resolver.resolveQuicklookPath("README.md", cwd: subdirectory) == nil)
+    }
+
+    @Test func outsideAnyRepositoryOnlyTheWorkingDirectoryIsProbed() {
+        let parentFile = "\(repoRoot)/README.md"
+        let resolver = TerminalPathResolver(fileExists: existsIn([parentFile]))
+        #expect(resolver.resolveQuicklookPath("README.md", cwd: subdirectory) == nil)
+    }
+}


### PR DESCRIPTION
## Problem

Cmd-clicking a repository-relative path printed by a tool, e.g. `.agents/skills/fix-lint/references/guide.md` from ESLint run in `frontend/`, opens `https://.agents/skills/fix-lint/references/guide.md` instead of the file.

Two things go wrong in sequence:

1. `TerminalPathResolver` resolves a relative candidate only against the surface cwd. Tools print paths relative to the repository root regardless of where the shell is, so the probe misses.
2. The text then falls through to `BrowserURLResolver.navigableURL`, which sees a `.` and a `/` and promotes it to `https://`. `.agents` has an empty leading host label, so no hostname can ever match it; the result is always a navigation error.

## Fix

- **`TerminalPathResolver`**: a relative candidate is probed against the cwd and then each ancestor up to and including the enclosing repository root, the first directory holding a `.git` entry (a directory in a primary checkout, a file in a worktree). Nearest match wins. Outside any repository only the cwd is probed, exactly as before, so a stray `src/main.swift` never resolves against an unrelated project higher up the tree.
- **`BrowserURLResolver`**: scheme-less text whose bare-host candidate contains an empty label (`.agents/x`, `a..b`, `foo.`) is no longer promoted to `https://`. Loopback hosts and bracketed IPv6 literals take their existing paths.

## Tests

Two commits per the regression-test policy: the tests alone first (CI red), then the fix.

- `TerminalRepoRelativePathResolutionTests` (5): subdirectory resolution, worktree `.git` file, nearest-wins, no lookup above the repo root, cwd-only outside a repo. Run locally: 14 tests in the resolver suites pass with the fix; 2 fail on the test-only commit.
- `BrowserURLResolverTests` (+2, one parameterized over 4 inputs): empty-label rejection and a bare domain with a path still promoting to https.

Local caveat: the `CmuxBrowser` test target needs Xcode 26 and my machine only has the Swift 6.0 command line tools, so those two tests are unrun here; the library target compiles. Relying on CI for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bEGUDzDPewRTYhSvxPNZz

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791468174&installation_model_id=21920&pr_number=12170&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12170&signature=b390e626947028d8ed2f74ce06668bdbd09e06f68d53f580544a71d487cf8cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to terminal QuickLook/link path heuristics and omnibar scheme-less URL promotion, with explicit guards so non-repo cwd behavior stays the same.
> 
> **Overview**
> Fixes cmd-click on repository-relative paths (e.g. `.agents/skills/...`) when the shell cwd is a subdirectory: **terminal path resolution** now tries the cwd first, then each parent up to the enclosing git root (`.git` as directory or worktree file), with the nearest existing file winning and no search above the repo root.
> 
> When resolution still fails, **omnibar URL handling** no longer turns scheme-less strings with invalid host labels (leading dot, `..`, trailing dot) into `https://...` URLs; real hosts like `example.com/docs/...` are unchanged.
> 
> Adds regression tests for both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a474cbf8eb7cccbb6b6a2cde6e0e20bea99a5733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmd-clicking a repo-relative path printed by a tool so `.agents/skills/guide.md` opened from a subdirectory like `frontend/` now opens the file instead of `https://.agents/skills/guide.md`.

**Bug Fixes**
- `TerminalPathResolver` probes relative candidates against the cwd and each ancestor up to the enclosing repository root, nearest match wins.
- Outside a repository only the cwd is probed, so unrelated projects higher up the tree never capture a stray path.
- `BrowserURLResolver` no longer promotes scheme-less text with an empty host label (`.agents/x`, `a..b`, `foo.`) to `https://`; loopback hosts and bracketed IPv6 literals are unaffected.

<sup>Written for commit a474cbf8eb7cccbb6b6a2cde6e0e20bea99a5733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented malformed hostnames with empty labels from being treated as HTTPS URLs; they are now handled as search queries.
  * Improved Quick Look path resolution for relative paths within repositories, including nested directories and worktrees.
  * Ensured path lookup does not extend beyond the repository root or outside the current working directory when no repository is present.

* **Tests**
  * Added coverage for malformed hostnames, repository-relative paths, worktrees, ancestor selection, and repository boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->