### PR TITLE
Fix cross-user Iroh rate-limit starvation

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxRetryAfterPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxRetryAfterPolicy.swift
@@ -1,0 +1,115 @@
+public import Foundation
+
+/// Shared interpretation of HTTP `Retry-After` for every automatic client
+/// retry owner. A server directive is a minimum wait, never a replacement for
+/// a longer local backoff.
+public enum CmxRetryAfterPolicy {
+    public static let defaultRateLimitSeconds = 60
+
+    /// Parses either delta-seconds or an HTTP-date. Invalid, zero, and expired
+    /// directives return nil so callers can apply their documented fallback.
+    public static func seconds(
+        from value: String?,
+        now: Date = Date()
+    ) -> Int? {
+        guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        if let seconds = Int(raw), seconds > 0 {
+            return seconds
+        }
+        for format in [
+            "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'",
+            "EEEE',' dd-MMM-yy HH':'mm':'ss 'GMT'",
+            "EEE MMM d HH':'mm':'ss yyyy",
+        ] {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = format
+            if let deadline = formatter.date(from: raw) {
+                let remaining = Int(ceil(deadline.timeIntervalSince(now)))
+                return remaining > 0 ? remaining : nil
+            }
+        }
+        return nil
+    }
+
+    public static func seconds(
+        from response: HTTPURLResponse,
+        now: Date = Date(),
+        defaultSeconds: Int? = nil
+    ) -> Int? {
+        seconds(
+            from: response.value(forHTTPHeaderField: "Retry-After"),
+            now: now
+        ) ?? defaultSeconds.flatMap { $0 > 0 ? $0 : nil }
+    }
+
+    public static func delay(
+        localSeconds: TimeInterval,
+        retryAfterSeconds: Int?
+    ) -> TimeInterval {
+        max(localSeconds, TimeInterval(max(0, retryAfterSeconds ?? 0)))
+    }
+}
+
+/// Transport-neutral rate-limit error used when Foundation exposes an HTTP
+/// handshake response only after a WebSocket operation fails.
+public struct CmxRateLimitedError: CmxRetryAfterProviding, Equatable {
+    public let retryAfterSeconds: Int?
+
+    public init(retryAfterSeconds: Int?) {
+        self.retryAfterSeconds = retryAfterSeconds
+    }
+}
+
+/// One monotonic cooldown shared by all triggers that can reach the same
+/// endpoint. Concurrent callers join the deadline, and a later directive may
+/// extend but never shorten it.
+public actor CmxRetryAfterGate {
+    public typealias Sleep = @Sendable (TimeInterval) async throws -> Void
+
+    private let now: @Sendable () -> TimeInterval
+    private let sleep: Sleep
+    private var deadline: TimeInterval?
+
+    public init() {
+        now = { ProcessInfo.processInfo.systemUptime }
+        sleep = { try await Task<Never, Never>.sleep(for: .seconds($0)) }
+    }
+
+    init(
+        now: @escaping @Sendable () -> TimeInterval,
+        sleep: @escaping Sleep
+    ) {
+        self.now = now
+        self.sleep = sleep
+    }
+
+    public func extend(by seconds: Int) {
+        guard seconds > 0 else { return }
+        let candidate = now() + TimeInterval(seconds)
+        deadline = max(deadline ?? candidate, candidate)
+    }
+
+    public func remainingSeconds() -> Int? {
+        guard let deadline else { return nil }
+        let remaining = Int(ceil(deadline - now()))
+        if remaining <= 0 {
+            self.deadline = nil
+            return nil
+        }
+        return remaining
+    }
+
+    public func wait() async throws {
+        while let deadline {
+            let remaining = deadline - now()
+            guard remaining > 0 else {
+                self.deadline = nil
+                return
+            }
+            try await sleep(remaining)
+        }
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxRetryAfterPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxRetryAfterPolicy.swift
@@ -27,7 +27,7 @@ public enum CmxRetryAfterPolicy {
             formatter.timeZone = TimeZone(secondsFromGMT: 0)
             formatter.dateFormat = format
             if let deadline = formatter.date(from: raw) {
-                let remaining = Int(ceil(deadline.timeIntervalSince(now)))
+                let remaining = roundedUpSeconds(deadline.timeIntervalSince(now))
                 return remaining > 0 ? remaining : nil
             }
         }
@@ -51,6 +51,31 @@ public enum CmxRetryAfterPolicy {
     ) -> TimeInterval {
         max(localSeconds, TimeInterval(max(0, retryAfterSeconds ?? 0)))
     }
+
+    /// Floating point rounds Int.max up to 2^63. Saturate that conversion
+    /// without shortening ordinary server directives or trapping on restore.
+    public static func roundedUpSeconds(_ seconds: TimeInterval) -> Int {
+        guard seconds > 0 else { return 0 }
+        let rounded = seconds.rounded(.up)
+        return rounded >= Double(Int.max) ? Int.max : Int(rounded)
+    }
+
+    /// Sleep in representable chunks while preserving the entire requested
+    /// wait. Converting an arbitrary server delay to UInt64 nanoseconds traps.
+    public static func sleep(
+        seconds: TimeInterval,
+        using sleeper: @Sendable (TimeInterval) async throws -> Void = {
+            try await Task<Never, Never>.sleep(for: .seconds($0))
+        }
+    ) async throws {
+        var remaining = seconds
+        while remaining > 0 {
+            try Task.checkCancellation()
+            let chunk = min(remaining, 86_400)
+            try await sleeper(chunk)
+            remaining -= chunk
+        }
+    }
 }
 
 /// Transport-neutral rate-limit error used when Foundation exposes an HTTP
@@ -72,6 +97,8 @@ public actor CmxRetryAfterGate {
     private let now: @Sendable () -> TimeInterval
     private let sleep: Sleep
     private var deadline: TimeInterval?
+    private var sending = false
+    private var sendWaiters: [(UUID, CheckedContinuation<Void, any Error>)] = []
 
     public init() {
         now = { ProcessInfo.processInfo.systemUptime }
@@ -94,7 +121,7 @@ public actor CmxRetryAfterGate {
 
     public func remainingSeconds() -> Int? {
         guard let deadline else { return nil }
-        let remaining = Int(ceil(deadline - now()))
+        let remaining = CmxRetryAfterPolicy.roundedUpSeconds(deadline - now())
         if remaining <= 0 {
             self.deadline = nil
             return nil
@@ -109,7 +136,50 @@ public actor CmxRetryAfterGate {
                 self.deadline = nil
                 return
             }
-            try await sleep(remaining)
+            try Task.checkCancellation()
+            try await sleep(min(remaining, 86_400))
+        }
+    }
+
+    /// Serialize final network admission through response handling. A 429 is
+    /// recorded before the next queued request can pass its cooldown check.
+    public func perform<Value: Sendable>(
+        waitForCooldown: Bool = true,
+        _ operation: @Sendable () async throws -> Value
+    ) async throws -> Value {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            if sending {
+                try await withCheckedThrowingContinuation { continuation in
+                    sendWaiters.append((id, continuation))
+                }
+            } else {
+                sending = true
+            }
+        } onCancel: {
+            Task { await self.cancelSendWaiter(id) }
+        }
+        defer { releaseSend() }
+        try Task.checkCancellation()
+        if !waitForCooldown, let seconds = remainingSeconds() {
+            throw CmxRateLimitedError(retryAfterSeconds: seconds)
+        }
+        try await wait()
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    private func cancelSendWaiter(_ id: UUID) {
+        guard let index = sendWaiters.firstIndex(where: { $0.0 == id }) else { return }
+        sendWaiters.remove(at: index).1.resume(throwing: CancellationError())
+    }
+
+    private func releaseSend() {
+        if sendWaiters.isEmpty {
+            sending = false
+        } else {
+            sendWaiters.removeFirst().1.resume()
         }
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
@@ -66,12 +66,19 @@ import Testing
     }
 
     @Test func oversizedSleepUsesSafeChunksWithoutShorteningTheWait() async throws {
+        do {
+            try await CmxRetryAfterPolicy.sleep(seconds: 18_446_744_074) { chunk in
+                #expect(chunk == 86_400)
+                throw CancellationError()
+            }
+            Issue.record("Expected cancellation to stop the long sleep")
+        } catch is CancellationError {}
         let time = RetryAfterTestTime()
-        try await CmxRetryAfterPolicy.sleep(seconds: 18_446_744_074) { chunk in
+        try await CmxRetryAfterPolicy.sleep(seconds: 172_801) { chunk in
             #expect(chunk > 0 && chunk <= 86_400)
             time.advance(by: chunk)
         }
-        #expect(time.now == 18_446_744_074)
+        #expect(time.now == 172_801)
     }
 }
 

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import CMUXMobileCore
+
+@Suite struct CmxRetryAfterPolicyTests {
+    @Test func parsesDeltaSecondsAndHTTPDate() throws {
+        #expect(CmxRetryAfterPolicy.seconds(from: "45") == 45)
+        #expect(CmxRetryAfterPolicy.seconds(from: "0") == nil)
+        #expect(CmxRetryAfterPolicy.seconds(from: "invalid") == nil)
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'"
+        let header = formatter.string(from: now.addingTimeInterval(45))
+        #expect(CmxRetryAfterPolicy.seconds(from: header, now: now) == 45)
+    }
+
+    @Test func serverDirectiveFloorsLocalBackoff() {
+        #expect(CmxRetryAfterPolicy.delay(localSeconds: 2, retryAfterSeconds: 45) == 45)
+        #expect(CmxRetryAfterPolicy.delay(localSeconds: 60, retryAfterSeconds: 45) == 60)
+        #expect(CmxRetryAfterPolicy.delay(localSeconds: 2, retryAfterSeconds: nil) == 2)
+    }
+
+    @Test func cooldownExtendsAndNeverShortens() async {
+        let time = RetryAfterTestTime()
+        let gate = CmxRetryAfterGate(
+            now: { time.now },
+            sleep: { delay in time.advance(by: delay) }
+        )
+
+        await gate.extend(by: 45)
+        await gate.extend(by: 10)
+        #expect(await gate.remainingSeconds() == 45)
+        try? await gate.wait()
+        #expect(time.now == 45)
+        #expect(await gate.remainingSeconds() == nil)
+    }
+}
+
+private final class RetryAfterTestTime: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: TimeInterval = 0
+
+    var now: TimeInterval {
+        lock.withLock { value }
+    }
+
+    func advance(by delay: TimeInterval) {
+        lock.withLock { value += delay }
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxRetryAfterPolicyTests.swift
@@ -38,6 +38,41 @@ import Testing
         #expect(time.now == 45)
         #expect(await gate.remainingSeconds() == nil)
     }
+
+    @Test func oversizedCooldownDoesNotOverflowOrLoseTheDeadline() async {
+        let gate = CmxRetryAfterGate(now: { 0 }, sleep: { _ in })
+        await gate.extend(by: Int.max)
+        #expect(await gate.remainingSeconds() == Int.max)
+    }
+
+    @Test func sendsWaitForThePreviousResponseAndItsCooldown() async throws {
+        let time = RetryAfterTestTime()
+        let gate = CmxRetryAfterGate(now: { time.now }, sleep: { time.advance(by: $0) })
+        let started = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+        let first = Task {
+            try await gate.perform {
+                started.continuation.yield(())
+                for await _ in release.stream { break }
+                await gate.extend(by: 45)
+                return 1
+            }
+        }
+        for await _ in started.stream { break }
+        let second = Task { try await gate.perform { time.now } }
+        release.continuation.yield(())
+        #expect(try await first.value == 1)
+        #expect(try await second.value == 45)
+    }
+
+    @Test func oversizedSleepUsesSafeChunksWithoutShorteningTheWait() async throws {
+        let time = RetryAfterTestTime()
+        try await CmxRetryAfterPolicy.sleep(seconds: 18_446_744_074) { chunk in
+            #expect(chunk > 0 && chunk <= 86_400)
+            time.advance(by: chunk)
+        }
+        #expect(time.now == 18_446_744_074)
+    }
 }
 
 private final class RetryAfterTestTime: @unchecked Sendable {

--- a/Packages/Shared/CmuxAuthRuntime/Package.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../CMUXAuthCore"),
+        .package(path: "../CMUXMobileCore"),
         .package(path: "../../../vendor/stack-auth-swift-sdk-prerelease"),
     ],
     targets: [
@@ -23,6 +24,7 @@ let package = Package(
             name: "CmuxAuthRuntime",
             dependencies: [
                 "CMUXAuthCore",
+                "CMUXMobileCore",
                 .product(name: "StackAuth", package: "stack-auth-swift-sdk-prerelease"),
             ],
             swiftSettings: [

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Push/PushRegistrationService.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Push/PushRegistrationService.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 import OSLog
 
@@ -740,10 +741,13 @@ public actor PushRegistrationService: PushRegistering {
     ) {
         guard failure.isRecoverable, !remainingDelays.isEmpty else { return }
         let fallbackDelay = remainingDelays[0]
-        let delay = retryAfter ?? Self.jittered(
+        let localDelay = Self.jittered(
             fallbackDelay,
             multiplier: retryJitter(0.8...1.2)
         )
+        // Retry-After is a server-owned floor. It can extend, but never
+        // shorten, the client's local backoff.
+        let delay = max(localDelay, retryAfter ?? .zero)
         let laterDelays = Array(remainingDelays.dropFirst())
         retryTask = Task { [weak self, retrySleep] in
             do {
@@ -1371,10 +1375,10 @@ public actor PushRegistrationService: PushRegistering {
             let seconds = retryAfterSeconds(
                 response: response,
                 body: data
-            )
+            ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
             return .failure(
                 .rateLimited(retryAfterSeconds: seconds),
-                retryAfter: seconds.map(Duration.seconds)
+                retryAfter: .seconds(seconds)
             )
         case 500...599:
             return .failure(.serviceUnavailable, retryAfter: nil)
@@ -1387,14 +1391,17 @@ public actor PushRegistrationService: PushRegistering {
         response: HTTPURLResponse,
         body: Data
     ) -> Int? {
-        let headerDelay = response.value(forHTTPHeaderField: "Retry-After")
-            .flatMap(Int.init)
+        let headerDelay = CmxRetryAfterPolicy.seconds(
+            from: response.value(forHTTPHeaderField: "Retry-After")
+        )
         let bodyDelay = try? JSONDecoder().decode(
             RegistrationErrorResponse.self,
             from: body
         ).retryAfterSeconds
-        guard let raw = headerDelay ?? bodyDelay else { return nil }
-        return min(max(raw, 0), 600)
+        guard let raw = headerDelay ?? bodyDelay, raw > 0 else { return nil }
+        // The backend owns this floor. Local retry ladders may wait longer,
+        // but must never shorten a valid server directive.
+        return raw
     }
 
     private static func jittered(_ duration: Duration, multiplier: Double) -> Duration {

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/PushRegistrationServiceTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/PushRegistrationServiceTests.swift
@@ -582,11 +582,15 @@ actor RetryDelayRecorder {
         statusCode: Int
     ) async {
         await PushRegistrationURLProtocol.script.reset([
-            .response(statusCode, headers: ["Retry-After": "0"]),
+            .response(statusCode, headers: ["Retry-After": "45"]),
             .response(200),
         ])
+        let delays = RetryDelayRecorder()
         let (service, _) = makeScriptedService(
-            retryDelays: [.seconds(30)]
+            retryDelays: [.seconds(30)],
+            retrySleep: { duration in
+                await delays.record(duration)
+            }
         )
 
         await service.register(deviceToken: Data(repeating: 0xAB, count: 32))
@@ -597,6 +601,7 @@ actor RetryDelayRecorder {
         #expect(await wait(for: .registered, from: service))
 
         #expect(await service.snapshot.backendState == .registered)
+        #expect(await delays.values.first == .seconds(45))
         #expect(await PushRegistrationURLProtocol.script.requests.count == 2)
     }
 
@@ -604,12 +609,18 @@ actor RetryDelayRecorder {
         await PushRegistrationURLProtocol.script.reset([
             .response(
                 429,
-                headers: ["Retry-After": "0"],
-                json: #"{"error":"rate_limited","retryAfterSeconds":0}"#
+                headers: ["Retry-After": "45"],
+                json: #"{"error":"rate_limited","retryAfterSeconds":45}"#
             ),
             .response(200),
         ])
-        let (service, _) = makeScriptedService(retryDelays: [.seconds(30)])
+        let delays = RetryDelayRecorder()
+        let (service, _) = makeScriptedService(
+            retryDelays: [.seconds(30)],
+            retrySleep: { duration in
+                await delays.record(duration)
+            }
+        )
 
         await service.register(deviceToken: Data(repeating: 0xAB, count: 32))
         await service.setEnabled(true)
@@ -619,6 +630,7 @@ actor RetryDelayRecorder {
         )
         #expect(await wait(for: .registered, from: service))
         #expect(await service.snapshot.backendState == .registered)
+        #expect(await delays.values.first == .seconds(45))
         #expect(await PushRegistrationURLProtocol.script.requests.count == 2)
     }
 
@@ -642,7 +654,7 @@ actor RetryDelayRecorder {
         )
         #expect(await wait(for: .registered, from: service))
 
-        #expect(await delays.values.first == .seconds(30))
+        #expect(await delays.values.first == .seconds(60))
         #expect(await PushRegistrationURLProtocol.script.requests.count == 2)
     }
 
@@ -674,7 +686,13 @@ actor RetryDelayRecorder {
             .response(429, headers: ["Retry-After": "0"], json: body),
             .response(200),
         ])
-        let (service, _) = makeScriptedService(retryDelays: [.zero])
+        let delays = RetryDelayRecorder()
+        let (service, _) = makeScriptedService(
+            retryDelays: [.zero],
+            retrySleep: { duration in
+                await delays.record(duration)
+            }
+        )
 
         await service.register(deviceToken: Data(repeating: 0xAB, count: 32))
         await service.setEnabled(true)
@@ -684,6 +702,7 @@ actor RetryDelayRecorder {
         #expect(await wait(for: .registered, from: service))
 
         #expect(await service.snapshot.backendState == .registered)
+        #expect(await delays.values.first == .seconds(60))
         #expect(await PushRegistrationURLProtocol.script.requests.count == 2)
     }
 

--- a/Packages/Shared/CmuxClientConfig/Package.swift
+++ b/Packages/Shared/CmuxClientConfig/Package.swift
@@ -14,9 +14,13 @@ let package = Package(
             targets: ["CmuxClientConfig"]
         ),
     ],
+    dependencies: [
+        .package(path: "../CMUXMobileCore"),
+    ],
     targets: [
         .target(
             name: "CmuxClientConfig",
+            dependencies: ["CMUXMobileCore"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigError.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigError.swift
@@ -1,9 +1,18 @@
+public import CMUXMobileCore
+
 /// Errors produced by the HTTP client-config loader before response decoding.
-public enum ClientConfigError: Error, Sendable, Equatable {
+public enum ClientConfigError: CmxRetryAfterProviding, Equatable, Sendable {
     /// The configured API base URL could not form a `/api/client-config` URL.
     case invalidBaseURL
     /// The transport returned a non-HTTP response.
     case invalidResponse
     /// The web route returned a non-2xx status code.
     case httpStatus(Int)
+    /// The server owns the earliest time another configuration fetch may run.
+    case rateLimited(retryAfterSeconds: Int)
+
+    public var retryAfterSeconds: Int? {
+        guard case .rateLimited(let seconds) = self else { return nil }
+        return seconds
+    }
 }

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// A URLSession-backed loader for the cmux `/api/client-config` route.
@@ -6,6 +7,7 @@ public struct HTTPClientConfigLoader: ClientConfigLoading {
     private let session: URLSession
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
+    private let retryAfterGate = CmxRetryAfterGate()
 
     /// Creates an HTTP loader.
     ///
@@ -28,6 +30,7 @@ public struct HTTPClientConfigLoader: ClientConfigLoading {
 
     /// POSTs the request to `/api/client-config` and decodes the typed response.
     public func load(_ request: ClientConfigRequest) async throws -> ClientConfig {
+        try await retryAfterGate.wait()
         guard let url = URL(string: apiBaseURL + "/api/client-config") else {
             throw ClientConfigError.invalidBaseURL
         }
@@ -41,6 +44,14 @@ public struct HTTPClientConfigLoader: ClientConfigLoading {
         let (data, response) = try await session.data(for: urlRequest)
         guard let http = response as? HTTPURLResponse else {
             throw ClientConfigError.invalidResponse
+        }
+        if http.statusCode == 429 {
+            let seconds = CmxRetryAfterPolicy.seconds(
+                from: http,
+                defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+            ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+            await retryAfterGate.extend(by: seconds)
+            throw ClientConfigError.rateLimited(retryAfterSeconds: seconds)
         }
         guard (200...299).contains(http.statusCode) else {
             throw ClientConfigError.httpStatus(http.statusCode)

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
@@ -105,6 +105,7 @@ import Testing
 
     @Test func httpLoaderPostsToClientConfigRoute() async throws {
         RecordingClientConfigURLProtocol.recorder.reset()
+        RecordingClientConfigURLProtocol.response = .success
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [RecordingClientConfigURLProtocol.self]
         let loader = HTTPClientConfigLoader(
@@ -120,5 +121,21 @@ import Testing
         #expect(request?.httpMethod == "POST")
         #expect(request?.value(forHTTPHeaderField: "Content-Type") == "application/json")
         #expect(request?.value(forHTTPHeaderField: "Accept") == "application/json")
+    }
+
+    @Test func httpLoaderSurfacesRetryAfter() async throws {
+        RecordingClientConfigURLProtocol.recorder.reset()
+        RecordingClientConfigURLProtocol.response = .rateLimited(seconds: 45)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RecordingClientConfigURLProtocol.self]
+        let loader = HTTPClientConfigLoader(
+            apiBaseURL: "https://cmux.test",
+            session: URLSession(configuration: configuration)
+        )
+
+        await #expect(throws: ClientConfigError.rateLimited(retryAfterSeconds: 45)) {
+            _ = try await loader.load(ClientConfigRequest(distinctId: "user-1"))
+        }
+        #expect(RecordingClientConfigURLProtocol.recorder.requests.count == 1)
     }
 }

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/RecordingClientConfigURLProtocol.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/RecordingClientConfigURLProtocol.swift
@@ -1,13 +1,35 @@
 import Foundation
 
 final class RecordingClientConfigURLProtocol: URLProtocol, @unchecked Sendable {
+    enum StubResponse: Sendable {
+        case success
+        case rateLimited(seconds: Int)
+    }
+
     static let recorder = ClientConfigRequestRecorder()
+    private static let responseLock = NSLock()
+    nonisolated(unsafe) private static var storedResponse: StubResponse = .success
+    static var response: StubResponse {
+        get { responseLock.withLock { storedResponse } }
+        set { responseLock.withLock { storedResponse = newValue } }
+    }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         Self.recorder.record(request)
+        let stub = Self.response
+        let statusCode: Int
+        let headers: [String: String]
+        switch stub {
+        case .success:
+            statusCode = 200
+            headers = ["Content-Type": "application/json"]
+        case .rateLimited(let seconds):
+            statusCode = 429
+            headers = ["Retry-After": String(seconds)]
+        }
         let body = Data("""
         {
           "featureFlags": { "cmux-for-windows": true },
@@ -17,9 +39,9 @@ final class RecordingClientConfigURLProtocol: URLProtocol, @unchecked Sendable {
         """.utf8)
         let response = HTTPURLResponse(
             url: request.url!,
-            statusCode: 200,
+            statusCode: statusCode,
             httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"]
+            headerFields: headers
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: body)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityInvalidationSubscriber.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityInvalidationSubscriber.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// Revision-only message carried by the account connectivity channel.
@@ -64,9 +65,9 @@ public actor CmxConnectivityInvalidationSubscriber {
     /// down are never replayed by the channel).
     public typealias StreamEventObserver = @Sendable (String) async -> Void
 
-    private enum StreamOutcome {
+    private enum StreamOutcome: Equatable {
         case served
-        case failed
+        case failed(retryAfterSeconds: Int?)
     }
 
     /// Cadence of the zombie-detection pings. Long enough to stay quiet,
@@ -148,10 +149,15 @@ public actor CmxConnectivityInvalidationSubscriber {
         while !Task.isCancelled {
             let outcome = await subscribeOnce()
             guard !Task.isCancelled else { return }
-            if outcome == .served {
+            let retryAfterSeconds: Int?
+            switch outcome {
+            case .served:
                 backoff.reset()
+                retryAfterSeconds = nil
+            case .failed(let serverFloor):
+                retryAfterSeconds = serverFloor
             }
-            let delay = backoff.nextDelay()
+            let delay = backoff.nextDelay(retryAfterSeconds: retryAfterSeconds)
             guard (try? await sleep(delay)) != nil else { return }
         }
     }
@@ -159,11 +165,11 @@ public actor CmxConnectivityInvalidationSubscriber {
     private func subscribeOnce() async -> StreamOutcome {
         guard let url = Self.subscribeURL(serviceBaseURL: serviceBaseURL) else {
             await onStreamEvent?("failed cause=invalid_url")
-            return .failed
+            return .failed(retryAfterSeconds: nil)
         }
         guard let token = await accessToken(), !token.isEmpty else {
             await onStreamEvent?("failed cause=no_token")
-            return .failed
+            return .failed(retryAfterSeconds: nil)
         }
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -214,11 +220,12 @@ public actor CmxConnectivityInvalidationSubscriber {
                     }
                     let closedCleanly = task.closeCode == .normalClosure
                         || task.closeCode == .goingAway
+                    let retryAfterSeconds = Self.retryAfterSeconds(from: task)
                     let outcome: StreamOutcome = closedCleanly && clock.now - startedAt >= .seconds(60)
                         ? .served
-                        : .failed
+                        : .failed(retryAfterSeconds: retryAfterSeconds)
                     await onStreamEvent?(
-                        "\(outcome == .served ? "served" : "failed") close=\(closeCode) error=\(String(describing: error))"
+                        "\(outcome == .served ? "served" : "failed") close=\(closeCode) retry_after_s=\(retryAfterSeconds.map(String.init) ?? "-") error=\(String(describing: error))"
                     )
                     return outcome
                 }
@@ -230,11 +237,11 @@ public actor CmxConnectivityInvalidationSubscriber {
                     data = bytes
                 @unknown default:
                     await onStreamEvent?("failed cause=unknown_message_kind")
-                    return .failed
+                    return .failed(retryAfterSeconds: nil)
                 }
                 guard let invalidation = try? CmxConnectivityInvalidation.parse(data) else {
                     await onStreamEvent?("failed cause=bad_frame bytes=\(data.count)")
-                    return .failed
+                    return .failed(retryAfterSeconds: nil)
                 }
                 guard !Task.isCancelled else { return .served }
                 delivered = true
@@ -244,5 +251,16 @@ public actor CmxConnectivityInvalidationSubscriber {
         } onCancel: {
             task.cancel(with: .goingAway, reason: nil)
         }
+    }
+
+    private static func retryAfterSeconds(
+        from task: URLSessionWebSocketTask
+    ) -> Int? {
+        guard let response = task.response as? HTTPURLResponse,
+              response.statusCode == 429 else { return nil }
+        return CmxRetryAfterPolicy.seconds(
+            from: response,
+            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+        )
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
@@ -342,7 +342,7 @@ public actor CmxIrohBrokerBackpressureGate {
         switch error as? CmxIrohTrustBrokerClientError {
         case let .rateLimited(code, retryAfterSeconds):
             directive = (
-                Self.boundedRetryAfter(retryAfterSeconds),
+                Self.normalizedRetryAfter(retryAfterSeconds),
                 .brokerRateLimit(code: code)
             )
         case let .rejected(statusCode, _) where statusCode == 429:
@@ -512,10 +512,7 @@ public actor CmxIrohBrokerBackpressureGate {
             && floor.retryAt.timeIntervalSince1970.isFinite
             && floor.recordedAt <= current
             && floor.retryAt > current
-            && floor.retryAt.timeIntervalSince(current)
-                <= TimeInterval(CmxIrohBrokerCooldown.maximumRetryAfterSeconds)
             && duration >= 1
-            && duration <= TimeInterval(CmxIrohBrokerCooldown.maximumRetryAfterSeconds)
     }
 
     private static func precedesForPersistence(
@@ -533,14 +530,11 @@ public actor CmxIrohBrokerBackpressureGate {
     private static func remainingSeconds(floor: Floor, now: Date) -> Int {
         let remaining = floor.retryAt.timeIntervalSince(now)
         let original = floor.retryAt.timeIntervalSince(floor.recordedAt)
-        return min(
-            CmxIrohBrokerCooldown.maximumRetryAfterSeconds,
-            max(1, Int(min(remaining, original).rounded(.up)))
-        )
+        return max(1, Int(min(remaining, original).rounded(.up)))
     }
 
-    private static func boundedRetryAfter(_ seconds: Int) -> Int {
-        min(CmxIrohBrokerCooldown.maximumRetryAfterSeconds, max(1, seconds))
+    private static func normalizedRetryAfter(_ seconds: Int) -> Int {
+        max(1, seconds)
     }
 
     private static func accountScope(_ accountID: String) -> String {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CryptoKit
 public import Foundation
 
@@ -530,7 +531,7 @@ public actor CmxIrohBrokerBackpressureGate {
     private static func remainingSeconds(floor: Floor, now: Date) -> Int {
         let remaining = floor.retryAt.timeIntervalSince(now)
         let original = floor.retryAt.timeIntervalSince(floor.recordedAt)
-        return max(1, Int(min(remaining, original).rounded(.up)))
+        return max(1, CmxRetryAfterPolicy.roundedUpSeconds(min(remaining, original)))
     }
 
     private static func normalizedRetryAfter(_ seconds: Int) -> Int {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerCooldown.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerCooldown.swift
@@ -59,9 +59,6 @@ public extension CmxIrohBrokerCooldown {
     /// Floor applied to a 429 whose response carried no Retry-After header.
     static let defaultRateLimitedSeconds = 60
 
-    /// Longest server Retry-After directive accepted from the broker.
-    static let maximumRetryAfterSeconds = 24 * 60 * 60
-
     /// Seconds of cooldown one broker failure demands, or `nil` when the
     /// error is not a rate-limit signal. Prefers the server's own Retry-After
     /// directive; a bare 429 still arms a short default floor so a missing

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohReconnectBackoff.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohReconnectBackoff.swift
@@ -66,8 +66,7 @@ public final class CmxIrohReconnectBackoff: Sendable {
     /// Returns the next retry delay after a failure.
     ///
     /// - Parameter retryAfterSeconds: A server-provided floor, when one exists.
-    ///   It always wins over the local schedule, bounded only by
-    ///   ``CmxIrohBrokerCooldown/maximumRetryAfterSeconds``.
+    ///   It always wins over the local schedule.
     /// - Returns: A delay within `[floor, cap]`, or the larger server floor.
     public func nextDelay(retryAfterSeconds: Int? = nil) -> TimeInterval {
         let drawn = state.withLock { state in
@@ -83,10 +82,7 @@ public final class CmxIrohReconnectBackoff: Sendable {
             return delay
         }
         guard let retryAfterSeconds else { return drawn }
-        let serverFloor = TimeInterval(min(
-            max(1, retryAfterSeconds),
-            CmxIrohBrokerCooldown.maximumRetryAfterSeconds
-        ))
+        let serverFloor = TimeInterval(max(1, retryAfterSeconds))
         return max(drawn, serverFloor)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRetrySchedule.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRetrySchedule.swift
@@ -6,7 +6,7 @@ public struct CmxIrohRetrySchedule: Equatable, Sendable {
     /// The first retry delay before jitter.
     public let initialDelay: TimeInterval
 
-    /// The largest accepted delay, including a validated `Retry-After` floor.
+    /// The largest locally generated delay. A server floor may exceed it.
     public let maximumDelay: TimeInterval
 
     /// The positive jitter fraction applied above the retry floor.
@@ -16,7 +16,7 @@ public struct CmxIrohRetrySchedule: Equatable, Sendable {
     ///
     /// - Parameters:
     ///   - initialDelay: The first retry delay before jitter.
-    ///   - maximumDelay: The hard delay cap.
+    ///   - maximumDelay: The local delay cap.
     ///   - jitterFraction: The maximum positive jitter as a fraction of the floor.
     public init(
         initialDelay: TimeInterval = 30,
@@ -45,7 +45,8 @@ public struct CmxIrohRetrySchedule: Equatable, Sendable {
     ///   - failureCount: Zero-based consecutive failure count.
     ///   - retryAfterSeconds: A validated server retry floor, when available.
     ///   - jitterUnitInterval: A deterministic value from zero through one.
-    /// - Returns: A positive delay bounded by ``maximumDelay``.
+    /// - Returns: A positive local delay bounded by ``maximumDelay``, or the
+    ///   larger server floor.
     public func delay(
         failureCount: Int,
         retryAfterSeconds: Int?,
@@ -55,7 +56,8 @@ public struct CmxIrohRetrySchedule: Equatable, Sendable {
         let exponential = initialDelay * pow(2, Double(boundedFailureCount))
         let base = min(maximumDelay, exponential)
         let serverFloor = retryAfterSeconds.map(TimeInterval.init) ?? 0
-        let floor = min(maximumDelay, max(base, serverFloor))
+        let floor = max(base, serverFloor)
+        guard floor < maximumDelay else { return floor }
         let jitter = min(1, max(0, jitterUnitInterval))
         let available = max(0, maximumDelay - floor)
         let jitterWindow = min(available, floor * jitterFraction)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -943,10 +943,10 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             let code = body.map { payload in
                 payload.source.map { "\(payload.error):\($0.rawValue)" } ?? payload.error
             }
-            if http.statusCode == 429,
-               let retryAfterSeconds = Self.retryAfterSeconds(
-                   http.value(forHTTPHeaderField: "Retry-After")
-               ) {
+            if http.statusCode == 429 {
+                let retryAfterSeconds = Self.retryAfterSeconds(
+                    http.value(forHTTPHeaderField: "Retry-After")
+                ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
                 throw CmxIrohTrustBrokerClientError.rateLimited(
                     code: code,
                     retryAfterSeconds: retryAfterSeconds
@@ -981,15 +981,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     }
 
     private static func retryAfterSeconds(_ value: String?) -> Int? {
-        guard let value,
-              !value.isEmpty,
-              value.utf8.allSatisfy({ (48 ... 57).contains($0) }),
-              let seconds = Int(value),
-              (1 ... CmxIrohBrokerCooldown.maximumRetryAfterSeconds).contains(seconds),
-              String(seconds) == value else {
-            return nil
-        }
-        return seconds
+        CmxRetryAfterPolicy.seconds(from: value)
     }
 
     private static func relayTokenResponse(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerBackpressureGateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerBackpressureGateTests.swift
@@ -6,6 +6,16 @@ import Testing
 struct CmxIrohBrokerBackpressureGateTests {
     private let start = Date(timeIntervalSince1970: 1_782_000_000)
 
+    @Test func oversizedPersistedCooldownDoesNotOverflow() async throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = CmxIrohUserDefaultsInstallStateStore(defaults: defaults)
+        let gate = CmxIrohBrokerBackpressureGate(store: store, now: { start })
+        await recordRateLimit(gate: gate, accountID: "account-a", operation: .discovery, seconds: Int.max)
+        let restored = CmxIrohBrokerBackpressureGate(store: store, now: { start })
+        #expect(await restored.remainingSeconds(accountID: "account-a", operation: .discovery) == Int.max)
+    }
+
     @Test
     func persistedDeadlineSurvivesGateRecreation() async throws {
         let (defaults, suiteName) = try makeDefaults()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohReconnectBackoffTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohReconnectBackoffTests.swift
@@ -61,11 +61,10 @@ struct CmxIrohReconnectBackoffTests {
     }
 
     @Test
-    func serverRetryAfterWinsOverLocalScheduleAndIsBounded() {
+    func serverRetryAfterWinsOverLocalScheduleWithoutBeingShortened() {
         let backoff = CmxIrohReconnectBackoff(seed: 9)
         #expect(backoff.nextDelay(retryAfterSeconds: 120) >= 120)
-        #expect(backoff.nextDelay(retryAfterSeconds: Int.max)
-            <= TimeInterval(CmxIrohBrokerCooldown.maximumRetryAfterSeconds))
+        #expect(backoff.nextDelay(retryAfterSeconds: 90_000) == 90_000)
         // A server directive never poisons the local streak: the next local
         // draw stays inside the decorrelated window, not the directive's.
         let after = backoff.nextDelay()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRetryScheduleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRetryScheduleTests.swift
@@ -62,6 +62,11 @@ struct CmxIrohRetryScheduleTests {
             retryAfterSeconds: 600,
             jitterUnitInterval: 1
         ) == 750)
+        #expect(schedule.delay(
+            failureCount: 20,
+            retryAfterSeconds: 7_200,
+            jitterUnitInterval: 1
+        ) == 7_200)
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 extension CmxIrohTrustBrokerClientTests {
     @Test
-    func rateLimitRetainsOnlyBoundedCanonicalRetryAfterSeconds() async throws {
+    func rateLimitRetainsEveryValidRetryAfterFloor() async throws {
         for (header, expected) in [
             ("600", CmxIrohTrustBrokerClientError.rateLimited(
                 code: "rate_limited",
@@ -14,17 +14,17 @@ extension CmxIrohTrustBrokerClientTests {
                 code: "rate_limited",
                 retryAfterSeconds: 86_400
             )),
-            ("0", CmxIrohTrustBrokerClientError.rejected(
-                statusCode: 429,
-                code: "rate_limited"
+            ("0", CmxIrohTrustBrokerClientError.rateLimited(
+                code: "rate_limited",
+                retryAfterSeconds: 60
             )),
-            ("86401", CmxIrohTrustBrokerClientError.rejected(
-                statusCode: 429,
-                code: "rate_limited"
+            ("86401", CmxIrohTrustBrokerClientError.rateLimited(
+                code: "rate_limited",
+                retryAfterSeconds: 86_401
             )),
-            ("0600", CmxIrohTrustBrokerClientError.rejected(
-                statusCode: 429,
-                code: "rate_limited"
+            ("0600", CmxIrohTrustBrokerClientError.rateLimited(
+                code: "rate_limited",
+                retryAfterSeconds: 600
             )),
         ] {
             let transport = RecordingBrokerTransport(responses: [

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/ControlPlane/IrxControlPlaneClient.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/ControlPlane/IrxControlPlaneClient.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// Persisted control-plane sync position: the highest account route revision
@@ -96,6 +97,7 @@ public actor IrxControlPlaneClient {
     /// old loop before starting its replacement.
     private var loopGeneration: UInt64 = 0
     private var backoff: Duration = .seconds(1)
+    private let retryAfterGate = CmxRetryAfterGate()
     /// Highest revision acknowledged on the CURRENT socket; duplicate acks
     /// (a directory frame that also fanned hint updates) collapse here.
     private var lastAckedRev: Int?
@@ -276,10 +278,22 @@ public actor IrxControlPlaneClient {
     private func run(generation: UInt64) async {
         while !Task.isCancelled && generation == loopGeneration {
             do {
+                try await retryAfterGate.wait()
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, generation == loopGeneration else { return }
+            var retryAfterSeconds: Int?
+            do {
                 try await connectAndServe(generation: generation)
             } catch is CancellationError {
                 return
             } catch {
+                retryAfterSeconds = (error as? any CmxRetryAfterProviding)?
+                    .retryAfterSeconds
+                if let retryAfterSeconds {
+                    await retryAfterGate.extend(by: retryAfterSeconds)
+                }
                 journal.record(
                     "control-plane", "socket-ended",
                     ["error": String(describing: error)]
@@ -287,11 +301,15 @@ public actor IrxControlPlaneClient {
             }
             if Task.isCancelled || generation != loopGeneration { return }
             let jitter = Duration.milliseconds(Int.random(in: 0...500))
-            let delay = backoff + jitter
+            let serverFloor = Duration.seconds(Int64(max(0, retryAfterSeconds ?? 0)))
+            let delay = max(backoff + jitter, serverFloor)
             backoff = min(backoff * 2, Self.maxBackoff)
             journal.record(
                 "control-plane", "reconnect-scheduled",
-                ["delay": String(describing: delay)]
+                [
+                    "delay": String(describing: delay),
+                    "server_floor_s": retryAfterSeconds.map(String.init) ?? "-",
+                ]
             )
             try? await Task.sleep(for: delay)
         }
@@ -336,14 +354,23 @@ public actor IrxControlPlaneClient {
             clientInfo: configuration.clientInfo
         )
         let helloData = try JSONEncoder().encode(hello)
-        try await task.send(.string(String(decoding: helloData, as: UTF8.self)))
+        do {
+            try await task.send(.string(String(decoding: helloData, as: UTF8.self)))
+        } catch {
+            throw Self.rateLimitError(from: task) ?? error
+        }
         journal.record(
             "control-plane", "hello-sent",
             ["have_rev": cursorCache.load()?.haveRev.map(String.init) ?? "-"]
         )
 
         while !Task.isCancelled && generation == loopGeneration {
-            let message = try await receive(from: task)
+            let message: URLSessionWebSocketTask.Message
+            do {
+                message = try await receive(from: task)
+            } catch {
+                throw Self.rateLimitError(from: task) ?? error
+            }
             guard generation == loopGeneration, socket === task else { return }
             // Record transport activity before consumer handlers run. The
             // exact generation/socket guard prevents an old receive loop from
@@ -357,6 +384,17 @@ public actor IrxControlPlaneClient {
             }
             await route(data, generation: generation, socket: task)
         }
+    }
+
+    private static func rateLimitError(
+        from task: URLSessionWebSocketTask
+    ) -> CmxRateLimitedError? {
+        guard let response = task.response as? HTTPURLResponse,
+              response.statusCode == 429 else { return nil }
+        return CmxRateLimitedError(retryAfterSeconds: CmxRetryAfterPolicy.seconds(
+            from: response,
+            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+        ))
     }
 
     private func route(

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxPeerEngine.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxPeerEngine.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// Session state for one Mac peer. Five states, no shadow copies anywhere
@@ -141,6 +142,14 @@ public actor IrxPeerEngine {
             throw IrxAdmissionDenied(
                 code: IrxCloseCode(rawValue: parkedCode) ?? .invalidGrant)
         }
+        if explicit,
+           let cooldownUntil,
+           ContinuousClock.now < cooldownUntil,
+           (lastDialError as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
+            // Foreground, route-change, and user retry triggers may bypass a
+            // local transport backoff, but never a server-owned deadline.
+            throw lastDialError ?? IrxConnectionError.closed(nil)
+        }
         if explicit {
             // An explicit replacement invalidates the old session before the
             // new dial starts. Keeping it here after a failed replacement
@@ -210,7 +219,7 @@ public actor IrxPeerEngine {
                     "trigger": trigger,
                     "error": String(describing: denial),
                 ])
-                scheduleRedial()
+                scheduleRedial(error: denial)
             } else {
                 parkedCode = denial.code.rawValue
                 record("dial-denied", ["code": denial.code.rawValue])
@@ -229,7 +238,7 @@ public actor IrxPeerEngine {
                 "dial-failed",
                 ["trigger": trigger, "error": String(describing: error)]
             )
-            scheduleRedial()
+            scheduleRedial(error: error)
             throw error
         }
     }
@@ -287,6 +296,12 @@ public actor IrxPeerEngine {
         if case .ready = state { return }
         if parkedCode != nil { return }
         guard dialTask != nil || redialTimer != nil || cooldownUntil != nil else {
+            return
+        }
+        if let cooldownUntil,
+           ContinuousClock.now < cooldownUntil,
+           (lastDialError as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
+            record("hint-race-redial-suppressed", ["reason": "retry-after"])
             return
         }
         record("hint-race-redial", ["trigger": trigger])
@@ -395,8 +410,11 @@ public actor IrxPeerEngine {
 
     /// Capped, cancellable backoff. The woken redial is an ordinary automatic
     /// trigger that joins whatever else happened since.
-    private func scheduleRedial() {
-        let delay = backoff
+    private func scheduleRedial(error: any Error) {
+        let retryAfterSeconds = (error as? any CmxRetryAfterProviding)?
+            .retryAfterSeconds
+        let serverFloor = Duration.seconds(Int64(max(0, retryAfterSeconds ?? 0)))
+        let delay = max(backoff, serverFloor)
         backoff = min(backoff * 2, config.maxBackoff)
         cooldownUntil = ContinuousClock.now.advanced(by: delay)
         redialTimer?.cancel()
@@ -405,7 +423,10 @@ public actor IrxPeerEngine {
             guard !Task.isCancelled else { return }
             await self?.clearCooldownAndRedial()
         }
-        record("redial-scheduled", ["delay": String(describing: delay)])
+        record("redial-scheduled", [
+            "delay": String(describing: delay),
+            "server_floor_s": retryAfterSeconds.map(String.init) ?? "-",
+        ])
     }
 
     private func clearCooldownAndRedial() async {

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxPeerEngine.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxPeerEngine.swift
@@ -61,6 +61,8 @@ public actor IrxPeerEngine {
     public typealias DialOnce = @Sendable () async throws -> IrxClientSession
 
     private let dialOnce: DialOnce
+    private let clockNow: @Sendable () -> ContinuousClock.Instant
+    private let retrySleep: @Sendable (Duration) async throws -> Void
     private let config: Config
     private let journal: IrxJournal
     /// Short peer identifier stamped on every journal event so multi-Mac
@@ -91,12 +93,16 @@ public actor IrxPeerEngine {
         config: Config = Config(),
         journal: IrxJournal,
         label: String = "",
+        clockNow: @escaping @Sendable () -> ContinuousClock.Instant = { .now },
+        retrySleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
         dialOnce: @escaping DialOnce
     ) {
         self.config = config
         self.journal = journal
         self.label = label
         self.dialOnce = dialOnce
+        self.clockNow = clockNow
+        self.retrySleep = retrySleep
         backoff = config.initialBackoff
     }
 
@@ -144,7 +150,7 @@ public actor IrxPeerEngine {
         }
         if explicit,
            let cooldownUntil,
-           ContinuousClock.now < cooldownUntil,
+           clockNow() < cooldownUntil,
            (lastDialError as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
             // Foreground, route-change, and user retry triggers may bypass a
             // local transport backoff, but never a server-owned deadline.
@@ -181,7 +187,7 @@ public actor IrxPeerEngine {
             }
             return joined
         }
-        if !explicit, let cooldownUntil, ContinuousClock.now < cooldownUntil {
+        if !explicit, let cooldownUntil, clockNow() < cooldownUntil {
             // The scheduled redial owns the next attempt; fail fast instead
             // of stacking another dial on top of it.
             throw lastDialError ?? IrxConnectionError.closed(nil)
@@ -258,7 +264,7 @@ public actor IrxPeerEngine {
                await !session.connection.isConnectionClosed()
             {
                 let recentlyAlive: Bool
-                if ContinuousClock.now - session.establishedAtMonotonic <= staleAfter {
+                if clockNow() - session.establishedAtMonotonic <= staleAfter {
                     // A newly admitted session has not necessarily completed
                     // its first keepalive round yet, but is still within the
                     // bounded fresh-session grace period.
@@ -299,7 +305,7 @@ public actor IrxPeerEngine {
             return
         }
         if let cooldownUntil,
-           ContinuousClock.now < cooldownUntil,
+           clockNow() < cooldownUntil,
            (lastDialError as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
             record("hint-race-redial-suppressed", ["reason": "retry-after"])
             return
@@ -416,10 +422,10 @@ public actor IrxPeerEngine {
         let serverFloor = Duration.seconds(Int64(max(0, retryAfterSeconds ?? 0)))
         let delay = max(backoff, serverFloor)
         backoff = min(backoff * 2, config.maxBackoff)
-        cooldownUntil = ContinuousClock.now.advanced(by: delay)
+        cooldownUntil = clockNow().advanced(by: delay)
         redialTimer?.cancel()
-        redialTimer = Task { [weak self] in
-            try? await Task.sleep(for: delay)
+        redialTimer = Task { [weak self, retrySleep] in
+            do { try await retrySleep(delay) } catch { return }
             guard !Task.isCancelled else { return }
             await self?.clearCooldownAndRedial()
         }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
@@ -1,3 +1,4 @@
+public import CMUXMobileCore
 public import Foundation
 
 /// Keeps the endpoint's relay credentials perpetually fresh: mints early
@@ -123,7 +124,12 @@ public actor IrxRelayCredentialAutopilot {
             } catch {
                 if Task.isCancelled || generation != loopGeneration { return }
                 let expiry = credentials.map(\.expiresAt).max() ?? Date()
-                let delay = IrxRelayCredentialPolicy.retryDelay(expiresAt: expiry, now: Date())
+                let delay = IrxRelayCredentialPolicy.retryDelay(
+                    expiresAt: expiry,
+                    now: Date(),
+                    retryAfterSeconds: (error as? any CmxRetryAfterProviding)?
+                        .retryAfterSeconds
+                )
                 journal.record(
                     "credential-autopilot", "mint-failed",
                     [

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentialAutopilot.swift
@@ -1,4 +1,4 @@
-public import CMUXMobileCore
+import CMUXMobileCore
 public import Foundation
 
 /// Keeps the endpoint's relay credentials perpetually fresh: mints early

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
@@ -47,9 +47,7 @@ public enum IrxRelayCredentialPolicy {
     ) -> Duration {
         let remaining = expiresAt.timeIntervalSince(now)
         let credentialDelay = remaining > 2 ? remaining / 2 : 1
-        let serverDelay = TimeInterval(
-            max(0, min(retryAfterSeconds ?? 0, 24 * 60 * 60))
-        )
+        let serverDelay = TimeInterval(max(0, retryAfterSeconds ?? 0))
         return .seconds(max(credentialDelay, serverDelay))
     }
 }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxRelayCredentials.swift
@@ -38,15 +38,19 @@ public enum IrxRelayCredentialPolicy {
         return base.addingTimeInterval(-max(0, min(jitter, 10)))
     }
 
-    /// On mint failure, retry at half the remaining validity (floor 1s), so
-    /// retries accelerate as expiry approaches instead of backing off past it.
+    /// On mint failure, retry at half the remaining validity (floor 1s), while
+    /// treating a validated server Retry-After value as an authoritative floor.
     public static func retryDelay(
         expiresAt: Date,
-        now: Date
+        now: Date,
+        retryAfterSeconds: Int? = nil
     ) -> Duration {
         let remaining = expiresAt.timeIntervalSince(now)
-        guard remaining > 2 else { return .seconds(1) }
-        return .seconds(remaining / 2)
+        let credentialDelay = remaining > 2 ? remaining / 2 : 1
+        let serverDelay = TimeInterval(
+            max(0, min(retryAfterSeconds ?? 0, 24 * 60 * 60))
+        )
+        return .seconds(max(credentialDelay, serverDelay))
     }
 }
 

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxControlPlaneTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxControlPlaneTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CMUXMobileCore
 
 @testable import CmuxIrxTransport
 
@@ -182,6 +183,27 @@ import Testing
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(gate.dialCount >= 2)
+        await engine.stop()
+    }
+
+    @Test func rateLimitedDialDoesNotRedialBeforeServerDeadline() async throws {
+        let journal = IrxJournal(subsystem: "test", category: "retry-after", journalFileURL: nil)
+        let gate = DialGate()
+        let engine = IrxPeerEngine(
+            config: .init(initialBackoff: .milliseconds(10), maxBackoff: .milliseconds(20)),
+            journal: journal,
+            label: "test"
+        ) {
+            gate.dialStarted()
+            throw CmxRateLimitedError(retryAfterSeconds: 1)
+        }
+
+        await engine.warmUp(trigger: "test-rate-limit")
+        for _ in 0..<100 where gate.dialCount == 0 {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(gate.dialCount == 1)
         await engine.stop()
     }
 }

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxControlPlaneTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxControlPlaneTests.swift
@@ -189,21 +189,48 @@ import CMUXMobileCore
     @Test func rateLimitedDialDoesNotRedialBeforeServerDeadline() async throws {
         let journal = IrxJournal(subsystem: "test", category: "retry-after", journalFileURL: nil)
         let gate = DialGate()
+        let clock = PeerRetryTestClock()
+        let sleeps = AsyncStream<Duration>.makeStream()
+        let wake = AsyncStream<Void>.makeStream()
+        let dials = AsyncStream<Void>.makeStream()
         let engine = IrxPeerEngine(
             config: .init(initialBackoff: .milliseconds(10), maxBackoff: .milliseconds(20)),
             journal: journal,
-            label: "test"
+            label: "test",
+            clockNow: { clock.now },
+            retrySleep: { duration in
+                sleeps.continuation.yield(duration)
+                for await _ in wake.stream { break }
+                try Task.checkCancellation()
+            }
         ) {
             gate.dialStarted()
+            dials.continuation.yield(())
             throw CmxRateLimitedError(retryAfterSeconds: 1)
         }
 
-        await engine.warmUp(trigger: "test-rate-limit")
-        for _ in 0..<100 where gate.dialCount == 0 {
-            try await Task.sleep(for: .milliseconds(1))
-        }
-        try await Task.sleep(for: .milliseconds(150))
+        _ = try? await engine.ensureSession(trigger: "test-rate-limit")
+        var dialIterator = dials.stream.makeAsyncIterator()
+        _ = await dialIterator.next()
+        var sleepIterator = sleeps.stream.makeAsyncIterator()
+        #expect(await sleepIterator.next() == .seconds(1))
+        clock.advance(by: .milliseconds(999))
+        _ = try? await engine.ensureSession(trigger: "foreground-before-deadline")
         #expect(gate.dialCount == 1)
+        clock.advance(by: .milliseconds(1))
+        wake.continuation.yield(())
+        _ = await dialIterator.next()
+        #expect(gate.dialCount == 2)
         await engine.stop()
+        wake.continuation.finish()
+        sleeps.continuation.finish()
+        dials.continuation.finish()
     }
+}
+
+private final class PeerRetryTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = ContinuousClock.now
+    var now: ContinuousClock.Instant { lock.withLock { instant } }
+    func advance(by duration: Duration) { lock.withLock { instant = instant.advanced(by: duration) } }
 }

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxProtocolTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxProtocolTests.swift
@@ -116,6 +116,13 @@ struct IrxRelayCredentialPolicyTests {
         let past = IrxRelayCredentialPolicy.retryDelay(
             expiresAt: now.addingTimeInterval(-5), now: now)
         #expect(past == .seconds(1))
+
+        let rateLimited = IrxRelayCredentialPolicy.retryDelay(
+            expiresAt: now.addingTimeInterval(1),
+            now: now,
+            retryAfterSeconds: 45
+        )
+        #expect(rateLimited == .seconds(45))
     }
 
     @Test("usability requires margin over expiry")

--- a/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPAnalyticsUploader.swift
+++ b/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPAnalyticsUploader.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 internal import OSLog
 
@@ -21,6 +22,7 @@ public struct HTTPAnalyticsUploader: AnalyticsUploading {
     private let tokenProvider: any AnalyticsTokenProviding
     private let session: URLSession
     private let taskRegistry = AnalyticsUploadTaskRegistry()
+    private let retryAfterGate = CmxRetryAfterGate()
 
     /// Creates an uploader.
     ///
@@ -81,6 +83,12 @@ public struct HTTPAnalyticsUploader: AnalyticsUploading {
         let task = Task<AnalyticsUploadResult, Never> { [self] in
             await startGate.wait()
             guard !Task.isCancelled else { return .drop }
+            do {
+                try await retryAfterGate.wait()
+            } catch {
+                return .drop
+            }
+            guard !Task.isCancelled else { return .drop }
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -113,6 +121,13 @@ public struct HTTPAnalyticsUploader: AnalyticsUploading {
         do {
             let (_, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else { return .retry }
+            if http.statusCode == 429,
+               let seconds = CmxRetryAfterPolicy.seconds(
+                   from: http,
+                   defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+               ) {
+                await retryAfterGate.extend(by: seconds)
+            }
             return Self.result(forStatusCode: http.statusCode, label: label)
         } catch {
             if Task.isCancelled { return .drop }

--- a/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPAnalyticsUploader.swift
+++ b/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPAnalyticsUploader.swift
@@ -101,7 +101,13 @@ public struct HTTPAnalyticsUploader: AnalyticsUploading {
                 request.setValue(refreshToken, forHTTPHeaderField: "X-Stack-Refresh-Token")
             }
             guard !Task.isCancelled else { return .drop }
-            return await perform(request: request, label: label)
+            do {
+                return try await retryAfterGate.perform { [request] in
+                    await perform(request: request, label: label)
+                }
+            } catch {
+                return .drop
+            }
         }
         guard taskRegistry.register(task, id: id) else {
             task.cancel()

--- a/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPMobileNetworkOutcomeUploader.swift
+++ b/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPMobileNetworkOutcomeUploader.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 internal import OSLog
 
@@ -16,6 +17,7 @@ public struct HTTPMobileNetworkOutcomeUploader: AnalyticsUploading {
     private let tokenProvider: any AnalyticsTokenProviding
     private let session: URLSession
     private let taskRegistry = AnalyticsUploadTaskRegistry()
+    private let retryAfterGate = CmxRetryAfterGate()
 
     /// Creates an operational network-outcome uploader.
     ///
@@ -77,6 +79,12 @@ public struct HTTPMobileNetworkOutcomeUploader: AnalyticsUploading {
         let task = Task<AnalyticsUploadResult, Never> { [self] in
             await startGate.wait()
             guard !Task.isCancelled else { return .drop }
+            do {
+                try await retryAfterGate.wait()
+            } catch {
+                return .drop
+            }
+            guard !Task.isCancelled else { return .drop }
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -109,6 +117,13 @@ public struct HTTPMobileNetworkOutcomeUploader: AnalyticsUploading {
         do {
             let (_, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else { return .retry }
+            if http.statusCode == 429,
+               let seconds = CmxRetryAfterPolicy.seconds(
+                   from: http,
+                   defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+               ) {
+                await retryAfterGate.extend(by: seconds)
+            }
             return Self.result(forStatusCode: http.statusCode)
         } catch {
             if Task.isCancelled { return .drop }

--- a/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPMobileNetworkOutcomeUploader.swift
+++ b/Packages/iOS/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/HTTPMobileNetworkOutcomeUploader.swift
@@ -97,7 +97,13 @@ public struct HTTPMobileNetworkOutcomeUploader: AnalyticsUploading {
                 request.setValue(refreshToken, forHTTPHeaderField: "X-Stack-Refresh-Token")
             }
             guard !Task.isCancelled else { return .drop }
-            return await perform(request)
+            do {
+                return try await retryAfterGate.perform { [request] in
+                    await perform(request)
+                }
+            } catch {
+                return .drop
+            }
         }
         guard taskRegistry.register(task, id: id) else {
             task.cancel()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -47,6 +47,7 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     private let teamIDProvider: @Sendable () async -> String?
     private let session: CmxCredentialedHTTPSession
     private let requestTimeout: TimeInterval
+    private let retryAfterGate = CmxRetryAfterGate()
     private struct RegistryResponse: Sendable {
         let data: Data
         let statusCode: Int
@@ -580,6 +581,9 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     /// team scope. This removes duplicate provider work without returning an old
     /// account or team's response after a session switch.
     private func fetchListResponse() async -> RegistryResponse? {
+        // A cached registry snapshot remains usable while the backend owns the
+        // next request time. Foreground and reconnect triggers must not bypass it.
+        guard await retryAfterGate.remainingSeconds() == nil else { return nil }
         guard let input = await makeListRequest() else { return nil }
         if let inFlight = listResponseTasks[input.scope] {
             return await inFlight.task.value
@@ -601,6 +605,13 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 return nil
+            }
+            if http.statusCode == 429 {
+                let seconds = CmxRetryAfterPolicy.seconds(
+                    from: http,
+                    defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+                ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                await retryAfterGate.extend(by: seconds)
             }
             return RegistryResponse(data: data, statusCode: http.statusCode)
         } catch {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -590,7 +590,9 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
         }
         let id = UUID()
         let task = Task { [self] in
-            await performListResponseRequest(input.request)
+            try? await retryAfterGate.perform(waitForCooldown: false) { [self] in
+                await performListResponseRequest(input.request)
+            }
         }
         listResponseTasks[input.scope] = InFlightRegistryRequest(id: id, task: task)
         let response = await task.value

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3856,6 +3856,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     mobileShellLog.debug(
                         "presence stream ended: \(String(describing: error), privacy: .public)"
                     )
+                    let serverFloor = Duration.seconds(Int64(max(
+                        0,
+                        (error as? any CmxRetryAfterProviding)?.retryAfterSeconds ?? 0
+                    )))
+                    if serverFloor > backoff {
+                        guard (try? await clock.sleep(for: serverFloor)) != nil else { return }
+                        backoff = min(backoff * 2, .seconds(60))
+                        continue
+                    }
                 }
                 if Task.isCancelled { return }
                 guard (try? await clock.sleep(for: backoff)) != nil else { return }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupClient.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupClient.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 internal import CmuxMobilePairedMac
 import os
@@ -18,6 +19,7 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
     private let requestTimeout: TimeInterval
     private let migrationDefaults: UserDefaults
     private let migrationClock: @Sendable () -> Date
+    private let retryAfterGate = CmxRetryAfterGate()
 
     /// Create a backup client for one presence service base URL and token source.
     public init(
@@ -144,6 +146,9 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
         routeDisclosureDate: Date,
         expectedRevision: Int? = nil
     ) async -> PairedMacBackupUploadOutcome {
+        guard await retryAfterGate.remainingSeconds() == nil else {
+            return PairedMacBackupUploadOutcome(succeeded: false, resolvedTeamID: nil)
+        }
         guard !ops.isEmpty else {
             return PairedMacBackupUploadOutcome(succeeded: true, resolvedTeamID: nil)
         }
@@ -168,6 +173,7 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
         do {
             let (responseData, response) = try await session.data(for: request)
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                await recordRetryAfterIfNeeded(http)
                 pairedMacBackupLog.warning("paired-mac backup upload failed: HTTP \(http.statusCode)")
                 return PairedMacBackupUploadOutcome(succeeded: false, resolvedTeamID: nil)
             }
@@ -316,6 +322,7 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
         expectedUserID: String?,
         scope: PairedMacBackupClientScopeSelection
     ) async -> PairedMacFetchedSnapshot? {
+        guard await retryAfterGate.remainingSeconds() == nil else { return nil }
         guard let request = await makeRequest(
             method: "GET",
             body: nil,
@@ -325,7 +332,11 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
         ) else { return nil }
         do {
             let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            guard let http = response as? HTTPURLResponse else { return nil }
+            if http.statusCode == 429 {
+                await recordRetryAfterIfNeeded(http)
+            }
+            guard (200...299).contains(http.statusCode) else {
                 pairedMacBackupLog.warning("paired-mac backup fetch failed: HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)")
                 return nil
             }
@@ -344,6 +355,15 @@ public actor PairedMacBackupClient: PairedMacBackingUp {
             pairedMacBackupLog.warning("paired-mac backup fetch error: \(String(describing: error), privacy: .public)")
             return nil
         }
+    }
+
+    private func recordRetryAfterIfNeeded(_ response: HTTPURLResponse) async {
+        guard response.statusCode == 429 else { return }
+        let seconds = CmxRetryAfterPolicy.seconds(
+            from: response,
+            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+        ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+        await retryAfterGate.extend(by: seconds)
     }
 
     public func clientScope() async -> String? {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceClient.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceClient.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// Subscribes to the team's live presence stream over WebSocket.
@@ -117,7 +118,20 @@ public actor PresenceClient {
                     }
                     continuation.finish()
                 } catch {
-                    continuation.finish(throwing: error)
+                    if let response = task.response as? HTTPURLResponse,
+                       response.statusCode == 429 {
+                        let seconds = CmxRetryAfterPolicy.seconds(
+                            from: response,
+                            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+                        ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                        continuation.finish(
+                            throwing: PresenceClientError.rateLimited(
+                                retryAfterSeconds: seconds
+                            )
+                        )
+                    } else {
+                        continuation.finish(throwing: error)
+                    }
                 }
             }
             continuation.onTermination = { _ in

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceClientError.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceClientError.swift
@@ -1,5 +1,7 @@
+public import CMUXMobileCore
+
 /// Errors thrown by ``PresenceClient`` and ``PresenceUpdate/parse(_:)``.
-public enum PresenceClientError: Error, Equatable, Sendable {
+public enum PresenceClientError: CmxRetryAfterProviding, Equatable, Sendable {
     /// The subscribe stream delivered a message type this client does not
     /// understand (a newer server speaking a newer protocol).
     case unknownMessage(type: String)
@@ -13,4 +15,11 @@ public enum PresenceClientError: Error, Equatable, Sendable {
     /// stream ends with this error instead, and reconnecting delivers a fresh
     /// snapshot first.
     case updatesDropped
+    /// The server rejected the WebSocket handshake and owns the next attempt.
+    case rateLimited(retryAfterSeconds: Int)
+
+    public var retryAfterSeconds: Int? {
+        guard case .rateLimited(let seconds) = self else { return nil }
+        return seconds
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ReplyRelayClient.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ReplyRelayClient.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import CMUXMobileCore
 import Foundation
 
 /// One inline notification reply handed to the server-side inbox.
@@ -67,6 +68,10 @@ public struct SystemReplyRelayClient: ReplyRelaying {
     private let serviceBaseURL: URL?
     private let accessToken: @Sendable () async -> String?
     private let session: URLSession
+    /// One service-owned deadline suppresses every outer reply-ladder wake.
+    /// The coordinator may check again after five seconds, but no HTTP request
+    /// escapes until the server's deadline has passed.
+    private let retryAfterGate = CmxRetryAfterGate()
 
     /// - Parameters:
     ///   - serviceBaseURL: The presence worker origin (the same one the
@@ -83,6 +88,7 @@ public struct SystemReplyRelayClient: ReplyRelaying {
     }
 
     public func relay(_ reply: RelayedReply) async -> Bool {
+        guard await retryAfterGate.remainingSeconds() == nil else { return false }
         guard let serviceBaseURL,
               var comps = URLComponents(
                   url: serviceBaseURL,
@@ -113,6 +119,12 @@ public struct SystemReplyRelayClient: ReplyRelaying {
         do {
             let (_, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else { return false }
+            if http.statusCode == 429 {
+                let seconds = CmxRetryAfterPolicy.seconds(
+                    from: http.value(forHTTPHeaderField: "Retry-After")
+                ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                await retryAfterGate.extend(by: seconds)
+            }
             return (200...299).contains(http.statusCode)
         } catch {
             return false

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePushReplyBackgroundLaneTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePushReplyBackgroundLaneTests.swift
@@ -115,6 +115,58 @@ private final class ReplyRelayFake: ReplyRelaying, @unchecked Sendable {
     }
 }
 
+private final class RateLimitedReplyURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private static var storedRequestCount = 0
+
+    static var requestCount: Int { lock.withLock { storedRequestCount } }
+
+    static func reset() {
+        lock.withLock { storedRequestCount = 0 }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.withLock { Self.storedRequestCount += 1 }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "120"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Test func replyRelayDoesNotRepeatRequestInsideServerCooldown() async {
+    RateLimitedReplyURLProtocol.reset()
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RateLimitedReplyURLProtocol.self]
+    let client = SystemReplyRelayClient(
+        serviceBaseURL: URL(string: "https://presence.test"),
+        accessToken: { "token" },
+        session: URLSession(configuration: configuration)
+    )
+    let reply = RelayedReply(
+        replyId: "reply-1",
+        macDeviceId: "mac-1",
+        workspaceId: "workspace-1",
+        surfaceId: "surface-1",
+        text: "hello"
+    )
+
+    let first = await client.relay(reply)
+    let second = await client.relay(reply)
+    #expect(!first)
+    #expect(!second)
+    #expect(RateLimitedReplyURLProtocol.requestCount == 1)
+}
+
 @MainActor
 private func makeReplyLaneCoordinator(
     runtime: ReplyRuntimeFake,

--- a/Packages/macOS/CmuxGit/Package.swift
+++ b/Packages/macOS/CmuxGit/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     dependencies: [
         .package(path: "../CmuxFoundation"),
         .package(path: "../../Shared/CmuxAgentChat"),
+        .package(path: "../../Shared/CMUXMobileCore"),
     ],
     targets: [
         .target(
@@ -23,6 +24,7 @@ let package = Package(
             dependencies: [
                 .product(name: "CmuxFoundation", package: "CmuxFoundation"),
                 .product(name: "CmuxAgentChat", package: "CmuxAgentChat"),
+                .product(name: "CMUXMobileCore", package: "CMUXMobileCore"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+internal import CMUXMobileCore
 
 private func githubAuthorizationFingerprint(for authHeader: String) -> Data {
     Data(SHA256.hash(data: Data(authHeader.utf8)))
@@ -308,11 +309,15 @@ public actor GitHubPullRequestRequestCoordinator {
         }
 
         if response.statusCode == 403 || response.statusCode == 429,
-           let rawRetryAfter = response.value(forHTTPHeaderField: "Retry-After"),
-           let retryAfter = TimeInterval(rawRetryAfter),
-           retryAfter > 0 {
+           let retryAfterSeconds = CmxRetryAfterPolicy.seconds(
+               from: response,
+               now: now(),
+               defaultSeconds: response.statusCode == 429
+                   ? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                   : nil
+           ) {
             extendRateLimitRetryDate(
-                to: now().addingTimeInterval(retryAfter),
+                to: now().addingTimeInterval(TimeInterval(retryAfterSeconds)),
                 authorizationFingerprint: authorizationFingerprint
             )
         }

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -352,6 +352,56 @@ struct GitHubPullRequestRequestTests {
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 
+    @Test func secondaryRateLimitAcceptsHTTPDateRetryAfter() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let retryDate = now.addingTimeInterval(120)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'"
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(
+                statusCode: 429,
+                headers: ["Retry-After": formatter.string(from: retryDate)]
+            ),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+
+        #expect(
+            await coordinator.retryDate(authHeader: "Bearer test-token")
+                == retryDate
+        )
+    }
+
+    @Test func bareRateLimitUsesConservativeRetryFloor() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 429),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+
+        #expect(
+            await coordinator.retryDate(authHeader: "Bearer test-token")
+                == now.addingTimeInterval(60)
+        )
+    }
+
     @Test func duplicateEndpointRequestsShareOneInFlightTransport() async {
         let body = Data("[]".utf8)
         let requestsStarted = GitHubPullRequestStubURLProtocol.reset(stubs: [

--- a/Sources/Cloud/DeviceRegistryClient.swift
+++ b/Sources/Cloud/DeviceRegistryClient.swift
@@ -22,6 +22,7 @@ final class DeviceRegistryClient {
     static let shared = DeviceRegistryClient()
 
     private let session = CmxCredentialedHTTPSession()
+    private let retryAfterGate = CmxRetryAfterGate()
     private var auth: AuthCoordinator?
     private var observeTask: Task<Void, Never>?
     /// The scope (team + tag + routes) most recently registered, used to skip
@@ -87,6 +88,9 @@ final class DeviceRegistryClient {
     }
 
     private func registerIfRoutesChanged(routes: [CmxAttachRoute]) async {
+        // Status, route, and foreground events share this gate. Cached routes
+        // remain valid while the server owns the next registration attempt.
+        guard await retryAfterGate.remainingSeconds() == nil else { return }
         guard let auth else { return }
         // Await tokens FIRST: this both gates on "signed in" and waits for launch
         // auth bootstrap. `resolvedTeamID` is derived from `availableTeams`, which
@@ -150,6 +154,13 @@ final class DeviceRegistryClient {
                     // transient failure retries on the next status tick.
                     lastRegistration = registration
                 } else {
+                    if http.statusCode == 429 {
+                        let seconds = CmxRetryAfterPolicy.seconds(
+                            from: http,
+                            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+                        ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                        await retryAfterGate.extend(by: seconds)
+                    }
                     NSLog("cmux.deviceRegistry register failed status=%d", http.statusCode)
                 }
             }

--- a/Sources/Cloud/MacPairedMacBackupPublisher.swift
+++ b/Sources/Cloud/MacPairedMacBackupPublisher.swift
@@ -28,6 +28,7 @@ final class MacPairedMacBackupPublisher {
     static let defaultsKey = "macPairedMacSelfPublish"
 
     private let session: URLSession = .shared
+    private let retryAfterGate = CmxRetryAfterGate()
     private var auth: AuthCoordinator?
     private var observeTask: Task<Void, Never>?
     /// The routes most recently published, so an unchanged status update (the
@@ -85,6 +86,7 @@ final class MacPairedMacBackupPublisher {
     }
 
     private func publish(routes: [CmxAttachRoute]) async {
+        guard (try? await retryAfterGate.wait()) != nil else { return }
         guard let auth, let baseURL = PresenceHeartbeatClient.resolvedServiceURL() else { return }
         let tokens: (accessToken: String, refreshToken: String)
         do {
@@ -137,7 +139,16 @@ final class MacPairedMacBackupPublisher {
 
         do {
             let (_, response) = try await session.data(for: req)
-            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            guard let http = response as? HTTPURLResponse else { return }
+            if http.statusCode == 429 {
+                let seconds = CmxRetryAfterPolicy.seconds(
+                    from: http,
+                    defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+                ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                await retryAfterGate.extend(by: seconds)
+                return
+            }
+            guard (200...299).contains(http.statusCode) else {
                 macPairedMacPublishLog.warning("self-publish failed: HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)")
                 return
             }

--- a/Sources/Cloud/PhonePushHTTPResult.swift
+++ b/Sources/Cloud/PhonePushHTTPResult.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import Foundation
 
 /// Truthful result of one Mac-to-push-API request.
@@ -81,8 +82,9 @@ enum PhonePushHTTPResult: Equatable, Sendable {
         response: HTTPURLResponse,
         data: Data
     ) -> Int? {
-        let header = response.value(forHTTPHeaderField: "Retry-After")
-            .flatMap(Int.init)
+        let header = CmxRetryAfterPolicy.seconds(
+            from: response.value(forHTTPHeaderField: "Retry-After")
+        )
         let summary = try? JSONDecoder().decode(
             PhonePushServerSummary.self,
             from: data
@@ -91,8 +93,13 @@ enum PhonePushHTTPResult: Equatable, Sendable {
             PhonePushErrorBody.self,
             from: data
         ).retryAfterSeconds
-        guard let value = header ?? summary ?? error else { return nil }
-        return max(value, 0)
+        let directive = [header, summary, error]
+            .compactMap { $0 }
+            .first(where: { $0 > 0 })
+        guard let value = directive ?? (response.statusCode == 429
+            ? CmxRetryAfterPolicy.defaultRateLimitSeconds
+            : nil) else { return nil }
+        return value
     }
 }
 

--- a/Sources/Cloud/PhonePushRetryPolicy.swift
+++ b/Sources/Cloud/PhonePushRetryPolicy.swift
@@ -17,7 +17,7 @@ enum PhonePushRetryPolicy {
         // Retry-After is the provider's lower bound, not a suggestion that the
         // client may shorten. The event TTL remains the upper bound: if the
         // requested delay would make this event stale, expire it instead.
-        let delay = max(retryAfterSeconds ?? fallback, 0)
+        let delay = max(fallback, retryAfterSeconds ?? 0)
         let (retryEpochSeconds, overflowed) = nowEpochSeconds
             .addingReportingOverflow(delay)
         guard !overflowed, retryEpochSeconds < expirationEpochSeconds else {

--- a/Sources/Cloud/PhoneReplyInboxClient.swift
+++ b/Sources/Cloud/PhoneReplyInboxClient.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxAuthRuntime
 import Foundation
 import OSLog
@@ -50,6 +51,7 @@ final class PhoneReplyInboxClient {
 
     @MainActor private weak var auth: AuthCoordinator?
     private let session: URLSession
+    private let retryAfterGate = CmxRetryAfterGate()
 
     init(session: URLSession = .shared) {
         self.session = session
@@ -69,6 +71,7 @@ final class PhoneReplyInboxClient {
     /// next nudge; the entries wait out their server-side TTL).
     @MainActor
     func fetchPending() async -> [PhoneReplyRecord]? {
+        guard (try? await retryAfterGate.wait()) != nil else { return nil }
         guard let request = await authorizedRequest(
             path: "/v1/replies",
             queryItems: [URLQueryItem(
@@ -78,8 +81,12 @@ final class PhoneReplyInboxClient {
         ) else { return nil }
         do {
             let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse,
-                  (200...299).contains(http.statusCode) else { return nil }
+            guard let http = response as? HTTPURLResponse else { return nil }
+            if http.statusCode == 429 {
+                await recordRetryAfter(http)
+                return nil
+            }
+            guard (200...299).contains(http.statusCode) else { return nil }
             return try JSONDecoder().decode(FetchEnvelope.self, from: data).replies
         } catch {
             phoneReplyLog.error("reply fetch failed: \(String(describing: error), privacy: .private)")
@@ -94,6 +101,7 @@ final class PhoneReplyInboxClient {
     @discardableResult
     func acknowledge(replyIds: [String]) async -> Bool {
         guard !replyIds.isEmpty else { return true }
+        guard (try? await retryAfterGate.wait()) != nil else { return false }
         guard var request = await authorizedRequest(path: "/v1/replies/ack") else { return false }
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "content-type")
@@ -103,13 +111,25 @@ final class PhoneReplyInboxClient {
         )
         do {
             let (_, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse,
-                  (200...299).contains(http.statusCode) else { return false }
+            guard let http = response as? HTTPURLResponse else { return false }
+            if http.statusCode == 429 {
+                await recordRetryAfter(http)
+                return false
+            }
+            guard (200...299).contains(http.statusCode) else { return false }
             return true
         } catch {
             phoneReplyLog.error("reply ack failed: \(String(describing: error), privacy: .private)")
             return false
         }
+    }
+
+    private func recordRetryAfter(_ response: HTTPURLResponse) async {
+        let seconds = CmxRetryAfterPolicy.seconds(
+            from: response,
+            defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+        ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+        await retryAfterGate.extend(by: seconds)
     }
 
     @MainActor

--- a/Sources/Cloud/PresenceHeartbeatClient.swift
+++ b/Sources/Cloud/PresenceHeartbeatClient.swift
@@ -27,6 +27,7 @@ final class PresenceHeartbeatClient {
     static let shared = PresenceHeartbeatClient()
 
     private let session: URLSession = .shared
+    private let retryAfterGate = CmxRetryAfterGate()
     private var auth: AuthCoordinator?
     private var loopTask: Task<Void, Never>?
     private var routesObserveTask: Task<Void, Never>?
@@ -177,6 +178,9 @@ final class PresenceHeartbeatClient {
     // MARK: - Heartbeat
 
     private func sendHeartbeat(stopping: Bool) async {
+        // Cadence, route-change, and shutdown triggers share one server-owned
+        // floor so an immediate trigger cannot reopen a rate-limited endpoint.
+        guard (try? await retryAfterGate.wait()) != nil else { return }
         guard let auth, let baseURL = Self.resolvedServiceURL() else { return }
         // Await tokens first, mirroring DeviceRegistryClient: gates on "signed
         // in" and on launch auth bootstrap so the team header resolves from a
@@ -215,7 +219,16 @@ final class PresenceHeartbeatClient {
 
         do {
             let (data, response) = try await session.data(for: req)
-            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            guard let http = response as? HTTPURLResponse else { return }
+            if http.statusCode == 429 {
+                let seconds = CmxRetryAfterPolicy.seconds(
+                    from: http,
+                    defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+                ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                await retryAfterGate.extend(by: seconds)
+                return
+            }
+            guard (200...299).contains(http.statusCode) else {
                 return // best-effort; retry happens on the next cadence tick
             }
             // Mirrors the JSONSerialization encode above; a typed Decodable

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -1,4 +1,5 @@
 import CmuxAuthRuntime
+import CMUXMobileCore
 import Foundation
 
 extension URLError.Code {
@@ -2045,8 +2046,10 @@ actor VMClient {
             if http.statusCode == 429, retriesLeft > 0 {
                 retriesLeft -= 1
                 onRetry()
-                let retryAfterSeconds = (http.value(forHTTPHeaderField: "Retry-After")).flatMap(Double.init)
-                let delaySeconds = min(max(retryAfterSeconds ?? 2, 1), 10)
+                let delaySeconds = Self.retryDelaySeconds(
+                    statusCode: http.statusCode,
+                    retryAfterHeader: http.value(forHTTPHeaderField: "Retry-After")
+                ) ?? 2
                 try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
                 continue
             }
@@ -2088,7 +2091,18 @@ actor VMClient {
         let error = object["error"] as? String
         guard retryable || error == "vm_cloud_service_unavailable" else { return nil }
         let requested = cloudVMInt(object["retryAfterSeconds"]) ?? 2
-        return .seconds(min(max(requested, 1), 10))
+        return .seconds(max(requested, 1))
+    }
+
+    nonisolated static func retryDelaySeconds(
+        statusCode: Int,
+        retryAfterHeader: String?
+    ) -> TimeInterval? {
+        guard statusCode == 429 else { return nil }
+        return TimeInterval(
+            CmxRetryAfterPolicy.seconds(from: retryAfterHeader)
+                ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+        )
     }
 
     private func decodeWebSocketDaemonEndpoint(_ value: Any?) throws -> VMWebSocketDaemonEndpoint? {

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -2050,7 +2050,7 @@ actor VMClient {
                     statusCode: http.statusCode,
                     retryAfterHeader: http.value(forHTTPHeaderField: "Retry-After")
                 ) ?? 2
-                try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+                try await CmxRetryAfterPolicy.sleep(seconds: delaySeconds)
                 continue
             }
             if retryTransientServiceUnavailable,
@@ -2058,9 +2058,7 @@ actor VMClient {
                let delaySeconds = Self.transientVMRetryDelay(http: http, data: data) {
                 retriesLeft -= 1
                 onRetry()
-                try await Task.sleep(
-                    nanoseconds: UInt64(delaySeconds.components.seconds) * 1_000_000_000
-                )
+                try await CmxRetryAfterPolicy.sleep(seconds: TimeInterval(delaySeconds.components.seconds))
                 continue
             }
             if let sessionIdentity {

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import Foundation
 import Observation
 import PostHog
@@ -71,6 +72,7 @@ final class CmuxFeatureFlags {
     private static let releaseControlDistinctIDPrefix =
         releaseControlProductWideDistinctID + "-"
     private nonisolated static let maximumPostHogControlPlaneResponseBytes = 1_048_576
+    private nonisolated static let releaseControlRetryAfterGate = CmxRetryAfterGate()
 
     // FLAG(key: sidebar-appkit-list-experiment, owner: lawrencecchen,
     //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
@@ -580,6 +582,7 @@ final class CmuxFeatureFlags {
         distinctID: String,
         personProperties: [String: String]
     ) async -> [String: Bool]? {
+        guard (try? await releaseControlRetryAfterGate.wait()) != nil else { return nil }
         guard let request = postHogControlPlaneRequest(
             distinctID: distinctID,
             personProperties: personProperties
@@ -590,8 +593,16 @@ final class CmuxFeatureFlags {
         let session = URLSession(configuration: configuration)
         defer { session.invalidateAndCancel() }
         guard let (bytes, response) = try? await session.bytes(for: request),
-              let http = response as? HTTPURLResponse,
-              (200..<300).contains(http.statusCode),
+              let http = response as? HTTPURLResponse else { return nil }
+        if http.statusCode == 429 {
+            let seconds = CmxRetryAfterPolicy.seconds(
+                from: http,
+                defaultSeconds: CmxRetryAfterPolicy.defaultRateLimitSeconds
+            ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+            await releaseControlRetryAfterGate.extend(by: seconds)
+            return nil
+        }
+        guard (200..<300).contains(http.statusCode),
               response.expectedContentLength < 0
                 || response.expectedContentLength <= maximumPostHogControlPlaneResponseBytes,
               let data = try? await boundedPostHogControlPlaneData(

--- a/cmuxTests/PhonePushPresenceGateTests.swift
+++ b/cmuxTests/PhonePushPresenceGateTests.swift
@@ -571,8 +571,7 @@ import Testing
                 expirationEpochSeconds: 1_120
             ) == 7
         )
-        // A malformed provider header can carry a negative Retry-After; the
-        // clamp floors it at an immediate retry instead of a negative delay.
+        // Malformed provider metadata must not shorten the local backoff.
         #expect(
             PhonePushRetryPolicy.delaySeconds(
                 afterAttempt: 1,
@@ -580,7 +579,16 @@ import Testing
                 retryAfterSeconds: -30,
                 nowEpochSeconds: 1_000,
                 expirationEpochSeconds: 1_120
-            ) == 0
+            ) == 1
+        )
+        #expect(
+            PhonePushRetryPolicy.delaySeconds(
+                afterAttempt: 2,
+                result: .retryableFailure,
+                retryAfterSeconds: 1,
+                nowEpochSeconds: 1_000,
+                expirationEpochSeconds: 1_120
+            ) == 2
         )
         #expect(
             PhonePushRetryPolicy.delaySeconds(
@@ -713,6 +721,24 @@ import Testing
         #expect(PhonePushHTTPResult.decode(statusCode: 429, data: Data()).shouldRetry)
         #expect(PhonePushHTTPResult.decode(statusCode: 503, data: Data()).shouldRetry)
         #expect(!PhonePushHTTPResult.decode(statusCode: 401, data: Data()).shouldRetry)
+    }
+
+    @Test func rateLimitWithoutDirectiveUsesConservativeFallback() throws {
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://cmux.test/api/push/send")!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        #expect(PhonePushHTTPResult.retryAfterSeconds(
+            response: response,
+            data: Data()
+        ) == 60)
+        #expect(PhonePushHTTPResult.retryAfterSeconds(
+            response: response,
+            data: Data(#"{"retryAfterSeconds":0}"#.utf8)
+        ) == 60)
     }
 
     @Test func retryClassificationSeparatesAuthConflictAndInProgressResponses() throws {

--- a/cmuxTests/VMClientTelemetryTests.swift
+++ b/cmuxTests/VMClientTelemetryTests.swift
@@ -159,6 +159,13 @@ struct VMClientTelemetryTests {
     func referenceLine() {
         #expect(cloudVMReferenceLine(traceId: "abc123").contains("abc123"))
     }
+
+    @Test("VM retries never shorten Retry-After")
+    func vmRetryAfterIsAuthoritative() {
+        #expect(VMClient.retryDelaySeconds(statusCode: 429, retryAfterHeader: "45") == 45)
+        #expect(VMClient.retryDelaySeconds(statusCode: 429, retryAfterHeader: nil) == 60)
+        #expect(VMClient.retryDelaySeconds(statusCode: 503, retryAfterHeader: "45") == nil)
+    }
 }
 
 private final class ManualClock: @unchecked Sendable {

--- a/web/app/api/analytics/events/route.ts
+++ b/web/app/api/analytics/events/route.ts
@@ -70,7 +70,11 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
       try {
         const { error, rateLimited } = await dependencies.checkRateLimit(rateLimitId, { request });
         if (rateLimited || error === "blocked") {
-          return jsonResponse({ error: "rate_limited" }, 429);
+          return jsonResponse(
+            { error: "rate_limited" },
+            429,
+            { "retry-after": "60" },
+          );
         }
         if (error === "not-found") {
           void reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { checkRateLimit } from "@vercel/firewall";
 import { NextResponse } from "next/server";
 
@@ -14,9 +16,17 @@ import {
   postHogFlagsBody,
   postHogFlagsUrl,
 } from "../../../services/client-config/posthogFlags";
+import { rateLimitDeploymentPartition } from "../../../services/rateLimitPartition";
 
 
 export async function POST(request: Request): Promise<Response> {
+  const rateLimitRequest = request.clone();
+  const body = await readBoundedJsonObject(request, MAX_CLIENT_CONFIG_REQUEST_BYTES);
+  if (!body.ok) {
+    return json({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
+  }
+  const distinctId = normalizeDistinctId(body.value.distinctId);
+
   // An unset rule id means no rate limiting; a deleted rule (not-found) fails
   // open rather than making client config unavailable for every app boot.
   const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
@@ -25,9 +35,16 @@ export async function POST(request: Request): Promise<Response> {
   }
   if (process.env.VERCEL === "1" && rateLimitId) {
     try {
-      const { error, rateLimited } = await checkRateLimit(rateLimitId, { request });
+      const { error, rateLimited } = await checkRateLimit(rateLimitId, {
+        request: rateLimitRequest,
+        rateLimitKey: clientConfigRateLimitKey(distinctId),
+      });
       if (rateLimited || error === "blocked") {
-        return json({ error: "rate_limited" }, 429);
+        return json(
+          { error: "rate_limited" },
+          429,
+          { "retry-after": "60" },
+        );
       }
       if (error === "not-found") {
         void reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
@@ -41,12 +58,6 @@ export async function POST(request: Request): Promise<Response> {
     }
   }
 
-  const body = await readBoundedJsonObject(request, MAX_CLIENT_CONFIG_REQUEST_BYTES);
-  if (!body.ok) {
-    return json({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
-  }
-
-  const distinctId = normalizeDistinctId(body.value.distinctId);
   const context = normalizeClientConfigEvaluationContext(body.value.context);
   try {
     const response = await fetch(postHogFlagsUrl(), {
@@ -74,11 +85,23 @@ export async function POST(request: Request): Promise<Response> {
   }
 }
 
-function json(body: Record<string, unknown>, status = 200): Response {
+function json(
+  body: Record<string, unknown>,
+  status = 200,
+  extraHeaders?: HeadersInit,
+): Response {
   return NextResponse.json(body, {
     status,
     headers: {
       "Cache-Control": "no-store",
+      ...Object.fromEntries(new Headers(extraHeaders)),
     },
   });
+}
+
+function clientConfigRateLimitKey(distinctId: string): string {
+  const installPartition = createHash("sha256")
+    .update(`cmux/client-config/v1\0${distinctId}`)
+    .digest("hex");
+  return `${rateLimitDeploymentPartition()}:${installPartition}`;
 }

--- a/web/app/api/observability/mobile-network/route.ts
+++ b/web/app/api/observability/mobile-network/route.ts
@@ -138,7 +138,11 @@ async function enforceRateLimit(
   try {
     const { error, rateLimited } = await dependencies.checkRateLimit(rateLimitId, { request });
     if (rateLimited || error === "blocked") {
-      return jsonResponse({ error: "rate_limited" }, 429, { "cache-control": "no-store" });
+      return jsonResponse(
+        { error: "rate_limited" },
+        429,
+        { "cache-control": "no-store", "retry-after": "60" },
+      );
     }
     if (error === "not-found") {
       void reportMissingRateLimitRule({ route: ROUTE, reason: "not-found" });

--- a/web/app/api/relay/preferences/route.ts
+++ b/web/app/api/relay/preferences/route.ts
@@ -78,6 +78,7 @@ async function authenticatedAccount(
     ruleId: deps.rateLimitRuleId(),
     check: deps.checkRateLimit,
     isVercel: deps.isVercel(),
+    retryAfterSeconds: 60,
   }));
   return user;
 }

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -86,7 +86,7 @@ export interface RelayTokenDeps {
 }
 
 const productionDeps: RelayTokenDeps = {
-  verifyRequest: (request) => verifyRequestIdentity(request, { allowCookie: false }),
+  verifyRequest: (request) => verifyRequestIdentity(request, { allowCookie: false, allowStackFallback: false }),
   signingKey: relaySigningKey,
   nowSeconds: () => Math.floor(Date.now() / 1_000),
   signedPolicy: async (accountId, nowSeconds) => {
@@ -158,6 +158,11 @@ export async function handleRelayTokenRequest(
     const { bindingProof, clientNamespace, endpointId } = parsed;
     const key = deps.signingKey();
     const nowSeconds = deps.nowSeconds();
+    // Namespaced requests always require a proof. Charge their credential
+    // partition before database/crypto work, including rejected signatures.
+    if (clientNamespace !== "legacy") {
+      await checkTokenQuota(request, deps, user.id, clientNamespace, endpointId, "credential", nowSeconds);
+    }
     const isEndpointAuthorized = await deps.isEndpointAuthorized({
       accountId: user.id,
       endpointId,
@@ -169,34 +174,21 @@ export async function handleRelayTokenRequest(
       return jsonResponse({ error: "invalid_binding_request_proof" }, 403);
     }
 
-    const policy = await deps.signedPolicy(user.id, nowSeconds);
     if (!key && deps.credentialSigningRequired()) {
       return jsonResponse({ error: "relay_token_not_configured" }, 503);
     }
-    const relayUrls = policy.payload.relays.map((relay) => relay.url);
     // A fresh endpoint must fetch policy before registration, then fetch its
     // bound credential immediately after registration. Renewals happen every
     // four minutes because both artifacts expire after five. Give bootstrap
     // and credential issuance separate one-minute partitions so the external
     // rule cannot make the valid two-leg bootstrap or renewal cadence
     // impossible. Duplicate work inside one phase and minute is still bounded.
-    const rateLimitBucket = Math.floor(
-      nowSeconds / RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS,
-    );
-    const rateLimitPhase = isEndpointAuthorized ? "credential" : "bootstrap";
-    const retryAfterSeconds = RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS -
-      (nowSeconds % RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS);
-    await runRelayEffect(enforceRelayRateLimit({
-      request,
-      accountId: user.id,
-      deploymentPartition: rateLimitDeploymentPartition(),
-      devicePartition:
-        `${clientNamespace}:${endpointId}:${rateLimitPhase}:${rateLimitBucket}`,
-      ruleId: deps.rateLimitRuleId(),
-      check: deps.checkRateLimit,
-      isVercel: deps.isVercel(),
-      retryAfterSeconds,
-    }));
+    if (clientNamespace === "legacy") {
+      await checkTokenQuota(request, deps, user.id, clientNamespace, endpointId,
+        isEndpointAuthorized ? "credential" : "bootstrap", nowSeconds);
+    }
+    const policy = await deps.signedPolicy(user.id, nowSeconds);
+    const relayUrls = policy.payload.relays.map((relay) => relay.url);
 
     // Local and preview runtimes intentionally operate without the private
     // relay JWT signer. They still return the signed fleet policy so clients
@@ -239,6 +231,29 @@ export async function handleRelayTokenRequest(
   } catch (error) {
     return relayErrorResponse(error);
   }
+}
+
+async function checkTokenQuota(
+  request: Request,
+  deps: RelayTokenDeps,
+  accountId: string,
+  namespace: string,
+  endpointId: string,
+  phase: "credential" | "bootstrap",
+  nowSeconds: number,
+): Promise<void> {
+  const bucket = Math.floor(nowSeconds / RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS);
+  await runRelayEffect(enforceRelayRateLimit({
+    request,
+    accountId,
+    deploymentPartition: rateLimitDeploymentPartition(),
+    devicePartition: `${namespace}:${endpointId}:${phase}:${bucket}`,
+    ruleId: deps.rateLimitRuleId(),
+    check: deps.checkRateLimit,
+    isVercel: deps.isVercel(),
+    retryAfterSeconds: RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS -
+      (nowSeconds % RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS),
+  }));
 }
 
 function hasExactCredentialSet(

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -46,6 +46,7 @@ import {
   unauthorized,
   verifyRequestIdentity,
 } from "../../../../services/vms/auth";
+import { rateLimitDeploymentPartition } from "../../../../services/rateLimitPartition";
 
 
 const MAX_BODY_BYTES = 4 * 1_024;
@@ -143,26 +144,6 @@ export async function handleRelayTokenRequest(
   request: Request,
   deps: RelayTokenDeps,
 ): Promise<Response> {
-  // Apply the cheap IP-scoped gate before calling Stack Auth. A storming
-  // client must not spend one upstream users/me request per retry. The clone
-  // preserves the existing auth-first semantics for malformed requests, which
-  // must not consume a valid relay-token budget.
-  if (await hasValidRelayEndpoint(request)) {
-    try {
-      await runRelayEffect(enforceRelayRateLimit({
-        request,
-        accountId: "pre-auth",
-        rateLimitKey: null,
-        ruleId: deps.rateLimitRuleId(),
-        check: deps.checkRateLimit,
-        isVercel: deps.isVercel(),
-        retryAfterSeconds: RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS,
-      }));
-    } catch (error) {
-      return relayErrorResponse(error);
-    }
-  }
-
   let user: { readonly id: string } | null;
   try {
     user = await deps.verifyRequest(request);
@@ -170,36 +151,13 @@ export async function handleRelayTokenRequest(
     return relayErrorResponse(relayAuthenticationError(error));
   }
   if (!user) return unauthorized();
-  const clientNamespace = request.headers.get("x-cmux-app-namespace") ?? "legacy";
-  if (!/^[A-Za-z0-9._:-]{1,255}$/.test(clientNamespace)) {
-    return jsonResponse({ error: "invalid_client_namespace" }, 400);
-  }
-  const proofRequest = request.clone();
 
   try {
+    const parsed = await parseRelayTokenRequest(request);
+    if (parsed instanceof Response) return parsed;
+    const { bindingProof, clientNamespace, endpointId } = parsed;
     const key = deps.signingKey();
-    const body = await readBoundedJsonObject(request, MAX_BODY_BYTES);
-    if (!body.ok) {
-      return jsonResponse(
-        { error: body.error },
-        body.error === "request_too_large" ? 413 : 400,
-      );
-    }
-    const rawEndpointId = body.value.endpointId;
-    if (typeof rawEndpointId !== "string" || !isValidEndpointId(rawEndpointId)) {
-      return jsonResponse({ error: "invalid_endpoint_id" }, 400);
-    }
-    const bindingProof = parseBindingRequestProof(
-      proofRequest,
-      new Uint8Array(await proofRequest.arrayBuffer()),
-    );
-    if (bindingProof instanceof Response) return bindingProof;
-    if (clientNamespace !== "legacy" && !bindingProof) {
-      return jsonResponse({ error: "binding_request_proof_required" }, 403);
-    }
-
     const nowSeconds = deps.nowSeconds();
-    const endpointId = rawEndpointId.toLowerCase();
     const isEndpointAuthorized = await deps.isEndpointAuthorized({
       accountId: user.id,
       endpointId,
@@ -231,8 +189,9 @@ export async function handleRelayTokenRequest(
     await runRelayEffect(enforceRelayRateLimit({
       request,
       accountId: user.id,
+      deploymentPartition: rateLimitDeploymentPartition(),
       devicePartition:
-        `${endpointId}:${rateLimitPhase}:${rateLimitBucket}`,
+        `${clientNamespace}:${endpointId}:${rateLimitPhase}:${rateLimitBucket}`,
       ruleId: deps.rateLimitRuleId(),
       check: deps.checkRateLimit,
       isVercel: deps.isVercel(),
@@ -324,16 +283,46 @@ function homogeneousLegacyCredential(
   ) ? first : null;
 }
 
-export function POST(request: Request): Promise<Response> {
-  return handleRelayTokenRequest(request, productionDeps);
+type RelayTokenRequest = {
+  readonly bindingProof: IrohBindingRequestProof | undefined;
+  readonly clientNamespace: string;
+  readonly endpointId: string;
+};
+
+async function parseRelayTokenRequest(
+  request: Request,
+): Promise<RelayTokenRequest | Response> {
+  const clientNamespace = request.headers.get("x-cmux-app-namespace") ?? "legacy";
+  if (!/^[A-Za-z0-9._:-]{1,255}$/.test(clientNamespace)) {
+    return jsonResponse({ error: "invalid_client_namespace" }, 400);
+  }
+  const proofRequest = request.clone();
+  const body = await readBoundedJsonObject(request, MAX_BODY_BYTES);
+  if (!body.ok) {
+    return jsonResponse(
+      { error: body.error },
+      body.error === "request_too_large" ? 413 : 400,
+    );
+  }
+  const rawEndpointId = body.value.endpointId;
+  if (typeof rawEndpointId !== "string" || !isValidEndpointId(rawEndpointId)) {
+    return jsonResponse({ error: "invalid_endpoint_id" }, 400);
+  }
+  const bindingProof = parseBindingRequestProof(
+    proofRequest,
+    new Uint8Array(await proofRequest.arrayBuffer()),
+  );
+  if (bindingProof instanceof Response) return bindingProof;
+  if (clientNamespace !== "legacy" && !bindingProof) {
+    return jsonResponse({ error: "binding_request_proof_required" }, 403);
+  }
+  return {
+    bindingProof,
+    clientNamespace,
+    endpointId: rawEndpointId.toLowerCase(),
+  };
 }
 
-async function hasValidRelayEndpoint(request: Request): Promise<boolean> {
-  try {
-    const body = await readBoundedJsonObject(request.clone(), MAX_BODY_BYTES);
-    const endpointId = body.ok ? body.value.endpointId : undefined;
-    return typeof endpointId === "string" && isValidEndpointId(endpointId);
-  } catch {
-    return false;
-  }
+export function POST(request: Request): Promise<Response> {
+  return handleRelayTokenRequest(request, productionDeps);
 }

--- a/web/oxlint-complexity-baseline.txt
+++ b/web/oxlint-complexity-baseline.txt
@@ -15,7 +15,6 @@ app/api/devices/route-classification.ts	513b71ee5fa1c204ab467c27ca2444b7f5b354c4
 app/api/devices/route.ts	efa8ebbabb3504addae597384da1583c5073c99743dc9760f6994b367d68b7be	async function `POST` has a complexity of 22. Maximum allowed is 20.
 app/api/enterprise/contact/route.ts	59834d0588bbdc79cd51791500241b2d478ccdf71f75acb2f5c95dc2b6865476	async function has a complexity of 21. Maximum allowed is 20.
 app/api/freestyle/forward-auth/route.ts	260875e349335e792f8c384a1297e9f43ef0d7f657421e070b32e247d998db18	async function `handleForwardAuthRequest` has a complexity of 24. Maximum allowed is 20.
-app/api/relay/token/route.ts	6ade4cdb012efa149c005e993066a799394f97204b9570d914e1302af530bac9	async function `handleRelayTokenRequest` has a complexity of 27. Maximum allowed is 20.
 app/api/stripe/founders-welcome/route.ts	c0c0ad634aa3a9cd96e424f10f245fa73ca6d19e66486cd3b95898c0e7e7b64e	async function has a complexity of 41. Maximum allowed is 20.
 app/api/support/contact/route.ts	3ae990ffbae762e5770962a2520b8aa9f2844e682db6b9a0a115ea2382b21d8f	async function has a complexity of 22. Maximum allowed is 20.
 app/handler/after-sign-in/handler.ts	2ed6972f1468f3daf7f2096a316faa3d5341d83263a917bb34cfc9c5ffbef89d	async function `GET` has a complexity of 44. Maximum allowed is 20.

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -30,7 +30,7 @@ export type IrohRouteOperation =
 type RouteDependencies = {
   readonly verify?: (
     request: Request,
-    options: { readonly allowCookie: false; readonly requireStackSession: boolean },
+    options: { readonly allowCookie: false; readonly requireStackSession: boolean; readonly allowStackFallback: false },
   ) => Promise<{ readonly id: string } | null>;
   readonly broker?: IrohTrustBrokerShape;
   readonly runtime?: Layer.Layer<IrohTrustBroker, never, never>;
@@ -59,6 +59,7 @@ export async function handleIrohRoute(
     user = await verify(request, {
       allowCookie: false,
       requireStackSession: requiresStackSession(operation),
+      allowStackFallback: false,
     });
   } catch (error) {
     // A Stack Auth throttle or outage is not the caller's fault. Answering 401

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -49,9 +49,10 @@ export async function handleIrohRoute(
   dependencies: RouteDependencies = {},
 ): Promise<Response> {
   // Identity only: the broker needs the user id, and local token verification
-  // keeps the ~100 req/s registration traffic off Stack's per-request API
-  // budget. Pair grants, revocation, and relay tokens are rare and sensitive,
-  // so they still ask Stack and refuse a revoked session immediately.
+  // keeps routine Iroh traffic off Stack's per-request API budget. Pair grants
+  // and revocation still ask Stack and refuse a revoked session immediately.
+  // Relay credentials are short lived and account-scoped by the broker, so a
+  // locally verified access token is the appropriate identity proof there.
   const verify = dependencies.verify ?? verifyRequestIdentity;
   let user: { readonly id: string } | null;
   try {
@@ -219,8 +220,9 @@ export function requiresStackSession(operation: IrohRouteOperation): boolean {
       return false;
     case "revoke":
     case "pair_grant":
-    case "relay_token":
       return true;
+    case "relay_token":
+      return false;
   }
 }
 

--- a/web/services/rateLimitPartition.ts
+++ b/web/services/rateLimitPartition.ts
@@ -1,0 +1,11 @@
+export function rateLimitDeploymentPartition(
+  runtimeEnvironment: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = runtimeEnvironment.VERCEL_ENV
+    ?? runtimeEnvironment.NODE_ENV
+    ?? "development";
+  const normalized = raw.trim().toLowerCase();
+  return /^[a-z0-9._-]{1,64}$/u.test(normalized)
+    ? normalized
+    : "unknown";
+}

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -36,6 +36,8 @@ export function enforceRelayRateLimit(input: {
    * other phones, simulators, and tagged builds.
    */
   readonly devicePartition?: string;
+  /** Server-owned deployment scope, keeping dev/staging budgets out of production. */
+  readonly deploymentPartition?: string;
   readonly ruleId: string | undefined;
   readonly check: RelayRateLimitCheck;
   readonly isVercel?: boolean;
@@ -58,9 +60,11 @@ export function enforceRelayRateLimit(input: {
       ...(input.rateLimitKey === null
         ? {}
         : {
-          rateLimitKey: input.rateLimitKey ?? (input.devicePartition
-            ? `${input.accountId}:${input.devicePartition}`
-            : input.accountId),
+          rateLimitKey: input.rateLimitKey ?? [
+            input.deploymentPartition,
+            input.accountId,
+            input.devicePartition,
+          ].filter((part): part is string => Boolean(part)).join(":"),
         }),
     }),
     catch: () => new RelayRateLimitError({ code: "rate_limit_unavailable" }),

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -700,6 +700,8 @@ type VerifyIdentityOptions = {
    * immediately. Use for sensitive, low-volume operations.
    */
   readonly requireStackSession?: boolean;
+  /** High-volume native routes reject invalid tokens locally instead of asking Stack. */
+  readonly allowStackFallback?: boolean;
   /** Test seam for the local token verifier. */
   readonly verifyAccessToken?: (
     accessToken: string,
@@ -738,6 +740,7 @@ export async function verifyRequestIdentity(
       return { id: local.userId, source: "access_token" };
     }
   }
+  if (options.allowStackFallback === false && !options.requireStackSession) return null;
   const user = await verifyRequest(request, { allowCookie: options.allowCookie });
   return user ? { id: user.id, source: "stack" } : null;
 }

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   checkRateLimit,
   installVercelFirewallMock,
@@ -275,7 +276,10 @@ describe("client config", () => {
     }).mock.calls;
     expect(calls[0]?.[0]).toBe("cmux-client-config-test");
     expect(calls[0]?.[1]?.request.url).toBe("https://cmux.test/api/client-config");
-    expect(calls[0]?.[1]?.rateLimitKey).toBe("production:browser-id");
+    const installPartition = createHash("sha256")
+      .update("cmux/client-config/v1\0browser-id")
+      .digest("hex");
+    expect(calls[0]?.[1]?.rateLimitKey).toBe(`production:${installPartition}`);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -12,6 +12,7 @@ process.env.POSTHOG_PROJECT_KEY = "test-project-key";
 process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
 
 const originalVercel = process.env.VERCEL;
+const originalVercelEnvironment = process.env.VERCEL_ENV;
 installVercelFirewallMock();
 
 const {
@@ -35,6 +36,7 @@ afterEach(() => {
   } else {
     process.env.VERCEL = originalVercel;
   }
+  restoreEnv("VERCEL_ENV", originalVercelEnvironment);
 });
 
 afterAll(() => {
@@ -248,8 +250,9 @@ describe("client config", () => {
     }
   });
 
-  test("applies the Vercel limiter before proxying flags", async () => {
+  test("partitions the Vercel limiter by deployment and install", async () => {
     process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "production";
     process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = " cmux-client-config-test\n";
     checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
     const fetchMock = mock(async () => {
@@ -260,18 +263,34 @@ describe("client config", () => {
     const response = await POST(new Request("https://cmux.test/api/client-config", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: "{",
+      body: JSON.stringify({ distinctId: "browser-id" }),
     }));
 
     expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
     expect(await response.json()).toEqual({ error: "rate_limited" });
     expect(checkRateLimit).toHaveBeenCalledTimes(1);
     const calls = (checkRateLimit as unknown as {
-      mock: { calls: Array<[string, { request: Request }]> };
+      mock: { calls: Array<[string, { request: Request; rateLimitKey?: string }]> };
     }).mock.calls;
     expect(calls[0]?.[0]).toBe("cmux-client-config-test");
     expect(calls[0]?.[1]?.request.url).toBe("https://cmux.test/api/client-config");
+    expect(calls[0]?.[1]?.rateLimitKey).toBe("production:browser-id");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed client config before consuming an install budget", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    }));
+
+    expect(response.status).toBe(400);
+    expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
   test("skips rate limiting on Vercel when the client-config limiter id is unset", async () => {

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -191,7 +191,7 @@ describe("Iroh route boundary", () => {
     expect(called).toBe(false);
   });
 
-  test("only high-volume operations use the local token fast path", async () => {
+  test("routine Iroh operations use the local token fast path", async () => {
     const seen: Array<[IrohRouteOperation, boolean]> = [];
     for (const operation of [
       "challenge", "register", "discover", "endpoint_attestation",
@@ -212,7 +212,7 @@ describe("Iroh route boundary", () => {
       ["endpoint_attestation", false],
       ["revoke", true],
       ["pair_grant", true],
-      ["relay_token", true],
+      ["relay_token", false],
     ]);
     expect(requiresStackSession("pair_grant")).toBe(true);
   });

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -90,6 +90,24 @@ function request(
 }
 
 describe("POST /api/relay/token", () => {
+  test("rate limits invalid binding proofs before database and signature work", async () => {
+    let authorizations = 0;
+    let policyReads = 0;
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }, "dev.cmux.app.beta", true),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => ({ rateLimited: true }),
+        isEndpointAuthorized: async () => { authorizations += 1; return false; },
+        signedPolicy: async () => { policyReads += 1; throw new Error("unexpected policy read"); },
+      }),
+    );
+    expect(response.status).toBe(429);
+    expect(authorizations).toBe(0);
+    expect(policyReads).toBe(0);
+  });
+
   test("keeps legacy token fields and adds policy plus separate preference metadata", async () => {
     const response = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -446,8 +446,9 @@ describe("POST /api/relay/token", () => {
     });
   });
 
-  test("blocks a valid relay request before calling Stack Auth when ingress is limited", async () => {
+  test("never lets an IP-wide ingress bucket reject an authenticated endpoint", async () => {
     let authCalls = 0;
+    const observedKeys: Array<string | undefined> = [];
     const response = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),
       deps({
@@ -458,19 +459,17 @@ describe("POST /api/relay/token", () => {
           return { id: "account-a" } as AuthedUser;
         },
         checkRateLimit: async (_id, options) => {
-          expect(options.rateLimitKey).toBeUndefined();
-          return { rateLimited: true };
+          observedKeys.push(options.rateLimitKey);
+          return { rateLimited: options.rateLimitKey === undefined };
         },
       }),
     );
 
-    expect(response.status).toBe(429);
-    expect(response.headers.get("retry-after")).toBe("60");
-    expect(await response.json()).toEqual({
-      error: "rate_limited",
-      source: "ingress_ip",
-    });
-    expect(authCalls).toBe(0);
+    expect(response.status).toBe(200);
+    expect(authCalls).toBe(1);
+    expect(observedKeys).toEqual([
+      `development:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
+    ]);
   });
 
   test("rate limits per account and endpoint and fails closed", async () => {
@@ -497,7 +496,7 @@ describe("POST /api/relay/token", () => {
     // starves only its duplicate work, never bootstrap, renewal, or another
     // phone, simulator, or tagged build.
     expect(key).toBe(
-      `account-a:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
+      `development:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
     );
     expect(limited.headers.get("retry-after")).toBe("40");
 

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -221,7 +221,7 @@ describe("POST /api/relay/token", () => {
     expect(await response.json()).toEqual({
       error: "binding_request_proof_required",
     });
-    expect(rateLimitChecks).toBe(1);
+    expect(rateLimitChecks).toBe(0);
   });
 
   test("returns signed policy without private relay credentials in local development", async () => {
@@ -468,7 +468,7 @@ describe("POST /api/relay/token", () => {
     expect(response.status).toBe(200);
     expect(authCalls).toBe(1);
     expect(observedKeys).toEqual([
-      `development:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
+      `test:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
     ]);
   });
 
@@ -496,7 +496,7 @@ describe("POST /api/relay/token", () => {
     // starves only its duplicate work, never bootstrap, renewal, or another
     // phone, simulator, or tagged build.
     expect(key).toBe(
-      `development:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
+      `test:account-a:legacy:${ENDPOINT_ID.toLowerCase()}:credential:28333333`,
     );
     expect(limited.headers.get("retry-after")).toBe("40");
 
@@ -514,7 +514,7 @@ describe("POST /api/relay/token", () => {
       }),
     );
     expect(invalid.status).toBe(400);
-    expect(checks).toBe(2);
+    expect(checks).toBe(1);
 
     const blocked = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),

--- a/web/tests/vm-auth-identity.test.ts
+++ b/web/tests/vm-auth-identity.test.ts
@@ -61,6 +61,16 @@ beforeEach(() => {
 });
 
 describe("verifyRequestIdentity", () => {
+  test("local-only verification rejects invalid tokens without spending Stack quota", async () => {
+    const identity = await verifyRequestIdentity(nativeRequest("invalid-token"), {
+      allowCookie: false,
+      allowStackFallback: false,
+      verifyAccessToken: localIdentity,
+    });
+    expect(identity).toBeNull();
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+
   test("a locally verified access token never calls Stack", async () => {
     const identity = await verifyRequestIdentity(nativeRequest("good-token"), {
       allowCookie: false,

--- a/workers/presence/src/controlPlane.ts
+++ b/workers/presence/src/controlPlane.ts
@@ -1240,9 +1240,12 @@ export class ControlPlaneCore {
       ));
       return;
     }
-    const activeCooldown = await this.upstreamCooldownRemainingSeconds(
-      MINT_RETRY_AT_KEY,
-    );
+    // Account and deployment are isolated by the DO. Preserve the upstream
+    // namespace/endpoint boundary across reconnects and hibernation as well.
+    const mintRetryKey = `${MINT_RETRY_AT_KEY}:${JSON.stringify([
+      attachment.namespace ?? "legacy", endpointId.trim().toLowerCase(),
+    ])}`;
+    const activeCooldown = await this.upstreamCooldownRemainingSeconds(mintRetryKey);
     if (activeCooldown !== null) {
       this.sendFrame(socket, attachment, errorFrame(
         "mint_upstream_unavailable",
@@ -1265,7 +1268,7 @@ export class ControlPlaneCore {
       return;
     }
     if (result.status < 200 || result.status >= 300) {
-      await this.recordUpstreamCooldown(MINT_RETRY_AT_KEY, result);
+      await this.recordUpstreamCooldown(mintRetryKey, result);
       const retryable = result.status >= 500 || result.status === 429;
       this.sendFrame(socket, attachment, errorFrame(
         retryable ? "mint_upstream_unavailable" : "mint_rejected",
@@ -1274,7 +1277,7 @@ export class ControlPlaneCore {
       ));
       return;
     }
-    await this.deps.storage.delete(MINT_RETRY_AT_KEY);
+    // An older in-flight success must not erase a newer request's cooldown.
     const generation = ((await this.deps.storage.get<number>(GEN_PREFIX + endpointId)) ?? 0) + 1;
     const passes = passesFromMintResponse(result.json, generation);
     if (passes === null) {

--- a/workers/presence/src/controlPlane.ts
+++ b/workers/presence/src/controlPlane.ts
@@ -36,6 +36,7 @@ import type {
   ReleaseTrack,
   Status,
 } from "./generated/controlPlane";
+import { DEFAULT_RETRY_AFTER_SECONDS } from "./retryAfterResponse";
 
 export const CONTROL_PROTOCOL_VERSION = 1;
 
@@ -107,6 +108,10 @@ export const REV_KEY = "ctl:rev";
  * Broker truth only: publish_hint announcements are never folded in, and the
  * DO-owned device overlay is joined in at directory build time, not here. */
 export const DIR_KEY = "ctl:dir";
+/** Account-wide upstream cooldowns survive DO hibernation and prevent a
+ * reconnecting fleet from replaying a Vercel 429 before its deadline. */
+export const DIRECTORY_RETRY_AT_KEY = "ctl:retry:directory";
+export const MINT_RETRY_AT_KEY = "ctl:retry:mint";
 /** Per-endpoint relay-pass mint generation counter (`ctl:gen:<endpointId>`).
  * The broker response carries no generation; passes minted in one batch share
  * one monotonically increasing number so clients can order credential sets. */
@@ -810,6 +815,9 @@ export interface CtlUpstreamInit {
 export interface CtlUpstreamResult {
   status: number;
   json: unknown;
+  /** Parsed Retry-After response header for HTTP 429, with a conservative
+   * fallback supplied by the adapter when the upstream omitted it. */
+  retryAfterSeconds?: number;
 }
 
 export interface CtlDeps {
@@ -1049,7 +1057,15 @@ export class ControlPlaneCore {
       } else {
         attachment.snapshotPending = true;
         socket.setAttachment(attachment);
-        await this.deps.scheduleAlarmAt(this.deps.now() + SNAPSHOT_RETRY_DELAY_MS);
+        const serverFloor = await this.upstreamCooldownRemainingSeconds(
+          DIRECTORY_RETRY_AT_KEY,
+        );
+        await this.deps.scheduleAlarmAt(
+          this.deps.now() + Math.max(
+            SNAPSHOT_RETRY_DELAY_MS,
+            (serverFloor ?? 0) * 1_000,
+          ),
+        );
       }
       return;
     }
@@ -1224,6 +1240,17 @@ export class ControlPlaneCore {
       ));
       return;
     }
+    const activeCooldown = await this.upstreamCooldownRemainingSeconds(
+      MINT_RETRY_AT_KEY,
+    );
+    if (activeCooldown !== null) {
+      this.sendFrame(socket, attachment, errorFrame(
+        "mint_upstream_unavailable",
+        `relay token mint rate limited; retry after ${activeCooldown}s`,
+        true,
+      ));
+      return;
+    }
     const result = await this.upstreamOnceRetry(MINT_PATH, {
       method: "POST",
       headers: upstreamHeaders(credentials, attachment.namespace, true),
@@ -1238,6 +1265,7 @@ export class ControlPlaneCore {
       return;
     }
     if (result.status < 200 || result.status >= 300) {
+      await this.recordUpstreamCooldown(MINT_RETRY_AT_KEY, result);
       const retryable = result.status >= 500 || result.status === 429;
       this.sendFrame(socket, attachment, errorFrame(
         retryable ? "mint_upstream_unavailable" : "mint_rejected",
@@ -1246,6 +1274,7 @@ export class ControlPlaneCore {
       ));
       return;
     }
+    await this.deps.storage.delete(MINT_RETRY_AT_KEY);
     const generation = ((await this.deps.storage.get<number>(GEN_PREFIX + endpointId)) ?? 0) + 1;
     const passes = passesFromMintResponse(result.json, generation);
     if (passes === null) {
@@ -1589,6 +1618,9 @@ export class ControlPlaneCore {
   private async fetchDirectory(
     attachment: CtlAttachment,
   ): Promise<{ revision: number | null; payload: BrokerDirectoryPayload } | null> {
+    if (await this.upstreamCooldownRemainingSeconds(DIRECTORY_RETRY_AT_KEY) !== null) {
+      return null;
+    }
     const credentials = decodeStoredCredentials(
       await this.deps.storage.get<string>(BEARER_PREFIX + attachment.sessionId),
     );
@@ -1604,8 +1636,38 @@ export class ControlPlaneCore {
       // mutation/relay requests.
       headers: upstreamHeaders(credentials, "legacy", false),
     });
-    if (result === null || result.status < 200 || result.status >= 300) return null;
+    if (result === null) return null;
+    if (result.status < 200 || result.status >= 300) {
+      await this.recordUpstreamCooldown(DIRECTORY_RETRY_AT_KEY, result);
+      return null;
+    }
+    await this.deps.storage.delete(DIRECTORY_RETRY_AT_KEY);
     return directoryPayloadFromDiscovery(result.json);
+  }
+
+  private async recordUpstreamCooldown(
+    key: string,
+    result: CtlUpstreamResult,
+  ): Promise<void> {
+    if (result.status !== 429) return;
+    const seconds = Math.max(
+      1,
+      result.retryAfterSeconds ?? DEFAULT_RETRY_AFTER_SECONDS,
+    );
+    const retryAt = this.deps.now() + seconds * 1_000;
+    const current = await this.deps.storage.get<number>(key);
+    if (current === undefined || retryAt > current) {
+      await this.deps.storage.put(key, retryAt);
+    }
+  }
+
+  private async upstreamCooldownRemainingSeconds(key: string): Promise<number | null> {
+    const retryAt = await this.deps.storage.get<number>(key);
+    if (retryAt === undefined) return null;
+    const remaining = Math.ceil((retryAt - this.deps.now()) / 1_000);
+    if (remaining > 0) return remaining;
+    await this.deps.storage.delete(key);
+    return null;
   }
 
   private async storeDirectory(

--- a/workers/presence/src/controlPlaneDo.ts
+++ b/workers/presence/src/controlPlaneDo.ts
@@ -23,6 +23,7 @@ import {
   type CtlStorage,
 } from "./controlPlane";
 import { captureSentryException, type SentryEnv } from "./sentry";
+import { parseRetryAfterSeconds, rateLimitedJson } from "./retryAfterResponse";
 
 export interface ControlPlaneEnv extends SentryEnv {
   /** Vercel web API origin the DO proxies (dev/prod), e.g. https://cmux.com.
@@ -122,7 +123,17 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
           failure: "http",
         });
       }
-      return { status: response.status, json };
+      return {
+        status: response.status,
+        json,
+        ...(response.status === 429
+          ? {
+            retryAfterSeconds: parseRetryAfterSeconds(
+              response.headers.get("retry-after"),
+            ),
+          }
+          : {}),
+      };
     },
     scheduleAlarmAt: (atMs) => this.ensureAlarmAt(atMs),
     sockets: () => this.ctx.getWebSockets().map(wrapSocket),
@@ -181,7 +192,7 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
       return attachment !== null;
     }).length;
     if (connected >= MAX_CONTROL_SUBSCRIBERS_PER_ACCOUNT) {
-      return json({ error: "too_many_subscribers" }, 429);
+      return rateLimitedJson({ error: "too_many_subscribers" });
     }
 
     const pair = new WebSocketPair();

--- a/workers/presence/src/do.ts
+++ b/workers/presence/src/do.ts
@@ -81,6 +81,7 @@ import {
   type StoredPhoneReply,
 } from "./replies";
 import { captureSentryException, type SentryEnv } from "./sentry";
+import { rateLimitedJson } from "./retryAfterResponse";
 
 const INSTANCE_PREFIX = "inst:";
 /** `owner:<deviceId>` -> Stack user id pinned on first heartbeat. Durable:
@@ -553,10 +554,7 @@ export class TeamPresence extends DurableObject<SentryEnv> {
     const userId = request.headers.get("x-presence-user-id")?.trim() || undefined;
 
     if (this.presenceSubscriberCount() >= MAX_SUBSCRIBERS_PER_TEAM) {
-      return new Response(JSON.stringify({ error: "too_many_subscribers" }), {
-        status: 429,
-        headers: { "content-type": "application/json" },
-      });
+      return rateLimitedJson({ error: "too_many_subscribers" });
     }
 
     if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
@@ -634,10 +632,7 @@ export class TeamPresence extends DurableObject<SentryEnv> {
       (ws) => wsConnectivityAccountId(ws) !== null && wsExpiresAt(ws) > now,
     ).length;
     if (connected >= MAX_CONNECTIVITY_SUBSCRIBERS_PER_ACCOUNT) {
-      return new Response(JSON.stringify({ error: "too_many_subscribers" }), {
-        status: 429,
-        headers: { "content-type": "application/json" },
-      });
+      return rateLimitedJson({ error: "too_many_subscribers" });
     }
     const pair = new WebSocketPair();
     const client = pair[0];

--- a/workers/presence/src/index.ts
+++ b/workers/presence/src/index.ts
@@ -51,6 +51,7 @@ import {
   parsePhoneReplyAck,
 } from "./replies";
 import { captureSentryException } from "./sentry";
+import { rateLimitedJson } from "./retryAfterResponse";
 
 export { TeamPresence, AccountControlPlane };
 
@@ -204,7 +205,7 @@ const worker = {
         const parsed = parsePhoneReply(body.value);
         if (!parsed.ok) return json({ error: parsed.error }, 400);
         const result = await stub.enqueuePhoneReply(user.id, parsed.reply);
-        if (!result.ok) return json({ error: result.error }, 429);
+        if (!result.ok) return rateLimitedJson({ error: result.error });
         return json(result);
       }
       if (request.method === "GET") {
@@ -240,7 +241,11 @@ const worker = {
       // The verified user id rides along so the DO can pin and enforce device
       // ownership (a co-member must not be able to spoof this device).
       const result = await team.stub.heartbeat(team.teamId, team.user.id, parsed.beat);
-      if ("error" in result) return json({ error: result.error }, result.status);
+      if ("error" in result) {
+        return result.status === 429
+          ? rateLimitedJson({ error: result.error })
+          : json({ error: result.error }, result.status);
+      }
       return json(result);
     }
 

--- a/workers/presence/src/retryAfterResponse.ts
+++ b/workers/presence/src/retryAfterResponse.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+/** Parses both RFC Retry-After forms. A past HTTP date is still a one-second
+ * floor so callers never turn a valid server directive into an immediate
+ * same-tick retry. */
+export function parseRetryAfterSeconds(
+  value: string | null,
+  nowMs = Date.now(),
+): number | undefined {
+  if (value === null) return undefined;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    return Number.isSafeInteger(seconds) ? Math.max(1, seconds) : undefined;
+  }
+  const retryAt = Date.parse(trimmed);
+  if (!Number.isFinite(retryAt)) return undefined;
+  return Math.max(1, Math.ceil((retryAt - nowMs) / 1_000));
+}
+
+/** Every transient 429 emitted by the presence/control-plane service carries
+ * one machine-readable deadline so automatic clients cannot invent a faster
+ * retry cadence. */
+export function rateLimitedJson(
+  body: unknown,
+  retryAfterSeconds = DEFAULT_RETRY_AFTER_SECONDS,
+): Response {
+  const bounded = Number.isSafeInteger(retryAfterSeconds) && retryAfterSeconds > 0
+    ? retryAfterSeconds
+    : DEFAULT_RETRY_AFTER_SECONDS;
+  return new Response(JSON.stringify(body), {
+    status: 429,
+    headers: {
+      "content-type": "application/json",
+      "retry-after": String(bounded),
+    },
+  });
+}

--- a/workers/presence/test/controlPlaneStreaming.test.ts
+++ b/workers/presence/test/controlPlaneStreaming.test.ts
@@ -570,6 +570,28 @@ describe("mint_request proxying", () => {
     expect(mint[0]?.init.headers.authorization).toBe("Bearer token-s2");
   });
 
+  it("isolates mint cooldowns by endpoint and namespace across object recreation", async () => {
+    const harness = new Harness();
+    seed(harness);
+    harness.serveMint(() => ({ status: 429, json: {}, retryAfterSeconds: 120 }));
+    const first = await harness.connect("limited", "mac:dev.cmux.app");
+    const same = await harness.connect("same", "mac:dev.cmux.app");
+    const other = await harness.connect("other", "ios:dev.cmux.app");
+    const mint = (endpointId: string) => ({ v: 1, type: "mint_request", payload: { endpointId } });
+    await harness.send(first, mint(ENDPOINT_A));
+    const restored = new Harness();
+    for (const [key, value] of harness.map) restored.map.set(key, value);
+    restored.socketList = harness.socketList;
+    restored.serveMint(init => ({ status: 200, json: mintResponse(JSON.parse(init.body!).endpointId) }));
+    await restored.send(same, mint(ENDPOINT_A.toUpperCase()));
+    expect(restored.mintCalls()).toHaveLength(0);
+    await restored.send(same, mint(ENDPOINT_B));
+    await restored.send(other, mint(ENDPOINT_A));
+    expect(restored.mintCalls()).toHaveLength(2);
+    await restored.send(first, mint(ENDPOINT_A));
+    expect(restored.mintCalls()).toHaveLength(2);
+  });
+
   it("bumps the per-endpoint generation on every successful mint", async () => {
     const harness = new Harness();
     seed(harness);

--- a/workers/presence/test/controlPlaneStreaming.test.ts
+++ b/workers/presence/test/controlPlaneStreaming.test.ts
@@ -360,6 +360,29 @@ describe("hello fact streaming", () => {
     expect(socket.getAttachment()?.snapshotPending).toBe(false);
   });
 
+  it("does not re-fetch a rate-limited directory before the upstream deadline", async () => {
+    const harness = new Harness();
+    harness.routes.set("/api/devices/iroh", () => ({
+      status: 429,
+      json: { error: "rate_limited" },
+      retryAfterSeconds: 120,
+    } as CtlUpstreamResult & { retryAfterSeconds: number }));
+
+    const socket = await harness.connect("s1");
+    await harness.hello(socket, { endpointId: ENDPOINT_A, haveRev: null, wantPasses: false });
+    expect(harness.discoveryCalls()).toHaveLength(1);
+
+    harness.now += 60_000;
+    await harness.core.handleAlarm();
+    expect(harness.discoveryCalls()).toHaveLength(1);
+
+    harness.now += 60_000;
+    harness.serveDiscovery(() => discoveryResponse(42));
+    await harness.core.handleAlarm();
+    expect(harness.discoveryCalls()).toHaveLength(2);
+    expect(socket.types()).toContain("snapshot_complete");
+  });
+
   it("answers the application heartbeat without routing it as a durable fact", async () => {
     const harness = new Harness();
     harness.serveDiscovery(() => discoveryResponse(42));
@@ -509,6 +532,28 @@ describe("mint_request proxying", () => {
     harness.serveMint(() => ({ status: 403, json: { error: "invalid_binding_request_proof" } }));
     await harness.send(socket, { v: 1, type: "mint_request", payload: { endpointId: ENDPOINT_A } });
     expect(socket.frame("error")?.payload).toMatchObject({ code: "mint_rejected", retryable: false });
+  });
+
+  it("suppresses repeated mint requests during an upstream rate-limit deadline", async () => {
+    const harness = new Harness();
+    seed(harness);
+    harness.serveMint(() => ({
+      status: 429,
+      json: { error: "rate_limited" },
+      retryAfterSeconds: 120,
+    } as CtlUpstreamResult & { retryAfterSeconds: number }));
+    const socket = await snapshotted(harness, "s1");
+    const request = { v: 1, type: "mint_request", payload: { endpointId: ENDPOINT_A } };
+
+    await harness.send(socket, request);
+    await harness.send(socket, request);
+    expect(harness.mintCalls()).toHaveLength(1);
+
+    harness.now += 120_000;
+    harness.serveMint(() => ({ status: 200, json: mintResponse(ENDPOINT_A) }));
+    await harness.send(socket, request);
+    expect(harness.mintCalls()).toHaveLength(2);
+    expect(socket.types()).toContain("relay_passes");
   });
 
   it("uses each socket's own bearer, never another socket's", async () => {

--- a/workers/presence/test/retryAfterResponse.test.ts
+++ b/workers/presence/test/retryAfterResponse.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { parseRetryAfterSeconds, rateLimitedJson } from "../src/retryAfterResponse";
+
+describe("rate-limited response", () => {
+  it("always carries the authoritative retry deadline", async () => {
+    const response = rateLimitedJson({ error: "too_many_subscribers" });
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({ error: "too_many_subscribers" });
+  });
+
+  it("parses both standard Retry-After forms", () => {
+    const now = Date.parse("2026-09-08T12:00:00Z");
+    expect(parseRetryAfterSeconds("45", now)).toBe(45);
+    expect(parseRetryAfterSeconds("Tue, 08 Sep 2026 12:02:00 GMT", now)).toBe(120);
+    expect(parseRetryAfterSeconds("invalid", now)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

IP-keyed relay limits let one noisy client starve unrelated users. Several retry owners did not consistently honor server cooldowns.

## Changes

- Partition relay quota by deployment, account, app namespace, endpoint, phase, and minute. Partition client-config limits by deployment and hashed installation identity.
- Verify routine relay identities locally without falling back to Stack for invalid tokens. Keep fresh-session verification for sensitive operations.
- Apply namespaced token admission before endpoint binding/signature work.
- Share Retry-After parsing and cooldown handling across Mac and iOS request/reconnect paths. Serialize final-send admission for analytics, network outcomes, and registry lists.
- Handle oversized retry values without integer traps or shortening the server deadline.
- Persist Durable Object mint cooldowns by namespace and normalized endpoint, isolated within the account/environment object.
- Test reconnect timing with a controlled clock, including foreground triggers during a cooldown.

This uses shared admission and deadline ownership rather than per-call timing workarounds.

## Verification at 8460ec55c51d60b8a25253166ff73e04cc12bb44

- Web: 51 route tests plus 7 identity tests pass; typecheck, focused ESLint, and complexity check pass.
- Presence worker: all 252 tests and TypeScript typecheck pass.
- Mac fleet: 121 focused Swift tests pass across retry policy (6), analytics (35), broker backpressure (11), IRX control-plane/credential policy (13), and mobile device registry (56).
- New regressions reproduced the auth fallback, admission-order, and shared mint-cooldown failures before their fixes.
- Final tagged Mac cloud rebuild passed (rliso-dc81611c5d47). No physical iPhone install or live-log stream was restarted.

## Follow-up

[Account-switch cooldown lifecycle](https://github.com/manaflow-ai/cmux/pull/12179#discussion_r3964375599): three Mac helper clients can conservatively retain the previous account's cooldown until it expires. This does not share backend quota or authorize cross-account requests. It remains an open minor finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Reliability**
  - Improved request validation before rate limiting and authentication checks.
  - Relay token requests now use local identity-proof verification.
  - Rate limits are partitioned by deployment environment and device or installation.
  - Added shared cooldown handling to prevent repeated requests during server-enforced rate limits.

- **User Experience**
  - Rate-limit responses now include clear retry guidance.
  - Clients and credential refreshes honor server-provided retry delays, including extended cooldowns.
  - Retry timing is handled consistently across networking, uploads, presence, and control-plane operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, rate limiting, and retry behavior across mobile, Mac, web API routes, and presence workers; mis-partitioning or cooldown bugs could block legitimate traffic or weaken abuse controls.
> 
> **Overview**
> Introduces shared **`CmxRetryAfterPolicy`** and **`CmxRetryAfterGate`** in `CMUXMobileCore` so clients treat **`Retry-After` as a floor** (never shorter than local backoff), parse HTTP-date headers, sleep safely for long delays, and serialize concurrent requests during a cooldown. That policy is wired through push registration, client-config loading, Iroh/IRX transports, analytics uploads, presence/relay clients, and Mac cloud heartbeat/registry paths; broker reconnect schedules **drop the old 24h cap** so large server directives are honored.
> 
> On the web side, several **429 responses now emit `Retry-After: 60`**, client-config rate limits are **partitioned by deployment + hashed install id** (with body validation before quota), and relay token limits move to **post-auth keys** scoped by deployment, account, namespace, endpoint, and minute—removing the **pre-auth IP gate** that could starve unrelated users. Relay/Iroh high-volume routes can verify access tokens **locally without Stack fallback**; the presence control-plane DO **persists upstream 429 cooldowns** so reconnect storms don’t replay blocked fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8460ec55c51d60b8a25253166ff73e04cc12bb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
