### PR TITLE
Warn for Macs missing a directory version

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -18,9 +18,10 @@ private func entriesWithMinimumSupportedVersion(
 /// authority), projected for UI.
 ///
 /// Written by the irx composition on every applied directory fact and on
-/// sign-out; read by the Computers surfaces to warn only when a remembered
-/// Mac build is below the current minimum. A seeded row with no remembered
-/// version remains informational until its first hello supplies the build.
+/// sign-out; read by the Computers surfaces to warn when a remembered Mac
+/// build is below the current minimum or when the directory has no build for
+/// that Mac yet. A missing build is treated as possibly too old until the Mac
+/// advertises its version.
 ///
 /// A process-wide shared instance is the seam here because the writer lives
 /// in `cmuxFeature` (the transport composition) and the readers live in
@@ -54,14 +55,15 @@ public final class MobileMacListAuthState {
             self.minimumSupportedVersion = minimumSupportedVersion
         }
 
-        /// True only when both versions are known and the Mac is below the
-        /// server floor. Malformed, missing, or channel-only values stay
-        /// informational so an unverified row fails open.
+        /// True when the server floor is valid and the Mac is either missing a
+        /// build version or is below that floor. A malformed reported version
+        /// stays informational because it cannot be safely compared.
         public var isOutdated: Bool {
-            guard let appVersion, let minimumSupportedVersion,
-                  let installed = Self.numericVersion(appVersion),
+            guard let minimumSupportedVersion,
                   let required = Self.numericVersion(minimumSupportedVersion)
             else { return false }
+            guard let appVersion else { return true }
+            guard let installed = Self.numericVersion(appVersion) else { return false }
             return installed.lexicographicallyPrecedes(required)
         }
 
@@ -156,8 +158,9 @@ public final class MobileMacListAuthState {
     }
 
     /// Whether the directory still has a seeded overlay for this Mac. This is
-    /// retained for connection admission diagnostics, not a user-facing update
-    /// warning; the UI waits for a remembered version and `isOutdated`.
+    /// retained for connection admission diagnostics; the user-facing warning
+    /// is derived from `isOutdated`, including when the seeded row has no
+    /// remembered version yet.
     public func isSeeded(deviceID: String) -> Bool {
         entriesByDeviceID[deviceID]?.status == "seeded"
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -55,15 +55,16 @@ public final class MobileMacListAuthState {
             self.minimumSupportedVersion = minimumSupportedVersion
         }
 
-        /// True when the server floor is valid and the Mac is either missing a
-        /// build version or is below that floor. A malformed reported version
-        /// stays informational because it cannot be safely compared.
+        /// True when the server floor is valid and the Mac is either missing
+        /// or has an unparsable build version, or is below that floor. An
+        /// unusable reported version cannot establish compatibility, so it is
+        /// treated as possibly too old until a valid hello arrives.
         public var isOutdated: Bool {
             guard let minimumSupportedVersion,
                   let required = Self.numericVersion(minimumSupportedVersion)
             else { return false }
             guard let appVersion else { return true }
-            guard let installed = Self.numericVersion(appVersion) else { return false }
+            guard let installed = Self.numericVersion(appVersion) else { return true }
             return installed.lexicographicallyPrecedes(required)
         }
 

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -26,7 +26,7 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
-    func missingVersionWarnsButMalformedVersionStaysInformational() {
+    func missingOrMalformedVersionWarns() {
         let unknown = MobileMacListAuthState.Entry(
             status: "active",
             revoked: false,
@@ -43,7 +43,7 @@ struct MobileMacListAuthStateTests {
             appVersion: "nightly",
             minimumSupportedVersion: "0.64.20"
         )
-        #expect(!malformed.isOutdated)
+        #expect(malformed.isOutdated)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -26,7 +26,7 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
-    func unknownOrMalformedVersionsDoNotWarn() {
+    func missingVersionWarnsButMalformedVersionStaysInformational() {
         let unknown = MobileMacListAuthState.Entry(
             status: "active",
             revoked: false,
@@ -34,7 +34,7 @@ struct MobileMacListAuthStateTests {
             appVersion: nil,
             minimumSupportedVersion: "0.64.20"
         )
-        #expect(!unknown.isOutdated)
+        #expect(unknown.isOutdated)
 
         let malformed = MobileMacListAuthState.Entry(
             status: "active",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -161,8 +161,8 @@ struct MacComputerRow: View {
         }
     }
 
-    /// Whether the account device list has a known-version compatibility warning
-    /// for this Mac. A seeded/unverified row stays quiet until its first hello
+    /// Whether the account device list has a compatibility warning for this
+    /// Mac. A row with no remembered version warns until its first hello
     /// records the build version in the durable overlay.
     private var showsListAuthWarning: Bool {
         MobileMacListAuthState.shared.entry(deviceID: computer.deviceId)?.isOutdated == true


### PR DESCRIPTION
When the iOS directory has a valid minimum Mac version but no remembered version for a Mac, surface the existing orange update warning as possibly too old.

Behavior:
- Missing appVersion is outdated when a valid minimum exists.
- Known versions below the floor remain outdated.
- Malformed versions and fail-open policies remain informational.
- Connection admission and background policy fetching are unchanged.

Tests: focused MobileMacListAuthStateTests on fleet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791484812&installation_model_id=21920&pr_number=12182&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12182&signature=280cace2f5b0daa337ab549218a4b3d6d2e6e50d068b1514aa373807efb61c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only warning logic in mobile shell model/UI; admission and policy fetching are unchanged, with a small behavior shift toward more warnings for unverified Macs.
> 
> **Overview**
> Changes **fail-closed** compatibility warnings on the Computers list when the account has a **parsable minimum Mac version** but a Mac row has **no remembered `appVersion`** or an **unparsable** build string—those cases now count as outdated instead of staying silent.
> 
> `MobileMacListAuthState.Entry.isOutdated` only stays informational when the minimum floor is missing or invalid; known versions below the floor still warn as before. `MacComputerRow` comments align with showing the orange list-auth warning via `isOutdated` for seeded/unverified rows until hello records a valid build.
> 
> Tests rename and flip expectations for nil and malformed `appVersion` when a valid minimum exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d031e61121fa384296848e7e56ddc5f5c8baa7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns for Macs that have a valid minimum Mac version but no usable remembered directory version, so unverified Macs no longer stay silent when they might be too old.

- Missing or malformed `appVersion` now counts as outdated when a valid minimum exists.
- Missing or invalid minimums still fail open and remain informational.
- Connection admission and background policy fetching are unchanged.

<sup>Written for commit d031e61121fa384296848e7e56ddc5f5c8baa7e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mac entries now show a compatibility warning when a required minimum build exists but the Mac’s build version is unavailable.
  - Malformed build versions remain informational and do not trigger an outdated warning.

- **Documentation**
  - Clarified the conditions for compatibility warnings and how Mac build status is interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->