### PR TITLE
fix(ios): prevent keyboard transition bounce loop

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -54,6 +54,7 @@ import UIKit
 public final class GhosttySurfaceHostView: UIView {
     public let surfaceView: GhosttySurfaceView
     private let keyboardFrameTracker: MobileKeyboardFrameTracker
+    private var isHandlingKeyboardTransition = false
     /// Safe-area value captured outside the SwiftUI terminal subtree. The
     /// surface can be intentionally underlapped, so its UIKit leaf may report
     /// zero even when the screen still has a home-indicator inset.
@@ -408,6 +409,9 @@ public final class GhosttySurfaceHostView: UIView {
     }
 
     @objc private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard !isHandlingKeyboardTransition else { return }
+        isHandlingKeyboardTransition = true
+        defer { isHandlingKeyboardTransition = false }
         guard window != nil,
               let transition = MobileKeyboardTransition(notification: notification) else { return }
         beginKeyboardLeg(


### PR DESCRIPTION
Prevent reentrant keyboard-frame handling while a transition is being applied. This stops the terminal dock from repeatedly starting opposing layout transitions when UIKit emits a nested frame notification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791486077&installation_model_id=21920&pr_number=12183&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12183&signature=6dd3ac448d68b035ced2c7dc397640342c7829974339ff8acf6946ab56d83b35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the terminal dock from bouncing by guarding against reentrant keyboard-frame handling. The new flag stops opposing layout transitions when UIKit emits a nested frame notification.

<sup>Written for commit e783402ebeef49ea35e0b0b8dce5a182dc879aca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keyboard notification handling on iOS terminal layout; no auth, data, or API surface impact.
> 
> **Overview**
> Adds a reentrancy guard on **`keyboardWillChangeFrame`** in `GhosttySurfaceHostView` so nested `keyboardWillChangeFrame` notifications are ignored while a transition is already being handled.
> 
> The host sets **`isHandlingKeyboardTransition`** at entry and clears it in **`defer`** before calling **`beginKeyboardLeg`**. That stops UIKit from starting opposing dock layout legs when a frame notification fires again during the same synchronous handling path (the bounce loop described in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e783402ebeef49ea35e0b0b8dce5a182dc879aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard transition handling to prevent duplicate or overlapping events from being processed.
  - Reduced the risk of unexpected terminal layout behavior during rapid keyboard changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->