### PR TITLE
Fix nightly Mac warning comparison

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11625,11 +11625,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// off the connection startup path.
     public func applyMacCompatibilityPolicy(_ policy: MobileMacCompatPolicy) {
         macCompatPolicy = policy
-        let requiredMacVersion = policy
-            .tier(forIOSVersion: versionGateIOSAppVersion)?
-            .stableMinVersion
-            .description
-        MobileMacListAuthState.shared.applyPolicyMinimumSupportedMacVersion(requiredMacVersion)
+        let tier = policy.tier(forIOSVersion: versionGateIOSAppVersion)
+        let requiredStableMacVersion = tier?.stableMinVersion.description
+        let requiredNightlyMacVersion = tier?.nightly.map {
+            "\($0.minBaseVersion)-nightly.\($0.minBuild)"
+        }
+        MobileMacListAuthState.shared.applyPolicyMinimumSupportedMacVersions(
+            stable: requiredStableMacVersion,
+            nightly: requiredNightlyMacVersion
+        )
     }
 
     func noteMacVersionUpdateRequired(for macDeviceID: String) {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -4,19 +4,12 @@ public import Observation
 private func entriesWithMinimumSupportedVersions(
     _ entries: [String: MobileMacListAuthState.Entry],
     stableMinimum: String?,
-    nightlyMinimum: String?,
-    overrideStable: Bool,
-    overrideNightly: Bool
+    nightlyMinimum: String?
 ) -> [String: MobileMacListAuthState.Entry] {
-    guard overrideStable || overrideNightly else { return entries }
     return entries.mapValues { entry in
         var updated = entry
-        if overrideStable {
-            updated.minimumSupportedVersion = stableMinimum
-        }
-        if overrideNightly {
-            updated.minimumSupportedNightlyVersion = nightlyMinimum
-        }
+        updated.minimumSupportedVersion = stableMinimum
+        updated.minimumSupportedNightlyVersion = nightlyMinimum
         return updated
     }
 }
@@ -160,35 +153,31 @@ public final class MobileMacListAuthState {
 
     public init() {}
 
+    /// Replaces the directory projection and its account-level floor.
+    ///
+    /// A missing directory floor is authoritative and clears the prior
+    /// directory value. The current iOS policy, when installed, remains the
+    /// higher-priority source for both release lanes.
     public func replace(
         entriesByEndpointID: [String: Entry],
         entriesByDeviceID: [String: Entry],
-        minimumSupportedMacVersion: String? = nil,
-        minimumSupportedNightlyMacVersion: String? = nil
+        minimumSupportedMacVersion: String? = nil
     ) {
         let effectiveStableMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedMacVersion
-            : minimumSupportedMacVersion ?? self.minimumSupportedMacVersion
+            : minimumSupportedMacVersion
         let effectiveNightlyMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedNightlyMacVersion
-            : minimumSupportedNightlyMacVersion ?? self.minimumSupportedNightlyMacVersion
-        let overrideStable = hasPolicyMinimumSupportedMacVersion
-            || effectiveStableMinimum != nil
-        let overrideNightly = hasPolicyMinimumSupportedMacVersion
-            || effectiveNightlyMinimum != nil
+            : nil
         self.entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
             stableMinimum: effectiveStableMinimum,
-            nightlyMinimum: effectiveNightlyMinimum,
-            overrideStable: overrideStable,
-            overrideNightly: overrideNightly
+            nightlyMinimum: effectiveNightlyMinimum
         )
         self.entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
             stableMinimum: effectiveStableMinimum,
-            nightlyMinimum: effectiveNightlyMinimum,
-            overrideStable: overrideStable,
-            overrideNightly: overrideNightly
+            nightlyMinimum: effectiveNightlyMinimum
         )
         self.minimumSupportedMacVersion = effectiveStableMinimum
         self.minimumSupportedNightlyMacVersion = effectiveNightlyMinimum
@@ -220,16 +209,12 @@ public final class MobileMacListAuthState {
         entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
             stableMinimum: stable,
-            nightlyMinimum: nightly,
-            overrideStable: true,
-            overrideNightly: true
+            nightlyMinimum: nightly
         )
         entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
             stableMinimum: stable,
-            nightlyMinimum: nightly,
-            overrideStable: true,
-            overrideNightly: true
+            nightlyMinimum: nightly
         )
         minimumSupportedMacVersion = stable
         minimumSupportedNightlyMacVersion = nightly

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -199,9 +199,12 @@ public final class MobileMacListAuthState {
     /// already-projected rows. A `nil` value is an intentional fail-open policy
     /// with no tier for the running iOS version.
     public func applyPolicyMinimumSupportedMacVersion(_ minimum: String?) {
+        let existingNightlyMinimum = hasPolicyMinimumSupportedMacVersion
+            ? policyMinimumSupportedNightlyMacVersion
+            : minimumSupportedNightlyMacVersion
         applyPolicyMinimumSupportedMacVersions(
             stable: minimum,
-            nightly: nil
+            nightly: existingNightlyMinimum
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -5,13 +5,18 @@ private func entriesWithMinimumSupportedVersions(
     _ entries: [String: MobileMacListAuthState.Entry],
     stableMinimum: String?,
     nightlyMinimum: String?,
-    shouldOverride: Bool
+    overrideStable: Bool,
+    overrideNightly: Bool
 ) -> [String: MobileMacListAuthState.Entry] {
-    guard shouldOverride else { return entries }
+    guard overrideStable || overrideNightly else { return entries }
     return entries.mapValues { entry in
         var updated = entry
-        updated.minimumSupportedVersion = stableMinimum
-        updated.minimumSupportedNightlyVersion = nightlyMinimum
+        if overrideStable {
+            updated.minimumSupportedVersion = stableMinimum
+        }
+        if overrideNightly {
+            updated.minimumSupportedNightlyVersion = nightlyMinimum
+        }
         return updated
     }
 }
@@ -100,8 +105,10 @@ public final class MobileMacListAuthState {
         }
 
         private var isNightly: Bool {
-            releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
-                || appVersion?.contains("-nightly.") == true
+            if let releaseTrack {
+                return releaseTrack.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
+            }
+            return appVersion?.contains("-nightly.") == true
         }
 
         private static func numericVersion(_ raw: String) -> [Int]? {
@@ -165,20 +172,23 @@ public final class MobileMacListAuthState {
         let effectiveNightlyMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedNightlyMacVersion
             : minimumSupportedNightlyMacVersion
-        let shouldOverride = hasPolicyMinimumSupportedMacVersion
+        let overrideStable = hasPolicyMinimumSupportedMacVersion
             || minimumSupportedMacVersion != nil
+        let overrideNightly = hasPolicyMinimumSupportedMacVersion
             || minimumSupportedNightlyMacVersion != nil
         self.entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
             stableMinimum: effectiveStableMinimum,
             nightlyMinimum: effectiveNightlyMinimum,
-            shouldOverride: shouldOverride
+            overrideStable: overrideStable,
+            overrideNightly: overrideNightly
         )
         self.entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
             stableMinimum: effectiveStableMinimum,
             nightlyMinimum: effectiveNightlyMinimum,
-            shouldOverride: shouldOverride
+            overrideStable: overrideStable,
+            overrideNightly: overrideNightly
         )
         self.minimumSupportedMacVersion = effectiveStableMinimum
         self.minimumSupportedNightlyMacVersion = effectiveNightlyMinimum

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -14,6 +14,30 @@ private func entriesWithMinimumSupportedVersions(
     }
 }
 
+private func numericMacVersion(_ raw: String) -> [Int]? {
+    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+    let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+    guard !parts.isEmpty,
+          parts.allSatisfy({ !$0.isEmpty && Int($0) != nil }) else { return nil }
+    var values = parts.map { Int($0)! }
+    while values.count < 3 { values.append(0) }
+    return values
+}
+
+private func nightlyMacVersion(_ raw: String) -> (base: [Int], build: UInt64)? {
+    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+    let marker = "-nightly."
+    guard let markerRange = core.range(of: marker),
+          let base = numericMacVersion(String(core[..<markerRange.lowerBound]))
+    else { return nil }
+    let buildText = core[markerRange.upperBound...]
+    guard !buildText.isEmpty,
+          buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
+          let build = UInt64(buildText)
+    else { return nil }
+    return (base, build)
+}
+
 /// The phone's view of the account device list (the list-auth admission
 /// authority), projected for UI.
 ///
@@ -73,10 +97,10 @@ public final class MobileMacListAuthState {
         public var isOutdated: Bool {
             if isNightly {
                 guard let minimumSupportedNightlyVersion,
-                      let required = Self.nightlyVersion(minimumSupportedNightlyVersion)
+                      let required = nightlyMacVersion(minimumSupportedNightlyVersion)
                 else { return false }
                 guard let appVersion,
-                      let installed = Self.nightlyVersion(appVersion)
+                      let installed = nightlyMacVersion(appVersion)
                 else { return true }
                 if installed.base != required.base {
                     return installed.base.lexicographicallyPrecedes(required.base)
@@ -84,10 +108,10 @@ public final class MobileMacListAuthState {
                 return installed.build < required.build
             }
             guard let minimumSupportedVersion,
-                  let required = Self.numericVersion(minimumSupportedVersion)
+                  let required = numericMacVersion(minimumSupportedVersion)
             else { return false }
             guard let appVersion else { return true }
-            guard let installed = Self.numericVersion(appVersion) else { return true }
+            guard let installed = numericMacVersion(appVersion) else { return true }
             return installed.lexicographicallyPrecedes(required)
         }
 
@@ -104,29 +128,6 @@ public final class MobileMacListAuthState {
             return appVersion?.contains("-nightly.") == true
         }
 
-        private static func numericVersion(_ raw: String) -> [Int]? {
-            let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-            let parts = core.split(separator: ".", omittingEmptySubsequences: false)
-            guard !parts.isEmpty,
-                  parts.allSatisfy({ !$0.isEmpty && Int($0) != nil }) else { return nil }
-            var values = parts.map { Int($0)! }
-            while values.count < 3 { values.append(0) }
-            return values
-        }
-
-        private static func nightlyVersion(_ raw: String) -> (base: [Int], build: UInt64)? {
-            let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-            let marker = "-nightly."
-            guard let markerRange = core.range(of: marker),
-                  let base = numericVersion(String(core[..<markerRange.lowerBound]))
-            else { return nil }
-            let buildText = core[markerRange.upperBound...]
-            guard !buildText.isEmpty,
-                  buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
-                  let build = UInt64(buildText)
-            else { return nil }
-            return (base, build)
-        }
     }
 
     public static let shared = MobileMacListAuthState()

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -1,15 +1,17 @@
 public import Foundation
 public import Observation
 
-private func entriesWithMinimumSupportedVersion(
+private func entriesWithMinimumSupportedVersions(
     _ entries: [String: MobileMacListAuthState.Entry],
-    minimum: String?,
+    stableMinimum: String?,
+    nightlyMinimum: String?,
     shouldOverride: Bool
 ) -> [String: MobileMacListAuthState.Entry] {
     guard shouldOverride else { return entries }
     return entries.mapValues { entry in
         var updated = entry
-        updated.minimumSupportedVersion = minimum
+        updated.minimumSupportedVersion = stableMinimum
+        updated.minimumSupportedNightlyVersion = nightlyMinimum
         return updated
     }
 }
@@ -38,34 +40,68 @@ public final class MobileMacListAuthState {
         /// Version reported by the Mac's control-plane hello, including an
         /// optional `+build` suffix.
         public var appVersion: String?
+        /// Release lane reported by the Mac's control-plane hello. Nightly
+        /// rows use the nightly counter floor instead of the stable floor.
+        public var releaseTrack: String?
         /// Server-advertised minimum Mac version for this account.
         public var minimumSupportedVersion: String?
+        /// Server-advertised minimum nightly stamp for this iOS build.
+        public var minimumSupportedNightlyVersion: String?
 
         public init(
             status: String,
             revoked: Bool,
             isFresh: Bool,
             appVersion: String? = nil,
-            minimumSupportedVersion: String? = nil
+            minimumSupportedVersion: String? = nil,
+            releaseTrack: String? = nil,
+            minimumSupportedNightlyVersion: String? = nil
         ) {
             self.status = status
             self.revoked = revoked
             self.isFresh = isFresh
             self.appVersion = appVersion
+            self.releaseTrack = releaseTrack
             self.minimumSupportedVersion = minimumSupportedVersion
+            self.minimumSupportedNightlyVersion = minimumSupportedNightlyVersion
         }
 
-        /// True when the server floor is valid and the Mac is either missing
-        /// or has an unparsable build version, or is below that floor. An
-        /// unusable reported version cannot establish compatibility, so it is
-        /// treated as possibly too old until a valid hello arrives.
+        /// True when the applicable server floor is valid and the Mac is
+        /// either missing or has an unparsable build version, or is below that
+        /// floor. Nightly rows compare their base version and monotonic build
+        /// counter against ``minimumSupportedNightlyVersion``. An unusable
+        /// reported version cannot establish compatibility, so it is treated
+        /// as possibly too old until a valid hello arrives.
         public var isOutdated: Bool {
+            if isNightly {
+                guard let minimumSupportedNightlyVersion,
+                      let required = Self.nightlyVersion(minimumSupportedNightlyVersion)
+                else { return false }
+                guard let appVersion,
+                      let installed = Self.nightlyVersion(appVersion)
+                else { return true }
+                if installed.base != required.base {
+                    return installed.base.lexicographicallyPrecedes(required.base)
+                }
+                return installed.build < required.build
+            }
             guard let minimumSupportedVersion,
                   let required = Self.numericVersion(minimumSupportedVersion)
             else { return false }
             guard let appVersion else { return true }
             guard let installed = Self.numericVersion(appVersion) else { return true }
             return installed.lexicographicallyPrecedes(required)
+        }
+
+        /// The floor to show in the warning for this row's release lane.
+        public var requiredVersionDisplay: String? {
+            guard isOutdated else { return nil }
+            return isNightly ? minimumSupportedNightlyVersion : minimumSupportedVersion
+        }
+
+        private var isNightly: Bool {
+            releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
+                || appVersion?.contains("-nightly.") == true
         }
 
         private static func numericVersion(_ raw: String) -> [Int]? {
@@ -76,6 +112,20 @@ public final class MobileMacListAuthState {
             var values = parts.map { Int($0)! }
             while values.count < 3 { values.append(0) }
             return values
+        }
+
+        private static func nightlyVersion(_ raw: String) -> (base: [Int], build: UInt64)? {
+            let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+            let marker = "-nightly."
+            guard let markerRange = core.range(of: marker),
+                  let base = numericVersion(String(core[..<markerRange.lowerBound]))
+            else { return nil }
+            let buildText = core[markerRange.upperBound...]
+            guard !buildText.isEmpty,
+                  buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
+                  let build = UInt64(buildText)
+            else { return nil }
+            return (base, build)
         }
     }
 
@@ -91,11 +141,14 @@ public final class MobileMacListAuthState {
     public private(set) var hasSnapshot = false
     /// Account-level minimum Mac version from the latest directory fact.
     public private(set) var minimumSupportedMacVersion: String?
+    /// Minimum nightly stamp for the current iOS build, when one applies.
+    public private(set) var minimumSupportedNightlyMacVersion: String?
 
     /// The current iOS build's policy floor, when the shell has installed one.
     /// This takes precedence over the legacy directory fact because the same
     /// account can be viewed by multiple iOS builds with different floors.
     private var policyMinimumSupportedMacVersion: String?
+    private var policyMinimumSupportedNightlyMacVersion: String?
     private var hasPolicyMinimumSupportedMacVersion = false
 
     public init() {}
@@ -103,24 +156,32 @@ public final class MobileMacListAuthState {
     public func replace(
         entriesByEndpointID: [String: Entry],
         entriesByDeviceID: [String: Entry],
-        minimumSupportedMacVersion: String? = nil
+        minimumSupportedMacVersion: String? = nil,
+        minimumSupportedNightlyMacVersion: String? = nil
     ) {
-        let effectiveMinimum = hasPolicyMinimumSupportedMacVersion
+        let effectiveStableMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedMacVersion
             : minimumSupportedMacVersion
+        let effectiveNightlyMinimum = hasPolicyMinimumSupportedMacVersion
+            ? policyMinimumSupportedNightlyMacVersion
+            : minimumSupportedNightlyMacVersion
         let shouldOverride = hasPolicyMinimumSupportedMacVersion
             || minimumSupportedMacVersion != nil
-        self.entriesByEndpointID = entriesWithMinimumSupportedVersion(
+            || minimumSupportedNightlyMacVersion != nil
+        self.entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
-            minimum: effectiveMinimum,
+            stableMinimum: effectiveStableMinimum,
+            nightlyMinimum: effectiveNightlyMinimum,
             shouldOverride: shouldOverride
         )
-        self.entriesByDeviceID = entriesWithMinimumSupportedVersion(
+        self.entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
-            minimum: effectiveMinimum,
+            stableMinimum: effectiveStableMinimum,
+            nightlyMinimum: effectiveNightlyMinimum,
             shouldOverride: shouldOverride
         )
-        self.minimumSupportedMacVersion = effectiveMinimum
+        self.minimumSupportedMacVersion = effectiveStableMinimum
+        self.minimumSupportedNightlyMacVersion = effectiveNightlyMinimum
         hasSnapshot = true
     }
 
@@ -128,25 +189,42 @@ public final class MobileMacListAuthState {
     /// already-projected rows. A `nil` value is an intentional fail-open policy
     /// with no tier for the running iOS version.
     public func applyPolicyMinimumSupportedMacVersion(_ minimum: String?) {
-        policyMinimumSupportedMacVersion = minimum
+        applyPolicyMinimumSupportedMacVersions(
+            stable: minimum,
+            nightly: nil
+        )
+    }
+
+    /// Installs both release-lane floors for this iOS build and reapplies them
+    /// to already-projected rows.
+    public func applyPolicyMinimumSupportedMacVersions(
+        stable: String?,
+        nightly: String?
+    ) {
+        policyMinimumSupportedMacVersion = stable
+        policyMinimumSupportedNightlyMacVersion = nightly
         hasPolicyMinimumSupportedMacVersion = true
-        entriesByEndpointID = entriesWithMinimumSupportedVersion(
+        entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
-            minimum: minimum,
+            stableMinimum: stable,
+            nightlyMinimum: nightly,
             shouldOverride: true
         )
-        entriesByDeviceID = entriesWithMinimumSupportedVersion(
+        entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
-            minimum: minimum,
+            stableMinimum: stable,
+            nightlyMinimum: nightly,
             shouldOverride: true
         )
-        minimumSupportedMacVersion = minimum
+        minimumSupportedMacVersion = stable
+        minimumSupportedNightlyMacVersion = nightly
     }
 
     public func clear() {
         entriesByEndpointID = [:]
         entriesByDeviceID = [:]
         minimumSupportedMacVersion = nil
+        minimumSupportedNightlyMacVersion = nil
         hasSnapshot = false
     }
 

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -168,14 +168,14 @@ public final class MobileMacListAuthState {
     ) {
         let effectiveStableMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedMacVersion
-            : minimumSupportedMacVersion
+            : minimumSupportedMacVersion ?? self.minimumSupportedMacVersion
         let effectiveNightlyMinimum = hasPolicyMinimumSupportedMacVersion
             ? policyMinimumSupportedNightlyMacVersion
-            : minimumSupportedNightlyMacVersion
+            : minimumSupportedNightlyMacVersion ?? self.minimumSupportedNightlyMacVersion
         let overrideStable = hasPolicyMinimumSupportedMacVersion
-            || minimumSupportedMacVersion != nil
+            || effectiveStableMinimum != nil
         let overrideNightly = hasPolicyMinimumSupportedMacVersion
-            || minimumSupportedNightlyMacVersion != nil
+            || effectiveNightlyMinimum != nil
         self.entriesByEndpointID = entriesWithMinimumSupportedVersions(
             entriesByEndpointID,
             stableMinimum: effectiveStableMinimum,

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -218,13 +218,15 @@ public final class MobileMacListAuthState {
             entriesByEndpointID,
             stableMinimum: stable,
             nightlyMinimum: nightly,
-            shouldOverride: true
+            overrideStable: true,
+            overrideNightly: true
         )
         entriesByDeviceID = entriesWithMinimumSupportedVersions(
             entriesByDeviceID,
             stableMinimum: stable,
             nightlyMinimum: nightly,
-            shouldOverride: true
+            overrideStable: true,
+            overrideNightly: true
         )
         minimumSupportedMacVersion = stable
         minimumSupportedNightlyMacVersion = nightly

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -100,6 +100,21 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
+    func explicitStableTrackDoesNotUseNightlyVersionHeuristic() {
+        let mislabeled = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013202+202609081235",
+            minimumSupportedVersion: "0.64.23",
+            releaseTrack: "stable",
+            minimumSupportedNightlyVersion: "0.64.22-nightly.3345650013202"
+        )
+        #expect(mislabeled.isOutdated)
+        #expect(mislabeled.requiredVersionDisplay == "0.64.23")
+    }
+
+    @Test
     func policyFloorOverridesDirectoryFloorAndSurvivesLaterSnapshots() {
         let state = MobileMacListAuthState()
         let entry = MobileMacListAuthState.Entry(
@@ -152,6 +167,46 @@ struct MobileMacListAuthStateTests {
         )
         #expect(!state.entry(deviceID: "device")!.isOutdated)
         #expect(state.entry(deviceID: "device")!.requiredVersionDisplay == nil)
+    }
+
+    @Test
+    func nightlyOnlyReplacementPreservesStableFloor() {
+        let state = MobileMacListAuthState()
+        let stable = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.20",
+            minimumSupportedVersion: "0.64.23"
+        )
+        state.replace(
+            entriesByEndpointID: ["endpoint": stable],
+            entriesByDeviceID: ["device": stable],
+            minimumSupportedMacVersion: "0.64.23"
+        )
+        #expect(state.entry(deviceID: "device")!.isOutdated)
+
+        let nightly = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013202",
+            releaseTrack: "nightly"
+        )
+        state.replace(
+            entriesByEndpointID: ["nightly-endpoint": nightly],
+            entriesByDeviceID: ["nightly-device": nightly],
+            minimumSupportedNightlyMacVersion: "0.64.22-nightly.3345650013202"
+        )
+        // A subsequent snapshot carrying only the Nightly floor must not
+        // erase the Stable floor on its rows when a Stable entry is present.
+        state.replace(
+            entriesByEndpointID: ["endpoint": stable],
+            entriesByDeviceID: ["device": stable],
+            minimumSupportedNightlyMacVersion: "0.64.22-nightly.3345650013202"
+        )
+        #expect(state.entry(deviceID: "device")!.minimumSupportedVersion == "0.64.23")
+        #expect(state.entry(deviceID: "device")!.isOutdated)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -176,7 +176,7 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
-    func nightlyOnlyReplacementPreservesStableFloor() {
+    func authoritativeReplacementClearsObsoleteFloors() {
         let state = MobileMacListAuthState()
         let stable = MobileMacListAuthState.Entry(
             status: "active",
@@ -200,19 +200,19 @@ struct MobileMacListAuthStateTests {
         )
         state.replace(
             entriesByEndpointID: ["nightly-endpoint": nightly],
-            entriesByDeviceID: ["nightly-device": nightly],
-            minimumSupportedNightlyMacVersion: "0.64.22-nightly.3345650013202"
+            entriesByDeviceID: ["nightly-device": nightly]
         )
-        #expect(state.minimumSupportedMacVersion == "0.64.23")
-        // A subsequent snapshot carrying only the Nightly floor must not
-        // erase the Stable floor on its rows when a Stable entry is present.
+        #expect(state.minimumSupportedMacVersion == nil)
+        #expect(state.entry(deviceID: "nightly-device")!.minimumSupportedVersion == nil)
+
+        // A subsequent authoritative snapshot without a floor clears the
+        // previous Stable requirement rather than retaining stale state.
         state.replace(
             entriesByEndpointID: ["endpoint": stable],
-            entriesByDeviceID: ["device": stable],
-            minimumSupportedNightlyMacVersion: "0.64.22-nightly.3345650013202"
+            entriesByDeviceID: ["device": stable]
         )
-        #expect(state.entry(deviceID: "device")!.minimumSupportedVersion == "0.64.23")
-        #expect(state.entry(deviceID: "device")!.isOutdated)
+        #expect(state.entry(deviceID: "device")!.minimumSupportedVersion == nil)
+        #expect(!state.entry(deviceID: "device")!.isOutdated)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -167,6 +167,12 @@ struct MobileMacListAuthStateTests {
         )
         #expect(!state.entry(deviceID: "device")!.isOutdated)
         #expect(state.entry(deviceID: "device")!.requiredVersionDisplay == nil)
+
+        // The legacy stable-only API must not clear an already-installed
+        // Nightly floor while updating the stable lane.
+        state.applyPolicyMinimumSupportedMacVersion("0.64.24")
+        #expect(state.minimumSupportedNightlyMacVersion == "0.64.22-nightly.3345650013202")
+        #expect(!state.entry(deviceID: "device")!.isOutdated)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -176,8 +176,7 @@ struct MobileMacListAuthStateTests {
             status: "active",
             revoked: false,
             isFresh: true,
-            appVersion: "0.64.20",
-            minimumSupportedVersion: "0.64.23"
+            appVersion: "0.64.20"
         )
         state.replace(
             entriesByEndpointID: ["endpoint": stable],
@@ -198,6 +197,7 @@ struct MobileMacListAuthStateTests {
             entriesByDeviceID: ["nightly-device": nightly],
             minimumSupportedNightlyMacVersion: "0.64.22-nightly.3345650013202"
         )
+        #expect(state.minimumSupportedMacVersion == "0.64.23")
         // A subsequent snapshot carrying only the Nightly floor must not
         // erase the Stable floor on its rows when a Stable entry is present.
         state.replace(

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -59,6 +59,47 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
+    func nightlyRowsUseNightlyCounterInsteadOfStableFloor() {
+        let current = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013202+202609081234",
+            minimumSupportedVersion: "0.64.23",
+            releaseTrack: "nightly",
+            minimumSupportedNightlyVersion: "0.64.22-nightly.3345650013202"
+        )
+        #expect(!current.isOutdated)
+        #expect(current.requiredVersionDisplay == nil)
+
+        let older = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013201+202609081233",
+            minimumSupportedVersion: "0.64.23",
+            releaseTrack: "nightly",
+            minimumSupportedNightlyVersion: "0.64.22-nightly.3345650013202"
+        )
+        #expect(older.isOutdated)
+        #expect(older.requiredVersionDisplay == "0.64.22-nightly.3345650013202")
+    }
+
+    @Test
+    func nightlyBaseAboveFloorIsAdmitted() {
+        let newerBase = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.23-nightly.1+202609081235",
+            minimumSupportedVersion: "0.64.23",
+            releaseTrack: "nightly",
+            minimumSupportedNightlyVersion: "0.64.22-nightly.3345650013202"
+        )
+        #expect(!newerBase.isOutdated)
+    }
+
+    @Test
     func policyFloorOverridesDirectoryFloorAndSurvivesLaterSnapshots() {
         let state = MobileMacListAuthState()
         let entry = MobileMacListAuthState.Entry(

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -47,6 +47,18 @@ struct MobileMacListAuthStateTests {
     }
 
     @Test
+    func nightlyVersionIsNotComparedToStableFloor() {
+        let current = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013202+202609081234",
+            minimumSupportedVersion: "0.64.23"
+        )
+        #expect(!current.isOutdated)
+    }
+
+    @Test
     func policyFloorOverridesDirectoryFloorAndSurvivesLaterSnapshots() {
         let state = MobileMacListAuthState()
         let entry = MobileMacListAuthState.Entry(
@@ -74,6 +86,31 @@ struct MobileMacListAuthStateTests {
         )
         #expect(state.entry(deviceID: "device")!.isOutdated)
         #expect(state.minimumSupportedMacVersion == "0.64.23")
+    }
+
+    @Test
+    func policyAppliesSeparateNightlyFloorToNightlyRows() {
+        let state = MobileMacListAuthState()
+        let nightly = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "0.64.22-nightly.3345650013202+202609081234",
+            releaseTrack: "nightly"
+        )
+        state.replace(
+            entriesByEndpointID: ["endpoint": nightly],
+            entriesByDeviceID: ["device": nightly],
+            minimumSupportedMacVersion: "0.64.23"
+        )
+        #expect(!state.entry(deviceID: "device")!.isOutdated)
+
+        state.applyPolicyMinimumSupportedMacVersions(
+            stable: "0.64.23",
+            nightly: "0.64.22-nightly.3345650013202"
+        )
+        #expect(!state.entry(deviceID: "device")!.isOutdated)
+        #expect(state.entry(deviceID: "device")!.requiredVersionDisplay == nil)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -1411,7 +1411,7 @@ private struct MacComputerCompatibilitySection: View {
     }
 
     private var warningMessage: String {
-        guard let required = entry.minimumSupportedVersion else { return "" }
+        guard let required = entry.requiredVersionDisplay else { return "" }
         let requirement = "cmux \(required) or later"
         return String(format: L10n.string(
             "mobile.macUpdate.requiredOnMacFormat",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -214,7 +214,7 @@ struct MacComputerRow: View {
     private var listAuthWarningMessage: String {
         guard let entry = MobileMacListAuthState.shared.entry(deviceID: computer.deviceId),
               entry.isOutdated,
-              let required = entry.minimumSupportedVersion
+              let required = entry.requiredVersionDisplay
         else {
             return ""
         }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -489,8 +489,8 @@ public actor MobileIrxRuntimeComposition {
                 revoked: entry.revoked,
                 isFresh: fresh,
                 appVersion: entry.appVersion,
-                releaseTrack: entry.releaseTrack ?? entry.tag,
-                minimumSupportedVersion: snapshot.minimumSupportedMacVersion
+                minimumSupportedVersion: snapshot.minimumSupportedMacVersion,
+                releaseTrack: entry.releaseTrack ?? entry.tag
             )
             byEndpoint[endpointIDHex] = projected
             if let deviceID = entry.deviceID {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -490,7 +490,7 @@ public actor MobileIrxRuntimeComposition {
                 isFresh: fresh,
                 appVersion: entry.appVersion,
                 minimumSupportedVersion: snapshot.minimumSupportedMacVersion,
-                releaseTrack: entry.releaseTrack ?? entry.tag
+                releaseTrack: entry.releaseTrack
             )
             byEndpoint[endpointIDHex] = projected
             if let deviceID = entry.deviceID {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -489,6 +489,7 @@ public actor MobileIrxRuntimeComposition {
                 revoked: entry.revoked,
                 isFresh: fresh,
                 appVersion: entry.appVersion,
+                releaseTrack: entry.releaseTrack ?? entry.tag,
                 minimumSupportedVersion: snapshot.minimumSupportedMacVersion
             )
             byEndpoint[endpointIDHex] = projected


### PR DESCRIPTION
Nightly Mac rows currently compare their `0.64.22-nightly.<counter>` advertisement against the stable `0.64.23` floor, so every nightly row shows an orange warning.

This carries the Mac release track and both policy floors into list-auth state. Nightly rows compare base version and counter against the nightly floor, while stable rows retain stable comparison. Warning copy uses the applicable floor.

Verification:
- 8 `MobileMacListAuthStateTests` pass on cmux13s-v.
- 33 `MobileMacCompatPolicyTests` pass on cmux13s-v.
- Apple HIG Status guidance checked: https://developer.apple.com/design/human-interface-guidelines/status

Regression commits are test-first then fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mac version-gating and warning logic for stable vs nightly lanes; incorrect parsing or floor precedence could hide real outdated Macs or show wrong requirements.
> 
> **Overview**
> Fixes **false “Mac update required” warnings** on nightly Mac rows by evaluating them against a **nightly stamp floor** instead of the stable semver floor.
> 
> **List-auth state** now carries `releaseTrack`, separate stable and nightly minimums, and lane-specific comparison: stable rows still use dotted semver; nightly rows parse `base-nightly.build` and compare base version then monotonic build counter. **`requiredVersionDisplay`** picks the floor shown in Computers warnings.
> 
> **Policy application** (`applyMacCompatibilityPolicy` / `applyPolicyMinimumSupportedMacVersions`) installs both floors from the iOS compat tier; updating stable-only policy no longer drops an existing nightly floor. Directory **`replace`** snapshots propagate `releaseTrack` and treat a missing directory floor as clearing stale stable requirements (policy still wins when installed).
> 
> UI copy in **MacComputerRow** and **MacComputerDetailView** now reads `requiredVersionDisplay` rather than always showing the stable minimum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c40ce8fd67ecbad54b8cadf6152145b75e8b952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly Mac rows showing an orange warning by comparing them against the nightly floor instead of the stable version floor.

- Carries the Mac release track and both policy floors into list-auth state, preserving each floor across partial updates and when only one lane changes.
- Authoritative directory snapshots now clear stale stable and nightly floors.
- Warning copy shows the applicable floor.

<sup>Written for commit 4c40ce8fd67ecbad54b8cadf6152145b75e8b952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate compatibility requirements for stable and nightly macOS releases.
  - Nightly Macs are evaluated against dedicated nightly build requirements.
  - Compatibility warnings display the appropriate requirement for each release track.

- **Bug Fixes**
  - Prevented nightly builds from being incorrectly evaluated against stable requirements.
  - Improved handling for nightly builds with newer base versions.
  - Preserved stable requirements when only nightly policy information changes.

- **Tests**
  - Added coverage for nightly version comparisons and separate policy requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->