### PR TITLE
web: recognize every Stack refresh cookie name in the dashboard session gate

### DIFF
--- a/web/app/lib/dashboard-session.ts
+++ b/web/app/lib/dashboard-session.ts
@@ -13,6 +13,7 @@ import {
   normalizeDashboardReturnPath,
 } from "./dashboard-return-path";
 import { isStackConfigured } from "./stack";
+import { stackRefreshCookies } from "./stack-session-cookies";
 import { localizedVaultPath, vaultSignInHref } from "./vault-auth";
 
 /**
@@ -45,23 +46,24 @@ export class DashboardSessionUnavailableError extends Error {
  */
 export const DASHBOARD_SESSION_STALE_SECONDS = 300;
 
-const STACK_REFRESH_COOKIE_PREFIX = "stack-refresh-";
-
 /**
  * Identify the browser session without reading token contents. Only the
- * refresh cookie changes across sign-in and sign-out, so its digest is enough
- * to key the private cache and never cache one user's session for another.
+ * refresh cookies change across sign-in and sign-out, so their digest is
+ * enough to key the private cache and never cache one user's session for
+ * another. Every Stack cookie name variant is included.
  */
 export async function dashboardSessionKey(): Promise<string> {
   const store = await cookies();
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
-  const refreshToken = projectId
-    ? store.get(`${STACK_REFRESH_COOKIE_PREFIX}${projectId}`)?.value
-    : undefined;
-  if (!refreshToken) return "anonymous";
+  const refreshCookies = projectId
+    ? stackRefreshCookies(store.getAll(), projectId)
+    : [];
+  if (refreshCookies.length === 0) return "anonymous";
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(refreshToken),
+    new TextEncoder().encode(
+      refreshCookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("\n"),
+    ),
   );
   return Array.from(new Uint8Array(digest).slice(0, 12), (byte) =>
     byte.toString(16).padStart(2, "0")

--- a/web/app/lib/stack-session-cookies.ts
+++ b/web/app/lib/stack-session-cookies.ts
@@ -1,0 +1,51 @@
+/**
+ * Where the Stack SDK keeps the browser refresh token. Current SDKs write
+ * `hexclave-refresh-<project>--<suffix>` (with a `__Host-` prefix on secure
+ * origins); older sessions still carry `stack-refresh-<project>` or the bare
+ * `stack-refresh`. Mirrors `_getRefreshTokenCookieNamePatterns` in
+ * `@stackframe/js`, so the edge gate and the session key agree with the SDK.
+ */
+export type CookieLike = { readonly name: string; readonly value: string };
+
+export function stackRefreshCookiePatterns(projectId: string): {
+  readonly exact: readonly string[];
+  readonly prefixes: readonly string[];
+} {
+  const current = `hexclave-refresh-${projectId}`;
+  const legacy = `stack-refresh-${projectId}`;
+  return {
+    exact: [legacy, "stack-refresh"],
+    prefixes: [
+      `${current}--`,
+      `__Host-${current}--`,
+      `${legacy}--`,
+      `__Host-${legacy}--`,
+    ],
+  };
+}
+
+/** The refresh cookies present for this project, current names first. */
+export function stackRefreshCookies(
+  cookies: Iterable<CookieLike>,
+  projectId: string,
+): CookieLike[] {
+  const { exact, prefixes } = stackRefreshCookiePatterns(projectId);
+  const structured: CookieLike[] = [];
+  const legacy: CookieLike[] = [];
+  for (const cookie of cookies) {
+    if (!cookie.value) continue;
+    if (prefixes.some((prefix) => cookie.name.startsWith(prefix))) {
+      structured.push(cookie);
+    } else if (exact.includes(cookie.name)) {
+      legacy.push(cookie);
+    }
+  }
+  return [...structured, ...legacy];
+}
+
+export function hasStackRefreshCookie(
+  cookies: Iterable<CookieLike>,
+  projectId: string,
+): boolean {
+  return stackRefreshCookies(cookies, projectId).length > 0;
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -18,6 +18,7 @@ import {
   dashboardReturnPathForRequest,
 } from "./app/lib/dashboard-return-path";
 import { localizedVaultPath, vaultSignInHref } from "./app/lib/vault-auth";
+import { hasStackRefreshCookie } from "./app/lib/stack-session-cookies";
 
 const intlMiddleware = createMiddleware(routing);
 const localeSet = new Set<string>(routing.locales);
@@ -405,7 +406,7 @@ function hasStackSessionCookie(request: NextRequest): boolean {
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
   // Without Stack the dashboard redirects home on the server instead.
   if (!projectId) return true;
-  return Boolean(request.cookies.get(`stack-refresh-${projectId}`)?.value);
+  return hasStackRefreshCookie(request.cookies.getAll(), projectId);
 }
 
 /**

--- a/web/tests/dashboard-middleware-session.test.ts
+++ b/web/tests/dashboard-middleware-session.test.ts
@@ -44,7 +44,7 @@ describe("dashboard session middleware", () => {
       new NextRequest("https://cmux.com/ja/dashboard/cloud", {
         headers: {
           host: "cmux.com",
-          cookie: `${TEST_STACK_REFRESH_COOKIE}=refresh-1`,
+          cookie: `__Host-hexclave-refresh-${TEST_STACK_PROJECT_ID}--abc=refresh-1`,
         },
       }),
     );

--- a/web/tests/helpers/dashboard-session-mock.ts
+++ b/web/tests/helpers/dashboard-session-mock.ts
@@ -12,13 +12,13 @@ export function nextHeadersMock(state: {
 }) {
   return {
     headers: async () => state.headers?.() ?? new Headers(),
-    cookies: async () => ({
-      get: (name: string) => {
-        const value = state.refreshToken?.() ?? null;
-        return name === TEST_STACK_REFRESH_COOKIE && value
-          ? { name, value }
-          : undefined;
-      },
-    }),
+    cookies: async () => {
+      const value = state.refreshToken?.() ?? null;
+      const all = value ? [{ name: TEST_STACK_REFRESH_COOKIE, value }] : [];
+      return {
+        get: (name: string) => all.find((cookie) => cookie.name === name),
+        getAll: () => all,
+      };
+    },
   };
 }

--- a/web/tests/stack-session-cookies.test.ts
+++ b/web/tests/stack-session-cookies.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasStackRefreshCookie,
+  stackRefreshCookies,
+} from "../app/lib/stack-session-cookies";
+
+const project = "9790718f-14cd-4f7e-824d-eaf527a82b82";
+
+describe("stack session cookies", () => {
+  test("recognizes every refresh cookie name the SDK writes", () => {
+    for (const name of [
+      `hexclave-refresh-${project}--abc`,
+      `__Host-hexclave-refresh-${project}--abc`,
+      `stack-refresh-${project}--abc`,
+      `__Host-stack-refresh-${project}--abc`,
+      `stack-refresh-${project}`,
+      "stack-refresh",
+    ]) {
+      expect(hasStackRefreshCookie([{ name, value: "token" }], project)).toBe(true);
+    }
+  });
+
+  test("ignores other cookies, empty values, and other projects", () => {
+    expect(hasStackRefreshCookie([
+      { name: "hexclave-access", value: "x" },
+      { name: `hexclave-refresh-${project}--abc`, value: "" },
+      { name: "hexclave-refresh-other-project--abc", value: "x" },
+      { name: "NEXT_LOCALE", value: "en" },
+    ], project)).toBe(false);
+  });
+
+  test("orders current cookies before legacy ones", () => {
+    const names = stackRefreshCookies([
+      { name: "stack-refresh", value: "old" },
+      { name: `hexclave-refresh-${project}--abc`, value: "new" },
+    ], project).map((cookie) => cookie.name);
+    expect(names).toEqual([`hexclave-refresh-${project}--abc`, "stack-refresh"]);
+  });
+});


### PR DESCRIPTION
Hotfix for the sign-in loop on cmux.com/dashboard after https://github.com/manaflow-ai/cmux/pull/12121.

The middleware gate and the private session key only looked for `stack-refresh-<project>`. Current Stack SDKs write `hexclave-refresh-<project>--<suffix>` (with a `__Host-` prefix on secure origins) and treat the old name as legacy, so every signed-in visitor was redirected to sign-in, which sent them back to the dashboard.

One shared resolver in `app/lib/stack-session-cookies.ts` mirrors the SDK's refresh cookie name patterns and is used by both the middleware and the session key. Unit tests cover every name variant. Typecheck passes and the dashboard test files pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b2b31349b4421a0fac76d63c8c78659f2ae77c1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard sign-in loop by recognizing every Stack refresh cookie name the SDK writes. Previously the middleware gate and session key only looked for `stack-refresh-<project>`, but current SDKs write `hexclave-refresh-<project>--<suffix>` (with a `__Host-` prefix on secure origins), so signed-in users were redirected to sign-in and bounced back to the dashboard.

**Refactors**
- Adds a shared resolver in `app/lib/stack-session-cookies.ts` used by both the middleware and the session key.
- Adds unit tests covering every cookie name variant.

<sup>Written for commit b2b31349b4421a0fac76d63c8c78659f2ae77c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session detection across current and legacy Stack refresh-cookie formats.
  * Dashboard sessions now recognize multiple valid refresh cookies and prioritize current cookie formats.
  * Requests without valid, non-empty refresh cookies continue to be treated as anonymous.

* **Tests**
  * Added coverage for supported cookie formats, legacy compatibility, unrelated cookies, empty values, and project-specific matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->