### PR TITLE
Fix flaky OpenCode completion notifications

### DIFF
--- a/.github/workflows/agent-notification-tests.yml
+++ b/.github/workflows/agent-notification-tests.yml
@@ -42,4 +42,4 @@ jobs:
       # change: its seeded Stop predates the Codex turn ledger's foreground
       # admission, the mock never answers agent.resolve_delivery_target, and its
       # fixture timestamp has aged past the seven-day session prune.
-      unit_test_suites: AgentNotificationRegressionTests,AgentJournalLifecycleCenterTests,FeedWaiterRegistryTests,ClaudeBackgroundWorkNotifyTests
+      unit_test_suites: AgentNotificationRegressionTests,AgentJournalLifecycleCenterTests,FeedWaiterRegistryTests,ClaudeBackgroundWorkNotifyTests,OpenCodeHookRegressionTests

--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -16,6 +16,7 @@ const MAX_PLAN_BYTES = 128 * 1024;
 export const CMUXFeed = async (ctx) => {
   let client = null;
   let buffered = "";
+  let telemetrySequence = 0;
   const pending = new Map();
   const messageRoles = new Map();
   const sessions = new Map();
@@ -27,6 +28,24 @@ export const CMUXFeed = async (ctx) => {
       if (typeof value === "string" && value.trim().length > 0) return value.trim();
     }
     return null;
+  };
+
+  // OpenCode has emitted both session.idle and session.status events over
+  // time, and the session identifier moved between top-level and nested
+  // properties. Keep the feed bridge tolerant of those wire-shape changes so
+  // completion notifications do not depend on one particular OpenCode build.
+  const sessionIdFromProperties = (props = {}) => firstString(
+    props.info && props.info.id,
+    props.sessionID,
+    props.sessionId,
+    props.session_id,
+    props.session && props.session.id
+  );
+
+  const sessionStatusIsIdle = (status) => {
+    if (typeof status === "string") return status.toLowerCase() === "idle";
+    if (!isObject(status)) return false;
+    return firstString(status.type, status.status, status.state)?.toLowerCase() === "idle";
   };
 
   const normalizeText = (value, max = 1000) => {
@@ -480,8 +499,12 @@ export const CMUXFeed = async (ctx) => {
   };
 
   const pushTelemetry = (event) => {
+    telemetrySequence += 1;
     write({
-      id: `opencode-telemetry-${Date.now()}`,
+      // Date.now() alone collides when OpenCode publishes a burst of events
+      // in one event-loop turn. The monotonic suffix keeps socket request IDs
+      // unique without relying on randomness or a second clock.
+      id: `opencode-telemetry-${Date.now()}-${telemetrySequence}`,
       method: "feed.push",
       params: { event, wait_timeout_seconds: 0 },
     });
@@ -496,17 +519,29 @@ export const CMUXFeed = async (ctx) => {
       }
       switch (event.type) {
         case "session.created": {
-          const info = event.properties?.info || {};
-          const state = sessionState(info.id || "unknown");
+          const props = event.properties || {};
+          const info = props.info || {};
+          const sid = sessionIdFromProperties(props) || "unknown";
+          const state = sessionState(sid);
           state.cwd = info.directory || ctx?.directory || state.cwd;
-          pushTelemetry(base(info.id || "unknown", {
+          pushTelemetry(base(sid, {
             hook_event_name: "SessionStart",
             cwd: state.cwd,
           }));
           break;
         }
+        case "session.status": {
+          const props = event.properties || {};
+          if (!sessionStatusIsIdle(props.status)) break;
+          const sid = sessionIdFromProperties(props);
+          if (!sid) break;
+          pushTelemetry(base(sid, {
+            hook_event_name: "Stop",
+          }));
+          break;
+        }
         case "session.idle": {
-          const sid = event.properties?.sessionID;
+          const sid = sessionIdFromProperties(event.properties || {});
           if (!sid) break;
           pushTelemetry(base(sid, {
             hook_event_name: "Stop",
@@ -514,7 +549,7 @@ export const CMUXFeed = async (ctx) => {
           break;
         }
         case "session.deleted": {
-          const sid = event.properties?.info?.id;
+          const sid = sessionIdFromProperties(event.properties || {});
           if (!sid) break;
           sessions.delete(sid);
           pushTelemetry(base(sid, {

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -45,7 +45,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
                   event["hook_event_name"] as? String == "Stop" else { return nil }
             return event
         }
-        XCTAssertEqual(stopEvents.count, 2, "Expected both OpenCode idle forms to emit Stop: \(frames)")
+        XCTAssertEqual(stopEvents.count, 3, "Expected all OpenCode idle forms to emit Stop: \(frames)")
         XCTAssertTrue(stopEvents.allSatisfy { $0["session_id"] as? String == "opencode-ses-feed-shape" })
         let requestIDs = frames.compactMap { $0["id"] as? String }
         XCTAssertEqual(requestIDs.count, Set(requestIDs).count, "OpenCode telemetry request IDs must not collide: \(frames)")
@@ -158,6 +158,10 @@ const fs = require("node:fs");
   await hooks.event({ event: {
     type: "session.status",
     properties: { info: { id: "ses-feed-shape" }, status: { type: "idle" } }
+  } });
+  await hooks.event({ event: {
+    type: "session.status",
+    properties: { session_id: "ses-feed-shape", status: "idle" }
   } });
   await new Promise((resolve) => setTimeout(resolve, 100));
   for (const socket of sockets) socket.destroy();

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -9,6 +9,48 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         let timedOut: Bool
     }
 
+    func testOpenCodeFeedPluginEmitsCompletionForBothIdleEventShapes() throws {
+        let fileManager = FileManager.default
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let pluginURL = repoRoot.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false)
+        XCTAssertTrue(fileManager.fileExists(atPath: pluginURL.path))
+
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-opencode-feed-\(UUID().uuidString)", isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let socketPath = root.appendingPathComponent("cmux.sock").path
+        let harnessURL = root.appendingPathComponent("harness.js")
+        try Self.openCodeFeedEventHarness.write(to: harnessURL, atomically: true, encoding: .utf8)
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: ["node", harnessURL.path, pluginURL.path, socketPath],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let data = try XCTUnwrap(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8))
+        let frames = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let stopEvents = frames.compactMap { frame -> [String: Any]? in
+            guard frame["method"] as? String == "feed.push",
+                  let params = frame["params"] as? [String: Any],
+                  let event = params["event"] as? [String: Any],
+                  event["hook_event_name"] as? String == "Stop" else { return nil }
+            return event
+        }
+        XCTAssertEqual(stopEvents.count, 2, "Expected both OpenCode idle forms to emit Stop: \(frames)")
+        XCTAssertTrue(stopEvents.allSatisfy { $0["session_id"] as? String == "opencode-ses-feed-shape" })
+        let requestIDs = frames.compactMap { $0["id"] as? String }
+        XCTAssertEqual(requestIDs.count, Set(requestIDs).count, "OpenCode telemetry request IDs must not collide: \(frames)")
+    }
+
     func testOpenCodeInstallHooksIsIdempotentForLegacySetupAlias() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("cmux-opencode-hooks-\(UUID().uuidString)", isDirectory: true)
@@ -68,6 +110,65 @@ final class OpenCodeHookRegressionTests: XCTestCase {
     private func bundledCLIPath() throws -> String {
         try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
+
+    private static let openCodeFeedEventHarness = #"""
+const net = require("node:net");
+const fs = require("node:fs");
+
+(async () => {
+  const [pluginPath, socketPath] = process.argv.slice(2);
+  try { fs.unlinkSync(socketPath); } catch (_) {}
+  const frames = [];
+  const sockets = new Set();
+  const server = net.createServer((conn) => {
+    sockets.add(conn);
+    conn.setEncoding("utf8");
+    let buffered = "";
+    conn.on("data", (chunk) => {
+      buffered += chunk;
+      let index;
+      while ((index = buffered.indexOf("\n")) >= 0) {
+        const line = buffered.slice(0, index);
+        buffered = buffered.slice(index + 1);
+        if (!line.trim()) continue;
+        const frame = JSON.parse(line);
+        frames.push(frame);
+        conn.write(JSON.stringify({ id: frame.id, ok: true, result: { status: "acknowledged" } }) + "\n");
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => { server.off("error", reject); resolve(); });
+  });
+
+  process.env.CMUX_SOCKET_PATH = socketPath;
+  const source = fs.readFileSync(pluginPath, "utf8")
+    .replace("export const CMUXFeed = async", "globalThis.CMUXFeed = async");
+  eval(source);
+  const hooks = await globalThis.CMUXFeed({ directory: "/tmp/opencode-project" });
+  await hooks.event({ event: {
+    type: "session.created",
+    properties: { info: { id: "ses-feed-shape", directory: "/tmp/opencode-project" } }
+  } });
+  await hooks.event({ event: {
+    type: "session.idle",
+    properties: { sessionId: "ses-feed-shape" }
+  } });
+  await hooks.event({ event: {
+    type: "session.status",
+    properties: { info: { id: "ses-feed-shape" }, status: { type: "idle" } }
+  } });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  for (const socket of sockets) socket.destroy();
+  await new Promise((resolve) => server.close(resolve));
+  try { fs.unlinkSync(socketPath); } catch (_) {}
+  console.log(JSON.stringify(frames));
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});
+"""#
 
     private func runProcess(
         executablePath: String,

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -119,6 +119,8 @@ const fs = require("node:fs");
   const [pluginPath, socketPath] = process.argv.slice(2);
   try { fs.unlinkSync(socketPath); } catch (_) {}
   const frames = [];
+  let resolveFrames;
+  const framesReady = new Promise((resolve) => { resolveFrames = resolve; });
   const sockets = new Set();
   const server = net.createServer((conn) => {
     sockets.add(conn);
@@ -133,6 +135,7 @@ const fs = require("node:fs");
         if (!line.trim()) continue;
         const frame = JSON.parse(line);
         frames.push(frame);
+        if (frames.length === 4) resolveFrames();
         conn.write(JSON.stringify({ id: frame.id, ok: true, result: { status: "acknowledged" } }) + "\n");
       }
     });
@@ -163,7 +166,7 @@ const fs = require("node:fs");
     type: "session.status",
     properties: { session_id: "ses-feed-shape", status: "idle" }
   } });
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  await framesReady;
   for (const socket of sockets) socket.destroy();
   await new Promise((resolve) => server.close(resolve));
   try { fs.unlinkSync(socketPath); } catch (_) {}


### PR DESCRIPTION
OpenCode completion notifications were unreliable because the feed bridge only handled `session.idle`, while other OpenCode versions report idle through `session.status`. The bridge also generated telemetry request IDs from `Date.now()` alone, allowing same-millisecond event bursts to collide on the cmux socket.

This follow-up:

- accepts both idle event forms and the session ID field variants emitted by OpenCode versions;
- gives every telemetry frame a monotonic suffix so request IDs remain unique;
- adds a Unix-socket regression that drives both event forms through the real plugin and checks delivery plus ID uniqueness.

Validation: direct Node socket harness passes for session creation and both completion event shapes. Tagged app build and focused XCTest are running/queued separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791506683&installation_model_id=21920&pr_number=12190&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12190&signature=b91eaebbd2a748a07846bdeb8dcdfb1023776fcb5361d8a28dd18c7a8e5980ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky OpenCode completion notifications by accepting both `session.idle` and `session.status` events and the session ID field variants OpenCode versions emit. Telemetry request IDs now get a monotonic suffix so same-millisecond event bursts no longer collide on the cmux socket.

- Adds a Unix-socket regression test that drives `session.idle` and both `session.status` forms (object and string) through the real plugin and checks delivery plus request ID uniqueness.
- Wires the regression test into the agent-notification CI workflow.

<sup>Written for commit 13f089daccd47e77099d7de823487c42d7ff3d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized feed-bridge event parsing and telemetry ID generation; regression test covers the changed paths with no auth or data-model impact.
> 
> **Overview**
> Fixes **flaky OpenCode completion notifications** by making the feed bridge tolerant of how different OpenCode builds signal “session done” and identify sessions.
> 
> The plugin now treats **`session.status`** (string or object idle) the same as **`session.idle`**, emitting **`Stop`** telemetry in both cases. Session IDs are resolved from several property layouts (`sessionID`, `sessionId`, `session_id`, nested `info.id`, etc.) for create, idle, status, and delete handlers.
> 
> **Telemetry `feed.push` request IDs** append a monotonic counter to `Date.now()` so bursts in one event-loop turn no longer collide on the cmux socket.
> 
> A new **XCTest** runs a Node Unix-socket harness against the real `opencode-plugin.js`, asserting three **`Stop`** events for the idle variants and that all frame IDs are unique.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f15aae198fc12e67ca5d3544f3c59c4cd491e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenCode session completion tracking across multiple event formats.
  - Completion telemetry is now emitted when sessions reach an idle status.
  - Prevented telemetry request ID collisions during bursts of activity.
  - Improved session identification when event details use alternate formats.
  - Increased reliability of completion reporting for rapidly changing sessions.

- **Tests**
  - Added regression coverage for completion events, session ID handling, idle statuses, and unique telemetry request IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->