### PR TITLE
web: re-land instant dashboard navigation with SDK-accurate session cookies

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+
+# Playwright output
+test-results/

--- a/web/app/[locale]/(landing)/docs/layout.tsx
+++ b/web/app/[locale]/(landing)/docs/layout.tsx
@@ -1,4 +1,6 @@
-import { getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getTranslations } from "next-intl/server";
+import { pruneClientMessages } from "@/i18n/client-messages";
 import { buildAlternates, openGraphDefaults } from "@/i18n/seo";
 import { DocsNav } from "./docs-nav";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
@@ -25,18 +27,23 @@ export async function generateMetadata({
   };
 }
 
-export default function DocsLayout({
+export default async function DocsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const channel = docsChannel();
+  // Docs client components read the `docs` namespace, which the shared
+  // catalog omits. A nested provider replaces the catalog for this subtree.
+  const messages = pruneClientMessages(await getMessages());
   return (
-    <div className="min-h-screen">
-      <SiteHeader section="docs" />
-      <DocsNav channel={channel}>
-        {children}
-      </DocsNav>
-    </div>
+    <NextIntlClientProvider messages={messages}>
+      <div className="min-h-screen">
+        <SiteHeader section="docs" />
+        <DocsNav channel={channel}>
+          {children}
+        </DocsNav>
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/web/app/[locale]/dashboard/cloud/page.tsx
+++ b/web/app/[locale]/dashboard/cloud/page.tsx
@@ -1,9 +1,18 @@
+import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
-import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
-import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { loadDashboardSection } from "@/app/lib/dashboard-auth";
+import { isStackConfigured } from "@/app/lib/stack";
 import { listVmAccessGrants, runVmWorkflow } from "@/services/vms/workflows";
+import { DashboardAuthRecovery } from "../components/dashboard-auth-recovery";
+import { DashboardSectionSkeleton } from "../components/dashboard-skeleton";
 import { CloudDeviceActions } from "./device-actions";
+
+const RETURN_PATH = "/dashboard/cloud";
+
+// The header is static and prefetched with the shell. Only the device list
+// reads the session, behind its own boundary.
+export const instant = true;
 
 export default async function CloudDevicesPage({
   params,
@@ -12,13 +21,7 @@ export default async function CloudDevicesPage({
 }) {
   const { locale } = await params;
   if (!isStackConfigured()) redirect("/");
-  const user = await getStackServerApp().getUser({ or: "return-null" });
-  if (!user) redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/cloud")));
-  const [t, devices] = await Promise.all([
-    getTranslations({ locale, namespace: "dashboard.cloud" }),
-    runVmWorkflow(listVmAccessGrants({ userId: user.id })),
-  ]);
-  const dates = new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" });
+  const t = await getTranslations({ locale, namespace: "dashboard.cloud" });
 
   return (
     <div className="mx-auto w-full max-w-5xl px-3 py-4">
@@ -26,32 +29,49 @@ export default async function CloudDevicesPage({
         <h1 className="text-sm font-medium">{t("title")}</h1>
         <p className="mt-1 max-w-2xl text-muted">{t("description")}</p>
       </div>
-      {devices.length === 0 ? (
-        <p className="border border-border p-3 text-muted">{t("empty")}</p>
-      ) : (
-        <div className="space-y-3">
-          {devices.map((device) => (
-            <section key={device.id} className="border border-border p-3">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h2 className="font-medium">{device.name}</h2>
-                  <p className="mt-1 text-xs text-muted">
-                    {[device.modelIdentifier, device.osVersion && `macOS ${device.osVersion}`, device.architecture]
-                      .filter(Boolean).join(" · ")}
-                  </p>
-                </div>
-                <CloudDeviceActions id={device.id} name={device.name} />
-              </div>
-              <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
-                <DeviceFact label={t("cmux")} value={[device.cmuxChannel, device.cmuxVersion, device.cmuxBuild && `(${device.cmuxBuild})`].filter(Boolean).join(" ") || t("unknown")} />
-                <DeviceFact label={t("access")} value={device.tunnelPurposes.length ? device.tunnelPurposes.map((purpose) => t(`purpose.${purpose}`)).join(", ") : t("none")} />
-                <DeviceFact label={t("lastContact")} value={dates.format(new Date(device.lastControlPlaneAt))} />
-                <DeviceFact label={t("deviceId")} value={`…${device.deviceId.slice(-8)}`} />
-              </dl>
-            </section>
-          ))}
-        </div>
-      )}
+      <Suspense fallback={<DashboardSectionSkeleton variant="rows" />}>
+        <CloudDevicesSection locale={locale} />
+      </Suspense>
+    </div>
+  );
+}
+
+export async function CloudDevicesSection({ locale }: { readonly locale: string }) {
+  const section = await loadDashboardSection(locale, RETURN_PATH);
+  if (section.kind === "unavailable") {
+    return <DashboardAuthRecovery locale={locale} returnPath={RETURN_PATH} />;
+  }
+  const [t, devices] = await Promise.all([
+    getTranslations({ locale, namespace: "dashboard.cloud" }),
+    runVmWorkflow(listVmAccessGrants({ userId: section.user.id })),
+  ]);
+  const dates = new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" });
+
+  if (devices.length === 0) {
+    return <p className="border border-border p-3 text-muted">{t("empty")}</p>;
+  }
+  return (
+    <div className="space-y-3">
+      {devices.map((device) => (
+        <section key={device.id} className="border border-border p-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="font-medium">{device.name}</h2>
+              <p className="mt-1 text-xs text-muted">
+                {[device.modelIdentifier, device.osVersion && `macOS ${device.osVersion}`, device.architecture]
+                  .filter(Boolean).join(" · ")}
+              </p>
+            </div>
+            <CloudDeviceActions id={device.id} name={device.name} />
+          </div>
+          <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+            <DeviceFact label={t("cmux")} value={[device.cmuxChannel, device.cmuxVersion, device.cmuxBuild && `(${device.cmuxBuild})`].filter(Boolean).join(" ") || t("unknown")} />
+            <DeviceFact label={t("access")} value={device.tunnelPurposes.length ? device.tunnelPurposes.map((purpose) => t(`purpose.${purpose}`)).join(", ") : t("none")} />
+            <DeviceFact label={t("lastContact")} value={dates.format(new Date(device.lastControlPlaneAt))} />
+            <DeviceFact label={t("deviceId")} value={`…${device.deviceId.slice(-8)}`} />
+          </dl>
+        </section>
+      ))}
     </div>
   );
 }

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -33,16 +33,14 @@ import {
 } from "../components/coderouter-accounts";
 import { listAccounts as listNativeAccounts } from "@/services/coderouter/repository";
 import { CoderouterPageHeader } from "../components/dashboard-page-headers";
+import { DashboardSectionSkeleton } from "../components/dashboard-skeleton";
 import { withPrioritySpan } from "@/services/telemetry";
 import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
-// The page resolves as one server render. Keeping the auth and data work in
-// this Suspense boundary prevents a header-only response while the private
-// content is still loading.
+// The header is part of the static shell and is prefetched with it. The
+// session, team grants, and team data stream in behind the section boundary,
+// so nothing private is ever part of a prefetch.
 export const instant = true;
-// The page reads the live browser session and team grants. Do not put a
-// private RSC response in the prefetch cache before the click is authorized.
-export const prefetch = "force-disabled";
 
 type PageProps = {
   params: Promise<{ locale: string }>;
@@ -83,9 +81,11 @@ export default function CoderouterOverviewPage(props: PageProps) {
   }
 
   return (
-    <Suspense fallback={null}>
-      <ResolvedCoderouterOverviewContent {...props} />
-    </Suspense>
+    <CoderouterPageFrame>
+      <Suspense fallback={<DashboardSectionSkeleton />}>
+        <ResolvedCoderouterOverviewContent {...props} />
+      </Suspense>
+    </CoderouterPageFrame>
   );
 }
 
@@ -115,9 +115,9 @@ export async function CoderouterOverviewContent({
   locale: string;
   team?: string;
 }) {
-  // Authorization and the access token are resolved for every request. There
-  // is no private page cache here, so a prefetched response cannot outlive a
-  // team grant or expose management controls after revocation.
+  // Team grants and the access token are resolved for every request, so a
+  // revoked membership stops showing team data on the next render. The
+  // static header above this section is what keeps the navigation instant.
   const requestHeaders = await headers();
   const authorization = await withPrioritySpan(
     "cmux-coderouter-dashboard",
@@ -171,7 +171,7 @@ export async function CoderouterOverviewContent({
   ]);
 
   return (
-    <CoderouterPageFrame>
+    <>
       <TeamMetricsSection
         locale={locale}
         metrics={metrics}
@@ -193,7 +193,7 @@ export async function CoderouterOverviewContent({
         teamName={selectedTeam.name}
         usage={machineUsage}
       />
-    </CoderouterPageFrame>
+    </>
   );
 }
 
@@ -277,11 +277,7 @@ async function resolveCoderouterAuthorization(
 
 async function renderCoderouterLoadError(locale: string) {
   const t = await getTranslations({ locale, namespace: "dashboard.coderouterAccounts" });
-  return (
-    <CoderouterPageFrame>
-      <StatusPanel title={t("pageErrorTitle")} body={t("pageErrorBody")} />
-    </CoderouterPageFrame>
-  );
+  return <StatusPanel title={t("pageErrorTitle")} body={t("pageErrorBody")} />;
 }
 
 function CoderouterPageFrame({ children }: React.PropsWithChildren) {

--- a/web/app/[locale]/dashboard/components/dashboard-auth-recovery.tsx
+++ b/web/app/[locale]/dashboard/components/dashboard-auth-recovery.tsx
@@ -1,0 +1,31 @@
+import { getTranslations } from "next-intl/server";
+import { dashboardAuthorizationSignInHref } from "@/app/lib/dashboard-auth";
+
+/**
+ * Shown in place of a private section when Stack cannot confirm the session.
+ * The recovery link preserves the exact dashboard destination.
+ */
+export async function DashboardAuthRecovery({
+  locale,
+  returnPath,
+}: {
+  locale: string;
+  returnPath: string;
+}) {
+  const t = await getTranslations({ locale, namespace: "authError" });
+  return (
+    <section
+      data-testid="dashboard-auth-recovery"
+      className="max-w-xl border border-border p-4"
+    >
+      <h1 className="text-sm font-medium">{t("genericTitle")}</h1>
+      <p className="mt-2 text-sm text-muted">{t("genericBody")}</p>
+      <a
+        href={dashboardAuthorizationSignInHref(locale, returnPath)}
+        className="mt-4 inline-block border border-border bg-foreground px-3 py-1.5 text-sm text-background focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+      >
+        {t("backToSignIn")}
+      </a>
+    </section>
+  );
+}

--- a/web/app/[locale]/dashboard/components/dashboard-skeleton.tsx
+++ b/web/app/[locale]/dashboard/components/dashboard-skeleton.tsx
@@ -13,7 +13,19 @@ export function DashboardSkeleton({ variant = "cards" }: DashboardSkeletonProps)
         <SkeletonBlock className="mt-2 h-4 w-32" />
         <SkeletonBlock className="mt-2 h-3 w-full max-w-lg" />
       </div>
+      <DashboardSectionSkeleton variant={variant} />
+    </div>
+  );
+}
 
+/**
+ * The placeholder for one private section below a page header that is
+ * already on screen. Pages render this as the Suspense fallback around the
+ * part of the tree that reads the session.
+ */
+export function DashboardSectionSkeleton({ variant = "cards" }: DashboardSkeletonProps) {
+  return (
+    <div aria-hidden="true" data-testid="dashboard-section-skeleton">
       {variant === "rows" ? (
         <div className="border border-border">
           {Array.from({ length: 5 }).map((_, index) => (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Menu } from "@base-ui-components/react/menu";
-import { UserAvatar, useUser } from "@stackframe/stack";
+import { UserAvatar, useStackApp } from "@stackframe/stack";
 import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import type { DashboardSessionUser } from "@/app/lib/dashboard-session";
 import { Link, useRouter } from "@/i18n/navigation";
 import { clearCoderouterOrganizationScope } from "@/services/coderouter/organizationScope";
 import { useThemeToggle } from "@/app/[locale]/theme";
@@ -13,11 +14,19 @@ import { useDashboardTeamScope, type DashboardCatalogTeam } from "./dashboard-te
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
 
-export function DashboardAccountMenu() {
+export function DashboardAccountMenuFallback() {
+  return <div aria-hidden="true" className="min-w-0 flex-1" />;
+}
+
+/**
+ * The identity row. The user arrives from the server session so the row
+ * paints with the shell instead of after a second client fetch to Stack.
+ */
+export function DashboardAccountMenu({ user }: { user: DashboardSessionUser | null }) {
   const t = useTranslations("dashboard.accountMenu");
   const locale = useLocale();
   const router = useRouter();
-  const user = useUser({ or: "return-null" });
+  const stackApp = useStackApp();
   const teamScope = useDashboardTeamScope(user?.id ?? null);
   const theme = useThemeToggle();
   const [signOutPending, setSignOutPending] = useState(false);
@@ -104,7 +113,7 @@ export function DashboardAccountMenu() {
                   setSignOutPending(true);
                   setSignOutError(false);
                   try {
-                    await user.signOut();
+                    await stackApp.signOut();
                     clearCoderouterOrganizationScope();
                     router.replace("/");
                     router.refresh();

--- a/web/app/[locale]/dashboard/dashboard-shell.tsx
+++ b/web/app/[locale]/dashboard/dashboard-shell.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { Link, usePathname } from "@/i18n/navigation";
-import { DashboardAccountMenu } from "./dashboard-account-menu";
 
 type DashboardNavGroup = {
   label: string;
@@ -11,16 +10,18 @@ type DashboardNavGroup = {
     href: string;
     label: string;
     active: boolean;
-    prefetch?: boolean;
   }>;
 };
 
 export function DashboardShell({
   children,
   vaultEnabled,
+  account,
 }: {
   children: React.ReactNode;
   vaultEnabled: boolean;
+  /** The identity row, streamed by the layout once the session resolves. */
+  account?: React.ReactNode;
 }) {
   const t = useTranslations("dashboard.nav");
   const common = useTranslations("common");
@@ -62,10 +63,6 @@ export function DashboardShell({
           href: "/dashboard/coderouter",
           label: t("coderouterOverview"),
           active: pathname.startsWith("/dashboard/coderouter"),
-          // These pages contain authorization-dependent data. Let the server
-          // check the session at click time instead of caching a private RSC
-          // snapshot in the browser before the click.
-          prefetch: false,
         },
       ],
     },
@@ -76,7 +73,6 @@ export function DashboardShell({
           href: "/dashboard/testflight",
           label: t("testflight"),
           active: pathname.startsWith("/dashboard/testflight"),
-          prefetch: false,
         },
       ],
     },
@@ -137,9 +133,7 @@ export function DashboardShell({
               >
                 <DashboardMenuIcon open={mobileNavOpen} />
               </button>
-              <Suspense fallback={<DashboardAccountMenuFallback />}>
-                <DashboardAccountMenu />
-              </Suspense>
+              {account}
             </div>
           </div>
           <DashboardNav
@@ -154,10 +148,6 @@ export function DashboardShell({
       </div>
     </div>
   );
-}
-
-function DashboardAccountMenuFallback() {
-  return <div aria-hidden="true" className="min-w-0 flex-1" />;
 }
 
 function DashboardNav({
@@ -184,7 +174,7 @@ function DashboardNav({
   );
 }
 
-function DashboardNavGroupView({
+export function DashboardNavGroupView({
   group,
   onNavigate,
 }: {
@@ -201,7 +191,6 @@ function DashboardNavGroupView({
           <Link
             key={item.href}
             href={item.href}
-            prefetch={item.prefetch}
             onClick={onNavigate}
             aria-current={item.active ? "page" : undefined}
             className={`block border-l px-2 py-1.5 focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground ${

--- a/web/app/[locale]/dashboard/layout.tsx
+++ b/web/app/[locale]/dashboard/layout.tsx
@@ -1,19 +1,25 @@
 import { StackProvider, StackTheme } from "@stackframe/stack";
-import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import {
   DashboardAuthorizationUnavailableError,
-  dashboardAuthorizationSignInHref,
   dashboardReturnPath,
+  optionalDashboardUser,
   requireDashboardUser,
 } from "@/app/lib/dashboard-auth";
-import { getStackServerApp } from "@/app/lib/stack";
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { isVaultEnabled } from "@/services/vault/config";
 import { DashboardQueryProvider } from "./components/query-provider";
+import {
+  DashboardAccountMenu,
+  DashboardAccountMenuFallback,
+} from "./dashboard-account-menu";
 import { DashboardShell } from "./dashboard-shell";
 
-// A cold entry must finish the server session check before any dashboard UI.
-// Sibling pages below this layout can still use instant navigation.
-export const instant = false;
+// The shell is static. Every session read sits behind its own Suspense
+// boundary, so navigations into and between dashboard pages paint the
+// sidebar and page frames from the prefetched app shell.
+export const instant = true;
 
 export default async function DashboardLayout({
   children,
@@ -23,41 +29,49 @@ export default async function DashboardLayout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const returnPath = await dashboardReturnPath();
-  try {
-    await requireDashboardUser(locale, returnPath);
-  } catch (error) {
-    if (!(error instanceof DashboardAuthorizationUnavailableError)) {
-      throw error;
-    }
-    // Keep the private shell out of the response when Stack is unavailable.
-    // The recovery link preserves the exact dashboard destination.
-    const t = await getTranslations({ locale, namespace: "authError" });
-    return (
-      <main className="mx-auto w-full max-w-5xl px-3 py-8">
-        <section className="max-w-xl border border-border p-4">
-          <h1 className="text-sm font-medium">{t("genericTitle")}</h1>
-          <p className="mt-2 text-sm text-muted">{t("genericBody")}</p>
-          <a
-            href={dashboardAuthorizationSignInHref(locale, returnPath)}
-            className="mt-4 inline-block border border-border bg-foreground px-3 py-1.5 text-sm text-background focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
-          >
-            {t("backToSignIn")}
-          </a>
-        </section>
-      </main>
-    );
-  }
+  if (!isStackConfigured()) redirect("/");
 
   return (
     <StackProvider app={getStackServerApp()}>
       <StackTheme>
         <DashboardQueryProvider>
-          <DashboardShell vaultEnabled={isVaultEnabled()}>
+          <DashboardShell
+            vaultEnabled={isVaultEnabled()}
+            account={
+              <Suspense fallback={<DashboardAccountMenuFallback />}>
+                <DashboardAccountSlot />
+              </Suspense>
+            }
+          >
+            <Suspense fallback={null}>
+              <DashboardSessionGuard locale={locale} />
+            </Suspense>
             {children}
           </DashboardShell>
         </DashboardQueryProvider>
       </StackTheme>
     </StackProvider>
   );
+}
+
+// Streams the identity row once the session resolves; signed-out visitors
+// get the sign-in control while the middleware redirect completes. Every
+// other server read in this render shares the same cached session.
+async function DashboardAccountSlot() {
+  const user = await optionalDashboardUser();
+  return <DashboardAccountMenu user={user} />;
+}
+
+// Middleware already turns away requests with no session cookie. This covers
+// a cookie whose session Stack rejects, for pages with no private section of
+// their own, without holding the page content behind the check.
+async function DashboardSessionGuard({ locale }: { locale: string }) {
+  try {
+    await requireDashboardUser(locale, await dashboardReturnPath());
+  } catch (error) {
+    // An outage is reported inside each private section. Redirects and
+    // unknown failures still propagate.
+    if (!(error instanceof DashboardAuthorizationUnavailableError)) throw error;
+  }
+  return null;
 }

--- a/web/app/[locale]/dashboard/page.tsx
+++ b/web/app/[locale]/dashboard/page.tsx
@@ -1,11 +1,13 @@
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 import { Link } from "@/i18n/navigation";
-import { getRequestScopedStackUser, isStackConfigured } from "@/app/lib/stack";
-import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { isStackConfigured } from "@/app/lib/stack";
 import { isVaultEnabled } from "@/services/vault/config";
-import { withPrioritySpan } from "@/services/telemetry";
 
+// The overview lists products only. It carries no private data, so it is
+// part of the static shell; the layout's session guard still redirects a
+// rejected session to sign-in.
+export const instant = true;
 
 export default async function DashboardIndexPage({
   params,
@@ -16,15 +18,6 @@ export default async function DashboardIndexPage({
 
   if (!isStackConfigured()) {
     redirect("/");
-  }
-  const user = await withPrioritySpan(
-    "cmux-dashboard",
-    "cmux.dashboard.auth",
-    { "http.route": "/dashboard", "cmux.locale": locale },
-    () => getRequestScopedStackUser("dashboard"),
-  );
-  if (!user) {
-    redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard")));
   }
 
   const t = await getTranslations({ locale, namespace: "dashboard.home" });

--- a/web/app/[locale]/dashboard/team/page.tsx
+++ b/web/app/[locale]/dashboard/team/page.tsx
@@ -1,8 +1,14 @@
 import { AccountSettings } from "@stackframe/stack";
 import { redirect } from "next/navigation";
-import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
-import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { Suspense } from "react";
+import { loadDashboardSection } from "@/app/lib/dashboard-auth";
+import { isStackConfigured } from "@/app/lib/stack";
+import { DashboardAuthRecovery } from "../components/dashboard-auth-recovery";
+import { DashboardSectionSkeleton } from "../components/dashboard-skeleton";
 
+const RETURN_PATH = "/dashboard/team";
+
+export const instant = true;
 
 export default async function DashboardTeamPage({
   params,
@@ -13,14 +19,20 @@ export default async function DashboardTeamPage({
   if (!isStackConfigured()) {
     redirect(`/${locale}`);
   }
-  const user = await getStackServerApp().getUser({ or: "return-null" });
-  if (!user) {
-    redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/team")));
-  }
 
   return (
     <div className="w-full px-3 py-4">
-      <AccountSettings />
+      <Suspense fallback={<DashboardSectionSkeleton variant="rows" />}>
+        <TeamSettingsSection locale={locale} />
+      </Suspense>
     </div>
   );
+}
+
+async function TeamSettingsSection({ locale }: { locale: string }) {
+  const section = await loadDashboardSection(locale, RETURN_PATH);
+  if (section.kind === "unavailable") {
+    return <DashboardAuthRecovery locale={locale} returnPath={RETURN_PATH} />;
+  }
+  return <AccountSettings />;
 }

--- a/web/app/[locale]/dashboard/testflight/page.tsx
+++ b/web/app/[locale]/dashboard/testflight/page.tsx
@@ -2,21 +2,22 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
-import { requireDashboardUser } from "@/app/lib/dashboard-auth";
+import { loadDashboardSection } from "@/app/lib/dashboard-auth";
 import { isStackConfigured } from "@/app/lib/stack";
 import { Link } from "@/i18n/navigation";
 import { isAscConfigured } from "@/services/asc/client";
 import { testerGroupStatus } from "@/services/asc/testflight";
 import { isTestflightEligible } from "@/services/billing/pro";
 import { captureAscError } from "@/services/errors";
+import { DashboardAuthRecovery } from "../components/dashboard-auth-recovery";
 import { TestflightPageHeader } from "../components/dashboard-page-headers";
+import { DashboardSectionSkeleton } from "../components/dashboard-skeleton";
 
-// This route renders the session and page data as one unit. The dashboard nav
-// disables prefetch for this authorization-dependent page.
+const RETURN_PATH = "/dashboard/testflight";
+
+// The header is part of the static shell. Entitlement and enrollment are
+// request-specific and stream in behind the section boundary.
 export const instant = true;
-// Entitlement and enrollment are request-specific. A route-level guard also
-// covers links outside the dashboard shell.
-export const prefetch = "force-disabled";
 
 type SearchParams = {
   testflight?: string | string[];
@@ -39,9 +40,12 @@ export default function DashboardTestflightPage(props: PageProps) {
   }
 
   return (
-    <Suspense fallback={null}>
-      <ResolvedDashboardTestflightContent {...props} />
-    </Suspense>
+    <div className="mx-auto w-full max-w-5xl px-3 py-4">
+      <TestflightPageHeader />
+      <Suspense fallback={<DashboardSectionSkeleton />}>
+        <ResolvedDashboardTestflightContent {...props} />
+      </Suspense>
+    </div>
   );
 }
 
@@ -49,7 +53,6 @@ async function ResolvedDashboardTestflightContent({
   params,
   searchParams,
 }: PageProps) {
-  // Framework promises are not stable cache keys across prerender phases.
   const [{ locale }, query] = await Promise.all([params, searchParams]);
   const testflight = Array.isArray(query?.testflight)
     ? query.testflight[0]
@@ -67,10 +70,13 @@ export async function DashboardTestflightContent({
   locale: string;
   testflight?: string;
 }) {
-  // Resolve the session and entitlement for every request. The page is one
-  // render unit, so a prefetched response cannot outlive the authorization
-  // check or reveal an old enrollment state.
-  const user = await requireDashboardUser(locale, "/dashboard/testflight");
+  // The session comes from the private cache; entitlement and enrollment are
+  // read fresh so a lapsed subscription or a leave action shows at once.
+  const section = await loadDashboardSection(locale, RETURN_PATH);
+  if (section.kind === "unavailable") {
+    return <DashboardAuthRecovery locale={locale} returnPath={RETURN_PATH} />;
+  }
+  const { user } = section;
   const eligible = await isTestflightEligible(user);
   const email = normalizedEmail(user.primaryEmail);
 
@@ -81,27 +87,24 @@ export async function DashboardTestflightContent({
   const banner = testflightBanner(testflight);
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-3 py-4">
-      <TestflightPageHeader />
-      <div>
-        {banner ? (
-          <div className="mb-3 border border-border bg-background p-3 text-sm">
-            {t(`banners.${banner}`)}
-          </div>
-        ) : null}
+    <div>
+      {banner ? (
+        <div className="mb-3 border border-border bg-background p-3 text-sm">
+          {t(`banners.${banner}`)}
+        </div>
+      ) : null}
 
-        {!eligible ? (
-          <NotEligible t={t} />
-        ) : !email ? (
-          <NeedsEmail t={t} />
-        ) : status.unavailable ? (
-          <Unavailable t={t} />
-        ) : status.enrolled ? (
-          <Enrolled t={t} email={email} state={status.state} />
-        ) : (
-          <Join t={t} email={email} />
-        )}
-      </div>
+      {!eligible ? (
+        <NotEligible t={t} />
+      ) : !email ? (
+        <NeedsEmail t={t} />
+      ) : status.unavailable ? (
+        <Unavailable t={t} />
+      ) : status.enrolled ? (
+        <Enrolled t={t} email={email} state={status.state} />
+      ) : (
+        <Join t={t} email={email} />
+      )}
     </div>
   );
 }

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -18,43 +18,9 @@ import { Providers } from "./providers";
 import { DevPanel } from "./components/spacing-control";
 import { ThemeBootstrapScript } from "./theme-bootstrap-script";
 import { darkThemeColor, lightThemeColor } from "./theme-colors";
+import { sharedClientMessages } from "../../i18n/client-messages";
 
 const themeBootstrapScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content=light?"${lightThemeColor}":"${darkThemeColor}"})}catch(e){}})()`;
-
-type MessageTree = Record<string, unknown>;
-
-function isMessageTree(value: unknown): value is MessageTree {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-function pruneClientMessages(messages: MessageTree): MessageTree {
-  const pruned: MessageTree = { ...messages };
-  const landing = isMessageTree(messages.landing)
-    ? { ...messages.landing }
-    : undefined;
-  if (landing && isMessageTree(landing.compare)) {
-    const compare = { ...landing.compare };
-    delete compare.pages;
-    landing.compare = compare;
-    pruned.landing = landing;
-  }
-
-  const blog = isMessageTree(messages.blog) ? { ...messages.blog } : undefined;
-  if (blog && isMessageTree(blog.posts)) {
-    blog.posts = Object.fromEntries(
-      Object.entries(blog.posts).map(([key, value]) => {
-        if (!isMessageTree(value)) {
-          return [key, value];
-        }
-        const { title, date, summary } = value;
-        return [key, { title, date, summary }];
-      }),
-    );
-    pruned.blog = blog;
-  }
-
-  return pruned;
-}
 
 export async function generateMetadata({
   params,
@@ -99,7 +65,7 @@ export default async function LocaleLayout({
 
   setRequestLocale(locale);
 
-  const messages = pruneClientMessages(await getMessages());
+  const messages = sharedClientMessages(await getMessages());
   const t = await getTranslations({ locale, namespace: "meta" });
   const { description: webSiteDescription } = homeSeoCopy(locale, t);
 

--- a/web/app/lib/dashboard-auth.ts
+++ b/web/app/lib/dashboard-auth.ts
@@ -1,12 +1,12 @@
-import { cache } from "react";
 import { headers } from "next/headers";
-import { redirect } from "next/navigation";
+import { redirect, unstable_rethrow } from "next/navigation";
 
 import {
-  isSubrouterAuthorizationError,
-  verifyBrowserSessionRequest,
-  withSubrouterAuthorizationDeadline,
-} from "../../services/vms/auth";
+  type DashboardSessionUser,
+  DashboardSessionMissingError,
+  DashboardSessionUnavailableError,
+  readDashboardSessionUser,
+} from "./dashboard-session";
 import { isStackConfigured } from "./stack";
 import {
   DASHBOARD_RETURN_PATH_HEADER,
@@ -14,48 +14,15 @@ import {
 } from "./dashboard-return-path";
 import { localizedVaultPath, vaultSignInHref } from "./vault-auth";
 
+export type { DashboardSessionUser } from "./dashboard-session";
+
 export class DashboardAuthorizationUnavailableError extends Error {
   override readonly name = "DashboardAuthorizationUnavailableError";
 }
 
-type DashboardAuthState =
-  | { readonly kind: "unconfigured" }
-  | { readonly kind: "missing" }
-  | {
-    readonly kind: "authenticated";
-    readonly user: NonNullable<Awaited<ReturnType<typeof verifyBrowserSessionRequest>>>;
-  }
+export type DashboardSection =
+  | { readonly kind: "user"; readonly user: DashboardSessionUser }
   | { readonly kind: "unavailable" };
-
-/**
- * Resolve the browser session once per server render. The Stack call is
- * bounded by the same authorization deadline used by API routes, so a slow
- * auth provider cannot hold the dashboard shell open forever.
- */
-const readDashboardAuth = cache(async (): Promise<DashboardAuthState> => {
-  if (!isStackConfigured()) return { kind: "unconfigured" };
-
-  try {
-    const requestHeaders = await headers();
-    const user = await withSubrouterAuthorizationDeadline((signal) =>
-      verifyBrowserSessionRequest(
-        new Request("https://cmux.com/dashboard", {
-          headers: Object.fromEntries(requestHeaders.entries()),
-        }),
-        signal,
-      )
-    );
-    return user ? { kind: "authenticated", user } : { kind: "missing" };
-  } catch (error) {
-    if (isSubrouterAuthorizationError(error)) {
-      console.error("Dashboard Stack authorization unavailable", {
-        errorType: error instanceof Error ? error.name : typeof error,
-      });
-      return { kind: "unavailable" };
-    }
-    throw error;
-  }
-});
 
 /**
  * Read the dashboard destination set by middleware. The value is restricted
@@ -71,24 +38,61 @@ export async function dashboardReturnPath(
   );
 }
 
+/**
+ * Resolve the signed-in user for a private dashboard section, redirecting a
+ * missing session to sign-in. Call it inside the section's own Suspense
+ * boundary so the static shell above it never waits on Stack.
+ */
 export async function requireDashboardUser(
   locale: string,
   returnPath: string = "/dashboard",
-) {
-  const state = await readDashboardAuth();
-  if (state.kind === "unconfigured") redirect("/");
-  if (state.kind === "unavailable") {
+): Promise<DashboardSessionUser> {
+  const section = await loadDashboardSection(locale, returnPath);
+  if (section.kind === "unavailable") {
     throw new DashboardAuthorizationUnavailableError(
       "Dashboard Stack authorization unavailable",
     );
   }
-  if (state.kind === "missing") {
-    redirect(vaultSignInHref(localizedVaultPath(
-      locale,
-      normalizeDashboardReturnPath(returnPath),
-    )));
+  return section.user;
+}
+
+/**
+ * Like `requireDashboardUser`, but reports a Stack outage as a value so a
+ * section can render recovery UI in place instead of failing the route.
+ */
+export async function loadDashboardSection(
+  locale: string,
+  returnPath: string = "/dashboard",
+): Promise<DashboardSection> {
+  if (!isStackConfigured()) redirect("/");
+  try {
+    return { kind: "user", user: await readDashboardSessionUser() };
+  } catch (error) {
+    // A framework redirect from inside the cached scope must propagate.
+    unstable_rethrow(error);
+    if (error instanceof DashboardSessionMissingError) {
+      redirect(dashboardAuthorizationSignInHref(locale, returnPath));
+    }
+    // Anything else crossed the cache boundary, where prototypes are not
+    // preserved, or is a Stack outage; both render recovery UI in place.
+    if (!(error instanceof DashboardSessionUnavailableError)) {
+      console.error("Dashboard session read failed", {
+        errorType: error instanceof Error ? error.name : typeof error,
+      });
+    }
+    return { kind: "unavailable" };
   }
-  return state.user;
+}
+
+/** The signed-in user for chrome that must render for signed-out visitors too. */
+export async function optionalDashboardUser(): Promise<DashboardSessionUser | null> {
+  if (!isStackConfigured()) return null;
+  try {
+    return await readDashboardSessionUser();
+  } catch (error) {
+    unstable_rethrow(error);
+    return null;
+  }
 }
 
 /** Render a standalone recovery view without mounting the private shell. */

--- a/web/app/lib/dashboard-session.ts
+++ b/web/app/lib/dashboard-session.ts
@@ -13,6 +13,7 @@ import {
   normalizeDashboardReturnPath,
 } from "./dashboard-return-path";
 import { isStackConfigured } from "./stack";
+import { stackRefreshCookies } from "./stack-session-cookies";
 import { localizedVaultPath, vaultSignInHref } from "./vault-auth";
 
 /**
@@ -45,23 +46,24 @@ export class DashboardSessionUnavailableError extends Error {
  */
 export const DASHBOARD_SESSION_STALE_SECONDS = 300;
 
-const STACK_REFRESH_COOKIE_PREFIX = "stack-refresh-";
-
 /**
  * Identify the browser session without reading token contents. Only the
- * refresh cookie changes across sign-in and sign-out, so its digest is enough
- * to key the private cache and never cache one user's session for another.
+ * refresh cookies change across sign-in and sign-out, so their digest is
+ * enough to key the private cache and never cache one user's session for
+ * another. Every Stack cookie name variant is included.
  */
 export async function dashboardSessionKey(): Promise<string> {
   const store = await cookies();
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
-  const refreshToken = projectId
-    ? store.get(`${STACK_REFRESH_COOKIE_PREFIX}${projectId}`)?.value
-    : undefined;
-  if (!refreshToken) return "anonymous";
+  const refreshCookies = projectId
+    ? stackRefreshCookies(store.getAll(), projectId)
+    : [];
+  if (refreshCookies.length === 0) return "anonymous";
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(refreshToken),
+    new TextEncoder().encode(
+      refreshCookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("\n"),
+    ),
   );
   return Array.from(new Uint8Array(digest).slice(0, 12), (byte) =>
     byte.toString(16).padStart(2, "0")

--- a/web/app/lib/dashboard-session.ts
+++ b/web/app/lib/dashboard-session.ts
@@ -1,0 +1,143 @@
+import { cache } from "react";
+import { cacheLife } from "next/cache";
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import {
+  isSubrouterAuthorizationError,
+  verifyBrowserSessionRequest,
+  withSubrouterAuthorizationDeadline,
+} from "../../services/vms/auth";
+import {
+  DASHBOARD_RETURN_PATH_HEADER,
+  normalizeDashboardReturnPath,
+} from "./dashboard-return-path";
+import { isStackConfigured } from "./stack";
+import { localizedVaultPath, vaultSignInHref } from "./vault-auth";
+
+/**
+ * The narrow, serializable view of the signed-in browser user that dashboard
+ * server components share. Only this shape may leave the private cache, so
+ * tokens and SDK objects never reach the client.
+ */
+export type DashboardSessionUser = {
+  readonly id: string;
+  readonly displayName: string | null;
+  readonly primaryEmail: string | null;
+  readonly primaryEmailVerified: boolean;
+  readonly profileImageUrl: string | null;
+  readonly selectedTeamId: string | null;
+  readonly isAnonymous: false;
+};
+
+export class DashboardSessionMissingError extends Error {
+  override readonly name = "DashboardSessionMissingError";
+}
+
+export class DashboardSessionUnavailableError extends Error {
+  override readonly name = "DashboardSessionUnavailableError";
+}
+
+/**
+ * Length of time the browser may reuse a resolved session between client
+ * navigations. API routes still verify every request, so this only bounds
+ * how long the dashboard chrome can lag a sign-out made elsewhere.
+ */
+export const DASHBOARD_SESSION_STALE_SECONDS = 300;
+
+const STACK_REFRESH_COOKIE_PREFIX = "stack-refresh-";
+
+/**
+ * Identify the browser session without reading token contents. Only the
+ * refresh cookie changes across sign-in and sign-out, so its digest is enough
+ * to key the private cache and never cache one user's session for another.
+ */
+export async function dashboardSessionKey(): Promise<string> {
+  const store = await cookies();
+  const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
+  const refreshToken = projectId
+    ? store.get(`${STACK_REFRESH_COOKIE_PREFIX}${projectId}`)?.value
+    : undefined;
+  if (!refreshToken) return "anonymous";
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(refreshToken),
+  );
+  return Array.from(new Uint8Array(digest).slice(0, 12), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+const INTL_LOCALE_HEADER = "x-next-intl-locale";
+
+/**
+ * Resolve the browser user once per server render and, through the private
+ * cache, once per browser session per stale window. Only a resolved user is
+ * cached: a rejected cookie redirects to sign-in from inside the cached
+ * scope, which the framework recognizes, and an outage throws.
+ */
+export const readDashboardSessionUser = cache(
+  async (): Promise<DashboardSessionUser> => {
+    if (!isStackConfigured()) throw new DashboardSessionMissingError("Stack Auth is not configured");
+    const sessionKey = await dashboardSessionKey();
+    if (sessionKey === "anonymous") {
+      throw new DashboardSessionMissingError("No dashboard session cookie");
+    }
+    return readCachedDashboardSessionUser(sessionKey);
+  },
+);
+
+async function readCachedDashboardSessionUser(
+  sessionKey: string,
+): Promise<DashboardSessionUser> {
+  "use cache: private";
+  cacheLife({ stale: DASHBOARD_SESSION_STALE_SECONDS });
+  // The key is part of the cache identity even though the body reads the
+  // request directly. Keep the reference so the argument is not elided.
+  void sessionKey;
+
+  let user: Awaited<ReturnType<typeof verifyBrowserSessionRequest>>;
+  try {
+    const requestHeaders = await headers();
+    user = await withSubrouterAuthorizationDeadline((signal) =>
+      verifyBrowserSessionRequest(
+        new Request("https://cmux.com/dashboard", {
+          headers: Object.fromEntries(requestHeaders.entries()),
+        }),
+        signal,
+      )
+    );
+  } catch (error) {
+    if (isSubrouterAuthorizationError(error)) {
+      console.error("Dashboard Stack authorization unavailable", {
+        errorType: error instanceof Error ? error.name : typeof error,
+      });
+      throw new DashboardSessionUnavailableError(
+        "Dashboard Stack authorization unavailable",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (!user) {
+    // The destination and locale come from request headers set by the
+    // middleware, so they stay out of the cache key.
+    const requestHeaders = await headers();
+    redirect(vaultSignInHref(localizedVaultPath(
+      requestHeaders.get(INTL_LOCALE_HEADER) ?? "en",
+      normalizeDashboardReturnPath(
+        requestHeaders.get(DASHBOARD_RETURN_PATH_HEADER),
+        "/dashboard",
+      ),
+    )));
+  }
+  return {
+    id: user.id,
+    displayName: user.displayName ?? null,
+    primaryEmail: user.primaryEmail ?? null,
+    primaryEmailVerified: user.primaryEmailVerified === true,
+    profileImageUrl: user.profileImageUrl ?? null,
+    selectedTeamId: user.selectedTeam?.id ?? null,
+    isAnonymous: false,
+  };
+}

--- a/web/app/lib/stack-session-cookies.ts
+++ b/web/app/lib/stack-session-cookies.ts
@@ -1,0 +1,51 @@
+/**
+ * Where the Stack SDK keeps the browser refresh token. Current SDKs write
+ * `hexclave-refresh-<project>--<suffix>` (with a `__Host-` prefix on secure
+ * origins); older sessions still carry `stack-refresh-<project>` or the bare
+ * `stack-refresh`. Mirrors `_getRefreshTokenCookieNamePatterns` in
+ * `@stackframe/js`, so the edge gate and the session key agree with the SDK.
+ */
+export type CookieLike = { readonly name: string; readonly value: string };
+
+export function stackRefreshCookiePatterns(projectId: string): {
+  readonly exact: readonly string[];
+  readonly prefixes: readonly string[];
+} {
+  const current = `hexclave-refresh-${projectId}`;
+  const legacy = `stack-refresh-${projectId}`;
+  return {
+    exact: [legacy, "stack-refresh"],
+    prefixes: [
+      `${current}--`,
+      `__Host-${current}--`,
+      `${legacy}--`,
+      `__Host-${legacy}--`,
+    ],
+  };
+}
+
+/** The refresh cookies present for this project, current names first. */
+export function stackRefreshCookies(
+  cookies: Iterable<CookieLike>,
+  projectId: string,
+): CookieLike[] {
+  const { exact, prefixes } = stackRefreshCookiePatterns(projectId);
+  const structured: CookieLike[] = [];
+  const legacy: CookieLike[] = [];
+  for (const cookie of cookies) {
+    if (!cookie.value) continue;
+    if (prefixes.some((prefix) => cookie.name.startsWith(prefix))) {
+      structured.push(cookie);
+    } else if (exact.includes(cookie.name)) {
+      legacy.push(cookie);
+    }
+  }
+  return [...structured, ...legacy];
+}
+
+export function hasStackRefreshCookie(
+  cookies: Iterable<CookieLike>,
+  projectId: string,
+): boolean {
+  return stackRefreshCookies(cookies, projectId).length > 0;
+}

--- a/web/e2e/instant/dashboard-navigation.instant.ts
+++ b/web/e2e/instant/dashboard-navigation.instant.ts
@@ -1,44 +1,28 @@
 import { expect, test } from "@playwright/test";
 
-const shellSeenKey = "cmux-dashboard-shell-seen-before-auth";
-
+// A visitor without a Stack session cookie is turned away at the edge. The
+// server never renders the dashboard shell for that request, and the browser
+// lands on sign-in with the exact destination preserved.
 for (const destination of [
   "/dashboard/coderouter",
   "/dashboard/testflight",
+  "/dashboard/cloud",
 ] as const) {
-  test(`${destination} authenticates before mounting the dashboard shell`, async ({
+  test(`${destination} redirects a signed-out visitor before the shell`, async ({
     page,
     request,
   }) => {
     const serverResponse = await request.get(destination, {
       maxRedirects: 0,
     });
-    const serverBody = await serverResponse.text();
-    const redirectEvidence = [
-      serverResponse.headers().location ?? "",
-      serverBody,
-    ].join("\n");
-    expect(redirectEvidence).toContain("/handler/sign-in?");
-    expect(serverBody).not.toContain("dashboard-shell");
-
-    await page.addInitScript(({ key }) => {
-      const markDashboardShell = () => {
-        if (document.querySelector('[data-testid="dashboard-shell"]')) {
-          window.sessionStorage.setItem(key, "true");
-        }
-      };
-      const observer = new MutationObserver(markDashboardShell);
-      observer.observe(document, { childList: true, subtree: true });
-      window.addEventListener("DOMContentLoaded", markDashboardShell, {
-        once: true,
-      });
-    }, { key: shellSeenKey });
+    expect(serverResponse.status()).toBe(307);
+    const location = serverResponse.headers().location ?? "";
+    expect(location).toContain("/handler/sign-in?");
+    expect(decodeURIComponent(decodeURIComponent(location))).toContain(destination);
+    expect(await serverResponse.text()).not.toContain("dashboard-shell");
 
     await page.goto(destination);
     await page.waitForURL((url) => url.pathname.startsWith("/handler/sign-in"));
-
-    expect(
-      await page.evaluate((key) => window.sessionStorage.getItem(key), shellSeenKey),
-    ).toBeNull();
+    expect(await page.locator('[data-testid="dashboard-shell"]').count()).toBe(0);
   });
 }

--- a/web/i18n/client-messages.ts
+++ b/web/i18n/client-messages.ts
@@ -1,0 +1,55 @@
+type MessageTree = Record<string, unknown>;
+
+function isMessageTree(value: unknown): value is MessageTree {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Namespaces only read by client components under their own route subtree.
+ * That subtree mounts a nested provider with the full catalog; every other
+ * page ships without them. `community` stays shared because the download
+ * confirmation reads it outside the community route.
+ */
+export const SUBTREE_CLIENT_NAMESPACES = ["docs"] as const;
+
+/**
+ * The catalog every client component may read. Large bodies that only
+ * server components render are dropped so they do not travel with each page.
+ */
+export function pruneClientMessages(messages: MessageTree): MessageTree {
+  const pruned: MessageTree = { ...messages };
+  const landing = isMessageTree(messages.landing)
+    ? { ...messages.landing }
+    : undefined;
+  if (landing && isMessageTree(landing.compare)) {
+    const compare = { ...landing.compare };
+    delete compare.pages;
+    landing.compare = compare;
+    pruned.landing = landing;
+  }
+
+  const blog = isMessageTree(messages.blog) ? { ...messages.blog } : undefined;
+  if (blog && isMessageTree(blog.posts)) {
+    blog.posts = Object.fromEntries(
+      Object.entries(blog.posts).map(([key, value]) => {
+        if (!isMessageTree(value)) {
+          return [key, value];
+        }
+        const { title, date, summary } = value;
+        return [key, { title, date, summary }];
+      }),
+    );
+    pruned.blog = blog;
+  }
+
+  return pruned;
+}
+
+/** The shared catalog without the subtree-only namespaces. */
+export function sharedClientMessages(messages: MessageTree): MessageTree {
+  const pruned = pruneClientMessages(messages);
+  for (const namespace of SUBTREE_CLIENT_NAMESPACES) {
+    delete pruned[namespace];
+  }
+  return pruned;
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -18,6 +18,7 @@ import {
   dashboardReturnPathForRequest,
 } from "./app/lib/dashboard-return-path";
 import { localizedVaultPath, vaultSignInHref } from "./app/lib/vault-auth";
+import { hasStackRefreshCookie } from "./app/lib/stack-session-cookies";
 
 const intlMiddleware = createMiddleware(routing);
 const localeSet = new Set<string>(routing.locales);
@@ -405,7 +406,7 @@ function hasStackSessionCookie(request: NextRequest): boolean {
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
   // Without Stack the dashboard redirects home on the server instead.
   if (!projectId) return true;
-  return Boolean(request.cookies.get(`stack-refresh-${projectId}`)?.value);
+  return hasStackRefreshCookie(request.cookies.getAll(), projectId);
 }
 
 /**

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -17,6 +17,7 @@ import {
   DASHBOARD_RETURN_PATH_HEADER,
   dashboardReturnPathForRequest,
 } from "./app/lib/dashboard-return-path";
+import { localizedVaultPath, vaultSignInHref } from "./app/lib/vault-auth";
 
 const intlMiddleware = createMiddleware(routing);
 const localeSet = new Set<string>(routing.locales);
@@ -356,15 +357,55 @@ export default function middleware(incomingRequest: NextRequest) {
     );
   }
 
-  if (dashboardReturnPath) {
-    setRequestHeaderOverride(
-      response,
-      DASHBOARD_RETURN_PATH_HEADER,
-      dashboardReturnPath,
-    );
-  }
+  return dashboardReturnPath
+    ? dashboardResponse(request, response, dashboardReturnPath)
+    : response;
+}
 
+/**
+ * A visitor with no Stack session cookie cannot be signed in. Redirect at the
+ * edge so a cold dashboard entry never renders the shell for them, and so the
+ * server components only meet sessions worth verifying. Otherwise forward the
+ * destination for the server-side sign-in redirect.
+ */
+function dashboardResponse(
+  request: NextRequest,
+  response: NextResponse,
+  dashboardReturnPath: string,
+): NextResponse {
+  if (!hasStackSessionCookie(request)) {
+    const url = request.nextUrl.clone();
+    const target = vaultSignInHref(
+      localizedVaultPath(requestPathLocale(request), dashboardReturnPath),
+    );
+    url.pathname = target.slice(0, target.indexOf("?"));
+    url.search = target.slice(target.indexOf("?"));
+    return NextResponse.redirect(url, 307);
+  }
+  setRequestHeaderOverride(
+    response,
+    DASHBOARD_RETURN_PATH_HEADER,
+    dashboardReturnPath,
+  );
   return response;
+}
+
+/** The locale already in the path, else the visitor's preferred locale. */
+function requestPathLocale(
+  request: NextRequest,
+): (typeof routing.locales)[number] {
+  const [, first] = request.nextUrl.pathname.split("/");
+  if (first && localeSet.has(first)) {
+    return first as (typeof routing.locales)[number];
+  }
+  return preferredAppRouteLocale(request);
+}
+
+function hasStackSessionCookie(request: NextRequest): boolean {
+  const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
+  // Without Stack the dashboard redirects home on the server instead.
+  if (!projectId) return true;
+  return Boolean(request.cookies.get(`stack-refresh-${projectId}`)?.value);
 }
 
 /**

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -580,7 +580,7 @@ export async function hasActiveTeamSubscriptionForTeam(
 }
 
 export async function isTestflightEligible(
-  user: ProReconcileUser,
+  user: Pick<ProReconcileUser, "id">,
   options: {
     hasActiveStripeSubscription?: ActiveStripeSubscriptionQuery;
   } = {},

--- a/web/tests/client-messages.test.ts
+++ b/web/tests/client-messages.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import enMessages from "../messages/en.json";
+import {
+  pruneClientMessages,
+  sharedClientMessages,
+} from "../i18n/client-messages";
+
+describe("client message catalogs", () => {
+  test("the shared catalog drops subtree-only namespaces and keeps the dashboard", () => {
+    const shared = sharedClientMessages(enMessages);
+
+    expect(shared.docs).toBeUndefined();
+    // Read by the download confirmation outside the community route.
+    expect(shared.community).toBeDefined();
+    expect(shared.dashboard).toBeDefined();
+    expect(shared.common).toBeDefined();
+    expect(shared.landing).toBeDefined();
+    // The docs namespace alone is about half of the catalog.
+    const before = JSON.stringify(pruneClientMessages(enMessages)).length;
+    const after = JSON.stringify(shared).length;
+    expect(after).toBeLessThan(before * 0.55);
+  });
+
+  test("the subtree catalog keeps docs for its nested provider", () => {
+    const pruned = pruneClientMessages(enMessages);
+
+    expect(pruned.docs).toBeDefined();
+    expect(enMessages.docs).toBeDefined();
+  });
+});

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -54,7 +54,12 @@ describe("coderouter middleware", () => {
     const response = middleware(
       new NextRequest(
         "https://cmux.com/ja/dashboard/coderouter?team=team-1",
-        { headers: { "x-cmux-dashboard-return-path": "/pricing" } },
+        {
+          headers: {
+            "x-cmux-dashboard-return-path": "/pricing",
+            cookie: `stack-refresh-${process.env.NEXT_PUBLIC_STACK_PROJECT_ID ?? "none"}=refresh-1`,
+          },
+        },
       ),
     );
 
@@ -66,7 +71,10 @@ describe("coderouter middleware", () => {
   test("keeps a dashboard POST body while adding the auth return path", async () => {
     const request = new NextRequest("https://cmux.com/en/dashboard/testflight", {
       method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: `stack-refresh-${process.env.NEXT_PUBLIC_STACK_PROJECT_ID ?? "none"}=refresh-1`,
+      },
       body: "action=join",
     });
     const response = middleware(request);

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -3,18 +3,15 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type React from "react";
 import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
-let currentUser: {
-  id: string;
-  displayName: string;
-  primaryEmail: string;
-  signOut: () => Promise<void>;
-} | null = null;
+type MenuUser = Parameters<typeof DashboardAccountMenu>[0]["user"];
+let currentUser: MenuUser = null;
+const appSignOut = mock(async () => undefined);
 const routerPush = mock(() => undefined);
 const routerReplace = mock(() => undefined);
 const routerRefresh = mock(() => undefined);
 
 mock.module("@stackframe/stack", () => ({
-  useUser: () => currentUser,
+  useStackApp: () => ({ signOut: appSignOut }),
   UserAvatar: ({ size }: { size: number }) => (
     <span data-testid="avatar" data-size={size} />
   ),
@@ -95,15 +92,22 @@ const { DashboardAccountMenu } = await import(
   "../app/[locale]/dashboard/dashboard-account-menu"
 );
 
+function sessionUser(): MenuUser {
+  return {
+    id: "user-lawrence",
+    displayName: "Lawrence",
+    primaryEmail: "lawrence@example.com",
+    primaryEmailVerified: true,
+    profileImageUrl: null,
+    selectedTeamId: null,
+    isAnonymous: false,
+  };
+}
+
 describe("dashboard account menu", () => {
   test("matches the chatmux identity row and exposes the account menu", () => {
-    currentUser = {
-      id: "user-lawrence",
-      displayName: "Lawrence",
-      primaryEmail: "lawrence@example.com",
-      signOut: async () => undefined,
-    };
-    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+    currentUser = sessionUser();
+    const html = renderToStaticMarkup(<DashboardAccountMenu user={currentUser} />);
 
     expect(html).toContain("Lawrence");
     expect(html).toContain("lawrence@example.com");
@@ -116,28 +120,18 @@ describe("dashboard account menu", () => {
   });
 
   test("offers the theme switch inside the menu, named after the theme it switches to", () => {
-    currentUser = {
-      id: "user-lawrence",
-      displayName: "Lawrence",
-      primaryEmail: "lawrence@example.com",
-      signOut: async () => undefined,
-    };
+    currentUser = sessionUser();
     resolvedTheme = "dark";
-    expect(renderToStaticMarkup(<DashboardAccountMenu />)).toContain(">themeLight<");
+    expect(renderToStaticMarkup(<DashboardAccountMenu user={currentUser} />)).toContain(">themeLight<");
     resolvedTheme = "light";
-    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+    const html = renderToStaticMarkup(<DashboardAccountMenu user={currentUser} />);
     expect(html).toContain(">themeDark<");
     expect(html.indexOf(">themeDark<")).toBeGreaterThan(html.indexOf("/dashboard/team"));
     expect(html.indexOf(">themeDark<")).toBeLessThan(html.indexOf("/dashboard/billing"));
   });
 
   test("lists every permitted team in a submenu and shows the current one on the trigger", () => {
-    currentUser = {
-      id: "user-lawrence",
-      displayName: "Lawrence",
-      primaryEmail: "lawrence@example.com",
-      signOut: async () => undefined,
-    };
+    currentUser = sessionUser();
     const teams = [
       { id: "user-lawrence", name: "Lawrence", personal: true, permissions: { use: true, manageAccounts: true } },
       { id: "team-2", name: "Manaflow", personal: false, permissions: { use: true, manageAccounts: true } },
@@ -145,7 +139,7 @@ describe("dashboard account menu", () => {
     ];
     teamScope = { status: "ready", teams, selected: teams[1], switchTeam: () => undefined };
     resolvedTheme = "dark";
-    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+    const html = renderToStaticMarkup(<DashboardAccountMenu user={currentUser} />);
     teamScope = { status: "unavailable" };
 
     expect(html.match(/data-testid="team-submenu"/g)).toHaveLength(1);
@@ -166,7 +160,7 @@ describe("dashboard account menu", () => {
 
   test("uses the unlocalized auth handler and names the compact sign-in link", () => {
     currentUser = null;
-    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+    const html = renderToStaticMarkup(<DashboardAccountMenu user={currentUser} />);
 
     expect(html).toContain('aria-label="signIn"');
     expect(html).toContain('href="/handler/sign-in?');

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -1,6 +1,20 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import enMessages from "../messages/en.json";
+import {
+  TEST_STACK_PROJECT_ID,
+  nextHeadersMock,
+} from "./helpers/dashboard-session-mock";
+
+const previousStackProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = TEST_STACK_PROJECT_ID;
+afterAll(() => {
+  if (previousStackProjectId === undefined) {
+    delete process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_STACK_PROJECT_ID = previousStackProjectId;
+  }
+});
 
 const authorizationFailure = new Error("Stack authorization deadline exceeded");
 const pendingAuthorization = new Promise<never>(() => {});
@@ -41,19 +55,21 @@ mock.module("next/server", () => ({
   },
 }));
 
-mock.module("next/headers", () => ({
-  headers: async () => {
-    return new Headers(
-      scopedTeamId
-        ? {
-          cookie: `cmux_coderouter_organization=${
-            encodeURIComponent(JSON.stringify(["user-1", scopedTeamId]))
-          }`,
-        }
-        : undefined,
-    );
-  },
-}));
+mock.module("next/headers", () =>
+  nextHeadersMock({
+    refreshToken: () => "refresh-1",
+    headers: () =>
+      new Headers(
+        scopedTeamId
+          ? {
+            cookie: `cmux_coderouter_organization=${
+              encodeURIComponent(JSON.stringify(["user-1", scopedTeamId]))
+            }`,
+          }
+          : undefined,
+      ),
+  }),
+);
 
 mock.module("next/cache", () => ({
   cacheLife: () => undefined,
@@ -63,6 +79,7 @@ mock.module("next/navigation", () => ({
   redirect: (target: string) => {
     throw new Error(`unexpected redirect to ${target}`);
   },
+  unstable_rethrow: () => undefined,
 }));
 
 mock.module("@/i18n/navigation", () => ({
@@ -113,6 +130,7 @@ mock.module("../services/vms/auth", () => ({
     authorizationCalls += 1;
     return { id: "user-1", selectedTeamId };
   },
+  verifyBrowserSessionRequest: async () => ({ id: "user-1", isAnonymous: false }),
   SubrouterAuthorizationUnavailableError:
     TestSubrouterAuthorizationUnavailableError,
   isSubrouterAuthorizationError: (error: unknown) =>
@@ -279,7 +297,7 @@ describe("coderouter dashboard", () => {
     }];
   });
 
-  test("keeps the page header hidden until the private page content is ready", () => {
+  test("paints the page header and a section skeleton before the private content", () => {
     authorizationPending = true;
 
     const html = renderToStaticMarkup(
@@ -289,7 +307,9 @@ describe("coderouter dashboard", () => {
       />,
     );
 
-    expect(html).not.toContain('data-testid="coderouter-page-header"');
+    expect(html).toContain('data-testid="coderouter-page-header"');
+    expect(html).toContain('data-testid="dashboard-section-skeleton"');
+    expect(html).not.toContain('data-testid="coderouter-accounts"');
   });
 
   test("renders recovery UI when Stack authorization is unavailable", async () => {
@@ -299,7 +319,6 @@ describe("coderouter dashboard", () => {
     const html = renderToStaticMarkup(page);
 
     expect(html).toContain("coderouter could not load");
-    expect(html).toContain('data-testid="coderouter-page-header"');
     expect(html).toContain(
       "The account service could not be reached. Try again shortly.",
     );

--- a/web/tests/dashboard-layout.test.tsx
+++ b/web/tests/dashboard-layout.test.tsx
@@ -1,24 +1,38 @@
-import { beforeEach, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type React from "react";
+import {
+  TEST_STACK_PROJECT_ID,
+  nextHeadersMock,
+} from "./helpers/dashboard-session-mock";
+import { renderSettled } from "./helpers/render-stream";
 
 type DashboardUser = {
   readonly id: string;
   readonly isAnonymous: boolean;
+  readonly primaryEmail?: string;
+  readonly primaryEmailVerified?: boolean;
+  readonly displayName?: string;
 };
 
 let currentUser: DashboardUser | null = {
   id: "user-1",
   isAnonymous: false,
+  primaryEmail: "user@example.com",
+  primaryEmailVerified: true,
+  displayName: "User One",
 };
+let refreshToken: string | null = "refresh-1";
 let requestHeaders = new Headers();
 let authUnavailable = false;
-let knownAuthError = true;
 let dashboardShellRenderCount = 0;
-const getUser = mock(async () => currentUser);
+let redirectedTo: string | null = null;
+const accountMenuUsers: unknown[] = [];
 const verifyBrowserSessionRequest = mock(async () =>
   currentUser && !currentUser.isAnonymous ? currentUser : null,
 );
+const previousProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = TEST_STACK_PROJECT_ID;
 
 mock.module("@stackframe/stack", () => ({
   StackProvider: ({ children }: React.PropsWithChildren) => children,
@@ -27,20 +41,23 @@ mock.module("@stackframe/stack", () => ({
 
 mock.module("next/navigation", () => ({
   redirect: (target: string) => {
+    redirectedTo = target;
     throw new Error(`redirect:${target}`);
+  },
+  unstable_rethrow: (error: unknown) => {
+    if (error instanceof Error && error.message.startsWith("redirect:")) throw error;
   },
 }));
 
-mock.module("next/headers", () => ({
-  headers: async () => requestHeaders,
-}));
+mock.module("next/headers", () =>
+  nextHeadersMock({
+    headers: () => requestHeaders,
+    refreshToken: () => refreshToken,
+  }),
+);
 
-mock.module("next-intl/server", () => ({
-  getTranslations: async () => (key: string) => ({
-    genericTitle: "Sign-in could not be completed",
-    genericBody: "Please try again.",
-    backToSignIn: "Back to sign in",
-  }[key] ?? key),
+mock.module("next/cache", () => ({
+  cacheLife: () => undefined,
 }));
 
 mock.module("../services/vms/auth", () => ({
@@ -51,15 +68,25 @@ mock.module("../services/vms/auth", () => ({
     if (authUnavailable) throw new Error("Stack unavailable");
     return operation(new AbortController().signal);
   },
-  isSubrouterAuthorizationError: () => knownAuthError,
+  isSubrouterAuthorizationError: () => true,
 }));
 
 mock.module("@/app/lib/stack", () => ({
-  getStackServerApp: () => ({ getUser }),
+  getStackServerApp: () => ({}),
+  isStackConfigured: () => true,
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({}),
   isStackConfigured: () => true,
 }));
 
 mock.module("@/app/lib/vault-auth", () => ({
+  localizedVaultPath: (locale: string, path: string) => `/${locale}${path}`,
+  vaultSignInHref: (returnPath: string) => `/sign-in?after=${returnPath}`,
+}));
+
+mock.module("../app/lib/vault-auth", () => ({
   localizedVaultPath: (locale: string, path: string) => `/${locale}${path}`,
   vaultSignInHref: (returnPath: string) => `/sign-in?after=${returnPath}`,
 }));
@@ -71,10 +98,26 @@ mock.module(
   }),
 );
 
+mock.module("../app/[locale]/dashboard/dashboard-account-menu", () => ({
+  DashboardAccountMenu: ({ user }: { user: unknown }) => {
+    accountMenuUsers.push(user);
+    return <span data-testid="account-menu" data-user={user ? "yes" : "no"} />;
+  },
+  DashboardAccountMenuFallback: () => <span data-testid="account-fallback" />,
+}));
+
 mock.module("../app/[locale]/dashboard/dashboard-shell", () => ({
-  DashboardShell: ({ children }: React.PropsWithChildren) => {
+  DashboardShell: ({
+    children,
+    account,
+  }: React.PropsWithChildren<{ account: React.ReactNode }>) => {
     dashboardShellRenderCount += 1;
-    return children;
+    return (
+      <div data-testid="dashboard-shell">
+        <header>{account}</header>
+        <main>{children}</main>
+      </div>
+    );
   },
 }));
 
@@ -83,91 +126,100 @@ const { default: DashboardLayout } = await import(
 );
 
 beforeEach(() => {
-  currentUser = { id: "user-1", isAnonymous: false };
+  currentUser = {
+    id: "user-1",
+    isAnonymous: false,
+    primaryEmail: "user@example.com",
+    primaryEmailVerified: true,
+    displayName: "User One",
+  };
+  refreshToken = "refresh-1";
   requestHeaders = new Headers();
   authUnavailable = false;
-  knownAuthError = true;
   dashboardShellRenderCount = 0;
-  getUser.mockClear();
+  redirectedTo = null;
+  accountMenuUsers.length = 0;
   verifyBrowserSessionRequest.mockClear();
+});
+
+afterAll(() => {
+  if (previousProjectId === undefined) {
+    delete process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_STACK_PROJECT_ID = previousProjectId;
+  }
+});
+
+async function layout(children: React.ReactNode = <p>Private dashboard content</p>) {
+  return DashboardLayout({
+    children,
+    params: Promise.resolve({ locale: "en" }),
+  });
+}
+
+test("renders the shell and page content without waiting on Stack", async () => {
+  const html = renderToStaticMarkup(await layout());
+
+  // The synchronous pass paints the shell, the page, and the account
+  // fallback. Nothing above the session boundaries awaited the session.
+  expect(dashboardShellRenderCount).toBe(1);
+  expect(html).toContain('data-testid="dashboard-shell"');
+  expect(html).toContain("Private dashboard content");
+  expect(html).toContain('data-testid="account-fallback"');
+  expect(html).not.toContain('data-testid="account-menu"');
+});
+
+test("streams the identity row from one session read shared by every slot", async () => {
+  const html = await renderSettled(await layout());
+
+  expect(html).toContain('data-user="yes"');
+  // React's per-render `cache` only dedupes under the server-components
+  // runtime, so the count is not observable here; the call itself is.
+  expect(verifyBrowserSessionRequest).toHaveBeenCalled();
+  expect(accountMenuUsers[0]).toEqual({
+    id: "user-1",
+    displayName: "User One",
+    primaryEmail: "user@example.com",
+    primaryEmailVerified: true,
+    profileImageUrl: null,
+    selectedTeamId: null,
+    isAnonymous: false,
+  });
 });
 
 for (const unauthenticatedUser of [
   null,
   { id: "anonymous-1", isAnonymous: true },
 ] as const) {
-  test(`redirects ${unauthenticatedUser ? "anonymous" : "missing"} users before rendering the dashboard shell`, async () => {
+  test(`redirects a ${unauthenticatedUser ? "anonymous" : "rejected"} session cookie to sign-in`, async () => {
     currentUser = unauthenticatedUser;
+    requestHeaders = new Headers({
+      "x-cmux-dashboard-return-path": "/dashboard/coderouter?team=team-1",
+    });
 
-    await expect(
-      DashboardLayout({
-        children: <main>Private dashboard content</main>,
-        params: Promise.resolve({ locale: "en" }),
-      }),
-    ).rejects.toThrow("redirect:/sign-in?after=/en/dashboard");
+    // The guard sits behind Suspense, so the redirect is thrown while the
+    // stream settles rather than before the shell renders.
+    await renderSettled(await layout());
 
-    expect(verifyBrowserSessionRequest).toHaveBeenCalledTimes(1);
-    expect(dashboardShellRenderCount).toBe(0);
+    expect(redirectedTo).toBe("/sign-in?after=/en/dashboard/coderouter?team=team-1");
   });
 }
 
-test("renders the dashboard shell only after server authentication succeeds", async () => {
-  const content = <main>Private dashboard content</main>;
-  const html = renderToStaticMarkup(
-    await DashboardLayout({
-      children: content,
-      params: Promise.resolve({ locale: "en" }),
-    }),
-  );
+test("shows the sign-in control without calling Stack when no session cookie exists", async () => {
+  refreshToken = null;
 
-  expect(verifyBrowserSessionRequest).toHaveBeenCalledTimes(1);
-  expect(dashboardShellRenderCount).toBe(1);
+  const html = await renderSettled(await layout());
+
+  expect(html).toContain('data-user="no"');
+  expect(verifyBrowserSessionRequest).not.toHaveBeenCalled();
+});
+
+test("keeps the shell and page content when Stack is unavailable", async () => {
+  authUnavailable = true;
+
+  const html = await renderSettled(await layout());
+
+  expect(html).toContain('data-testid="dashboard-shell"');
   expect(html).toContain("Private dashboard content");
-});
-
-test("preserves the deep dashboard destination through sign-in", async () => {
-  currentUser = null;
-  requestHeaders = new Headers({
-    "x-cmux-dashboard-return-path": "/dashboard/coderouter?team=team-1",
-  });
-
-  await expect(
-    DashboardLayout({
-      children: <main>Private dashboard content</main>,
-      params: Promise.resolve({ locale: "en" }),
-    }),
-  ).rejects.toThrow(
-    "redirect:/sign-in?after=/en/dashboard/coderouter?team=team-1",
-  );
-  expect(dashboardShellRenderCount).toBe(0);
-});
-
-test("returns recovery UI without mounting the shell when auth times out", async () => {
-  authUnavailable = true;
-
-  const html = renderToStaticMarkup(
-    await DashboardLayout({
-      children: <main>Private dashboard content</main>,
-      params: Promise.resolve({ locale: "en" }),
-    }),
-  );
-
-  expect(html).toContain("Sign-in could not be completed");
-  expect(html).toContain("Back to sign in");
-  expect(html).not.toContain("Private dashboard content");
-  expect(html).not.toContain('data-testid="dashboard-shell"');
-  expect(dashboardShellRenderCount).toBe(0);
-});
-
-test("does not hide an unknown server failure as an auth outage", async () => {
-  authUnavailable = true;
-  knownAuthError = false;
-
-  await expect(
-    DashboardLayout({
-      children: <main>Private dashboard content</main>,
-      params: Promise.resolve({ locale: "en" }),
-    }),
-  ).rejects.toThrow("Stack unavailable");
-  expect(dashboardShellRenderCount).toBe(0);
+  expect(html).toContain('data-user="no"');
 });

--- a/web/tests/dashboard-middleware-session.test.ts
+++ b/web/tests/dashboard-middleware-session.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import middleware from "../proxy";
+import {
+  TEST_STACK_PROJECT_ID,
+  TEST_STACK_REFRESH_COOKIE,
+} from "./helpers/dashboard-session-mock";
+
+const previousProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+
+describe("dashboard session middleware", () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_STACK_PROJECT_ID = TEST_STACK_PROJECT_ID;
+  });
+  afterAll(() => {
+    if (previousProjectId === undefined) {
+      delete process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+    } else {
+      process.env.NEXT_PUBLIC_STACK_PROJECT_ID = previousProjectId;
+    }
+  });
+
+  test("redirects a dashboard request without a Stack session cookie to sign-in", () => {
+    const response = middleware(
+      new NextRequest("https://cmux.com/ja/dashboard/coderouter?team=team-1", {
+        headers: { host: "cmux.com" },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location") ?? "");
+    expect(location.pathname).toBe("/handler/sign-in");
+    const afterSignIn = new URL(
+      location.searchParams.get("after_auth_return_to") ?? "",
+      "https://cmux.com",
+    );
+    expect(afterSignIn.searchParams.get("after_auth_return_to")).toBe(
+      "/ja/dashboard/coderouter?team=team-1",
+    );
+  });
+
+  test("lets a request with the session cookie reach the dashboard", () => {
+    const response = middleware(
+      new NextRequest("https://cmux.com/ja/dashboard/cloud", {
+        headers: {
+          host: "cmux.com",
+          cookie: `${TEST_STACK_REFRESH_COOKIE}=refresh-1`,
+        },
+      }),
+    );
+
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get("location")).toBeNull();
+    expect(
+      response.headers.get("x-middleware-request-x-cmux-dashboard-return-path"),
+    ).toBe("/dashboard/cloud");
+  });
+
+  test("ignores the cookie gate outside the dashboard", () => {
+    const response = middleware(
+      new NextRequest("https://cmux.com/pricing", {
+        headers: { host: "cmux.com" },
+      }),
+    );
+
+    expect(response.status).not.toBe(307);
+  });
+});

--- a/web/tests/dashboard-middleware-session.test.ts
+++ b/web/tests/dashboard-middleware-session.test.ts
@@ -44,7 +44,7 @@ describe("dashboard session middleware", () => {
       new NextRequest("https://cmux.com/ja/dashboard/cloud", {
         headers: {
           host: "cmux.com",
-          cookie: `${TEST_STACK_REFRESH_COOKIE}=refresh-1`,
+          cookie: `__Host-hexclave-refresh-${TEST_STACK_PROJECT_ID}--abc=refresh-1`,
         },
       }),
     );

--- a/web/tests/dashboard-shell.test.tsx
+++ b/web/tests/dashboard-shell.test.tsx
@@ -3,10 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type React from "react";
 
 const linkPrefetch = new Map<string, boolean | undefined>();
-
-mock.module("../app/[locale]/dashboard/dashboard-account-menu", () => ({
-  DashboardAccountMenu: () => <span data-testid="account-control" />,
-}));
+const accountControl = <span data-testid="account-control" />;
 
 mock.module("next-intl", () => ({
   NextIntlClientProvider: ({ children }: { children: React.ReactNode }) =>
@@ -38,7 +35,7 @@ const { DashboardShell } = await import(
 describe("dashboard shell", () => {
   test("mounts one account control across responsive layouts", () => {
     const html = renderToStaticMarkup(
-      <DashboardShell vaultEnabled>
+      <DashboardShell vaultEnabled account={accountControl}>
         <p>Dashboard content</p>
       </DashboardShell>,
     );
@@ -65,7 +62,7 @@ describe("dashboard shell", () => {
 
   test("removes every Vault navigation entry when the release flag is off", () => {
     const html = renderToStaticMarkup(
-      <DashboardShell vaultEnabled={false}>
+      <DashboardShell vaultEnabled={false} account={accountControl}>
         <p>Dashboard content</p>
       </DashboardShell>,
     );
@@ -79,7 +76,7 @@ describe("dashboard shell", () => {
   test("renders iOS TestFlight in its own section below coderouter", () => {
     linkPrefetch.clear();
     const html = renderToStaticMarkup(
-      <DashboardShell vaultEnabled>
+      <DashboardShell vaultEnabled account={accountControl}>
         <p>Dashboard content</p>
       </DashboardShell>,
     );
@@ -93,8 +90,9 @@ describe("dashboard shell", () => {
     expect(coderouterIndex).toBeGreaterThan(-1);
     expect(testflightIndex).toBeGreaterThan(coderouterIndex);
     expect(billingIndex).toBeGreaterThan(testflightIndex);
-    // Auth-dependent pages must not be prefetched into a client snapshot.
-    expect(linkPrefetch.get("/dashboard/coderouter")).toBe(false);
-    expect(linkPrefetch.get("/dashboard/testflight")).toBe(false);
+    // Every page prefetches its static shell; private data streams behind
+    // Suspense and is never part of a prefetch, so no link opts out.
+    expect(linkPrefetch.get("/dashboard/coderouter")).toBeUndefined();
+    expect(linkPrefetch.get("/dashboard/testflight")).toBeUndefined();
   });
 });

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -1,6 +1,21 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createNextNavigationMock } from "./helpers/next-navigation-mock";
+import {
+  TEST_STACK_PROJECT_ID,
+  nextHeadersMock,
+} from "./helpers/dashboard-session-mock";
+import { renderSettled } from "./helpers/render-stream";
+
+const previousStackProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = TEST_STACK_PROJECT_ID;
+afterAll(() => {
+  if (previousStackProjectId === undefined) {
+    delete process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_STACK_PROJECT_ID = previousStackProjectId;
+  }
+});
 
 let signedIn = true;
 let stackConfigured = true;
@@ -25,6 +40,18 @@ mock.module("next/navigation", () => {
   return navigation;
 });
 
+mock.module("next/headers", () =>
+  nextHeadersMock({
+    refreshToken: () => "refresh-1",
+    // Middleware forwards the destination for the sign-in redirect.
+    headers: () => new Headers({ "x-cmux-dashboard-return-path": "/dashboard/team" }),
+  }),
+);
+
+mock.module("next/cache", () => ({
+  cacheLife: () => undefined,
+}));
+
 mock.module("@tanstack/react-query", () => ({
   useQuery: () => ({ data: undefined, isPending: true, isError: false }),
   useQueryClient: () => ({
@@ -36,7 +63,7 @@ mock.module("@tanstack/react-query", () => ({
 mock.module("../app/lib/stack", () => ({
   isStackConfigured: () => stackConfigured,
   getStackServerApp: () => ({
-    getUser: async () => signedIn ? { id: "user-1" } : null,
+    getUser: async () => signedIn ? { id: "user-1", isAnonymous: false } : null,
   }),
 }));
 
@@ -60,7 +87,10 @@ describe("dashboard team settings", () => {
     const page = await DashboardTeamPage({
       params: Promise.resolve({ locale: "en" }),
     });
-    const html = renderToStaticMarkup(page);
+    expect(renderToStaticMarkup(page)).toContain(
+      'data-testid="dashboard-section-skeleton"',
+    );
+    const html = await renderSettled(page);
 
     expect(html).toContain('data-testid="stack-account-settings"');
     expect(html).toContain("teams, and invitations");
@@ -70,9 +100,12 @@ describe("dashboard team settings", () => {
   test("preserves the team settings return path when signed out", async () => {
     signedIn = false;
 
-    await expect(DashboardTeamPage({
+    const html = await renderSettled(await DashboardTeamPage({
       params: Promise.resolve({ locale: "en" }),
-    })).rejects.toThrow("redirect:/handler/sign-in");
+    }));
+
+    expect(html).not.toContain('data-testid="stack-account-settings"');
+    expect(redirectedTo).toContain("/handler/sign-in");
     expect(redirectedTo).toContain("/dashboard/team");
   });
 

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -1,7 +1,21 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import enMessages from "../messages/en.json";
+import {
+  TEST_STACK_PROJECT_ID,
+  nextHeadersMock,
+} from "./helpers/dashboard-session-mock";
+
+const previousStackProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = TEST_STACK_PROJECT_ID;
+afterAll(() => {
+  if (previousStackProjectId === undefined) {
+    delete process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_STACK_PROJECT_ID = previousStackProjectId;
+  }
+});
 import {
   createTestflightUser,
   testflightUserEligibility,
@@ -15,8 +29,12 @@ let status = { enrolled: false } as { enrolled: boolean; state?: string };
 
 const pendingUser = new Promise<never>(() => {});
 const getUser = mock(async () => userPending ? pendingUser : currentUser);
+// The section receives the narrow session user, so eligibility is looked up
+// on the Stack user the test configured rather than on the argument.
 const isTestflightEligible = mock(async (user: unknown) =>
-  testflightUserEligibility(user) ?? false,
+  (user as { id?: string }).id === currentUser?.id
+    ? (testflightUserEligibility(currentUser) ?? false)
+    : false,
 );
 const billingProModule = await import("../services/billing/pro");
 const ascFetch = mock(async (path: unknown) => {
@@ -53,9 +71,9 @@ mock.module("next-intl/server", () => ({
   setRequestLocale: () => undefined,
 }));
 
-mock.module("next/headers", () => ({
-  headers: async () => new Headers(),
-}));
+mock.module("next/headers", () =>
+  nextHeadersMock({ refreshToken: () => "refresh-1" }),
+);
 
 mock.module("next/cache", () => ({
   cacheLife: () => undefined,
@@ -124,7 +142,7 @@ describe("dashboard TestFlight page", () => {
     captureAscError.mockClear();
   });
 
-  test("keeps the page header hidden until the private page content is ready", () => {
+  test("paints the page header and a section skeleton before the private content", () => {
     userPending = true;
 
     const html = renderToStaticMarkup(
@@ -134,7 +152,9 @@ describe("dashboard TestFlight page", () => {
       />,
     );
 
-    expect(html).not.toContain('data-testid="testflight-page-header"');
+    expect(html).toContain('data-testid="testflight-page-header"');
+    expect(html).toContain('data-testid="dashboard-section-skeleton"');
+    expect(html).not.toContain("/api/testflight");
   });
 
   test("renders not eligible state with pricing link", async () => {
@@ -143,7 +163,6 @@ describe("dashboard TestFlight page", () => {
     const html = await renderTestflightPage();
 
     expect(html).toContain("Subscription required");
-    expect(html).toContain('data-testid="testflight-page-header"');
     expect(html).toContain("active personal Pro subscribers");
     expect(html).toContain('href="/pricing"');
     expect(html).not.toContain("/api/testflight");

--- a/web/tests/helpers/dashboard-session-mock.ts
+++ b/web/tests/helpers/dashboard-session-mock.ts
@@ -12,13 +12,13 @@ export function nextHeadersMock(state: {
 }) {
   return {
     headers: async () => state.headers?.() ?? new Headers(),
-    cookies: async () => ({
-      get: (name: string) => {
-        const value = state.refreshToken?.() ?? null;
-        return name === TEST_STACK_REFRESH_COOKIE && value
-          ? { name, value }
-          : undefined;
-      },
-    }),
+    cookies: async () => {
+      const value = state.refreshToken?.() ?? null;
+      const all = value ? [{ name: TEST_STACK_REFRESH_COOKIE, value }] : [];
+      return {
+        get: (name: string) => all.find((cookie) => cookie.name === name),
+        getAll: () => all,
+      };
+    },
   };
 }

--- a/web/tests/helpers/dashboard-session-mock.ts
+++ b/web/tests/helpers/dashboard-session-mock.ts
@@ -1,0 +1,24 @@
+/**
+ * Request-scope stand-ins for dashboard server components. The session key
+ * is derived from the Stack refresh cookie, so tests that want a signed-in
+ * request set the cookie and the matching project id.
+ */
+export const TEST_STACK_PROJECT_ID = "123e4567-e89b-12d3-a456-426614174000";
+export const TEST_STACK_REFRESH_COOKIE = `stack-refresh-${TEST_STACK_PROJECT_ID}`;
+
+export function nextHeadersMock(state: {
+  readonly headers?: () => Headers;
+  readonly refreshToken?: () => string | null;
+}) {
+  return {
+    headers: async () => state.headers?.() ?? new Headers(),
+    cookies: async () => ({
+      get: (name: string) => {
+        const value = state.refreshToken?.() ?? null;
+        return name === TEST_STACK_REFRESH_COOKIE && value
+          ? { name, value }
+          : undefined;
+      },
+    }),
+  };
+}

--- a/web/tests/helpers/next-navigation-mock.ts
+++ b/web/tests/helpers/next-navigation-mock.ts
@@ -13,6 +13,10 @@ export function createNextNavigationMock(redirect: Redirect) {
   return {
     redirect,
     permanentRedirect: redirect,
+    // Mirrors Next: a thrown redirect propagates through catch blocks.
+    unstable_rethrow: (error: unknown) => {
+      if (error instanceof Error && error.message.startsWith("redirect:")) throw error;
+    },
     notFound: () => {
       throw new Error("notFound");
     },

--- a/web/tests/helpers/render-stream.ts
+++ b/web/tests/helpers/render-stream.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+
+/** Render a tree with async server components to its settled HTML. */
+export async function renderSettled(node: ReactNode): Promise<string> {
+  const stream = await renderToReadableStream(node);
+  await stream.allReady;
+  return new Response(stream).text();
+}

--- a/web/tests/stack-session-cookies.test.ts
+++ b/web/tests/stack-session-cookies.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasStackRefreshCookie,
+  stackRefreshCookies,
+} from "../app/lib/stack-session-cookies";
+
+const project = "9790718f-14cd-4f7e-824d-eaf527a82b82";
+
+describe("stack session cookies", () => {
+  test("recognizes every refresh cookie name the SDK writes", () => {
+    for (const name of [
+      `hexclave-refresh-${project}--abc`,
+      `__Host-hexclave-refresh-${project}--abc`,
+      `stack-refresh-${project}--abc`,
+      `__Host-stack-refresh-${project}--abc`,
+      `stack-refresh-${project}`,
+      "stack-refresh",
+    ]) {
+      expect(hasStackRefreshCookie([{ name, value: "token" }], project)).toBe(true);
+    }
+  });
+
+  test("ignores other cookies, empty values, and other projects", () => {
+    expect(hasStackRefreshCookie([
+      { name: "hexclave-access", value: "x" },
+      { name: `hexclave-refresh-${project}--abc`, value: "" },
+      { name: "hexclave-refresh-other-project--abc", value: "x" },
+      { name: "NEXT_LOCALE", value: "en" },
+    ], project)).toBe(false);
+  });
+
+  test("orders current cookies before legacy ones", () => {
+    const names = stackRefreshCookies([
+      { name: "stack-refresh", value: "old" },
+      { name: `hexclave-refresh-${project}--abc`, value: "new" },
+    ], project).map((cookie) => cookie.name);
+    expect(names).toEqual([`hexclave-refresh-${project}--abc`, "stack-refresh"]);
+  });
+});


### PR DESCRIPTION
Re-lands https://github.com/manaflow-ai/cmux/pull/12121 (reverted in https://github.com/manaflow-ai/cmux/pull/12189) with the sign-in loop fixed.

The loop: the edge gate and the private session key only looked for `stack-refresh-<project>`. Current Stack SDKs store the refresh token as `hexclave-refresh-<project>--<suffix>` (with a `__Host-` prefix on secure origins) and treat the old name as legacy, so every signed-in visitor was sent to sign-in and back.

The fix: one resolver in `app/lib/stack-session-cookies.ts` mirrors the SDK's refresh cookie name patterns and is used by both the middleware and the session key. Unit tests cover every name variant.

Proof this time used a real browser, not hand-built cookies: headless Chromium signed in through Stack's own password form against a local production build with the dev Stack project. The browser received `hexclave-refresh-<project>--default`, then loaded /dashboard/coderouter, /dashboard/cloud, /dashboard/coderouter and /dashboard, staying on each page with the account email rendered and zero visits to /handler/sign-in.

Everything else is the reviewed content of the original PR: private session cache, static shell with Suspense sections, edge redirect for cookieless visitors, prefetch opt-outs removed, docs namespace dropped from the shared client catalog.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791509270&installation_model_id=21920&pr_number=12191&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12191&signature=165b27d934d85f8e9be41920047824459d215557c5e465a75b8a2cf4bda83b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-lands instant dashboard navigation with a fix for the sign-in loop that sent every signed-in visitor back to sign-in.

**Bug Fixes**
- Aligns session cookie detection with current Stack SDK naming, which uses `hexclave-refresh-*` and legacy `stack-refresh-*` patterns.
- Adds a shared resolver in `web/app/lib/stack-session-cookies.ts` used by both middleware and the session key.
- Covers all cookie name variants with unit tests and verifies the flow in a headless browser against a production build.

**Dashboard Navigation**
- Restores the private session cache and static dashboard shell with Suspense-bounded private sections.
- Redirects cookieless visitors at the edge before rendering any dashboard shell.
- Removes prefetch opt-outs from dashboard links and drops the docs namespace from the shared client catalog.

<sup>Written for commit 316166eb0e23e54e35b27e667c0a19f7e660762a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dashboard pages now load static navigation and headers immediately while private content streams in with loading placeholders.
  - Signed-out dashboard visitors are redirected to sign-in with their original destination preserved.
  - Dashboard sections provide contextual recovery prompts when authentication services are temporarily unavailable.
  - Documentation pages now load their localized messages correctly.

- **Bug Fixes**
  - Improved dashboard session and sign-out handling across cloud, team, Coderouter, and TestFlight pages.
  - Dashboard authentication now recognizes current and legacy session cookie formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->