### PR TITLE
Add "Move to Bottom" workspace action

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19140,7 +19140,7 @@ struct CMUXCLI {
               pin | unpin
               rename | clear-name
               set-description | clear-description
-              move-up | move-down | move-top
+              move-up | move-down | move-top | move-bottom
               close-others | close-above | close-below
               mark-read | mark-unread
               set-color | clear-color

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -101,6 +101,47 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
         }
     }
 
+    // MARK: - Move to bottom
+
+    /// Moves one workspace to the bottom of its pin tier.
+    public func moveTabToBottom(_ tabId: UUID) {
+        moveTabsToBottom([tabId])
+    }
+
+    /// Moves the given workspaces to the bottom of their pin tiers, preserving
+    /// their relative order (group members trail behind their anchors).
+    public func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        guard !tabIds.isEmpty else { return }
+        let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
+        guard !selectedTabs.isEmpty else { return }
+        let previousOrder = model.tabs.map(\.id)
+
+        if !model.workspaceGroups.isEmpty {
+            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
+            let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
+            let selectedTopLevelIdSet = Set(selectedTopLevelIds)
+            let pinnedTopLevelIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
+            let desiredTopLevelIds =
+                topLevelIds.filter { pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
+                selectedTopLevelIds.filter { pinnedTopLevelIds.contains($0) } +
+                topLevelIds.filter { !pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
+                selectedTopLevelIds.filter { !pinnedTopLevelIds.contains($0) }
+            model.normalizeWorkspaceGroupRunsPreservingOrder(desiredTopLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: desiredTopLevelIds)
+        } else {
+            let remainingTabs = model.tabs.filter { !tabIds.contains($0.id) }
+            let selectedPinned = selectedTabs.filter { $0.isPinned }
+            let selectedUnpinned = selectedTabs.filter { !$0.isPinned }
+            let remainingPinned = remainingTabs.filter { $0.isPinned }
+            let remainingUnpinned = remainingTabs.filter { !$0.isPinned }
+            model.tabs = remainingPinned + selectedPinned + remainingUnpinned + selectedUnpinned
+        }
+        if model.tabs.map(\.id) != previousOrder {
+            host?.workspaceOrderDidChange(movedWorkspaceIds: selectedTabs.map(\.id))
+        }
+    }
+
     // MARK: - Single reorder
 
     /// Reorders one workspace to the clamped target index; drag operations

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -117,7 +117,7 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
         let previousOrder = model.tabs.map(\.id)
 
         if !model.workspaceGroups.isEmpty {
-            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
+            model.moveWorkspaceGroupMembersToGroupEnd(workspaceIds: selectedTabs.map(\.id))
             let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
             let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
             let selectedTopLevelIdSet = Set(selectedTopLevelIds)

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
@@ -197,6 +197,62 @@ extension WorkspacesModel {
 
     /// Hoist promoted (non-anchor) members to the front of their group's
     /// member run, right after the anchor, preserving each group's position.
+    /// Mirror of ``moveWorkspaceGroupMembersAfterAnchors(workspaceIds:)`` for the
+    /// downward direction: the named members sink to the end of their group run
+    /// instead of hoisting behind the anchor. The anchor itself never moves.
+    func moveWorkspaceGroupMembersToGroupEnd(workspaceIds: [UUID]) {
+        let groupsById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
+        let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
+        var sunkIdsByGroupId: [UUID: [UUID]] = [:]
+        for workspaceId in workspaceIds {
+            guard let tab = tabsById[workspaceId],
+                  let groupId = tab.groupId,
+                  let group = groupsById[groupId],
+                  tab.id != group.anchorWorkspaceId else {
+                continue
+            }
+            sunkIdsByGroupId[groupId, default: []].append(workspaceId)
+        }
+        guard !sunkIdsByGroupId.isEmpty else { return }
+
+        var replacementMembersByGroupId: [UUID: [Tab]] = [:]
+        for (groupId, sunkIds) in sunkIdsByGroupId {
+            guard let group = groupsById[groupId] else { continue }
+            let orderedMembers = anchorFirst(
+                tabs.filter { $0.groupId == groupId },
+                anchorId: group.anchorWorkspaceId
+            )
+            guard let anchor = orderedMembers.first(where: { $0.id == group.anchorWorkspaceId }) else { continue }
+            var emittedSunkIds = Set<UUID>()
+            // Preserve the caller's relative order among the sunk members.
+            let sunkMembers = sunkIds.compactMap { id -> Tab? in
+                guard emittedSunkIds.insert(id).inserted else { return nil }
+                return tabsById[id]
+            }
+            let sunkIdSet = Set(sunkMembers.map(\.id))
+            let remainingMembers = orderedMembers.filter {
+                $0.id != group.anchorWorkspaceId && !sunkIdSet.contains($0.id)
+            }
+            replacementMembersByGroupId[groupId] = [anchor] + remainingMembers + sunkMembers
+        }
+        guard !replacementMembersByGroupId.isEmpty else { return }
+
+        var emittedGroupIds = Set<UUID>()
+        var reordered: [Tab] = []
+        reordered.reserveCapacity(tabs.count)
+        for tab in tabs {
+            if let groupId = tab.groupId,
+               let replacementMembers = replacementMembersByGroupId[groupId] {
+                if emittedGroupIds.insert(groupId).inserted {
+                    reordered.append(contentsOf: replacementMembers)
+                }
+            } else {
+                reordered.append(tab)
+            }
+        }
+        tabs = reordered
+    }
+
     func moveWorkspaceGroupMembersAfterAnchors(workspaceIds: [UUID]) {
         let groupsById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
         let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -142,6 +142,44 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func moveTabsToBottomKeepsPinnedTierAboveUnpinned() {
+        let (model, host, _, reorder) = makeWorld()
+        let pinnedA = CoordinatorStubTab(isPinned: true)
+        let pinnedB = CoordinatorStubTab(isPinned: true)
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [pinnedA, pinnedB, plain1, plain2]
+        reorder.moveTabsToBottom([plain1.id, pinnedA.id])
+        // Each selection sinks to the end of its own tier; tiers stay separated.
+        #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
+        #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
+            == [pinnedA.id, plain1.id].sorted(by: { $0.uuidString < $1.uuidString }))
+    }
+
+    @Test
+    func moveTabToBottomSinksSingleRowWithinItsTier() {
+        let (model, _, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        let plain3 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2, plain3]
+        reorder.moveTabToBottom(plain1.id)
+        #expect(model.tabs.map(\.id) == [plain2.id, plain3.id, plain1.id])
+    }
+
+    @Test
+    func moveTabToBottomOnLastRowPublishesNoOrderChange() {
+        let (model, host, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2]
+        let before = host.orderChanges.count
+        reorder.moveTabToBottom(plain2.id)
+        #expect(model.tabs.map(\.id) == [plain1.id, plain2.id])
+        #expect(host.orderChanges.count == before)
+    }
+
+    @Test
     func reorderWorkspaceClampsUnpinnedAbovePinnedBoundary() {
         let (model, host, _, reorder) = makeWorld()
         _ = host

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -180,6 +180,31 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func moveToBottomSinksGroupedChildrenAndKeepsAnchorFirst() throws {
+        let (model, host, groups, reorder) = makeWorld()
+        let first = CoordinatorStubTab()
+        let middle = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        let outside = CoordinatorStubTab()
+        model.tabs = [first, middle, last, outside]
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "G", childWorkspaceIds: [first.id, middle.id, last.id]
+        ))
+        let anchorId = try #require(model.workspaceGroups.first { $0.id == groupId }?.anchorWorkspaceId)
+
+        reorder.moveTabsToBottom([first.id, middle.id])
+
+        #expect(model.tabs.map(\.id) == [outside.id, anchorId, last.id, first.id, middle.id])
+        #expect([first, middle, last].allSatisfy { $0.groupId == groupId })
+        let changes = host.orderChanges.count
+        reorder.moveTabsToBottom([first.id, middle.id])
+        #expect(host.orderChanges.count == changes)
+
+        reorder.moveTabToTop(middle.id)
+        #expect(model.tabs.map(\.id) == [anchorId, middle.id, last.id, first.id, outside.id])
+    }
+
+    @Test
     func reorderWorkspaceClampsUnpinnedAbovePinnedBoundary() {
         let (model, host, _, reorder) = makeWorld()
         _ = host

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -94511,7 +94511,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nach unten bewegen"
+            "value": "Ganz nach unten verschieben"
           }
         },
         "en": {
@@ -94571,7 +94571,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Переместить вниз"
+            "value": "Переместить в конец"
           }
         },
         "th": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -94487,6 +94487,125 @@
         }
       }
     },
+    "contextMenu.moveToBottom": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقل إلى الأسفل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomjeri na dno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flyt til bunden"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten bewegen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Bottom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover al final"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer en bas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta in fondo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一番下に移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "맨 아래로 이동"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flytt til bunnen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś na dół"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para o Final"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить вниз"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ย้ายไปด้านล่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En Alta Taşı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемістити в кінець"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移到底部"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移至最下方"
+          }
+        }
+      }
+    },
     "contextMenu.moveToTop": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7818,6 +7818,16 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.moveWorkspaceToBottom",
+                title: constant(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")),
+                subtitle: workspaceSubtitle,
+                keywords: ["workspace", "move", "bottom", "reorder"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceHasBelow) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.closeOtherWorkspaces",
                 title: constant(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")),
                 subtitle: workspaceSubtitle,
@@ -8927,6 +8937,14 @@ struct ContentView: View {
                 return
             }
             tabManager.moveTabsToTop([workspace.id])
+            tabManager.selectWorkspace(workspace)
+        }
+        registry.register(commandId: "palette.moveWorkspaceToBottom") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            tabManager.moveTabsToBottom([workspace.id])
             tabManager.selectWorkspace(workspace)
         }
         WorkspaceTodoPaletteCommands.registerHandlers(in: &registry, tabManager: tabManager)
@@ -15027,6 +15045,10 @@ struct VerticalTabsSidebar: View, Equatable {
             },
             moveTargetsToTop: { targetIds in
                 tabManager.moveTabsToTop(Set(targetIds))
+                syncWorkspaceRowSelectionAfterMutation()
+            },
+            moveTargetsToBottom: { targetIds in
+                tabManager.moveTabsToBottom(Set(targetIds))
                 syncWorkspaceRowSelectionAfterMutation()
             },
             currentWindowMoveTargets: {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -648,6 +648,14 @@ struct SidebarWorkspaceRowMenuBuilder {
             tabManager.moveTabsToTop(Set(commands.contextMenuWorkspaceIds))
             commands.syncSelectionAfterMutation()
         })
+        menu.addItem(item(
+            String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom"),
+            enabled: !targetIds.isEmpty
+        ) { [weak tabManager, commands] in
+            guard let tabManager else { return }
+            tabManager.moveTabsToBottom(Set(commands.contextMenuWorkspaceIds))
+            commands.syncSelectionAfterMutation()
+        })
 
         let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
         let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []

--- a/Sources/SidebarWorkspaceRowActions.swift
+++ b/Sources/SidebarWorkspaceRowActions.swift
@@ -17,6 +17,7 @@ struct SidebarWorkspaceRowActions {
     let closeWorkspace: () -> Void
     let moveBy: (Int) -> Void
     let moveTargetsToTop: ([UUID]) -> Void
+    let moveTargetsToBottom: ([UUID]) -> Void
     /// Resolves volatile app-window topology when the deferred menu is presented.
     let currentWindowMoveTargets: () -> [SidebarWorkspaceWindowMoveTarget]
     let moveTargetsToWindow: ([UUID], UUID) -> Void

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -221,6 +221,11 @@ extension TabItemView {
         }
         .disabled(targetIds.isEmpty)
 
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            actions.moveTargetsToBottom(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
+
         Menu(moveMenuTitle) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
                 actions.moveTargetsToNewWindow(targetIds)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1931,6 +1931,14 @@ class TabManager: ObservableObject {
         workspaceReordering.moveTabToTopForNotification(tabId)
     }
 
+    func moveTabToBottom(_ tabId: UUID) {
+        workspaceReordering.moveTabToBottom(tabId)
+    }
+
+    func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        workspaceReordering.moveTabsToBottom(tabIds)
+    }
+
     @discardableResult
     func reorderWorkspace(tabId: UUID, toIndex targetIndex: Int, isDragOperation: Bool = false) -> Bool {
         workspaceReordering.reorderWorkspace(tabId: tabId, toIndex: targetIndex, isDragOperation: isDragOperation)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5289,7 +5289,7 @@ class TerminalController {
         let supportedActions = [
             "pin", "unpin", "rename", "clear_name",
             "set_description", "clear_description",
-            "move_up", "move_down", "move_top",
+            "move_up", "move_down", "move_top", "move_bottom",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
             "set_color", "clear_color", "mobile_connect"
@@ -5416,6 +5416,10 @@ class TerminalController {
 
             case "move_top":
                 tabManager.moveTabToTop(workspace.id)
+                finish(["index": v2OrNull(tabManager.tabs.firstIndex(where: { $0.id == workspace.id }))])
+
+            case "move_bottom":
+                tabManager.moveTabToBottom(workspace.id)
                 finish(["index": v2OrNull(tabManager.tabs.firstIndex(where: { $0.id == workspace.id }))])
 
             case "close_others":

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1380,6 +1380,12 @@ struct cmuxApp: App {
         manager.selectWorkspace(workspace)
     }
 
+    private func moveSelectedWorkspaceToBottom(in manager: TabManager) {
+        guard let workspace = manager.selectedWorkspace else { return }
+        manager.moveTabsToBottom([workspace.id])
+        manager.selectWorkspace(workspace)
+    }
+
     private func moveSelectedWorkspace(in manager: TabManager, toWindow windowId: UUID) {
         guard let workspace = manager.selectedWorkspace else { return }
         _ = AppDelegate.shared?.moveWorkspaceToWindow(workspaceId: workspace.id, windowId: windowId, focus: true)
@@ -1482,6 +1488,11 @@ struct cmuxApp: App {
             moveSelectedWorkspaceToTop(in: manager)
         }
         .disabled(workspace == nil || workspaceIndex == 0)
+
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            moveSelectedWorkspaceToBottom(in: manager)
+        }
+        .disabled(workspace == nil || workspaceIndex == manager.tabs.count - 1)
 
         Menu(String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {

--- a/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
+++ b/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
@@ -145,6 +145,7 @@ struct SidebarWorkspaceContextMenuWindowTargetsTests {
             closeWorkspace: {},
             moveBy: { _ in },
             moveTargetsToTop: { _ in },
+            moveTargetsToBottom: { _ in },
             currentWindowMoveTargets: currentWindowMoveTargets,
             moveTargetsToWindow: { _, _ in },
             moveTargetsToNewWindow: { _ in },

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -370,7 +370,7 @@ Workspace and tab action names:
 
 | Command | Actions |
 | --- | --- |
-| `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
+| `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `move-bottom`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
 | `tab-action` | `rename`, `clear-name`, `close-left`, `close-right`, `close-others`, `new-terminal-right`, `new-browser-right`, `reload`, `duplicate`, `pin`, `unpin`, `mark-unread` |
 
 ### Workspace environment variables

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -165,7 +165,7 @@ Rules of the runtime:
   items are ordinary Button/Menu/Divider nodes, so labels and actions can be
   live bindings (`Button(() => w().pinned ? "Unpin" : "Pin", ...)`). Useful
   verbs: `workspace.action` (pin/unpin, mark_read/mark_unread,
-  move_up/move_down/move_top, close_others, set/clear color and description),
+  move_up/move_down/move_top/move_bottom, close_others, set/clear color and description),
   `workspace.close`, `workspace.move_to_window`, `workspace.group.action`
   (pin/unpin/ungroup/delete), `workspace.group.collapse` / `.expand`.
 - Actions: `cmux(method, params)`, `openURL(url)`, `log(message)` anywhere in

--- a/skills/cmux/references/windows-workspaces.md
+++ b/skills/cmux/references/windows-workspaces.md
@@ -32,4 +32,4 @@ cmux workspace-action --action pin
 cmux workspace-action --action clear-color
 ```
 
-Other actions: `unpin`, `clear-name`, `clear-description`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`, `close-others`/`close-above`/`close-below`. Named colors: Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua, Blue, Navy, Indigo, Purple, Magenta, Rose, Brown, Charcoal. `set-color` tints a single workspace (stored as workspace state); the `workspaceColors` block in `cmux.json` defines the shared palette and selection/badge colors, not per-workspace assignments.
+Other actions: `unpin`, `clear-name`, `clear-description`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`/`move-bottom`, `close-others`/`close-above`/`close-below`. Named colors: Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua, Blue, Navy, Indigo, Purple, Magenta, Rose, Brown, Charcoal. `set-color` tints a single workspace (stored as workspace state); the `workspaceColors` block in `cmux.json` defines the shared palette and selection/badge colors, not per-workspace assignments.


### PR DESCRIPTION
Fixes #10447.

## Why

"Move to Top" has existed since #1204, but there is no way to send a workspace the other
way. As @aerickson describes it, with many workspaces open a project you are done with keeps
rising to the top on notification bumps, and the only ways back down are dragging across a
long list or clicking "Move Down" repeatedly.

## What

`moveTabToBottom` / `moveTabsToBottom` sit next to their top counterparts in
`WorkspaceReorderCoordinator` and reuse the same grouped and ungrouped branches, so group
anchors and pin tiers behave identically in both directions. The only difference is the
concatenation order: a selection sinks to the end of its own tier instead of the front.

Two behaviours worth calling out for review:

- **Pin tiers are preserved.** A pinned row sinks to the bottom of the *pinned* tier, never
  below unpinned rows — mirroring how "Move to Top" hoists within its tier. Silently
  unpinning a workspace would be a surprising side effect of a reorder.
- **A no-op stays silent.** Moving an already-last workspace publishes no order-change
  event, matching the existing `previousOrder` guard. There is a test for this.

Per the shared-behavior policy, every entrypoint that offers "Move to Top" now offers
"Move to Bottom", and all of them route through the single coordinator method:

| Entrypoint | File |
| --- | --- |
| Sidebar context menu | `TabItemView+WorkspaceContextMenu.swift` |
| App menu | `cmuxApp.swift` |
| Command palette (`palette.moveWorkspaceToBottom`) | `ContentView.swift` |
| AppKit sidebar row | `SidebarWorkspaceRowCommands.swift` |
| Socket / CLI (`workspace-action --action move-bottom`) | `TerminalController.swift` |

`contextMenu.moveToBottom` is localized across the same 19 locales as `contextMenu.moveToTop`,
each mirroring that locale's existing phrasing rather than a fresh translation (e.g. ja
`一番上に移動` -> `一番下に移動`, de `Nach oben bewegen` -> `Nach unten bewegen`).
`docs/cli-contract.md`, `docs/custom-sidebars.md`, and the skills reference list the new
action alongside the existing ones.

## Testing

Three tests added next to the existing reorder coverage in `WorkspaceCoordinatorTests`
(package tests, so no pbxproj wiring needed):

- `moveTabsToBottomKeepsPinnedTierAboveUnpinned`
- `moveTabToBottomSinksSingleRowWithinItsTier`
- `moveTabToBottomOnLastRowPublishesNoOrderChange`

All pass, and the existing `moveTabsToTopKeepsPinnedTierAboveUnpinned` still passes.

Dogfooded on a tagged Debug build (`./scripts/reload.sh --tag ...`), macOS 26.5.2, Xcode 26.6.
Verified the sidebar context menu item and the command palette entry by hand, and the socket
path end to end:

```
before:  ~, gamma, beta, alpha
$ cmux workspace-action --workspace workspace:4 --action move-bottom
  OK action=move_bottom workspace=workspace:4 index=3
after:   ~, beta, alpha, gamma

# existing action still correct
$ cmux workspace-action --workspace workspace:2 --action move-top
  OK action=move_top index=0
after:   alpha, ~, beta, gamma
```

## Notes

First contribution here, so please push back if any of the above does not match how you would
rather see it done — particularly the pin-tier semantics, which are a judgement call.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791509789&installation_model_id=21920&pr_number=12192&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12192&signature=206dfa0dd13bc5a7137df08cf803514ae3d9b2287941dd73a06c577240b52c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reorder-only feature following established move-to-top patterns; pin-tier and group semantics are covered by new coordinator tests.
> 
> **Overview**
> Adds **Move to Bottom** as the counterpart to **Move to Top**, so workspaces can jump to the end of their pin tier without repeated **Move Down** or long drags.
> 
> Core logic lives in `WorkspaceReorderCoordinator` (`moveTabToBottom` / `moveTabsToBottom`), mirroring the top APIs: selections sink to the bottom of pinned vs unpinned tiers, grouped sidebars use the same anchor/group normalization path, and a no-op when already last skips `workspaceOrderDidChange`.
> 
> **TabManager** forwards to the coordinator; UI and automation wire through everywhere **Move to Top** already exists—sidebar context menus (SwiftUI + AppKit), app menu, command palette (`palette.moveWorkspaceToBottom`), and socket/CLI `workspace-action --action move-bottom`. New `contextMenu.moveToBottom` strings and docs/skills references are updated accordingly.
> 
> Package tests cover pin tiers, single-row sink, no-op order events, and grouped workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4443103dd2c18730fa0889dcb781bfbed7027f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Move to Bottom” for workspaces in context menus, the command palette, workspace actions, and CLI automation.
  - Supports moving one or multiple workspaces to the bottom of their pinned or unpinned tier while preserving relative order.
  - Keeps grouped workspaces organized without moving group anchors.

- **Documentation**
  - Updated workspace action references and custom sidebar documentation.
  - Added translations for the new menu option.

- **Tests**
  - Added coverage for ordering, pinned tiers, grouped workspaces, and no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
