### PR TITLE
Fix OpenCode notification regression harness runtime

### DIFF
--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -29,7 +29,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
 
         let result = runProcess(
             executablePath: "/usr/bin/env",
-            arguments: ["node", harnessURL.path, pluginURL.path, socketPath],
+            arguments: ["bun", harnessURL.path, pluginURL.path, socketPath],
             environment: ProcessInfo.processInfo.environment,
             timeout: 5
         )

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -26,10 +26,11 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         let socketPath = root.appendingPathComponent("cmux.sock").path
         let harnessURL = root.appendingPathComponent("harness.js")
         try Self.openCodeFeedEventHarness.write(to: harnessURL, atomically: true, encoding: .utf8)
+        let bunURL = try Self.bunExecutableURL()
 
         let result = runProcess(
-            executablePath: "/usr/bin/env",
-            arguments: ["bun", harnessURL.path, pluginURL.path, socketPath],
+            executablePath: bunURL.path,
+            arguments: [harnessURL.path, pluginURL.path, socketPath],
             environment: ProcessInfo.processInfo.environment,
             timeout: 5
         )
@@ -109,6 +110,23 @@ final class OpenCodeHookRegressionTests: XCTestCase {
 
     private func bundledCLIPath() throws -> String {
         try BundledCLITestSupport.bundledCLIPath(for: Self.self)
+    }
+
+    private static func bunExecutableURL() throws -> URL {
+        let fileManager = FileManager.default
+        var candidates: [String] = []
+        if let install = ProcessInfo.processInfo.environment["BUN_INSTALL"], !install.isEmpty {
+            candidates.append(URL(fileURLWithPath: install).appendingPathComponent("bin/bun").path)
+        }
+        candidates += [
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".bun/bin/bun").path,
+            "/opt/homebrew/bin/bun",
+            "/usr/local/bin/bun",
+        ]
+        if let path = candidates.first(where: { fileManager.isExecutableFile(atPath: $0) }) {
+            return URL(fileURLWithPath: path)
+        }
+        throw XCTSkip("Bun runtime is required for the OpenCode plugin harness")
     }
 
     private static let openCodeFeedEventHarness = #"""


### PR DESCRIPTION
The OpenCode notification regression harness invoked `node`, but the CI integration runner provisions Bun and does not have a `node` executable. Use the provisioned Bun runtime so the real socket-level OpenCode test executes in CI.

Validation: this is a one-line test harness correction; the parent PR's production fix and regression coverage are already merged in #12190.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791516473&installation_model_id=21920&pr_number=12193&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12193&signature=e0ff023a108ca1071ee0673b41dade56c0860e59923c0c5ddf23b8137f6dc5ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the OpenCode notification regression harness from `node` to a Bun runtime so it runs in CI, where Node isn't provisioned. The harness now locates Bun from `BUN_INSTALL` or common install paths, and skips the test if Bun isn't found.

<sup>Written for commit 38024750c07bec9c72e01bed74640483b73d073a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test harness invocation change with no production or security impact.
> 
> **Overview**
> Updates the OpenCode feed-plugin regression test so it launches the embedded `harness.js` with **`bun`** instead of **`node`**, matching the CI integration environment where Bun is installed and Node is not.
> 
> No production or plugin behavior changes—only how the socket-level harness is executed so the existing regression test can run in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d810de1259c758e30ed0708368f965aaa0838ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the OpenCode feed regression test to run with the Bun runtime.
  * Improved runtime detection across common installation locations.
  * Tests now skip cleanly when Bun is unavailable instead of failing due to an unsupported runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->