### PR TITLE
web: backfill Stripe mirror tables from Stripe

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "coderouter:reconcile-billing": "bun scripts/coderouter/reconcile-billing.ts",
     "clickhouse:migrate": "bun scripts/clickhouse-migrate.ts",
     "testflight:backfill-legacy-ownership": "bun scripts/stripe/backfill-pro-testflight-legacy-ownership.ts",
+    "stripe:backfill-subscriptions": "bun scripts/stripe/backfill-subscriptions-from-stripe.ts",
     "billing:backfill-founders-lockout": "bun scripts/backfill-founders-lockout.ts",
     "cloud-vm:env:audit": "bun scripts/cloud-vm/audit-vercel-env.mjs",
     "cloud-vm:migrate": "bun scripts/cloud-vm/migrate-vercel-aurora-iam.mjs",

--- a/web/scripts/stripe/backfill-subscriptions-from-stripe.ts
+++ b/web/scripts/stripe/backfill-subscriptions-from-stripe.ts
@@ -1,0 +1,23 @@
+import { backfillSubscriptionsFromStripe } from "../../services/billing/backfillFromStripe";
+
+// Rebuild stripe_customers, stripe_subscriptions, and Stack Pro metadata from
+// Stripe. Dry-run by default; `--apply` writes.
+//
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts            # report only
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts --apply    # write
+//
+// Needs STRIPE_SECRET_KEY, the Stack server keys, and DATABASE_URL (or the
+// aws-rds-iam variables) for the target database.
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const unknown = args.filter((argument) => argument !== "--apply");
+if (unknown.length > 0) {
+  throw new Error(`Unknown argument: ${unknown[0]}`);
+}
+
+const result = await backfillSubscriptionsFromStripe({
+  apply_mode: apply ? "apply" : "dry-run",
+  log: (line) => console.log(line),
+});
+console.log(JSON.stringify({ mode: apply ? "apply" : "dry-run", ...result }, null, 2));
+if (result.failed > 0) process.exit(1);

--- a/web/scripts/stripe/backfill-subscriptions-from-stripe.ts
+++ b/web/scripts/stripe/backfill-subscriptions-from-stripe.ts
@@ -1,23 +1,33 @@
+import { backfillPaidPurchasesByEmail } from "../../services/billing/backfillPaidPurchases";
 import { backfillSubscriptionsFromStripe } from "../../services/billing/backfillFromStripe";
 
-// Rebuild stripe_customers, stripe_subscriptions, and Stack Pro metadata from
-// Stripe. Dry-run by default; `--apply` writes.
+// Rebuild stripe_customers, stripe_subscriptions, and Stack plan metadata
+// from Stripe. Dry-run by default; `--apply` writes.
 //
-//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts            # report only
-//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts --apply    # write
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts                       # metadata-tagged subscriptions, report
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts --apply               # write them
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts --by-email            # Founder and legacy Pro by customer email, report
+//   bun scripts/stripe/backfill-subscriptions-from-stripe.ts --by-email --apply    # write them (existing Stack accounts only)
+//   ... --by-email --apply --create-missing-users                                  # also create shell accounts, as checkout does
 //
 // Needs STRIPE_SECRET_KEY, the Stack server keys, and DATABASE_URL (or the
 // aws-rds-iam variables) for the target database.
 const args = process.argv.slice(2);
-const apply = args.includes("--apply");
-const unknown = args.filter((argument) => argument !== "--apply");
+const known = new Set(["--apply", "--by-email", "--create-missing-users"]);
+const unknown = args.filter((argument) => !known.has(argument));
 if (unknown.length > 0) {
   throw new Error(`Unknown argument: ${unknown[0]}`);
 }
+const apply = args.includes("--apply");
+const mode = apply ? "apply" : "dry-run";
+const log = (line: string) => console.log(line);
 
-const result = await backfillSubscriptionsFromStripe({
-  apply_mode: apply ? "apply" : "dry-run",
-  log: (line) => console.log(line),
-});
-console.log(JSON.stringify({ mode: apply ? "apply" : "dry-run", ...result }, null, 2));
+const result = args.includes("--by-email")
+  ? await backfillPaidPurchasesByEmail({
+    mode,
+    createMissingUsers: args.includes("--create-missing-users"),
+    log,
+  })
+  : await backfillSubscriptionsFromStripe({ apply_mode: mode, log });
+console.log(JSON.stringify({ mode, ...result }, null, 2));
 if (result.failed > 0) process.exit(1);

--- a/web/services/billing/backfillFromStripe.ts
+++ b/web/services/billing/backfillFromStripe.ts
@@ -1,0 +1,90 @@
+import type Stripe from "stripe";
+import { applySubscriptionUpdate } from "./purchase";
+import { stripe } from "./stripe";
+
+/**
+ * Rebuild the Stripe mirror tables from Stripe itself.
+ *
+ * `reconcileStripeSubscriptions` repairs drift for subscriptions the database
+ * already knows about. This walks every subscription in Stripe instead, so it
+ * can rebuild an empty database after a migration or a lost mirror. Stripe
+ * stays authoritative: each subscription goes through the same
+ * `applySubscriptionUpdate` path as a signed webhook, which maps the customer
+ * to a Stack user from the `stackUserId` metadata when no customer row
+ * exists yet, upserts the customer and subscription rows, and re-syncs the
+ * Pro plan metadata on the Stack user.
+ */
+export type StripeBackfillResult = {
+  readonly listed: number;
+  readonly cmux: number;
+  readonly applied: number;
+  readonly skipped: number;
+  readonly failed: number;
+  readonly failures: readonly { readonly id: string; readonly message: string }[];
+};
+
+export type StripeBackfillDependencies = {
+  readonly list?: () => AsyncIterable<Stripe.Subscription>;
+  readonly apply?: (subscription: Stripe.Subscription) => Promise<unknown>;
+  readonly apply_mode?: "dry-run" | "apply";
+  readonly log?: (line: string) => void;
+};
+
+export function isCmuxSubscription(subscription: Stripe.Subscription): boolean {
+  return subscription.metadata?.app === "cmux";
+}
+
+export async function backfillSubscriptionsFromStripe(
+  dependencies: StripeBackfillDependencies = {},
+): Promise<StripeBackfillResult> {
+  const list = dependencies.list ?? defaultList;
+  const apply = dependencies.apply ?? ((subscription) => applySubscriptionUpdate(subscription));
+  const mode = dependencies.apply_mode ?? "dry-run";
+  const log = dependencies.log ?? (() => undefined);
+
+  let listed = 0;
+  let cmux = 0;
+  let applied = 0;
+  let skipped = 0;
+  const failures: { id: string; message: string }[] = [];
+
+  for await (const subscription of list()) {
+    listed += 1;
+    if (!isCmuxSubscription(subscription)) continue;
+    cmux += 1;
+    const owner = subscription.metadata?.stackTeamId
+      ? `team ${subscription.metadata.stackTeamId}`
+      : `user ${subscription.metadata?.stackUserId ?? "<no stackUserId>"}`;
+    if (mode === "dry-run") {
+      log(`would apply ${subscription.id} status=${subscription.status} ${owner}`);
+      continue;
+    }
+    try {
+      const result = await apply(subscription);
+      if (result && typeof result === "object" && "skipped" in result) {
+        skipped += 1;
+        log(`skipped ${subscription.id} status=${subscription.status} ${owner}`);
+      } else {
+        applied += 1;
+        log(`applied ${subscription.id} status=${subscription.status} ${owner}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failures.push({ id: subscription.id, message });
+      log(`failed ${subscription.id}: ${message}`);
+    }
+  }
+
+  return { listed, cmux, applied, skipped, failed: failures.length, failures };
+}
+
+async function* defaultList(): AsyncIterable<Stripe.Subscription> {
+  // `status: "all"` includes canceled subscriptions, whose rows matter for
+  // grace periods and for founders lockout history.
+  for await (const subscription of stripe().subscriptions.list({
+    status: "all",
+    limit: 100,
+  })) {
+    yield subscription;
+  }
+}

--- a/web/services/billing/backfillPaidPurchases.ts
+++ b/web/services/billing/backfillPaidPurchases.ts
@@ -1,0 +1,147 @@
+import type Stripe from "stripe";
+import { canonicalizeEmailForMatching } from "./emailMatching";
+import {
+  findPaidBillingPurchaseByEmail,
+  provisionPaidBillingPurchase,
+  type PaidBillingPurchase,
+} from "./recovery";
+import { stripe } from "./stripe";
+
+/**
+ * Rebuild paid ownership rows for purchases that carry no `stackUserId`
+ * metadata, which is every Founder's Edition payment-link purchase and the
+ * oldest Pro subscriptions. The webhook path cannot map those, so this walks
+ * the customer emails behind every Stripe subscription and routes each one
+ * through the same recovery recorder that `/api/billing/recover` uses. That
+ * recorder finds the Stack account for the email, writes the customer and
+ * subscription rows, and syncs the plan metadata on the Stack user.
+ *
+ * By default a purchase whose email has no Stack account is reported and
+ * skipped, because the recorder would create a shell account for it. Pass
+ * `createMissingUsers` to allow that, which is what the checkout webhook does
+ * at purchase time.
+ */
+export type PaidPurchaseBackfillResult = {
+  readonly customers: number;
+  readonly found: number;
+  readonly provisioned: number;
+  readonly skipped: number;
+  readonly noStackUser: number;
+  readonly failed: number;
+  readonly failures: readonly { readonly email: string; readonly message: string }[];
+};
+
+export type PaidPurchaseBackfillDependencies = {
+  /** Distinct customer emails behind Stripe subscriptions, any status. */
+  readonly emails?: () => AsyncIterable<string>;
+  readonly find?: (email: string) => Promise<PaidBillingPurchase | null>;
+  readonly hasStackUser?: (email: string) => Promise<boolean>;
+  readonly provision?: (purchase: PaidBillingPurchase) => Promise<unknown>;
+  readonly mode?: "dry-run" | "apply";
+  readonly createMissingUsers?: boolean;
+  readonly log?: (line: string) => void;
+};
+
+export async function backfillPaidPurchasesByEmail(
+  dependencies: PaidPurchaseBackfillDependencies = {},
+): Promise<PaidPurchaseBackfillResult> {
+  const emails = dependencies.emails ?? defaultEmails;
+  const find = dependencies.find ?? ((email) => findPaidBillingPurchaseByEmail(email));
+  const hasStackUser = dependencies.hasStackUser ?? defaultHasStackUser;
+  const provision = dependencies.provision ?? ((purchase) => provisionPaidBillingPurchase(purchase));
+  const mode = dependencies.mode ?? "dry-run";
+  const log = dependencies.log ?? (() => undefined);
+
+  let customers = 0;
+  let found = 0;
+  let provisioned = 0;
+  let skipped = 0;
+  let noStackUser = 0;
+  const failures: { email: string; message: string }[] = [];
+  const seen = new Set<string>();
+
+  for await (const rawEmail of emails()) {
+    const email = rawEmail.trim().toLowerCase();
+    const canonical = canonicalizeEmailForMatching(email);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    customers += 1;
+    try {
+      const purchase = await find(email);
+      if (!purchase) continue;
+      found += 1;
+      const label = `${purchase.kind} ${redact(email)}`;
+      if (!dependencies.createMissingUsers && !(await hasStackUser(email))) {
+        noStackUser += 1;
+        log(`no stack user ${label}`);
+        continue;
+      }
+      if (mode === "dry-run") {
+        log(`would provision ${label}`);
+        continue;
+      }
+      const result = await provision(purchase);
+      if (result && typeof result === "object" && "skipped" in result) {
+        skipped += 1;
+        log(`skipped ${label}: ${String((result as { skipped: unknown }).skipped)}`);
+      } else {
+        provisioned += 1;
+        log(`provisioned ${label}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failures.push({ email: redact(email), message });
+      log(`failed ${redact(email)}: ${message}`);
+    }
+  }
+
+  return {
+    customers,
+    found,
+    provisioned,
+    skipped,
+    noStackUser,
+    failed: failures.length,
+    failures,
+  };
+}
+
+/** Keep operator logs free of full addresses. */
+function redact(email: string): string {
+  const [local, domain] = email.split("@");
+  if (!domain) return "<invalid>";
+  return `${local.slice(0, 2)}***@${domain}`;
+}
+
+async function* defaultEmails(): AsyncIterable<string> {
+  const client = stripe();
+  for await (const subscription of client.subscriptions.list({
+    status: "all",
+    limit: 100,
+    expand: ["data.customer"],
+  })) {
+    const customer = subscription.customer;
+    if (typeof customer === "string" || customer.deleted) continue;
+    if (customer.email) yield customer.email;
+  }
+}
+
+async function defaultHasStackUser(email: string): Promise<boolean> {
+  const { getStackServerApp } = await import("../../app/lib/stack");
+  const canonical = canonicalizeEmailForMatching(email);
+  const literal = email.trim().toLowerCase();
+  const queries = literal === canonical ? [canonical] : [canonical, literal];
+  for (const query of queries) {
+    const users = await getStackServerApp().listUsers({
+      query,
+      limit: 50,
+      includeAnonymous: false,
+    });
+    if (
+      users.some((user) =>
+        user.primaryEmail && canonicalizeEmailForMatching(user.primaryEmail) === canonical
+      )
+    ) return true;
+  }
+  return false;
+}

--- a/web/tests/billing-backfill-from-stripe.test.ts
+++ b/web/tests/billing-backfill-from-stripe.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type Stripe from "stripe";
+import { backfillSubscriptionsFromStripe } from "../services/billing/backfillFromStripe";
+
+function subscription(
+  id: string,
+  metadata: Record<string, string>,
+  status: Stripe.Subscription.Status = "active",
+): Stripe.Subscription {
+  return { id, status, metadata } as unknown as Stripe.Subscription;
+}
+
+async function* listOf(items: Stripe.Subscription[]) {
+  for (const item of items) yield item;
+}
+
+describe("backfill subscriptions from Stripe", () => {
+  const rows = [
+    subscription("sub_user", { app: "cmux", stackUserId: "user-1" }),
+    subscription("sub_team", { app: "cmux", stackUserId: "user-2", stackTeamId: "team-1" }),
+    subscription("sub_other_app", { app: "other" }),
+    subscription("sub_founder", { app: "cmux", founders_edition: "true" }, "canceled"),
+    subscription("sub_no_metadata", {}),
+  ];
+
+  test("dry run counts cmux subscriptions and writes nothing", async () => {
+    const applied: string[] = [];
+    const lines: string[] = [];
+    const result = await backfillSubscriptionsFromStripe({
+      list: () => listOf(rows),
+      apply: async (row) => {
+        applied.push(row.id);
+        return { scope: "user" };
+      },
+      log: (line) => lines.push(line),
+    });
+
+    expect(applied).toEqual([]);
+    expect(result).toMatchObject({ listed: 5, cmux: 3, applied: 0, skipped: 0, failed: 0 });
+    expect(lines.some((line) => line.includes("sub_team") && line.includes("team team-1"))).toBe(true);
+  });
+
+  test("apply routes every cmux subscription through the webhook path and reports skips and failures", async () => {
+    const applied: string[] = [];
+    const result = await backfillSubscriptionsFromStripe({
+      apply_mode: "apply",
+      list: () => listOf(rows),
+      apply: async (row) => {
+        applied.push(row.id);
+        if (row.id === "sub_founder") return { skipped: true };
+        if (row.id === "sub_team") throw new Error("Stack user not found");
+        return { scope: "user", stackUserId: "user-1", isActive: true };
+      },
+    });
+
+    expect(applied).toEqual(["sub_user", "sub_team", "sub_founder"]);
+    expect(result).toMatchObject({ listed: 5, cmux: 3, applied: 1, skipped: 1, failed: 1 });
+    expect(result.failures).toEqual([{ id: "sub_team", message: "Stack user not found" }]);
+  });
+});

--- a/web/tests/billing-backfill-paid-purchases.test.ts
+++ b/web/tests/billing-backfill-paid-purchases.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { backfillPaidPurchasesByEmail } from "../services/billing/backfillPaidPurchases";
+import type { PaidBillingPurchase } from "../services/billing/recovery";
+
+async function* emailsOf(items: string[]) {
+  for (const item of items) yield item;
+}
+
+const purchase = (kind: PaidBillingPurchase["kind"]): PaidBillingPurchase =>
+  ({ kind, input: { session: { id: `cs_${kind}` } } }) as unknown as PaidBillingPurchase;
+
+describe("backfill paid purchases by email", () => {
+  const emails = ["Founder@Example.com", "founder@example.com", "pro@example.com", "nobody@example.com", "free@example.com"];
+  const find = async (email: string) => {
+    if (email.startsWith("founder")) return purchase("founders_edition");
+    if (email.startsWith("pro") || email.startsWith("nobody")) return purchase("pro");
+    return null;
+  };
+  const hasStackUser = async (email: string) => !email.startsWith("nobody");
+
+  test("dry run dedupes emails, reports purchases, and flags missing Stack accounts", async () => {
+    const provisioned: string[] = [];
+    const lines: string[] = [];
+    const result = await backfillPaidPurchasesByEmail({
+      emails: () => emailsOf(emails),
+      find,
+      hasStackUser,
+      provision: async (item) => { provisioned.push(item.kind); return { scope: "user" }; },
+      log: (line) => lines.push(line),
+    });
+
+    expect(provisioned).toEqual([]);
+    expect(result).toMatchObject({ customers: 4, found: 3, provisioned: 0, noStackUser: 1, failed: 0 });
+    expect(lines.some((line) => line.startsWith("would provision founders_edition fo***@example.com"))).toBe(true);
+    expect(lines.some((line) => line.startsWith("no stack user pro no***@example.com"))).toBe(true);
+    expect(lines.join("\n")).not.toContain("nobody@example.com");
+  });
+
+  test("apply provisions found purchases, skips missing accounts unless allowed, and collects failures", async () => {
+    const provisioned: string[] = [];
+    const result = await backfillPaidPurchasesByEmail({
+      mode: "apply",
+      emails: () => emailsOf(emails),
+      find,
+      hasStackUser,
+      provision: async (item) => {
+        provisioned.push(item.kind);
+        if (item.kind === "pro") throw new Error("boom");
+        return { scope: "user", stackUserId: "u1", subscriptionId: "sub" };
+      },
+    });
+    expect(provisioned).toEqual(["founders_edition", "pro"]);
+    expect(result).toMatchObject({ customers: 4, found: 3, provisioned: 1, noStackUser: 1, failed: 1 });
+
+    const withCreate = await backfillPaidPurchasesByEmail({
+      mode: "apply",
+      createMissingUsers: true,
+      emails: () => emailsOf(["nobody@example.com"]),
+      find,
+      hasStackUser,
+      provision: async () => ({ skipped: "account_deletion_in_progress" }),
+    });
+    expect(withCreate).toMatchObject({ customers: 1, found: 1, provisioned: 0, skipped: 1, noStackUser: 0 });
+  });
+});


### PR DESCRIPTION
Adds `bun run stripe:backfill-subscriptions` (dry-run) and `--apply`.

Needed for the PlanetScale migration: the new database starts empty, and `reconcileStripeSubscriptions` only repairs subscriptions the database already lists. This walks every subscription in Stripe (`status: all`) and sends each `metadata.app === "cmux"` subscription through `applySubscriptionUpdate`, the same path as a signed webhook. With no customer row present that path resolves the Stack user from `metadata.stackUserId` (or the team mapping), upserts `stripe_customers` and `stripe_subscriptions`, and re-syncs the Pro plan metadata on the Stack user. Founder's Edition rows are skipped by that path, which is correct: the Founder entitlement lives in Stack metadata.

The service is dependency-injected and unit tested for dry-run counting, apply routing, skip reporting, and failure collection. Typecheck passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791518812&installation_model_id=21920&pr_number=12195&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12195&signature=aacbf70fad664152d74bdaf6d33fcd361a0b5e18c080143b048c5cc8b714bec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Apply mode mutates billing mirror tables and Stack plan metadata at scale, though dry-run is default and logic reuses existing webhook/recovery code paths.
> 
> **Overview**
> Adds **`bun run stripe:backfill-subscriptions`** (dry-run by default) so operators can rebuild **`stripe_customers`**, **`stripe_subscriptions`**, and Stack plan metadata after an empty DB migration—something **`reconcileStripeSubscriptions`** cannot do because it only repairs subscriptions already in the database.
> 
> The default mode lists every Stripe subscription (`status: all`), keeps **`metadata.app === "cmux"`** rows, and in **`--apply`** runs each through **`applySubscriptionUpdate`** (same path as signed webhooks). **`--by-email`** targets Founder’s Edition and legacy Pro purchases without **`stackUserId`** metadata by deduping customer emails from Stripe and calling the **`/api/billing/recover`** provisioning helpers; **`--create-missing-users`** optionally creates shell Stack accounts like checkout.
> 
> Both flows are dependency-injected, emit JSON stats (and exit non-zero on failures), redact emails in logs, and ship with unit tests for dry-run, apply, skips, and error collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d07423540aac59337c33c567e7f376388c998c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `stripe:backfill-subscriptions` script that rebuilds billing mirror tables for the PlanetScale migration, where the new database starts empty. The existing reconcile job only repairs subscriptions the database already lists; this walks Stripe directly and routes each through the same paths as live webhooks. Dry-run by default; `--apply` writes and the script exits non-zero on failures.

Two modes:
- CMUX subscriptions with `stackUserId` metadata go through `applySubscriptionUpdate`, which resolves the Stack user and re-syncs Pro plan metadata. Founder's Edition rows are skipped by that path, which is correct since that entitlement lives in Stack metadata.
- `--by-email` covers Founder and legacy Pro purchases that carry no Stack metadata, walking customer emails through the same recovery recorder as `/api/billing/recover`. Emails with no Stack account are reported and skipped unless `--create-missing-users` is passed; logs redact addresses.

<sup>Written for commit 4d07423540aac59337c33c567e7f376388c998c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a utility to backfill eligible Stripe subscriptions, with dry-run and apply modes.
  - Added email-based backfilling for paid purchases, including optional creation of missing accounts.
  - Added JSON summaries for processed, skipped, provisioned, and failed records.
  - Added command-line options with validation and continued processing after individual failures.

- **Tests**
  - Added coverage for subscription and purchase backfills, including dry runs, successful updates, skipped records, missing accounts, and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->