### PR TITLE
ci: bypass stale Gatekeeper assessments for Computer Use helper

### DIFF
--- a/scripts/ci/notarize-computer-use-helper.sh
+++ b/scripts/ci/notarize-computer-use-helper.sh
@@ -47,17 +47,19 @@ DITTO_TOOL="${CMUX_DITTO_TOOL:-/usr/bin/ditto}"
 XCRUN_TOOL="${CMUX_XCRUN_TOOL:-xcrun}"
 CODESIGN_TOOL="${CMUX_CODESIGN_TOOL:-/usr/bin/codesign}"
 SPCTL_TOOL="${CMUX_SPCTL_TOOL:-spctl}"
-# Gatekeeper learns about a fresh notarization ticket from Apple's CDN, which
-# lags the notarytool "Accepted" status by up to a few minutes. A stapled,
-# valid helper can therefore still assess as "Unnotarized Developer ID" right
-# after stapling. Poll until it is accepted or the budget runs out.
+# Gatekeeper keeps negative assessments in a cache keyed by the helper's code
+# directory hash. The helper has the same CDHash before and after stapling, so
+# an assessment made before the ticket is attached can otherwise be replayed
+# after stapling and reported as "Unnotarized Developer ID". Force every poll
+# to assess the copied helper without consulting or populating that cache;
+# retries still cover propagation of the fresh ticket to Apple's service.
 GATEKEEPER_ASSESS_ATTEMPTS="${CMUX_GATEKEEPER_ASSESS_ATTEMPTS:-20}"
 GATEKEEPER_ASSESS_DELAY_SECONDS="${CMUX_GATEKEEPER_ASSESS_DELAY_SECONDS:-15}"
 
 assess_with_gatekeeper() {
   local target="$1" attempt=1
   while :; do
-    if "$SPCTL_TOOL" -a -vv --type execute "$target"; then
+    if "$SPCTL_TOOL" -a -vv --ignore-cache --no-cache --type execute "$target"; then
       return 0
     fi
     if [ "$attempt" -ge "$GATEKEEPER_ASSESS_ATTEMPTS" ]; then

--- a/tests/test_notarize_computer_use_helper.sh
+++ b/tests/test_notarize_computer_use_helper.sh
@@ -57,6 +57,14 @@ cat > "$FAKE_BIN/spctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'spctl %s\n' "$*" >> "$CMUX_TEST_CALL_LOG"
+# Gatekeeper keeps negative assessments in a code-directory cache. A fresh
+# stapled ticket must be assessed without consulting or populating that cache.
+if [ "${CMUX_TEST_SPCTL_REQUIRE_FRESH:-0}" = "1" ]; then
+  if [[ " $* " != *" --ignore-cache "* || " $* " != *" --no-cache "* ]]; then
+    echo "assessment cache was reused" >&2
+    exit 2
+  fi
+fi
 # Simulate Gatekeeper not yet seeing the notarization ticket: reject the first
 # CMUX_TEST_SPCTL_REJECTS assessments, then accept.
 count_file="${CMUX_TEST_SPCTL_COUNT_FILE:-}"
@@ -129,7 +137,7 @@ if ! [ "$helper_sign_line" -lt "$submit_line" ] \
   echo "FAIL: helper notarization, stapling, and outer resealing ran out of order" >&2
   exit 1
 fi
-if ! grep -Eq '^spctl -a -vv --type execute .*/standalone/cmux Computer Use\.app$' "$LOG"; then
+if ! grep -Eq '^spctl -a -vv --ignore-cache --no-cache --type execute .*/standalone/cmux Computer Use\.app$' "$LOG"; then
   echo "FAIL: independently copied helper did not pass the Gatekeeper check" >&2
   exit 1
 fi
@@ -209,7 +217,7 @@ if ! CMUX_TEST_SPCTL_COUNT_FILE="$TMP_DIR/spctl-count" CMUX_TEST_SPCTL_REJECTS=2
   echo "FAIL: helper notarization gave up while the Gatekeeper ticket was still propagating" >&2
   exit 1
 fi
-if [ "$(grep -c '^spctl -a -vv --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
+if [ "$(grep -c '^spctl -a -vv --ignore-cache --no-cache --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
   echo "FAIL: expected three Gatekeeper assessments (two rejected, one accepted)" >&2
   exit 1
 fi
@@ -221,8 +229,22 @@ if CMUX_TEST_SPCTL_COUNT_FILE="$TMP_DIR/spctl-count" CMUX_TEST_SPCTL_REJECTS=5 C
   echo "FAIL: helper notarization passed although Gatekeeper never accepted the helper" >&2
   exit 1
 fi
-if [ "$(grep -c '^spctl -a -vv --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
+if [ "$(grep -c '^spctl -a -vv --ignore-cache --no-cache --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
   echo "FAIL: Gatekeeper assessment must stop after the attempt budget" >&2
+  exit 1
+fi
+
+# Regression: a stale negative assessment must not make a valid stapled helper
+# fail just because the same CDHash was assessed before stapling. The fake
+# Gatekeeper rejects any assessment that does not opt out of its cache.
+: > "$LOG"
+if ! CMUX_TEST_SPCTL_REQUIRE_FRESH=1 CMUX_GATEKEEPER_ASSESS_ATTEMPTS=1 run_helper >"$TMP_DIR/fresh-assessment.out" 2>&1; then
+  echo "FAIL: Gatekeeper assessment reused a stale negative cache entry" >&2
+  cat "$TMP_DIR/fresh-assessment.out" >&2
+  exit 1
+fi
+if ! grep -Eq '^spctl -a -vv --ignore-cache --no-cache --type execute .*/standalone/cmux Computer Use\.app$' "$LOG"; then
+  echo "FAIL: Gatekeeper assessment did not bypass its cache" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

The nightly universal signing job failed in [job 102338573415](https://github.com/manaflow-ai/cmux/actions/runs/34309428538/job/102338573415) while finishing the Computer Use helper notarization. Apple returned `Accepted` with both architectures in `ticketContents`; stapler and codesign validated the helper and an independent copy, but every `spctl` retry reported `source=Unnotarized Developer ID`.

The run was triggered by commit `e15f81c32f7e9758fe96a87544254e4f62e9637e` (`#12186`). That identifies the failing build only; this PR does not attribute the notarization behavior to that change.

## Cause and fix

SecAssessment caches negative execution assessments by code-directory hash. The helper's CDHash is unchanged when its stapled ticket is attached, so the ordinary `spctl` retry loop can reuse the pre-staple negative result. The assessment contract provides separate flags to bypass existing cache entries and avoid writing a new outcome.

Every standalone helper assessment now runs:

```text
spctl -a -vv --ignore-cache --no-cache --type execute <copied-helper>
```

This keeps the independent, offline Gatekeeper check and the existing retry budget while ensuring each poll evaluates the stapled copy against current policy. `--no-cache` also prevents a transient negative result from poisoning later checks.

## Tests

- `tests/test_notarize_computer_use_helper.sh` first adds a deterministic failing regression for stale cached assessments, then the fix makes it pass.
- `bash -n` on the touched shell scripts.
- `python3 scripts/swift_file_length_budget.py` (no Swift files changed).
- Related nightly packaging tests will run in CI.

The open [#12157](https://github.com/manaflow-ai/cmux/pull/12157) change raises the propagation wait budget; this PR addresses the separate local assessment-cache contract and does not depend on that branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791528348&installation_model_id=21920&pr_number=12202&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12202&signature=48ca41189b1993eff9297d96e55a959affc9e35285cb83e3712f96995f78040c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows release signing behavior to correct Gatekeeper cache semantics; no change to notarization credentials, stapling order, or outer resealing logic beyond more reliable `spctl` checks.
> 
> **Overview**
> Fixes nightly release failures where a stapled Computer Use helper still failed Gatekeeper checks because **SecAssessment reused a cached negative result** for the same CDHash from before stapling.
> 
> Standalone helper validation now requires **`spctl -a -vv --ignore-cache --no-cache --type execute`** on the copied helper so each poll (and the final check) evaluates the stapled app without reading or writing the assessment cache, while keeping the existing retry budget for ticket propagation.
> 
> **`tests/test_notarize_computer_use_helper.sh`** updates the fake `spctl` to fail when those flags are missing (`CMUX_TEST_SPCTL_REQUIRE_FRESH`), aligns log assertions with the new command line, and adds a regression case so a previously cached “unnotarized” outcome cannot block a valid stapled helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffda951cb71c50c74165b77c63dde18e44410301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypasses the Gatekeeper assessment cache in Computer Use helper notarization so stale negative results no longer fail nightly verification.

- Every standalone `spctl` assessment now runs with `--ignore-cache --no-cache`, and the fake Gatekeeper test harness rejects assessments that reuse the cache.
- Adds a regression test that fails if a stale negative assessment is reused for a valid stapled helper.

<sup>Written for commit 5e56675e9e2cfc24bcd7ba4a87c0c8ace4a9ae1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gatekeeper assessments now bypass cached results, ensuring each retry evaluates the current helper.
  * Improved validation for notarized helpers when stale negative assessment results are present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->