### PR TITLE
fix(web): open CodeRouter CLI login on cmux.com

### DIFF
--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -91,6 +91,7 @@ function cliAuthConfirmationURL(request: Request): string {
     PRODUCTION_CODEROUTER_HOSTS.has(url.hostname)
   ) {
     url.hostname = "cmux.com";
+    url.port = "";
   }
   return url.toString();
 }

--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -5,6 +5,10 @@ import {
 
 
 const DEFAULT_STACK_API_URL = "https://api.stack-auth.com/api/v1";
+const PRODUCTION_CODEROUTER_HOSTS = new Set([
+  "coderouter.dev",
+  "www.coderouter.dev",
+]);
 
 // This metadata is informational for now. Keep the legacy `version` field
 // below for clients that already consume the config response, and do not gate
@@ -45,7 +49,7 @@ export function GET(request: Request): Response {
         publishableClientKey,
         // Start and complete the CLI login against the same deployment so the
         // confirmation page uses the Stack project that issued the login code.
-        confirmUrl: new URL("/handler/cli-auth-confirm", request.url).toString(),
+        confirmUrl: cliAuthConfirmationURL(request),
       },
       coderouter: {
         sessionUrl: new URL("/api/coderouter/session", request.url).toString(),
@@ -72,6 +76,23 @@ export function GET(request: Request): Response {
       },
     },
   );
+}
+
+/**
+ * Keep the CodeRouter data plane on its dedicated host while sending browser
+ * sign-in through cmux.com's canonical auth surface. The Stack login code is
+ * issued by the same deployment and remains in the CLI confirmation query.
+ * Non-production and explicitly configured hosts stay on their own origin.
+ */
+function cliAuthConfirmationURL(request: Request): string {
+  const url = new URL("/handler/cli-auth-confirm", request.url);
+  if (
+    url.protocol === "https:" &&
+    PRODUCTION_CODEROUTER_HOSTS.has(url.hostname)
+  ) {
+    url.hostname = "cmux.com";
+  }
+  return url.toString();
 }
 
 function unavailableResponse(): Response {

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -64,6 +64,17 @@ describe("CLI config route", () => {
       );
       expect(body.coderouter.openaiBaseUrl).toBe("https://coderouter.dev/v1");
 
+      const nonDefaultPortResponse = GET(
+        new Request("https://coderouter.dev:4443/api/cli/config"),
+      );
+      const nonDefaultPortBody = await nonDefaultPortResponse.json();
+      expect(nonDefaultPortBody.auth.confirmUrl).toBe(
+        "https://cmux.com/handler/cli-auth-confirm",
+      );
+      expect(nonDefaultPortBody.coderouter.sessionUrl).toBe(
+        "https://coderouter.dev:4443/api/coderouter/session",
+      );
+
       const confirmation = new URL(body.auth.confirmUrl);
       confirmation.searchParams.set("login_code", "fresh-test-login-code");
       const signIn = new URL("https://cmux.com/handler/sign-in");

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -48,6 +48,35 @@ async function withCliConfigEnvironment(
 }
 
 describe("CLI config route", () => {
+  test("uses cmux.com for production CodeRouter browser auth and preserves the login code", async () => {
+    await withCliConfigEnvironment(testEnvironment, async () => {
+      const response = GET(
+        new Request("https://coderouter.dev/api/cli/config"),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.auth.confirmUrl).toBe(
+        "https://cmux.com/handler/cli-auth-confirm",
+      );
+      expect(body.coderouter.sessionUrl).toBe(
+        "https://coderouter.dev/api/coderouter/session",
+      );
+      expect(body.coderouter.openaiBaseUrl).toBe("https://coderouter.dev/v1");
+
+      const confirmation = new URL(body.auth.confirmUrl);
+      confirmation.searchParams.set("login_code", "fresh-test-login-code");
+      const signIn = new URL("https://cmux.com/handler/sign-in");
+      signIn.searchParams.set(
+        "after_auth_return_to",
+        `${confirmation.pathname}${confirmation.search}`,
+      );
+      expect(signIn.toString()).toBe(
+        "https://cmux.com/handler/sign-in?after_auth_return_to=%2Fhandler%2Fcli-auth-confirm%3Flogin_code%3Dfresh-test-login-code",
+      );
+    });
+  });
+
   test("publishes CodeRouter and the hosted Subrouter POST contract", async () => {
     await withCliConfigEnvironment(testEnvironment, async () => {
       const response = GET(new Request("https://cmux.com/api/cli/config"));
@@ -124,6 +153,23 @@ describe("CLI config route", () => {
       );
       expect(body.coderouter.sessionUrl).toBe(
         "http://127.0.0.1:4152/api/coderouter/session",
+      );
+    });
+  });
+
+  test("keeps confirmation on a custom staging origin", async () => {
+    await withCliConfigEnvironment(testEnvironment, async () => {
+      const response = GET(
+        new Request("https://coderouter-staging.example.test/api/cli/config"),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.auth.confirmUrl).toBe(
+        "https://coderouter-staging.example.test/handler/cli-auth-confirm",
+      );
+      expect(body.coderouter.sessionUrl).toBe(
+        "https://coderouter-staging.example.test/api/coderouter/session",
       );
     });
   });


### PR DESCRIPTION
Fixes #12203

`cmux cr login` delegates to the CodeRouter CLI, which uses the `auth.confirmUrl` advertised by `/api/cli/config`. Production requests served on `coderouter.dev` were advertising the CodeRouter host for browser confirmation, even though cmux owns the canonical sign-in surface.

This changes only the production browser confirmation origin to `https://cmux.com/handler/cli-auth-confirm`. CodeRouter data-plane URLs remain on `coderouter.dev`, and loopback, staging, and custom origins remain request-local. The CLI appends its one-time `login_code` after receiving this URL, so the confirmation path and code continue through Stack’s existing flow.

Regression coverage is split into two commits:

1. `test(web): cover production CodeRouter login origin` — fails on the previous `coderouter.dev` confirmation URL and covers the synthetic code/redirect composition plus loopback and custom-origin behavior.
2. `fix(web): send CodeRouter login through cmux.com` — maps only the canonical production CodeRouter hosts at the config boundary.

Validation:

- `bun test --preload ./tests/test-preload.ts tests/cli-config-route.test.ts`
- `bunx eslint app/api/cli/config/route.ts tests/cli-config-route.test.ts`
- `bun run lint:complexity`
- Released CodeRouter CLI 0.3.4 against an isolated local fixture: browser URL printed with a synthetic login code, polling completed, and route credentials persisted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791530793&installation_model_id=21920&pr_number=12205&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12205&signature=8bf5ce4bc5c77c5fc09a5611c3f7e7ff3066464adee492645b0765e36d48681d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production CodeRouter CLI login so browser confirmation goes through `cmux.com` instead of `coderouter.dev`, now also normalizing the port.

- Maps only canonical production `coderouter.dev` hosts to `https://cmux.com/handler/cli-auth-confirm` and clears non-default ports.
- CodeRouter data-plane URLs, loopback, staging, and custom origins keep their request-local host.
- Adds regression tests for production confirmation with default and non-default ports, plus staging origins.

<sup>Written for commit 71cf9c5ccc003cad5e1fee205e8a3ad0d038726a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows production CLI browser auth to cmux.com while leaving data-plane URLs on CodeRouter; mis-host detection could break login for production hosts only.
> 
> **Overview**
> Production CLI config requests on **`coderouter.dev`** / **`www.coderouter.dev`** now advertise **`auth.confirmUrl`** on **`https://cmux.com/handler/cli-auth-confirm`** instead of the CodeRouter host, via a new **`cliAuthConfirmationURL`** helper that only rewrites HTTPS production CodeRouter hostnames. **CodeRouter** session/API URLs and loopback, staging, and other custom origins are unchanged.
> 
> Tests assert production gets cmux confirmation while data-plane URLs stay on `coderouter.dev`, sign-in redirect composition with `login_code` still works, and custom staging keeps confirmation on its own origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726bdb97a4df765c74d66590c8605fe4b39c54e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Production CLI authentication confirmation links now consistently use the `cmux.com` host when accessed securely.
  - Login codes are preserved when returning users to the sign-in flow.
  - Custom staging origins continue to route confirmation and session links correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->