### PR TITLE
agent-chat: skip the launchd PATH prefix on Windows so agent CLIs resolve

### DIFF
--- a/agent-chat/package.json
+++ b/agent-chat/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "bun server.ts",
     "build": "bun run build.ts",
-    "check": "bun x tsc --noEmit && bun test/claude-environment.test.ts && bun test/model-label.test.ts && bun test/model-picker-loading.test.ts && bun test/activity.test.ts && bun test/keymap.test.ts && bun test/options-store.test.ts && bun test/options-ui.test.ts && bun test/turns.test.ts && bun test/selection-css.test.ts && bun test/highlight.test.ts"
+    "check": "bun x tsc --noEmit && bun test/path-environment.test.ts && bun test/claude-environment.test.ts && bun test/model-label.test.ts && bun test/model-picker-loading.test.ts && bun test/activity.test.ts && bun test/keymap.test.ts && bun test/options-store.test.ts && bun test/options-ui.test.ts && bun test/turns.test.ts && bun test/selection-css.test.ts && bun test/highlight.test.ts"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",

--- a/agent-chat/path-environment.ts
+++ b/agent-chat/path-environment.ts
@@ -1,0 +1,9 @@
+/** Supplement minimal launchd environments without changing Windows search paths. */
+export function initializeAgentPath(env: Record<string, string | undefined>, platform: NodeJS.Platform): void {
+  // Windows uses semicolons and may spell the variable "Path". Leave it intact.
+  if (platform === "win32") return;
+  const home = env.HOME ?? "";
+  const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
+  const cur = (env.PATH ?? "").split(":");
+  env.PATH = [...extra.filter((p) => !cur.includes(p)), ...cur].join(":");
+}

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -107,7 +107,10 @@ export async function writeStateFileForTest(path: string, port: number) {
 }
 
 // Under launchd the PATH is minimal; make sure the agent CLIs resolve.
-{
+// launchd is macOS-only and these are POSIX paths joined with ":", so skip the
+// block on Windows, where ";" separates PATH entries and a ":"-joined prefix
+// would fuse all four additions onto the first real entry and hide it.
+if (process.platform !== "win32") {
   const home = process.env.HOME ?? "";
   const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
   const cur = (process.env.PATH ?? "").split(":");

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -1,3 +1,4 @@
+import { initializeAgentPath } from "./path-environment";
 import type {
   Adapter,
   AgentEvent,
@@ -106,16 +107,7 @@ export async function writeStateFileForTest(path: string, port: number) {
   await writeStateFilePath(path, port);
 }
 
-// Under launchd the PATH is minimal; make sure the agent CLIs resolve.
-// launchd is macOS-only and these are POSIX paths joined with ":", so skip the
-// block on Windows, where ";" separates PATH entries and a ":"-joined prefix
-// would fuse all four additions onto the first real entry and hide it.
-if (process.platform !== "win32") {
-  const home = process.env.HOME ?? "";
-  const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
-  const cur = (process.env.PATH ?? "").split(":");
-  process.env.PATH = [...extra.filter((p) => !cur.includes(p)), ...cur].join(":");
-}
+initializeAgentPath(process.env, process.platform);
 const ROOT = import.meta.dir;
 const DEFAULT_CWD = `${ROOT}/scratch`;
 const ICON_ROOT = resolve(ROOT, "../Assets.xcassets/AgentIcons");

--- a/agent-chat/test/path-environment.test.ts
+++ b/agent-chat/test/path-environment.test.ts
@@ -1,0 +1,25 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { initializeAgentPath } from "../path-environment";
+
+// Preserve the first search entry, spelling of Path, and even an absent PATH.
+for (const inherited of [
+  { PATH: "C:\\Python314\\Scripts\\;C:\\Windows\\System32", USERPROFILE: "C:\\Users\\test" },
+  { Path: "C:\\Tools;C:\\Windows\\System32" },
+  { PATH: "" },
+  {},
+]) {
+  const env = { ...inherited };
+  initializeAgentPath(env, "win32");
+  deepStrictEqual(env, inherited);
+}
+
+for (const platform of ["darwin", "linux"] as const) {
+  const env = { HOME: "/home/test", PATH: "/usr/bin:/usr/local/bin:/bin", KEEP: "value" };
+  initializeAgentPath(env, platform);
+  strictEqual(env.PATH, "/home/test/.local/bin:/home/test/.bun/bin:/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin");
+  strictEqual(env.KEEP, "value");
+  const once = { ...env };
+  initializeAgentPath(env, platform);
+  deepStrictEqual(env, once);
+}
+console.log("PATH environment assertions passed");


### PR DESCRIPTION
## Summary
Preserve the inherited Windows PATH while continuing to prepend agent CLI directories on POSIX platforms. This prevents semicolon-separated Windows entries from being corrupted by the POSIX `:` join.

## Verification
- `bun test/path-environment.test.ts` (Linux)
- `git diff --check`
- Swift/macOS builds, xcodebuild, reload, cloud-build, and dogfood were not run (Linux-only task).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only environment tweak with platform guard and unit tests; POSIX PATH behavior preserved.
> 
> **Overview**
> Moves launchd **PATH** supplementation out of `server.ts` into **`initializeAgentPath`** in `path-environment.ts`, called at startup with `process.env` and `process.platform`.
> 
> **On Windows (`win32`)** the helper is now a no-op so inherited semicolon-separated `PATH`/`Path` values are never split on `:` and rewritten. **On darwin/linux** behavior is unchanged: common agent CLI directories are prepended when missing, without duplicating entries.
> 
> Adds **`path-environment.test.ts`** and wires it into the package **`check`** script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133b22f4395c8efda5e2a82e85244ed913d62ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line tool discovery by consistently including common local binary directories in the search path on macOS and Linux.
  * Preserved existing Windows path behavior.

* **Tests**
  * Added coverage for platform-specific path handling, environment preservation, and repeated initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->