### PR TITLE
ci: fail closed on masked app-host failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
       - name: Validate app-host xcodebuild attempt budget
         run: ./tests/test_ci_app_host_xcodebuild_attempts.sh
 
+      - name: Validate app-host test failure classification
+        run: python3 tests/test_ci_app_host_test_output.py
+
       - name: Validate app-host user configuration isolation
         run: python3 tests/test_ci_app_host_home_isolation.py
 
@@ -1292,13 +1295,10 @@ jobs:
             } | tee "$batch_output"
             batch_status="${PIPESTATUS[0]}"
 
-            if [ "$batch_status" -ne 0 ]; then
-              local batch_summary
-              batch_summary="$(grep "Executed.*tests.*with.*failures" "$batch_output" | tail -1 || true)"
-              if echo "$batch_summary" | grep -q "(0 unexpected)"; then
+            if [ "$batch_status" -eq 65 ] \
+              && python3 scripts/ci/classify-app-host-test-output.py "$batch_output"; then
                 echo "All failures in app-host batch ${logical_shard}/${LOGICAL_SHARD_TOTAL} are expected, continuing"
                 return 0
-              fi
             fi
             return "$batch_status"
           }

--- a/scripts/ci/classify-app-host-test-output.py
+++ b/scripts/ci/classify-app-host-test-output.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+
+SUMMARY_RE = re.compile(
+    r"Executed\s+(?P<tests>\d+)\s+tests?,\s+"
+    r"with\s+(?P<failures>\d+)\s+failures?\s+"
+    r"\((?P<unexpected>\d+)\s+unexpected\)"
+)
+
+
+def classify(output: str) -> tuple[bool, str]:
+    summaries = list(SUMMARY_RE.finditer(output))
+    if not summaries:
+        return False, "no trustworthy XCTest summary was found"
+
+    unexpected = sum(int(match.group("unexpected")) for match in summaries)
+    if unexpected:
+        return False, f"{unexpected} unexpected failure(s) found across all XCTest summaries"
+
+    return True, f"{len(summaries)} XCTest summary(ies) contained no unexpected failures"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} <xcodebuild-output>", file=sys.stderr)
+        return 2
+
+    output_path = Path(sys.argv[1])
+    try:
+        output = output_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        print(f"could not read {output_path}: {error}", file=sys.stderr)
+        return 2
+
+    passed, message = classify(output)
+    print(message, file=sys.stderr if not passed else sys.stdout)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_app_host_test_output.py
+++ b/tests/test_ci_app_host_test_output.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/ci/classify-app-host-test-output.py"
+SPEC = importlib.util.spec_from_file_location("classify_app_host_test_output", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class AppHostTestOutputTests(unittest.TestCase):
+    def test_all_expected_failures_are_tolerated(self) -> None:
+        passed, message = MODULE.classify(
+            "Executed 4 tests, with 1 failure (0 unexpected)\n"
+            "Executed 8 tests, with 2 failures (0 unexpected)\n"
+        )
+
+        self.assertTrue(passed)
+        self.assertIn("2 XCTest summary", message)
+
+    def test_unexpected_failure_in_earlier_summary_is_not_masked(self) -> None:
+        passed, message = MODULE.classify(
+            "Executed 4 tests, with 1 failure (1 unexpected)\n"
+            "Executed 8 tests, with 2 failures (0 unexpected)\n"
+        )
+
+        self.assertFalse(passed)
+        self.assertIn("1 unexpected failure", message)
+
+    def test_missing_summary_is_not_tolerated(self) -> None:
+        passed, message = MODULE.classify("xcodebuild aborted before reporting results\n")
+
+        self.assertFalse(passed)
+        self.assertIn("no trustworthy XCTest summary", message)
+
+    def test_singular_summary_is_supported(self) -> None:
+        passed, _ = MODULE.classify("Executed 1 test, with 0 failures (0 unexpected)\n")
+
+        self.assertTrue(passed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -226,6 +227,10 @@ def run_app_host_unit_test_step(
         runner_temp.mkdir()
         fake_bin.mkdir()
         ci_scripts.mkdir(parents=True)
+        shutil.copy2(
+            ROOT / "scripts/ci/classify-app-host-test-output.py",
+            ci_scripts / "classify-app-host-test-output.py",
+        )
 
         shard_helper = ci_scripts / "cmux_unit_test_shard.py"
         shard_helper.write_text(
@@ -260,7 +265,7 @@ iteration=$((iteration + 1))
 printf '%s\n' "$iteration" > "$counter"
 if [ "$iteration" -eq 1 ]; then
   echo "Executed 2 tests, with 2 failures (0 unexpected)"
-  exit 1
+  exit 65
 fi
 echo "simulated app-host crash before test summary" >&2
 exit 9


### PR DESCRIPTION
## Summary
- replace last-summary-only app-host failure classification with an all-summary classifier
- only tolerate expected XCTest assertion failures from exit code 65
- fail closed on crashes, timeouts, missing summaries, and earlier unexpected failures
- add regression coverage for mixed summaries and crashed batches

## Validation
- `python3 tests/test_ci_app_host_test_output.py`
- `python3 tests/test_ci_app_host_home_isolation.py`
- `bash tests/test_ci_app_host_xcodebuild_attempts.sh`
- CI workflow YAML parse
- targeted `tests/test_ci_change_areas.py` app-host routing cases

Closes #5641

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791531440&installation_model_id=21920&pr_number=12207&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12207&signature=47101fbd25df92e06af376bdba644d41a0c495e3d148800395cf496c9d680dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when sharded app-host CI passes vs fails; misclassified logs could block merges or briefly allow bad runs, but the logic is intentionally conservative.
> 
> **Overview**
> **Tightens app-host unit-test batch handling** so CI no longer treats a failed `xcodebuild` as green by reading only the **last** `Executed … (0 unexpected)` line.
> 
> App-host batches now call **`scripts/ci/classify-app-host-test-output.py`**, which scans **every** XCTest summary in the log and tolerates the run only when **exit code is 65** and **no unexpected failures** appear anywhere. Crashes, timeouts, missing summaries, and earlier unexpected failures stay **red**.
> 
> Workflow guard tests run **`tests/test_ci_app_host_test_output.py`**, and **`tests/test_ci_change_areas.py`** simulates a second batch that crashes without a summary (exit **9** instead of **65**) so a prior expected-failure batch cannot mask it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded2e807f3267223722944cc38f1fca2ccda8d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI flakiness by failing closed when app-host test batches contain unexpected failures, instead of only checking the last summary. Closes #5641.

**Changes**
- Only tolerates exit code 65 when all XCTest summaries in the batch report 0 unexpected failures.
- Crashes, timeouts, missing summaries, and earlier unexpected failures now cause the batch to fail.
- Adds regression tests covering mixed summaries and crashed batches.

<sup>Written for commit ded2e807f3267223722944cc38f1fca2ccda8d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved continuous integration handling of app-host test results.
  - Test runs now distinguish expected failures from unexpected failures more reliably, including when output contains multiple test summaries.
  - Invalid, incomplete, or ambiguous test output is no longer incorrectly classified as successful.

- **Tests**
  - Added automated coverage for expected failures, unexpected failures, missing summaries, and zero-failure test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->