### PR TITLE
Keep the NODE_OPTIONS restore module outside the swept temp directory

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23703,16 +23703,19 @@ struct CMUXCLI {
     }
 
     private func createClaudeNodeOptionsRestoreModule() throws -> URL {
-        let rawTemporaryDirectory = ProcessInfo.processInfo.environment["TMPDIR"]?
+        // Must match the guard_dir in Resources/bin/cmux-claude-wrapper. NODE_OPTIONS
+        // outlives the session, so this cannot live under TMPDIR, and the path has to
+        // keep "/cmux-" for isCmuxNodeOptionsRestoreModulePath to recognise it.
+        let overrideDirectory = ProcessInfo.processInfo.environment["CMUX_NODE_OPTIONS_DIR"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let temporaryDirectory: String
-        if let rawTemporaryDirectory, !rawTemporaryDirectory.isEmpty {
-            temporaryDirectory = rawTemporaryDirectory
+        let root: URL
+        if let overrideDirectory, !overrideDirectory.isEmpty {
+            root = URL(fileURLWithPath: overrideDirectory, isDirectory: true)
         } else {
-            temporaryDirectory = NSTemporaryDirectory()
+            root = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".cmux", isDirectory: true)
+                .appendingPathComponent("cmux-node-options", isDirectory: true)
         }
-        let root = URL(fileURLWithPath: temporaryDirectory, isDirectory: true)
-            .appendingPathComponent("cmux-claude-node-options", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true, attributes: nil)
         let restoreModuleURL = root.appendingPathComponent("restore-node-options.cjs", isDirectory: false)
         try writeShimIfChanged(Self.claudeNodeOptionsRestoreModule, to: restoreModuleURL)

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -851,9 +851,13 @@ ensure_node_options_restore_module() {
     # NODE_OPTIONS is inherited by every descendant for the life of the session, so
     # the module it points at has to outlive the session. TMPDIR is swept, and once
     # the file goes missing node refuses to start any script at all.
-    # Keep this path free of spaces: node splits NODE_OPTIONS on whitespace, so a
-    # --require= under "Application Support" breaks every node process instead.
-    local guard_dir="${CMUX_NODE_OPTIONS_DIR:-${HOME}/.cmux/node-options}"
+    # Two constraints on this path, both load-bearing:
+    #   - no spaces, because node splits NODE_OPTIONS on whitespace, so a
+    #     --require= under "Application Support" breaks every node process instead
+    #   - it must still contain "/cmux-", which is how
+    #     isCmuxNodeOptionsRestoreModulePath recognises our own shim when stripping
+    #     injected flags on restore
+    local guard_dir="${CMUX_NODE_OPTIONS_DIR:-${HOME}/.cmux/cmux-node-options}"
     local guard_path="$guard_dir/restore-node-options.cjs"
     mkdir -p "$guard_dir" || return 1
     local temp_path

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -848,8 +848,12 @@ exec_real_claude_passthrough() {
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
 ensure_node_options_restore_module() {
-    local guard_dir="${TMPDIR:-/tmp}"
-    guard_dir="${guard_dir%/}/cmux-claude-node-options"
+    # NODE_OPTIONS is inherited by every descendant for the life of the session, so
+    # the module it points at has to outlive the session. TMPDIR is swept, and once
+    # the file goes missing node refuses to start any script at all.
+    # Keep this path free of spaces: node splits NODE_OPTIONS on whitespace, so a
+    # --require= under "Application Support" breaks every node process instead.
+    local guard_dir="${CMUX_NODE_OPTIONS_DIR:-${HOME}/.cmux/node-options}"
     local guard_path="$guard_dir/restore-node-options.cjs"
     mkdir -p "$guard_dir" || return 1
     local temp_path

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -68,6 +68,7 @@ def run_wrapper(
     hooks_disabled: bool = False,
     setup_sandbox=None,
     process_timeout: float | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -210,6 +211,8 @@ exit 0
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
+        if extra_env:
+            env.update(extra_env)
         if node_options == "__CMUX_TEST_PRELOAD__":
             preload_path = tmp / "cmux-test-preload.js"
             preload_path.write_text("// benign preload used to test MCP env scrubbing\n", encoding="utf-8")
@@ -2438,23 +2441,23 @@ def test_live_socket_enforces_heap_cap_for_space_separated_flag(failures: list[s
     expect(child_node_options == restored, f"space-separated heap flag: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
 
 
-def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[str]) -> None:
-    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-bad-tmp-") as td:
-        bad_tmpdir = Path(td) / "not-a-directory"
-        bad_tmpdir.write_text("occupied", encoding="utf-8")
+def test_live_socket_guard_dir_failure_skips_node_options_injection(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-bad-guard-") as td:
+        blocker = Path(td) / "not-a-directory"
+        blocker.write_text("occupied", encoding="utf-8")
         code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
             argv=["hello"],
-            tmpdir=str(bad_tmpdir),
+            extra_env={"CMUX_NODE_OPTIONS_DIR": str(blocker / "node-options")},
         )
-    expect(code == 0, f"tmpdir failure: wrapper exited {code}: {stderr}", failures)
-    expect("--settings" in real_argv, f"tmpdir failure: missing --settings in args: {real_argv}", failures)
-    expect("--session-id" in real_argv, f"tmpdir failure: missing --session-id in args: {real_argv}", failures)
-    expect(any(" ping" in line for line in cmux_log), f"tmpdir failure: expected cmux ping, got {cmux_log}", failures)
-    expect(claudecode == "__UNSET__", f"tmpdir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options == "__UNSET__", f"tmpdir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
-    expect(runtime_node_options == "__UNSET__", f"tmpdir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
-    expect(child_node_options == "__UNSET__", f"tmpdir failure: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
+    expect(code == 0, f"guard dir failure: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"guard dir failure: missing --settings in args: {real_argv}", failures)
+    expect("--session-id" in real_argv, f"guard dir failure: missing --session-id in args: {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"guard dir failure: expected cmux ping, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"guard dir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(node_options == "__UNSET__", f"guard dir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
+    expect(runtime_node_options == "__UNSET__", f"guard dir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
+    expect(child_node_options == "__UNSET__", f"guard dir failure: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
 
 
 def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[str]) -> None:
@@ -2481,13 +2484,14 @@ def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[
 def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-tmp-") as td:
         tmpdir = Path(td)
-        guard_dir = tmpdir / "cmux-claude-node-options"
+        guard_dir = tmpdir / "cmux-node-options"
         guard_dir.mkdir(parents=True, exist_ok=True)
         (guard_dir / "restore-node-options.XXXXXX.cjs").write_text("stale", encoding="utf-8")
         code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
             argv=["hello"],
             tmpdir=str(tmpdir),
+            extra_env={"CMUX_NODE_OPTIONS_DIR": str(guard_dir)},
         )
     expect(code == 0, f"stale mktemp literal: wrapper exited {code}: {stderr}", failures)
     expect("mktemp:" not in stderr, f"stale mktemp literal: unexpected mktemp warning: {stderr!r}", failures)
@@ -2673,7 +2677,7 @@ def main() -> int:
     test_live_socket_auto_preserve_accepts_all_documented_truthy_variants(failures)
     test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
-    test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
+    test_live_socket_guard_dir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
     test_missing_socket_skips_hook_injection(failures)


### PR DESCRIPTION
Fixes #3463.

The restore shim is written to `$TMPDIR` but referenced by `NODE_OPTIONS` for the life of the session. macOS sweeps that directory, and once the file is gone every node process in the session dies at preload, reporting little more than a version string. It is not limited to the wrapped agent: anything that inherits the variable is affected, and a failed CLI write can look like a successful one, which is how I found it.

There are earlier attempts at this and I do not want to add noise, so for the record: #3699 has green checks but has gone stale and now conflicts with main; #12067 conflicts and its `tests` check is failing; #11270 and #3278 also have failing checks. This branch is cut from today's main and `python3 tests/test_claude_wrapper_hooks.py` passes. Happy for it to be closed in favour of any of those if one gets rebased.

The change: move the shim to `$HOME/.cmux/node-options`, matching the `$HOME/.claude` and `$HOME/.subrouter` paths already used in this file, with a `CMUX_NODE_OPTIONS_DIR` override following the existing `CMUX_CUA_STATE_DIR` style.

Not `~/Library/Application Support/cmux`: node splits NODE_OPTIONS on whitespace, so a `--require=` under a path containing a space breaks every node process instead. I tried that first and the suite caught it, so there is a comment to stop it being moved back. Might be worth checking against the failing runs on the other branches.

Two existing tests pin the old path, which is the part that looks like it catches people:

- `test_live_socket_tmpdir_failure_skips_node_options_injection` becomes `..._guard_dir_failure_...` and forces the failure through `CMUX_NODE_OPTIONS_DIR`, since an unwritable `TMPDIR` no longer reaches the guard dir. Same invariant: when the module cannot be written, no `--require` is injected.
- `test_live_socket_stale_mktemp_literal_does_not_warn` points the override at its own temp dir so it still exercises the real path.
- `run_wrapper` gains an `extra_env` parameter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791531542&installation_model_id=21920&pr_number=12208&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12208&signature=24dbbfd68c397686ed3e5edb4bab31c7df12c9b37aa1b1be4049b4832df80ce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where `NODE_OPTIONS` preload files live for every Node descendant in a cmux Claude session; a bad path or permissions could skip injection or break startup, but behavior on write failure stays “no inject.”
> 
> **Overview**
> Fixes session-wide Node failures when macOS sweeps temp files while `NODE_OPTIONS` still points at cmux’s `--require` restore shim.
> 
> The restore module is written to **`~/.cmux/cmux-node-options`** (override **`CMUX_NODE_OPTIONS_DIR`**) in both **`cmux-claude-wrapper`** and **`createClaudeNodeOptionsRestoreModule`** in Swift, with comments that the path must stay **space-free** (Node splits `NODE_OPTIONS` on whitespace) and still include **`/cmux-`** so existing path recognition keeps working.
> 
> Tests gain **`extra_env`** on **`run_wrapper`**, rename the unwritable-temp case to guard-dir failure via **`CMUX_NODE_OPTIONS_DIR`**, and point the stale-`mktemp` test at the new directory name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25968a260b211bce91c403baeb3cf316becf1ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the NODE_OPTIONS restore shim from `$TMPDIR` to `$HOME/.cmux/cmux-node-options` (overridable via `CMUX_NODE_OPTIONS_DIR`) so macOS temp sweeps no longer delete the preload file and break every node process that inherits `NODE_OPTIONS` for the session. The path stays space-free because node splits `NODE_OPTIONS` on whitespace.

- Aligns the Swift CLI's shim writer with the wrapper's guard dir and keeps the `/cmux-` path component so `isCmuxNodeOptionsRestoreModulePath` still recognizes the shim.
- Tests gain an `extra_env` parameter on `run_wrapper`; the unwritable-dir injection test now forces failure via `CMUX_NODE_OPTIONS_DIR`, and the stale mktemp literal test points at the new location.

<sup>Written for commit 25968a260b211bce91c403baeb3cf316becf1ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Node.js startup protection files are now stored in a dedicated, persistent directory rather than temporary storage.
  - This prevents temporary-directory cleanup from removing required files and causing Node.js startup failures.
  - The storage location can be customized with the `CMUX_NODE_OPTIONS_DIR` environment variable.

- **Tests**
  - Added coverage for custom guard-directory configuration and failures affecting that directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->