### PR TITLE
web: delete registration challenges on consumption

### DIFF
--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -1693,7 +1693,7 @@ async function irohRetentionBacklogExists(
         where expires_at < ${challengeRetentionCutoff.toISOString()}::timestamptz
       ) or exists (
         select 1 from iroh_registration_challenges
-        where consumed_at < ${challengeRetentionCutoff.toISOString()}::timestamptz
+        where consumed_at is not null
       ) or exists (
         select 1 from iroh_relay_token_issuances
         where requested_at < ${auditRetentionCutoff.toISOString()}::timestamptz

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -38,8 +38,14 @@ import {
 import type { IrohDiscoveryScope } from "./discoveryScope";
 
 export const IROH_RETENTION_BATCH_SIZE = 500;
-export const IROH_RETENTION_MAX_ROWS = 10_000;
+export const IROH_RETENTION_MAX_ROWS = 50_000;
 export const IROH_RETENTION_MAX_DURATION_MS = 8_000;
+/**
+ * An expired registration challenge can never be consumed. Keep it briefly
+ * for incident debugging, then drop it. Consumed challenges are deleted in
+ * the transaction that consumes them, so they never need retention.
+ */
+export const IROH_EXPIRED_CHALLENGE_RETENTION_MS = 60 * 60 * 1_000;
 export const IROH_RELAY_RESERVATION_LEASE_MS = 60 * 1_000;
 
 export type IrohRetentionCategory =
@@ -247,8 +253,26 @@ function makeLiveRepository(): IrohRepositoryShape {
           ))
           .orderBy(desc(irohRegistrationChallenges.createdAt))
           .limit(1);
-        const createdAt = priorChallenge && input.now <= priorChallenge.createdAt
-          ? new Date(priorChallenge.createdAt.getTime() + 1)
+        // A consumed challenge is deleted with its registration, so the slot's
+        // registeredAt (stamped from that challenge's createdAt) is the other
+        // high-water mark the new mint must clear.
+        const [slot] = await tx
+          .select({ registeredAt: irohEndpointBindings.registeredAt })
+          .from(irohEndpointBindings)
+          .where(and(
+            eq(irohEndpointBindings.userId, input.userId),
+            eq(irohEndpointBindings.deviceUuid, input.deviceUuid),
+            eq(irohEndpointBindings.clientNamespace, input.clientNamespace ?? "legacy"),
+            eq(irohEndpointBindings.tag, input.tag),
+            isNull(irohEndpointBindings.revokedAt),
+          ))
+          .limit(1);
+        const floor = Math.max(
+          priorChallenge?.createdAt.getTime() ?? 0,
+          slot?.registeredAt?.getTime() ?? 0,
+        );
+        const createdAt = input.now.getTime() <= floor
+          ? new Date(floor + 1)
           : input.now;
         const [challenge] = await tx
           .insert(irohRegistrationChallenges)
@@ -450,9 +474,10 @@ function makeLiveRepository(): IrohRepositoryShape {
             })
             .where(eq(irohEndpointBindings.id, existingSlot.id))
             .returning();
+          // The challenge has done its job; a replay now reads as not found.
+          // Deleting here keeps the table bounded by in-flight challenges.
           await tx
-            .update(irohRegistrationChallenges)
-            .set({ consumedAt: input.now })
+            .delete(irohRegistrationChallenges)
             .where(eq(irohRegistrationChallenges.id, challenge.id));
           if (!updated) throw new Error("binding update returned no row");
           const accountRevision = await advanceRouteRevision(tx, input.userId, input.now);
@@ -545,12 +570,8 @@ function makeLiveRepository(): IrohRepositoryShape {
             });
         }
         await tx
-          .update(irohRegistrationChallenges)
-          .set({ consumedAt: input.now })
-          .where(and(
-            eq(irohRegistrationChallenges.id, challenge.id),
-            isNull(irohRegistrationChallenges.consumedAt),
-          ));
+          .delete(irohRegistrationChallenges)
+          .where(eq(irohRegistrationChallenges.id, challenge.id));
         const accountRevision = await advanceRouteRevision(tx, input.userId, input.now);
         return { binding, created: true, accountRevision };
       });
@@ -985,7 +1006,7 @@ function makeLiveRepository(): IrohRepositoryShape {
           await advanceRouteRevision(tx, input.userId, input.now);
         }
 
-        const challengeRetentionCutoff = new Date(input.now.getTime() - 24 * 60 * 60 * 1_000);
+        const challengeRetentionCutoff = new Date(input.now.getTime() - IROH_EXPIRED_CHALLENGE_RETENTION_MS);
         const auditRetentionCutoff = new Date(input.now.getTime() - 30 * 24 * 60 * 60 * 1_000);
         await tx.execute(sql`
           with candidates as materialized (
@@ -1006,7 +1027,7 @@ function makeLiveRepository(): IrohRepositoryShape {
             select id
             from iroh_registration_challenges
             where user_id = ${input.userId}
-              and consumed_at < ${challengeRetentionCutoff.toISOString()}::timestamptz
+              and consumed_at is not null
             order by consumed_at, id
             limit ${IROH_RETENTION_BATCH_SIZE}
             for update skip locked
@@ -1407,7 +1428,7 @@ async function drainIrohRetention(input: {
     30_000,
     "maxDurationMs",
   );
-  const challengeRetentionCutoff = new Date(input.now.getTime() - 24 * 60 * 60 * 1_000);
+  const challengeRetentionCutoff = new Date(input.now.getTime() - IROH_EXPIRED_CHALLENGE_RETENTION_MS);
   const auditRetentionCutoff = new Date(input.now.getTime() - 30 * 24 * 60 * 60 * 1_000);
   const nowIso = input.now.toISOString();
   const challengeCutoffIso = challengeRetentionCutoff.toISOString();
@@ -1519,7 +1540,7 @@ async function drainIrohRetention(input: {
         with candidates as materialized (
           select id
           from iroh_registration_challenges
-          where consumed_at < ${challengeCutoffIso}::timestamptz
+          where consumed_at is not null
           order by consumed_at, id
           limit ${limit}
           for update skip locked

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -404,19 +404,21 @@ describe("Iroh trust broker database behavior", () => {
     const results = await Promise.allSettled([register(), register()]);
     expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
     expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
-    const [{ bindings, consumed, nextExpiry, pathHints }] = await requiredSql()<Array<{
+    const [{ bindings, challenges, nextExpiry, pathHints }] = await requiredSql()<Array<{
       bindings: string;
-      consumed: string;
+      challenges: string;
       nextExpiry: Date | null;
       pathHints: unknown[];
     }>>`
       select
         (select count(*)::text from iroh_endpoint_bindings) as bindings,
-        (select count(*)::text from iroh_registration_challenges where consumed_at is not null) as consumed,
+        (select count(*)::text from iroh_registration_challenges) as challenges,
         (select path_hints_next_expiry from iroh_endpoint_bindings limit 1) as "nextExpiry",
         (select path_hints from iroh_endpoint_bindings limit 1) as "pathHints"
     `;
-    expect({ bindings, consumed }).toEqual({ bindings: "1", consumed: "1" });
+    // The consumed challenge is deleted with its registration, so the table
+    // holds only in-flight challenges and never grows with heartbeats.
+    expect({ bindings, challenges }).toEqual({ bindings: "1", challenges: "0" });
     expect(nextExpiry).toBeNull();
     expect(pathHints).toEqual([]);
   });
@@ -1982,6 +1984,108 @@ describe("Iroh trust broker database behavior", () => {
       status: "failed",
       failureCode: "binding_inactive_after_mint",
     });
+  });
+
+  dbTest("deletes a consumed challenge and keeps later heartbeats strictly ordered", async () => {
+    const repo = requiredRepository();
+    const userId = "user-heartbeat-order";
+    const deviceId = randomUUID();
+    const appInstanceId = randomUUID();
+    const endpointId = "11".repeat(32);
+    const mint = (nonceHash: string, payloadSha256: string) => Effect.runPromise(repo.issueChallenge({
+      userId,
+      deviceUuid: deviceId,
+      appInstanceId,
+      tag: "stable",
+      endpointId,
+      identityGeneration: 1,
+      payloadSha256,
+      nonceHash,
+      now: NOW,
+      expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
+    }));
+    const register = (challengeId: string, nonceHash: string) => Effect.runPromise(repo.consumeChallengeAndRegister({
+      userId,
+      challengeId,
+      nonceHash,
+      payload: {
+        route_contract_version: 1,
+        deviceId,
+        appInstanceId,
+        clientNamespace: "legacy",
+        tag: "stable",
+        platform: "mac",
+        endpointId,
+        identityGeneration: 1,
+        pairingEnabled: true,
+        capabilities: [],
+        pathHints: [],
+      },
+      now: NOW,
+    }));
+
+    const first = await mint("21".repeat(32), "31".repeat(32));
+    await register(first.id, "21".repeat(32));
+    const [afterFirst] = await requiredSql()<Array<{ challenges: string; registeredAt: Date }>>`
+      select
+        (select count(*)::text from iroh_registration_challenges where user_id = ${userId}) as challenges,
+        (select registered_at from iroh_endpoint_bindings where user_id = ${userId}) as "registeredAt"
+    `;
+    // Consumption deletes the challenge; the slot remembers its mint time.
+    expect(afterFirst.challenges).toBe("0");
+    expect(afterFirst.registeredAt).toEqual(first.createdAt);
+
+    // A replay of the consumed challenge is an unknown challenge, not a
+    // conflict, because the row is gone.
+    await expect(register(first.id, "21".repeat(32))).rejects.toThrow();
+
+    // A heartbeat minted at the same wall-clock instant must still land
+    // strictly after the slot's registeredAt, or the staleness gate would
+    // reject it as superseded now that the prior challenge row is gone.
+    const heartbeat = await mint("22".repeat(32), "32".repeat(32));
+    expect(heartbeat.createdAt.getTime()).toBeGreaterThan(first.createdAt.getTime());
+    const result = await register(heartbeat.id, "22".repeat(32));
+    expect(result.created).toBe(false);
+    expect(result.binding.registeredAt).toEqual(heartbeat.createdAt);
+    const [afterHeartbeat] = await requiredSql()<Array<{ challenges: string }>>`
+      select count(*)::text as challenges from iroh_registration_challenges where user_id = ${userId}
+    `;
+    expect(afterHeartbeat.challenges).toBe("0");
+  });
+
+  dbTest("global retention drops legacy consumed challenges of any age and keeps in-flight ones", async () => {
+    const repo = requiredRepository();
+    const userId = "user-challenge-backlog";
+    const deviceId = randomUUID();
+    const insertChallenge = async (nonceHash: string, consumedAt: Date | null, expiresAt: Date) => {
+      const [row] = await requiredSql()<Array<{ id: string }>>`
+        insert into iroh_registration_challenges (
+          user_id, device_uuid, app_instance_id, client_namespace, tag, endpoint_id,
+          identity_generation, payload_sha256, nonce_hash, created_at, expires_at, consumed_at
+        ) values (
+          ${userId}, ${deviceId}, ${randomUUID()}, 'legacy', 'stable', ${"12".repeat(32)},
+          1, ${"33".repeat(32)}, ${nonceHash}, ${new Date(expiresAt.getTime() - 5 * 60 * 1_000)}, ${expiresAt}, ${consumedAt}
+        ) returning id::text
+      `;
+      return row!.id;
+    };
+    // Consumed one minute ago: the pre-fix backlog shape. Must go.
+    const recentConsumed = await insertChallenge("41".repeat(32), new Date(NOW.getTime() - 60_000), new Date(NOW.getTime() + 4 * 60_000));
+    // Expired two hours ago, never consumed: past the grace period. Must go.
+    const staleExpired = await insertChallenge("42".repeat(32), null, new Date(NOW.getTime() - 2 * 60 * 60_000));
+    // Expired ten minutes ago, never consumed: inside the grace period. Stays.
+    const freshExpired = await insertChallenge("43".repeat(32), null, new Date(NOW.getTime() - 10 * 60_000));
+    // In flight. Stays.
+    const inFlight = await insertChallenge("44".repeat(32), null, new Date(NOW.getTime() + 4 * 60_000));
+
+    await Effect.runPromise(repo.pruneExpiredStateGlobally({ now: NOW }));
+
+    const rows = await requiredSql()<Array<{ id: string }>>`
+      select id::text from iroh_registration_challenges where user_id = ${userId}
+    `;
+    expect(rows.map((row) => row.id).sort()).toEqual([freshExpired, inFlight].sort());
+    expect(rows.map((row) => row.id)).not.toContain(recentConsumed);
+    expect(rows.map((row) => row.id)).not.toContain(staleExpired);
   });
 
   dbTest("global retention clears revoked hints and expired private data from Aurora", async () => {

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -529,7 +529,9 @@ describe("Iroh trust broker registration", () => {
     const replay = makeFixture();
     const request = await replay.signedRegistration();
     await Effect.runPromise(replay.broker.register(USER_A, request, NOW));
-    await expectEffectFailure(replay.broker.register(USER_A, request, NOW), "IrohConflictError");
+    // A consumed challenge is deleted with its registration, so a replay of
+    // the same signed request reads as an unknown challenge.
+    await expectEffectFailure(replay.broker.register(USER_A, request, NOW), "IrohNotFoundError");
   });
 
   test("re-keys the slot onto a fresh binding id when the endpoint rotates", async () => {
@@ -2004,7 +2006,7 @@ class MemoryRepository implements IrohRepositoryShape {
       existing.platform === input.payload.platform &&
       existing.identityGeneration === input.payload.identityGeneration
     ) {
-      challenge.consumedAt = input.now;
+      this.challenges.splice(this.challenges.indexOf(challenge), 1);
       existing.appInstanceId = input.payload.appInstanceId;
       existing.platform = input.payload.platform;
       existing.identityGeneration = input.payload.identityGeneration;
@@ -2060,7 +2062,7 @@ class MemoryRepository implements IrohRepositoryShape {
       updatedAt: input.now,
       lastSeenAt: input.now,
     });
-    challenge.consumedAt = input.now;
+    this.challenges.splice(this.challenges.indexOf(challenge), 1);
     this.bindings.push(inserted);
     if (!existing) {
       this.lanGenerations.set(

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "/api/internal/iroh/retention",
-      "schedule": "43 * * * *"
+      "schedule": "3,13,23,33,43,53 * * * *"
     },
     {
       "path": "/api/cron/vm-reaper",


### PR DESCRIPTION
Root-cause fix for the relay challenge table growing about 3 GB a day. Measured on production after the PlanetScale move: 219,007 rows and 235 MB in two hours, 98 percent consumed, about 2,000 new rows a minute from 3,978 devices; 208,460 expired rows never deleted.

Why it grew: every Mac heartbeat mints a signed registration challenge, consumes it within seconds, and the row was retained for 24 hours. The retention drain ran hourly with a 10,000-row budget against 2.9 million rows a day.

The fix: a challenge has no purpose after it is consumed, so it is deleted in the same transaction that consumes it. The table is now bounded by in-flight challenges, roughly the device count. A replay of a consumed challenge reads as an unknown challenge instead of a conflict; both are rejected. The strict per-slot mint ordering that used to read the prior challenge row now also floors on the slot's `registeredAt`, which is stamped from that deleted challenge, so a heartbeat minted at the same wall-clock instant still lands strictly after it and is not rejected as superseded.

Retention: expired unconsumed challenges are kept one hour instead of a day; legacy consumed rows are dropped regardless of age so the existing backlog drains; the cron runs every ten minutes with a 50,000-row budget.

Commits: the first adds the database behavior tests and the updated replay expectation, which fail on main; the second adds the fix. Verified against a local Postgres: 37 iroh behavior tests pass, 74 trust broker and route handler tests pass, full web suite 2,905 tests pass, complexity gate unchanged.

Follow-up, not in this PR: the client heartbeat cadence of one registration every 25 to 40 seconds per Mac is what drives the write rate; a longer interval is a Mac app change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791531648&installation_model_id=21920&pr_number=12209&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12209&signature=30ac4f5b6d396aed9426f83196e06b4d5903f28f02e9ce033a35705b6fcfa386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Iroh registration and heartbeat paths and changes replay error semantics; mitigated by transactional delete, mint ordering fix, and expanded retention tests.
> 
> **Overview**
> Stops **`iroh_registration_challenges`** from growing with Mac heartbeats by **deleting** each challenge in the same transaction that consumes it, instead of setting `consumedAt` and retaining rows for a day.
> 
> **Replay behavior:** a second register with the same signed request now fails as an **unknown challenge** (`IrohNotFoundError`) rather than `challenge_replayed`, because the row is gone. **`issueChallenge`** still enforces strict mint ordering per slot by flooring new `createdAt` on both the latest in-flight challenge and the binding’s **`registeredAt`** (stamped from the deleted challenge), so same-clock heartbeats are not rejected as superseded.
> 
> **Retention / ops:** expired unconsumed challenges use a **1-hour** grace (`IROH_EXPIRED_CHALLENGE_RETENTION_MS`); legacy rows with `consumed_at` set are deleted regardless of age; global max rows per run rises to **50,000**; the **`/api/internal/iroh/retention`** cron runs **every 10 minutes** instead of once per hour. Tests and the in-memory trust-broker mock match delete-on-consume semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f930a39ea42c07a161adf075fe5f21f36a71eab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes registration challenges in the same transaction that consumes them, so the challenge table stops growing ~3 GB a day. Heartbeats previously minted a challenge, consumed it within seconds, and left the row behind for 24 hours while the hourly retention drain cleared only 10,000 rows.

- Replaying a consumed challenge now fails as an unknown challenge instead of a conflict; both are rejected.
- Mint ordering floors on the slot's `registeredAt` since the prior challenge row is gone, keeping same-instant heartbeats strictly ordered.
- Retention keeps expired unconsumed challenges for one hour, drops legacy consumed rows of any age, and runs every ten minutes with a 50,000-row budget.
- The retention backlog probe now treats any consumed row as backlog, so a budget-limited run no longer reports clear while consumed rows remain.

<sup>Written for commit f930a39ea42c07a161adf075fe5f21f36a71eab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved challenge handling to prevent replayed registration challenges from being accepted.
  - Ensured heartbeat timestamps remain correctly ordered after challenge consumption.
  - Preserved active challenges while removing consumed and appropriately expired challenges.
  - Retained recently expired challenges during the 60-minute grace period.

- **Performance**
  - Increased the maximum retained Iroh records from 10,000 to 50,000.
  - Increased retention cleanup frequency to every 10 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->