### PR TITLE
Fix terminal colors and pane clipping

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -59,13 +59,12 @@ public struct GhosttyConfig {
     public var command: String?
     /// The scrollback limit. Ghostty measures this in bytes, not lines.
     public var scrollbackLimit: Int = 50_000_000
-    /// The opacity (0...1) applied to unfocused split panes.
-    public var unfocusedSplitOpacity: Double = 0.7
-    /// The fill color for the unfocused-split overlay, or `nil` to use the
-    /// background color.
+    /// The opacity (0...1) applied to unfocused split panes; the cmux default keeps terminal content at full contrast.
+    public var unfocusedSplitOpacity: Double = 1.0
+    private var hasUnfocusedSplitOpacityDirective = false
+    /// The unfocused-split overlay fill, or `nil` to use the background color.
     public var unfocusedSplitFill: NSColor?
-    /// The explicit split-divider color, or `nil` to derive one from the
-    /// background.
+    /// The split-divider color, or `nil` to derive one from the background.
     public var splitDividerColor: NSColor?
 
     // Colors (from theme or config)
@@ -186,15 +185,13 @@ public struct GhosttyConfig {
     /// config file, theme, or optional cmux managed appearance is parsed.
     public init() {}
 
-    /// The opacity (0...1) of the overlay drawn over unfocused splits, derived
-    /// from ``unfocusedSplitOpacity``.
+    /// The overlay opacity (0...1) over unfocused splits, derived from ``unfocusedSplitOpacity``.
     public var unfocusedSplitOverlayOpacity: Double {
         let clamped = min(1.0, max(0.15, unfocusedSplitOpacity))
         return min(1.0, max(0.0, 1.0 - clamped))
     }
 
-    /// The fill color of the unfocused-split overlay: the explicit
-    /// ``unfocusedSplitFill`` when set, otherwise the background color.
+    /// The overlay fill: ``unfocusedSplitFill`` when set, otherwise the background color.
     public var unfocusedSplitOverlayFill: NSColor {
         unfocusedSplitFill ?? backgroundColor
     }
@@ -716,10 +713,13 @@ public struct GhosttyConfig {
                 case "unfocused-split-opacity":
                     if let opacity = Double(value) {
                         unfocusedSplitOpacity = opacity
+                        hasUnfocusedSplitOpacityDirective = true
                     }
                 case "unfocused-split-fill":
                     if let color = NSColor(hex: value) {
                         unfocusedSplitFill = color
+                        // A fill-only config opts into Ghostty's default dimming.
+                        if !hasUnfocusedSplitOpacityDirective { unfocusedSplitOpacity = 0.7 }
                     }
                 case "split-divider-color":
                     if let color = NSColor(hex: value) {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -494,53 +494,53 @@ public struct GhosttyConfig {
         switch preferredColorScheme {
         case .light:
             return """
-            palette = 0=#1a1a1a
-            palette = 1=#cc372e
-            palette = 2=#26a439
-            palette = 3=#cdac08
-            palette = 4=#0869cb
-            palette = 5=#9647bf
-            palette = 6=#479ec2
-            palette = 7=#98989d
-            palette = 8=#464646
-            palette = 9=#ff453a
-            palette = 10=#32d74b
-            palette = 11=#e5bc00
-            palette = 12=#0a84ff
-            palette = 13=#bf5af2
-            palette = 14=#69c9f2
-            palette = 15=#ffffff
-            background = #feffff
-            foreground = #000000
-            cursor-color = #98989d
-            cursor-text = #ffffff
-            selection-background = #abd8ff
-            selection-foreground = #000000
+            palette = 0=#5c5f77
+            palette = 1=#d20f39
+            palette = 2=#40a02b
+            palette = 3=#df8e1d
+            palette = 4=#1e66f5
+            palette = 5=#ea76cb
+            palette = 6=#179299
+            palette = 7=#acb0be
+            palette = 8=#6c6f85
+            palette = 9=#de293e
+            palette = 10=#49af3d
+            palette = 11=#eea02d
+            palette = 12=#456eff
+            palette = 13=#fe85d8
+            palette = 14=#2d9fa8
+            palette = 15=#bcc0cc
+            background = #eff1f5
+            foreground = #4c4f69
+            cursor-color = #dc8a78
+            cursor-text = #eff1f5
+            selection-background = #acb0be
+            selection-foreground = #4c4f69
             """
         case .dark:
             return """
-            palette = 0=#1a1a1a
-            palette = 1=#cc372e
-            palette = 2=#26a439
-            palette = 3=#cdac08
-            palette = 4=#0869cb
-            palette = 5=#9647bf
-            palette = 6=#479ec2
-            palette = 7=#98989d
-            palette = 8=#464646
-            palette = 9=#ff453a
-            palette = 10=#32d74b
-            palette = 11=#ffd60a
-            palette = 12=#0a84ff
-            palette = 13=#bf5af2
-            palette = 14=#76d6ff
-            palette = 15=#ffffff
-            background = #1e1e1e
-            foreground = #ffffff
-            cursor-color = #98989d
-            cursor-text = #ffffff
-            selection-background = #3f638b
-            selection-foreground = #ffffff
+            palette = 0=#45475a
+            palette = 1=#f38ba8
+            palette = 2=#a6e3a1
+            palette = 3=#f9e2af
+            palette = 4=#89b4fa
+            palette = 5=#f5c2e7
+            palette = 6=#94e2d5
+            palette = 7=#a6adc8
+            palette = 8=#585b70
+            palette = 9=#f37799
+            palette = 10=#89d88b
+            palette = 11=#ebd391
+            palette = 12=#74a8fc
+            palette = 13=#f2aede
+            palette = 14=#6bd7ca
+            palette = 15=#bac2de
+            background = #1e1e2e
+            foreground = #cdd6f4
+            cursor-color = #f5e0dc
+            cursor-text = #1e1e2e
+            selection-background = #585b70
+            selection-foreground = #cdd6f4
             """
         }
     }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -488,7 +488,7 @@ public struct GhosttyConfig {
         return nil
     }
 
-    private static func cmuxDefaultFallbackConfigContents(
+    static func cmuxDefaultFallbackConfigContents(
         preferredColorScheme: ColorSchemePreference
     ) -> String {
         switch preferredColorScheme {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -20,12 +20,14 @@ public struct GhosttyConfig {
     /// terminal view/engine code.
     public typealias ColorSchemePreference = TerminalColorSchemePreference
 
-    /// Native fallback light theme name used for fresh installs before the user
-    /// has chosen terminal colors.
-    public static let cmuxDefaultLightThemeName = "Apple System Colors Light"
-    /// Native fallback dark theme name used for fresh installs before the user
-    /// has chosen terminal colors.
-    public static let cmuxDefaultDarkThemeName = "Apple System Colors"
+    /// Catppuccin's light palette used for fresh installs before the user has
+    /// chosen terminal colors. This keeps the default terminal in sync with
+    /// Codex's default TUI theme.
+    public static let cmuxDefaultLightThemeName = "Catppuccin Latte"
+    /// Catppuccin's dark palette used for fresh installs before the user has
+    /// chosen terminal colors. This keeps the default terminal in sync with
+    /// Codex's default TUI theme.
+    public static let cmuxDefaultDarkThemeName = "Catppuccin Mocha"
 
     private static let loadCacheLock = NSLock()
     // Every read/write of this cache is serialized by `loadCacheLock`; the

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigInactiveSplitAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigInactiveSplitAppearanceTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Testing
+@testable import CmuxTerminalCore
+
+@Suite
+struct GhosttyConfigInactiveSplitAppearanceTests {
+    @Test
+    func defaultInactiveSplitAppearanceDoesNotWashTerminalContent() {
+        let config = GhosttyConfig()
+
+        #expect(config.unfocusedSplitOpacity == 1.0)
+        #expect(config.unfocusedSplitOverlayOpacity == 0.0)
+    }
+
+    @Test(arguments: ["#FFFFFF", "#282C34"])
+    func themeColorsDoNotOptIntoInactiveSplitDimming(background: String) {
+        var config = GhosttyConfig()
+        config.parse("background = \(background)\npalette = 1=#FF0000")
+
+        #expect(config.unfocusedSplitOverlayOpacity == 0.0)
+        #expect(config.palette[1]?.hexString() == "#FF0000")
+    }
+
+    @Test
+    func explicitInactiveSplitAppearanceRemainsIntact() {
+        var config = GhosttyConfig()
+
+        config.parse(
+            """
+            unfocused-split-opacity = 0.7
+            unfocused-split-fill = #FDF6E3
+            """
+        )
+
+        #expect(config.unfocusedSplitOpacity == 0.7)
+        #expect(abs(config.unfocusedSplitOverlayOpacity - 0.3) < 0.0001)
+        #expect(config.unfocusedSplitFill?.hexString() == "#FDF6E3")
+
+        var fillOnlyConfig = GhosttyConfig()
+        fillOnlyConfig.parse("unfocused-split-fill = #FDF6E3")
+        #expect(abs(fillOnlyConfig.unfocusedSplitOverlayOpacity - 0.3) < 0.0001)
+    }
+
+    @Test
+    func explicitFullContrastWinsOverFillInEitherDirectiveOrder() {
+        for directives in [
+            "unfocused-split-opacity = 1\nunfocused-split-fill = #FDF6E3",
+            "unfocused-split-fill = #FDF6E3\nunfocused-split-opacity = 1"
+        ] {
+            var config = GhosttyConfig()
+            config.parse(directives)
+            #expect(config.unfocusedSplitOverlayOpacity == 0.0)
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
@@ -16,6 +16,45 @@ import Testing
         #expect(GhosttyConfig.cmuxDefaultDarkThemeName == "Catppuccin Mocha")
     }
 
+    @Test(arguments: [GhosttyConfig.ColorSchemePreference.light, .dark])
+    func managedFallbackPreservesCatppuccinColors(
+        colorScheme: GhosttyConfig.ColorSchemePreference
+    ) {
+        // Exercise the missing-resource fallback directly so installed theme
+        // files cannot hide a stale built-in palette.
+        var config = GhosttyConfig()
+        config.parse(GhosttyConfig.cmuxDefaultFallbackConfigContents(
+            preferredColorScheme: colorScheme
+        ))
+        let expected: [String]
+        switch colorScheme {
+        case .light:
+            expected = [
+                "#5C5F77", "#D20F39", "#40A02B", "#DF8E1D",
+                "#1E66F5", "#EA76CB", "#179299", "#ACB0BE",
+                "#6C6F85", "#DE293E", "#49AF3D", "#EEA02D",
+                "#456EFF", "#FE85D8", "#2D9FA8", "#BCC0CC",
+                "#EFF1F5", "#4C4F69", "#DC8A78", "#EFF1F5",
+                "#ACB0BE", "#4C4F69"
+            ]
+        case .dark:
+            expected = [
+                "#45475A", "#F38BA8", "#A6E3A1", "#F9E2AF",
+                "#89B4FA", "#F5C2E7", "#94E2D5", "#A6ADC8",
+                "#585B70", "#F37799", "#89D88B", "#EBD391",
+                "#74A8FC", "#F2AEDE", "#6BD7CA", "#BAC2DE",
+                "#1E1E2E", "#CDD6F4", "#F5E0DC", "#1E1E2E",
+                "#585B70", "#CDD6F4"
+            ]
+        }
+        let actual = (0..<16).map { config.palette[$0]?.hexString() } + [
+            config.backgroundColor.hexString(), config.foregroundColor.hexString(),
+            config.cursorColor.hexString(), config.cursorTextColor.hexString(),
+            config.selectionBackground.hexString(), config.selectionForeground.hexString()
+        ]
+        #expect(actual == expected.map(Optional.some))
+    }
+
     private func withTempConfigDir(
         body: (_ dir: URL) throws -> Void
     ) throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
@@ -6,10 +6,16 @@ import Testing
 /// Regression coverage for https://github.com/manaflow-ai/cmux/issues/7161
 /// and https://github.com/manaflow-ai/cmux/issues/10199.
 ///
-/// cmux's managed default terminal theme ("Apple System Colors") applies only
+/// cmux's managed default terminal theme (Catppuccin Latte/Mocha) applies only
 /// when enabled and the user has no effective Ghostty settings. Any configured
 /// directive preserves Ghostty's own resolved base and user overrides.
 @Suite(.serialized) struct GhosttyConfigManagedDefaultAppearanceTests {
+    @Test("managed defaults match the Codex dark and light palettes")
+    func managedDefaultsMatchCodexThemePair() {
+        #expect(GhosttyConfig.cmuxDefaultLightThemeName == "Catppuccin Latte")
+        #expect(GhosttyConfig.cmuxDefaultDarkThemeName == "Catppuccin Mocha")
+    }
+
     private func withTempConfigDir(
         body: (_ dir: URL) throws -> Void
     ) throws {
@@ -171,7 +177,7 @@ import Testing
 
     // MARK: Managed base + user override precedence
 
-    /// Writes sentinel "Apple System Colors" theme files into a themes root the
+    /// Writes sentinel managed theme files into a themes root the
     /// managed-default resolution finds via `GHOSTTY_RESOURCES_DIR`, keeping the
     /// resolved managed colors deterministic on machines with Ghostty installed.
     private func makeManagedThemesRoot(in dir: URL) throws -> URL {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigThemeParityTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigThemeParityTests.swift
@@ -41,17 +41,17 @@ import Testing
     ]
 
     private static let managedLightPalette = [
-        "#1A1A1A", "#CC372E", "#26A439", "#CDAC08",
-        "#0869CB", "#9647BF", "#479EC2", "#98989D",
-        "#464646", "#FF453A", "#32D74B", "#E5BC00",
-        "#0A84FF", "#BF5AF2", "#69C9F2", "#FFFFFF",
+        "#5C5F77", "#D20F39", "#40A02B", "#DF8E1D",
+        "#1E66F5", "#EA76CB", "#179299", "#ACB0BE",
+        "#6C6F85", "#DE293E", "#49AF3D", "#EEA02D",
+        "#456EFF", "#FE85D8", "#2D9FA8", "#BCC0CC",
     ]
 
     private static let managedDarkPalette = [
-        "#1A1A1A", "#CC372E", "#26A439", "#CDAC08",
-        "#0869CB", "#9647BF", "#479EC2", "#98989D",
-        "#464646", "#FF453A", "#32D74B", "#FFD60A",
-        "#0A84FF", "#BF5AF2", "#76D6FF", "#FFFFFF",
+        "#45475A", "#F38BA8", "#A6E3A1", "#F9E2AF",
+        "#89B4FA", "#F5C2E7", "#94E2D5", "#A6ADC8",
+        "#585B70", "#F37799", "#89D88B", "#EBD391",
+        "#74A8FC", "#F2AEDE", "#6BD7CA", "#BAC2DE",
     ]
 
     private static let fullExplicitPalette = [
@@ -119,21 +119,21 @@ import Testing
             return ScenarioFixture(
                 configContents: "# no Ghostty settings\n",
                 light: snapshot(
-                    foreground: "#000000",
-                    background: "#FEFFFF",
-                    cursor: "#98989D",
-                    cursorText: "#FFFFFF",
-                    selectionBackground: "#ABD8FF",
-                    selectionForeground: "#000000",
+                    foreground: "#4C4F69",
+                    background: "#EFF1F5",
+                    cursor: "#DC8A78",
+                    cursorText: "#EFF1F5",
+                    selectionBackground: "#ACB0BE",
+                    selectionForeground: "#4C4F69",
                     palette: Self.managedLightPalette
                 ),
                 dark: snapshot(
-                    foreground: "#FFFFFF",
-                    background: "#1E1E1E",
-                    cursor: "#98989D",
-                    cursorText: "#FFFFFF",
-                    selectionBackground: "#3F638B",
-                    selectionForeground: "#FFFFFF",
+                    foreground: "#CDD6F4",
+                    background: "#1E1E2E",
+                    cursor: "#F5E0DC",
+                    cursorText: "#1E1E2E",
+                    selectionBackground: "#585B70",
+                    selectionForeground: "#CDD6F4",
                     palette: Self.managedDarkPalette
                 ),
                 changesWithAppearance: true

--- a/Sources/GhosttyScrollView.swift
+++ b/Sources/GhosttyScrollView.swift
@@ -8,6 +8,11 @@ final class GhosttyScrollView: NSScrollView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
+        // NSScrollView is a layer-backed viewport in the terminal hierarchy.
+        // Keep its view boundary clipped even when AppKit retile/reparent work
+        // changes the backing layer during a live window resize.
+        clipsToBounds = true
+
         // Bonsplit lays out the tab strip outside this viewport, so AppKit must not
         // infer another terminal-content inset from the window title bar.
         automaticallyAdjustsContentInsets = false

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4255,6 +4255,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // GhosttyMetalLayer provides render stats and opt-in frame notifications for
         // input sequencing that needs to wait for terminal redraws.
         wantsLayer = true
+        // Ghostty installs and can replace the backing layer after this view is
+        // created. Keep clipping at the view boundary as well as on the layer,
+        // so a stale drawable cannot paint outside the terminal pane.
+        clipsToBounds = true
         layer?.masksToBounds = true
         setupKeyboardCopyModeCursorOverlay()
         installEventMonitor()
@@ -5249,6 +5253,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         if pendingSurfaceSize != size { deferredSurfaceSizeNonMetalRetryCount = 0 }
         pendingSurfaceSize = size
+        // Reassert the view-level boundary on every size publication. AppKit
+        // may re-materialize the layer while a window is resized, and the
+        // renderer must remain contained without adding a redraw or queue hop.
+        clipsToBounds = true
+        layer?.masksToBounds = true
         if let deferralReason = activeSurfaceResizeDeferralReason() {
             scheduleDeferredSurfaceSizeRetryIfNeeded()
 #if DEBUG
@@ -10124,12 +10133,22 @@ final class GhosttySurfaceScrollView: NSView {
         scrollView.surfaceView = surfaceView
 
         documentView = NSView(frame: .zero)
+        // The surface is positioned explicitly below. Clearing its inherited
+        // autoresizing mask prevents AppKit from growing it past the viewport
+        // between two synchronous resize ticks.
+        surfaceView.autoresizingMask = []
+        surfaceView.translatesAutoresizingMaskIntoConstraints = true
         scrollView.documentView = documentView
         documentView.addSubview(surfaceView)
 
         super.init(frame: .zero)
         wantsLayer = true
+        clipsToBounds = true
         layer?.masksToBounds = true
+        scrollView.clipsToBounds = true
+        documentView.clipsToBounds = true
+        surfaceView.clipsToBounds = true
+        surfaceView.layer?.masksToBounds = true
 
         backgroundView.wantsLayer = true
         backgroundView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -10587,6 +10606,17 @@ final class GhosttySurfaceScrollView: NSView {
         forceViewportSync: Bool? = nil,
         preservedReviewOriginY: CGFloat? = nil
     ) -> Bool {
+        // Keep every AppKit boundary in the rendering chain clipped. These
+        // assignments are idempotent and avoid any deferred layout or display
+        // work, which is important while the window resize callback is open.
+        clipsToBounds = true
+        layer?.masksToBounds = true
+        scrollView.clipsToBounds = true
+        scrollView.contentView.clipsToBounds = true
+        documentView.clipsToBounds = true
+        surfaceView.clipsToBounds = true
+        surfaceView.layer?.masksToBounds = true
+        surfaceView.autoresizingMask = []
         let preservedReviewOriginY = preservedReviewOriginY ?? {
             guard scrollbackViewportIntent.preservesViewportDuringPendingSync else { return nil }
             return max(scrollView.contentView.bounds.origin.y, 0)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10633,17 +10633,13 @@ final class GhosttySurfaceScrollView: NSView {
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         let contentFrame = sessionContentFrame
         _ = setFrameIfNeeded(scrollView, to: contentFrame)
-        let targetSize = scrollView.bounds.size
+        if didScrollbarAppearanceChange {
+            scrollView.tile()
+        }
+        let targetSize = synchronizeTerminalContentFrames()
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
-        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
-        _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
-        let targetDocumentFrame = CGRect(
-            origin: documentView.frame.origin,
-            size: CGSize(width: scrollView.bounds.width, height: documentView.frame.height)
-        )
-        _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         _ = setFrameIfNeeded(mobileViewportBorderOverlayView, to: contentFrame)
         _ = setFrameIfNeeded(inactiveOverlayView, to: bounds)
         _ = setFrameIfNeeded(paneDropTargetView, to: bounds)
@@ -10677,12 +10673,6 @@ final class GhosttySurfaceScrollView: NSView {
             _ = setFrameIfNeeded(overlay, to: contentFrame)
         }
         bringPaneDropTargetToFrontIfNeeded()
-        // NSScrollView can defer clip-view/content-size updates until its own layout pass,
-        // which makes interactive width changes arrive a queue turn late on Sequoia.
-        if didScrollbarAppearanceChange {
-            scrollView.tile()
-        }
-        scrollView.layoutSubtreeIfNeeded()
         updateNotificationRingPath()
         updateFlashPath(style: lastFlashStyle)
         updateFlashAppearance(style: lastFlashStyle)
@@ -13427,17 +13417,22 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func synchronizeTerminalGeometryAfterScrollerStyleChange() {
+        _ = synchronizeTerminalContentFrames()
+        synchronizeSurfaceView()
+        _ = synchronizeCoreSurface()
+    }
+
+    private func synchronizeTerminalContentFrames() -> CGSize {
         scrollView.layoutSubtreeIfNeeded()
         let targetSize = scrollView.contentView.bounds.size
         let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
             origin: documentView.frame.origin,
-            size: CGSize(width: scrollView.contentView.bounds.width, height: documentView.frame.height)
+            size: CGSize(width: targetSize.width, height: documentView.frame.height)
         )
         _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
-        synchronizeSurfaceView()
-        _ = synchronizeCoreSurface()
+        return targetSize
     }
 
     private func handleTerminalScrollBarPreferenceChange() {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -749,6 +749,10 @@ final class WindowTerminalPortal: NSObject {
         self.window = window
         super.init()
         hostView.wantsLayer = true
+        // The portal is a sibling of the SwiftUI content tree. Keep a
+        // view-level boundary while AppKit and layer-backed terminal views
+        // change frames during a live resize.
+        hostView.clipsToBounds = true
         hostView.layer?.masksToBounds = true
         hostView.postsFrameChangedNotifications = true
         hostView.postsBoundsChangedNotifications = true
@@ -1243,6 +1247,11 @@ final class WindowTerminalPortal: NSObject {
     @discardableResult
     private func ensureInstalled(syncLayout: Bool = true) -> Bool {
         guard let window else { return false }
+        // AppKit can re-materialize a layer-backed host during a resize.
+        // Reassert the cheap view and layer clips at this installation choke
+        // point before any child frame is written.
+        hostView.clipsToBounds = true
+        hostView.layer?.masksToBounds = true
         guard let (container, reference) = installedTargetIfStillValid(for: window) ?? installationTarget(for: window)
         else { return false }
         let browserHost = preferredBrowserHost(in: container)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4453,7 +4453,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             return
         }
 
-        let surfaceView = ScrollbarPostingSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 120))
+        let surfaceView = AuthoritativeScrollbarSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 120))
         surfaceView.cellSize = CGSize(width: 10, height: 10)
         let hostedView = GhosttySurfaceScrollView(surfaceView: surfaceView)
         hostedView.frame = contentView.bounds
@@ -4479,7 +4479,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
 
-        surfaceView.nextScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
+        surfaceView.authoritativeScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
 
         guard let cgEvent = CGEvent(
             scrollWheelEvent2Source: nil,


### PR DESCRIPTION
Fixes #12204. Inactive terminals now keep full contrast by default, while explicit Ghostty dimming settings continue to work. Fresh-install adaptive colors use Catppuccin Latte/Mocha, including the fallback when theme files are unavailable. Terminal surfaces stay clipped to their panes during resizing and portal rebinding, with terminal dimensions derived from the actual scroll viewport.

This includes follow-up #12295, an authoritative-snapshot correction to the existing wheel-scroll test fixture, and independently specified fallback palette coverage. The fallback regression was committed before its fix and failed for both light and dark on the pre-fix commit.

Validation:
- Tagged app rebuilt and installed for pushed HEAD `24125c7e4a`.
- Xcode Release terminal-core suite: all 313 tests in 55 suites passed (exit 0).
- macOS 15 GhosttySurfaceOverlayTests: https://github.com/manaflow-ai/cmux/actions/runs/34558113554 (test and summary steps passed).
- The original wheel test failed identically on the parent commit and the original follow-up head; its fixture now supplies the same authoritative response as the production input path.
- Fleet runtime check: three terminals and a focused browser survived 12 window resizes and workspace switching. Terminal output and live geometry remained intact; inspected before/after screenshots show containment and full inactive-pane contrast.
- Built app contains both managed theme resources, matching their tracked contents. Package-lock policy, test wiring, and whitespace checks pass.
- Localization audit: no new user-facing strings; existing theme names and resources are reused.

Production requires the normal macOS app release. No backend deployment, database migration, secret, or remote feature-flag change is needed. Managed defaults apply only when adaptive defaults are enabled and the user's effective Ghostty configuration has no directives. Explicit opacity remains authoritative; a fill-only setting retains Ghostty's normal dimming behavior.
