### PR TITLE
web: space same-identity registrations and keep the revision on no-op heartbeats

### DIFF
--- a/web/services/iroh/model.ts
+++ b/web/services/iroh/model.ts
@@ -14,6 +14,13 @@ export const IROH_ENDPOINT_ATTESTATION_VERSION = 1;
 export const IROH_ENDPOINT_ATTESTATION_TYP = "cmux-endpoint-attestation-v1+jwt";
 export const IROH_ENDPOINT_ATTESTATION_SCOPE = "cmux.offline-pair.same-account";
 export const IROH_CHALLENGE_LIFETIME_MS = 5 * 60 * 1_000;
+/**
+ * The floor between two accepted registrations of the same slot. A client
+ * whose observed addresses churn faster than this is answered with 429 and
+ * Retry-After at challenge mint time, before anything is written. Identity
+ * rotation (new endpoint id or generation) is never delayed.
+ */
+export const IROH_MIN_REGISTRATION_SPACING_MS = 60 * 1_000;
 export const IROH_PAIR_GRANT_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
 export const IROH_ENDPOINT_ATTESTATION_LIFETIME_SECONDS = 24 * 60 * 60;
 export const IROH_OFFLINE_PAIR_SESSION_LIFETIME_SECONDS = 5 * 60;

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -29,6 +29,7 @@ import {
   sha256,
   type IrohPathHint,
   type IrohRegistrationPayload,
+  IROH_MIN_REGISTRATION_SPACING_MS,
 } from "./model";
 import {
   canIOSBindingForgetMac,
@@ -98,6 +99,8 @@ export type IrohRepositoryShape = {
     readonly nonceHash: string;
     readonly now: Date;
     readonly expiresAt: Date;
+    /** Floor between accepted registrations of one identity; tests may lower it. */
+    readonly minimumSpacingMs?: number;
   }) => Effect.Effect<IrohChallengeRecord, RepositoryError>;
   readonly findChallenge: (
     userId: string,
@@ -257,7 +260,11 @@ function makeLiveRepository(): IrohRepositoryShape {
         // registeredAt (stamped from that challenge's createdAt) is the other
         // high-water mark the new mint must clear.
         const [slot] = await tx
-          .select({ registeredAt: irohEndpointBindings.registeredAt })
+          .select({
+            registeredAt: irohEndpointBindings.registeredAt,
+            endpointId: irohEndpointBindings.endpointId,
+            identityGeneration: irohEndpointBindings.identityGeneration,
+          })
           .from(irohEndpointBindings)
           .where(and(
             eq(irohEndpointBindings.userId, input.userId),
@@ -267,6 +274,27 @@ function makeLiveRepository(): IrohRepositoryShape {
             isNull(irohEndpointBindings.revokedAt),
           ))
           .limit(1);
+        // A live slot re-registering the same identity too soon is told to
+        // wait. Nothing has been written yet, and the client's rate-limit
+        // path sleeps for Retry-After and then publishes once, so the fleet
+        // write rate is capped per slot however fast observed addresses churn.
+        if (
+          slot
+          && slot.endpointId === input.endpointId
+          && slot.identityGeneration === input.identityGeneration
+        ) {
+          const minimumSpacingMs = input.minimumSpacingMs ?? IROH_MIN_REGISTRATION_SPACING_MS;
+          const elapsedMs = input.now.getTime() - slot.registeredAt.getTime();
+          if (elapsedMs < minimumSpacingMs) {
+            throw new IrohQuotaExceededError({
+              code: "registration_spacing",
+              retryAfterSeconds: Math.max(
+                1,
+                Math.ceil((minimumSpacingMs - elapsedMs) / 1_000),
+              ),
+            });
+          }
+        }
         const floor = Math.max(
           priorChallenge?.createdAt.getTime() ?? 0,
           slot?.registeredAt?.getTime() ?? 0,
@@ -480,7 +508,16 @@ function makeLiveRepository(): IrohRepositoryShape {
             .delete(irohRegistrationChallenges)
             .where(eq(irohRegistrationChallenges.id, challenge.id));
           if (!updated) throw new Error("binding update returned no row");
-          const accountRevision = await advanceRouteRevision(tx, input.userId, input.now);
+          // A heartbeat that changes nothing a peer can act on must not bump
+          // the account route revision: every other device on the account
+          // treats a bump as "the route table changed" and refetches
+          // discovery. Liveness is already refreshed through lastSeenAt.
+          const accountRevision = await heartbeatRouteRevision(
+            tx,
+            input.userId,
+            input.now,
+            bindingMateriallyEqual(existingSlot, input.payload, accountPrivatePathHints),
+          );
           return { binding: updated, created: false, accountRevision };
         }
 
@@ -1355,6 +1392,70 @@ async function revokeActiveBindings(
       },
     });
   return revokedIds;
+}
+
+/** Keep the account revision for a no-op heartbeat; advance it for real news. */
+async function heartbeatRouteRevision(
+  tx: CloudDbTransaction,
+  userId: string,
+  now: Date,
+  unchanged: boolean,
+): Promise<number> {
+  return unchanged
+    ? await currentRouteRevision(tx, userId, now)
+    : await advanceRouteRevision(tx, userId, now);
+}
+
+/** The material fields of a binding as a peer sees them, timestamps excluded. */
+function bindingMateriallyEqual(
+  existing: {
+    readonly appInstanceId: string;
+    readonly displayName: string | null;
+    readonly pairingEnabled: boolean;
+    readonly capabilities: readonly string[] | unknown;
+    readonly directPortV4: number | null;
+    readonly directPortV6: number | null;
+    readonly pathHints: readonly unknown[] | unknown;
+  },
+  payload: {
+    readonly appInstanceId: string;
+    readonly displayName?: string | null;
+    readonly pairingEnabled: boolean;
+    readonly capabilities: readonly string[];
+    readonly directPorts?: { readonly ipv4?: number | null; readonly ipv6?: number | null } | null;
+  },
+  nextPathHints: readonly IrohPathHint[],
+): boolean {
+  const existingCapabilities = Array.isArray(existing.capabilities)
+    ? [...existing.capabilities].map(String).sort()
+    : [];
+  const nextCapabilities = [...payload.capabilities].sort();
+  if (existing.appInstanceId !== payload.appInstanceId) return false;
+  if ((existing.displayName ?? null) !== (payload.displayName ?? null)) return false;
+  if (existing.pairingEnabled !== payload.pairingEnabled) return false;
+  if (existingCapabilities.join("\u001f") !== nextCapabilities.join("\u001f")) return false;
+  if ((existing.directPortV4 ?? null) !== (payload.directPorts?.ipv4 ?? null)) return false;
+  if ((existing.directPortV6 ?? null) !== (payload.directPorts?.ipv6 ?? null)) return false;
+  return routeKeys(Array.isArray(existing.pathHints) ? existing.pathHints : []) ===
+    routeKeys(nextPathHints);
+}
+
+/** Hint identity without observed_at and expires_at, sorted for comparison. */
+function routeKeys(hints: readonly unknown[]): string {
+  return hints
+    .map((raw) => {
+      const hint = raw as Partial<IrohPathHint>;
+      return [
+        hint.kind ?? "",
+        hint.value ?? "",
+        hint.source ?? "",
+        hint.privacy_scope ?? "",
+        hint.network_profile?.source ?? "",
+        hint.network_profile?.profile_id ?? "",
+      ].join("\u001f");
+    })
+    .sort()
+    .join("\u001e");
 }
 
 async function advanceRouteRevision(

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -37,6 +37,7 @@ import {
 import {
   IROH_ALPN,
   IROH_CHALLENGE_LIFETIME_MS,
+  IROH_MIN_REGISTRATION_SPACING_MS,
   IROH_ENDPOINT_ATTESTATION_LIFETIME_SECONDS,
   IROH_ENDPOINT_ATTESTATION_SCOPE,
   IROH_ENDPOINT_ATTESTATION_VERSION,
@@ -531,6 +532,10 @@ export function makeIrohTrustBroker(
       return {
         revision: registration.accountRevision,
         binding: publicBinding(registration.binding, now, savedCustomRelayURLs),
+        // Server-owned publication policy. Clients that read it space their
+        // own publications; older clients ignore the field and meet the same
+        // floor as a 429 at challenge mint time.
+        minimum_publication_spacing_seconds: IROH_MIN_REGISTRATION_SPACING_MS / 1_000,
         relay,
         discovery,
         discovery_complete: request.discoveryScope

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -205,6 +205,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: "08".repeat(32),
         nonceHash: "07".repeat(32),
+        minimumSpacingMs: 0,
         now: NOW,
         expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
       }));
@@ -379,6 +380,7 @@ describe("Iroh trust broker database behavior", () => {
       identityGeneration: 1,
       payloadSha256: "30".repeat(32),
       nonceHash,
+      minimumSpacingMs: 0,
       now: NOW,
       expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
     }));
@@ -444,6 +446,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: "36".repeat(32),
         nonceHash,
+        minimumSpacingMs: 0,
         now: NOW,
         expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
       }));
@@ -662,6 +665,7 @@ describe("Iroh trust broker database behavior", () => {
       identityGeneration: 1,
       payloadSha256: "42".repeat(32),
       nonceHash,
+      minimumSpacingMs: 0,
       now: NOW,
       expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
     }));
@@ -723,6 +727,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: (sequence + 10).toString(16).padStart(64, "0"),
         nonceHash,
+        minimumSpacingMs: 0,
         now,
         expiresAt: new Date(now.getTime() + 5 * 60 * 1_000),
       }));
@@ -809,6 +814,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: `${suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now,
         expiresAt: new Date(now.getTime() + 5 * 60 * 1_000),
       }));
@@ -941,6 +947,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: input.identityGeneration,
         payloadSha256: `${input.suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now: input.now,
         expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
       }));
@@ -1064,6 +1071,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: `${input.suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now: input.now,
         expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
       }));
@@ -1162,6 +1170,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: `${input.suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now: input.now,
         expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
       }));
@@ -1247,6 +1256,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: `${input.suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now: input.now,
         expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
       }));
@@ -1334,6 +1344,7 @@ describe("Iroh trust broker database behavior", () => {
         identityGeneration: 1,
         payloadSha256: `${input.suffix}${"0".repeat(63)}`,
         nonceHash,
+        minimumSpacingMs: 0,
         now: input.now,
         expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
       }));
@@ -1452,6 +1463,7 @@ describe("Iroh trust broker database behavior", () => {
       identityGeneration: 1,
       payloadSha256: `8${"0".repeat(63)}`,
       nonceHash,
+      minimumSpacingMs: 0,
       now: new Date(NOW.getTime() + 301_000),
       expiresAt: new Date(NOW.getTime() + 601_000),
     }));
@@ -2001,6 +2013,7 @@ describe("Iroh trust broker database behavior", () => {
       identityGeneration: 1,
       payloadSha256,
       nonceHash,
+      minimumSpacingMs: 0,
       now: NOW,
       expiresAt: new Date(NOW.getTime() + 5 * 60 * 1_000),
     }));
@@ -2051,6 +2064,148 @@ describe("Iroh trust broker database behavior", () => {
       select count(*)::text as challenges from iroh_registration_challenges where user_id = ${userId}
     `;
     expect(afterHeartbeat.challenges).toBe("0");
+  });
+
+  dbTest("spaces same-identity re-registrations and never delays identity rotation", async () => {
+    const repo = requiredRepository();
+    const userId = "user-spacing";
+    const deviceId = randomUUID();
+    const appInstanceId = randomUUID();
+    const endpointId = "13".repeat(32);
+    const mint = (nonceHash: string, at: Date, endpoint = endpointId, generation = 1) => Effect.runPromise(repo.issueChallenge({
+      userId,
+      deviceUuid: deviceId,
+      appInstanceId,
+      tag: "stable",
+      endpointId: endpoint,
+      identityGeneration: generation,
+      payloadSha256: "34".repeat(32),
+      nonceHash,
+      now: at,
+      expiresAt: new Date(at.getTime() + 5 * 60 * 1_000),
+    }));
+    const first = await mint("51".repeat(32), NOW);
+    await Effect.runPromise(repo.consumeChallengeAndRegister({
+      userId,
+      challengeId: first.id,
+      nonceHash: "51".repeat(32),
+      payload: {
+        route_contract_version: 1,
+        deviceId,
+        appInstanceId,
+        clientNamespace: "legacy",
+        tag: "stable",
+        platform: "mac",
+        endpointId,
+        identityGeneration: 1,
+        pairingEnabled: true,
+        capabilities: [],
+        pathHints: [],
+      },
+      now: NOW,
+    }));
+
+    // Same identity, ten seconds later: told to wait for the remainder.
+    const tooSoon = await Effect.runPromiseExit(repo.issueChallenge({
+      userId,
+      deviceUuid: deviceId,
+      appInstanceId,
+      tag: "stable",
+      endpointId,
+      identityGeneration: 1,
+      payloadSha256: "34".repeat(32),
+      nonceHash: "52".repeat(32),
+      now: new Date(NOW.getTime() + 10_000),
+      expiresAt: new Date(NOW.getTime() + 10_000 + 5 * 60 * 1_000),
+    }));
+    expect(tooSoon._tag).toBe("Failure");
+    const failure = tooSoon._tag === "Failure"
+      ? Option.getOrUndefined(Cause.failureOption(tooSoon.cause))
+      : undefined;
+    expect(failure).toMatchObject({
+      _tag: "IrohQuotaExceededError",
+      code: "registration_spacing",
+      retryAfterSeconds: 50,
+    });
+    // A rotated identity on the same slot is never delayed.
+    const rotated = await mint("53".repeat(32), new Date(NOW.getTime() + 10_000), "14".repeat(32), 2);
+    expect(rotated.endpointId).toBe("14".repeat(32));
+    // Same identity after the floor: accepted.
+    const later = await mint("54".repeat(32), new Date(NOW.getTime() + 61_000));
+    expect(later.createdAt.getTime()).toBeGreaterThan(first.createdAt.getTime());
+  });
+
+  dbTest("keeps the route revision on a heartbeat that changes nothing a peer can act on", async () => {
+    const repo = requiredRepository();
+    const userId = "user-noop-heartbeat";
+    const deviceId = randomUUID();
+    const appInstanceId = randomUUID();
+    const endpointId = "15".repeat(32);
+    let counter = 0x60;
+    const registerAt = async (at: Date, pathHints: Parameters<typeof repo.consumeChallengeAndRegister>[0]["payload"]["pathHints"]) => {
+      const nonceHash = (counter++).toString(16).repeat(32);
+      const challenge = await Effect.runPromise(repo.issueChallenge({
+        userId,
+        deviceUuid: deviceId,
+        appInstanceId,
+        tag: "stable",
+        endpointId,
+        identityGeneration: 1,
+        payloadSha256: "35".repeat(32),
+        nonceHash,
+        minimumSpacingMs: 0,
+        now: at,
+        expiresAt: new Date(at.getTime() + 5 * 60 * 1_000),
+      }));
+      return Effect.runPromise(repo.consumeChallengeAndRegister({
+        userId,
+        challengeId: challenge.id,
+        nonceHash,
+        payload: {
+          route_contract_version: 1,
+          deviceId,
+          appInstanceId,
+          clientNamespace: "legacy",
+          tag: "stable",
+          platform: "mac",
+          endpointId,
+          identityGeneration: 1,
+          pairingEnabled: true,
+          capabilities: ["attach"],
+          pathHints,
+        },
+        now: at,
+      }));
+    };
+    const relay = (observedAt: Date) => ({
+      kind: "relay_url" as const,
+      value: "https://use1.relay.cmux.dev/",
+      source: "native" as const,
+      privacy_scope: "public_internet" as const,
+      observed_at: observedAt.toISOString(),
+      expires_at: new Date(observedAt.getTime() + 60 * 60 * 1_000).toISOString(),
+    });
+    const t0 = NOW;
+    const t1 = new Date(NOW.getTime() + 61_000);
+    const t2 = new Date(NOW.getTime() + 122_000);
+
+    const created = await registerAt(t0, [relay(t0)]);
+    expect(created.created).toBe(true);
+    // Same route, fresh timestamps: liveness refreshed, revision untouched.
+    const heartbeat = await registerAt(t1, [relay(t1)]);
+    expect(heartbeat.created).toBe(false);
+    expect(heartbeat.accountRevision).toBe(created.accountRevision);
+    expect(heartbeat.binding.lastSeenAt).toEqual(t1);
+    // A new direct address is news for peers: revision advances.
+    const changed = await registerAt(t2, [relay(t2), {
+      kind: "direct_address" as const,
+      value: "203.0.113.7:4433",
+      source: "native" as const,
+      privacy_scope: "public_internet" as const,
+      observed_at: t2.toISOString(),
+      expires_at: new Date(t2.getTime() + 60 * 60 * 1_000).toISOString(),
+    }]);
+    expect(changed.accountRevision).toBe(created.accountRevision + 1);
   });
 
   dbTest("global retention drops legacy consumed challenges of any age and keeps in-flight ones", async () => {

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -212,6 +212,7 @@ describe("Iroh trust broker registration", () => {
     const result = await Effect.runPromise(fixture.broker.register(USER_A, request, NOW)) as {
       revision: number;
       binding: { endpoint_id: string };
+      minimum_publication_spacing_seconds: number;
       relay: { status: string; token: string };
       discovery_complete: boolean;
       discovery: {
@@ -220,6 +221,8 @@ describe("Iroh trust broker registration", () => {
       };
     };
     expect(result.binding.endpoint_id).toBe(fixture.endpointId);
+    // Server-owned publication policy travels with every registration.
+    expect(result.minimum_publication_spacing_seconds).toBe(60);
     expect(result.relay.status).toBe("issued");
     expect(result.discovery.revision).toBe(result.revision);
     expect(result.discovery_complete).toBe(true);


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/12209. Backend changes for the relay heartbeat load, measured at a 46-second median per Mac and about 2,000 registrations a minute fleet-wide.

1. **Registration spacing at mint time.** `issueChallenge` in `services/iroh/repository.ts` answers a same-identity mint within 60 seconds of the slot's last accepted registration with `IrohQuotaExceededError` (`registration_spacing`), which `routeHandler.ts` already maps to 429 plus `Retry-After`. Nothing is written for a refused mint. The Mac client's `rateLimited` path in `CmxIrohTrustBrokerClientError.swift` preserves verified state and `scheduleRegistrationRetry` sleeps for `Retry-After` then publishes once, so the fleet write rate is capped per slot regardless of how fast observed addresses churn. A new endpoint id or identity generation is never delayed. `IROH_MIN_REGISTRATION_SPACING_MS` lives in `services/iroh/model.ts`; tests may lower the floor per call.

2. **No-op heartbeats keep the route revision.** `consumeChallengeAndRegister` compares the incoming payload with the stored binding on the fields a peer can act on (hint kind, value, source, scope, profile; direct ports; capabilities; display name; pairing) and keeps the account route revision when nothing changed. `lastSeenAt` and `registeredAt` still advance and the embedded discovery snapshot is still returned, so old clients see no difference except fewer discovery refetches on their other devices.

3. **Advertised spacing.** Every register response carries `minimum_publication_spacing_seconds`. Old clients ignore the field; a client that reads the field can space publications itself.

Tests: first commit adds the behavior tests (fail on the base branch), second adds the implementation. 39 iroh database behavior tests, 74 trust broker and route tests, full suite of 2,907 pass; complexity gate unchanged. End-to-end run against a dev backend stack with a tagged Mac build follows in the PR comments.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534169&installation_model_id=21920&pr_number=12211&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12211&signature=7f9f486953470dbdf1b00621124510d5b09d8b00c8bb23a99bb61489157d13be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps fleet registration write rate for Iroh heartbeats and stops no-op heartbeats from bumping the account route revision.

- Same-identity registrations within 60 seconds of the slot's last accepted registration are rejected at challenge mint time with `IrohQuotaExceededError`, which the route handler maps to 429 plus `Retry-After`; nothing is written and identity rotation (new endpoint id or generation) is never delayed.
- Heartbeats that change nothing a peer can act on (hint identities, ports, capabilities, display name, pairing) keep the account route revision, so other devices stop refetching discovery for liveness-only heartbeats; `lastSeenAt` and `registeredAt` still advance.
- Every register response now carries `minimum_publication_spacing_seconds` so clients can space publications themselves; old clients ignore the field and meet the same floor via the 429 path.

<sup>Written for commit 65037c16345908c31a5667092694243ad6ebf8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-wide registration acceptance and route-revision semantics for heartbeats; behavior is covered by new DB tests but affects live discovery refresh patterns.
> 
> **Overview**
> Reduces Iroh registration churn and unnecessary discovery refetches by tightening when the backend accepts publications and when it bumps the account route revision.
> 
> **Registration spacing (60s per slot).** `issueChallenge` now rejects a mint for the same `endpointId` and `identityGeneration` on an active slot if the last accepted registration was less than `IROH_MIN_REGISTRATION_SPACING_MS` ago, returning `IrohQuotaExceededError` (`registration_spacing`) with `Retry-After` before any DB write. Endpoint or generation rotation is not throttled. Tests can override via `minimumSpacingMs`.
> 
> **No-op heartbeats.** On in-place binding updates, the repo compares peer-visible fields (capabilities, ports, path-hint identity without timestamps, etc.) and **does not** advance `routeRevision` when nothing materially changed; `lastSeenAt` / `registeredAt` still update.
> 
> **Client policy.** Register responses include `minimum_publication_spacing_seconds` (60) so newer clients can self-space; older clients rely on the server-side 429 at mint time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65037c16345908c31a5667092694243ad6ebf8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->