### PR TITLE
web: cut device-registry poll writes by raising the presence touch interval

### DIFF
--- a/web/services/devices/registrationNoOp.ts
+++ b/web/services/devices/registrationNoOp.ts
@@ -12,8 +12,23 @@
  * answer it without taking the per-team advisory lock or writing two rows.
  */
 
-/** How stale a presence timestamp may get before a no-op POST refreshes it. */
-const DEFAULT_PRESENCE_TOUCH_INTERVAL_MS = 60_000;
+/**
+ * How stale a presence timestamp may get before a no-op POST refreshes it.
+ *
+ * This interval is the registry's entire write budget. A device that keeps
+ * re-POSTing an identical row writes at most once per interval, so the steady
+ * write rate is `live devices / interval`. At one minute and ~2,900 live
+ * devices that was ~53,000 `devices` upserts an hour in production, the single
+ * hottest write in the database; five minutes brings the ceiling down by five.
+ *
+ * Five minutes is safe because nothing reads `last_seen_at` as a liveness
+ * signal. Online/offline is owned by the presence service, which heartbeats
+ * every 15 seconds over its own path; the registry timestamp only orders and
+ * labels the device list a phone shows. Raising it further trades nothing but
+ * the ordering of two Macs that were both active inside the same window, and
+ * `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS` retunes it without a deploy.
+ */
+const DEFAULT_PRESENCE_TOUCH_INTERVAL_MS = 300_000;
 
 export function presenceTouchIntervalMs(
   raw = process.env.CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS,

--- a/web/tests/device-registration-no-op.test.ts
+++ b/web/tests/device-registration-no-op.test.ts
@@ -40,7 +40,7 @@ const incoming = {
 function check(
   storedValue: StoredRegistration | null,
   incomingValue = incoming,
-  touchIntervalMs = 60_000,
+  touchIntervalMs = presenceTouchIntervalMs(undefined),
 ): boolean {
   return registrationIsUnchanged({
     stored: storedValue,
@@ -74,9 +74,16 @@ describe("device registration no-op detection", () => {
   });
 
   test("a stale presence timestamp forces the write through", () => {
-    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 61_000) })).valueOf()).toBe(false);
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 301_000) })).valueOf()).toBe(false);
     // Exactly at the interval still writes: the boundary belongs to freshness.
-    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 60_000) }))).toBe(false);
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 300_000) }))).toBe(false);
+  });
+
+  test("the interval is the write budget: a four-minute-old row is still fresh", () => {
+    // The registry's steady write rate is one row per device per interval, so
+    // this case is the reduction itself: at the old one-minute default every
+    // poll this far apart wrote two rows.
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 240_000) }))).toBe(true);
   });
 
   test("a presence timestamp from the future never looks fresh", () => {
@@ -119,9 +126,9 @@ describe("device registration no-op detection", () => {
 });
 
 describe("presenceTouchIntervalMs", () => {
-  test("defaults to one minute", () => {
-    expect(presenceTouchIntervalMs(undefined)).toBe(60_000);
-    expect(presenceTouchIntervalMs("  ")).toBe(60_000);
+  test("defaults to five minutes", () => {
+    expect(presenceTouchIntervalMs(undefined)).toBe(300_000);
+    expect(presenceTouchIntervalMs("  ")).toBe(300_000);
   });
 
   test("honors an override, including zero to disable", () => {
@@ -130,7 +137,7 @@ describe("presenceTouchIntervalMs", () => {
   });
 
   test("ignores values that are not whole non-negative milliseconds", () => {
-    expect(presenceTouchIntervalMs("-1")).toBe(60_000);
-    expect(presenceTouchIntervalMs("soon")).toBe(60_000);
+    expect(presenceTouchIntervalMs("-1")).toBe(300_000);
+    expect(presenceTouchIntervalMs("soon")).toBe(300_000);
   });
 });

--- a/web/tests/devices-route.test.ts
+++ b/web/tests/devices-route.test.ts
@@ -305,6 +305,53 @@ describe("device registry route", () => {
     expect((third.routes[0] as { kind: string }).kind).toBe("tailscale");
   }, 30_000);
 
+  dbTest("presence is refreshed once per touch interval, not once per poll", async () => {
+    if (!sql) throw new Error("test database not initialized");
+
+    const body = {
+      deviceId: DEVICE_A,
+      platform: "mac",
+      displayName: "Registry Mac",
+      tag: "default",
+      routes: [privateIrohRoute],
+    };
+    expect((await POST(registerRequest(body))).status).toBe(200);
+
+    const instanceUpdatedAt = async (): Promise<Date> => {
+      const [row] = await sql!<{ updated_at: Date }[]>`
+        select updated_at from device_app_instances
+        where tag = 'default' and device_id in (
+          select id from devices where device_uuid = ${DEVICE_A}
+        )
+      `;
+      return row.updated_at;
+    };
+    const backdatePresence = async (minutes: number): Promise<void> => {
+      await sql!`
+        update device_app_instances
+        set last_seen_at = now() - make_interval(mins => ${minutes})
+        where tag = 'default' and device_id in (
+          select id from devices where device_uuid = ${DEVICE_A}
+        )
+      `;
+    };
+
+    // Four minutes of identical polls stay inside the five-minute touch
+    // interval, so the registry answers them without writing. At the previous
+    // one-minute default every one of these polls wrote both rows, which is
+    // what made this the hottest write in production.
+    const before = await instanceUpdatedAt();
+    await backdatePresence(4);
+    expect((await POST(registerRequest(body))).status).toBe(200);
+    expect((await instanceUpdatedAt()).getTime()).toBe(before.getTime());
+
+    // Past the interval, presence is refreshed so the device list keeps a
+    // roughly current "last seen" without a write per poll.
+    await backdatePresence(6);
+    expect((await POST(registerRequest(body))).status).toBe(200);
+    expect((await instanceUpdatedAt()).getTime()).toBeGreaterThan(before.getTime());
+  }, 30_000);
+
   // 26 sequential registrations, each a full HTTP + transaction round trip
   // against a containerized Postgres. The assertion is the instance cap, not
   // latency, and the default 5s budget leaves no headroom for a cold pool.


### PR DESCRIPTION
The device registry upsert is the hottest write in production. PlanetScale Insights on `cmux-prod`, 3-hour window:

- `insert into devices(...) on conflict ...` from `web/app/api/devices/route.ts`: **157,899 executions** (~53,000/hour)
- `select devices.user_id, devices.platform, ... from devices join device_app_instances`: **263,058 executions**

The second query is the no-op precheck that runs once per POST, so ~88,000 POSTs an hour produce ~53,000 writes: the guard added in #11769 already suppresses about 40% of them.

## Why the rest still write

The guard is a freshness window, not a rate limiter. It skips the write when every stored column matches and `last_seen_at` is younger than `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS`, and a suppressed poll does not refresh the timestamp. So a device that re-POSTs an identical row writes once per interval, and the steady write rate is exactly `live devices / interval`. At the one-minute default and 2,883 instances seen in the last five minutes (`select count(*) from device_app_instances where last_seen_at > now() - interval '5 minutes'`), the Mac's ~2-minute effective poll spacing lands most polls outside the window.

Five minutes makes the ceiling five times lower.

## Why five minutes is safe

Nothing reads `last_seen_at` as a liveness signal. Online/offline is owned by the presence service, which heartbeats every 15 seconds over its own path (`Sources/Cloud/PresenceHeartbeatClient.swift`: "DO = live cache, registry = truth"). In `web/`, the only readers are the GET list's `order by last_seen_at desc` and the timestamp it returns for display. There is no pruning job and no staleness cutoff. The one cost is the ordering of two Macs that were both active inside the same window, which matters only to a multi-Mac user and is recoverable by name.

`CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS` retunes this without a deploy. **Open question for Lawrence:** 15 minutes would cut the write rate ~5x instead of ~2x on the measured poll spacing, at the cost of coarser device-list ordering. I shipped the conservative value; say the word and I will set the env var higher in production rather than land another PR.

## Tests

Two commits so CI shows the guard working: the first adds the tests (red at the old default), the second changes the default.

- `web/tests/devices-route.test.ts`: a route-level DB test that backdates `last_seen_at` by four minutes, re-POSTs the identical body, and asserts `updated_at` did not move; then backdates by six and asserts it did. Verified failing with `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS=60000` and passing at the new default.
- `web/tests/device-registration-no-op.test.ts`: the interval-as-write-budget case, and the default assertions.

Ran locally against a containerized Postgres: `bun test tests/devices-route.test.ts` 28 pass, `bun test tests/device-registration-no-op.test.ts` 13 pass, `bun run typecheck` clean, `bun run lint:complexity` matched baseline.

No migration. No client change; the Mac's POST cadence is a separate PR.

https://claude.ai/code/session_014XnYXJQEVR6WoPf9yDrdvi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534452&installation_model_id=21920&pr_number=12212&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12212&signature=e08a8f0a4687806865fd3db1378a5c062dc7cd35bc62093269013ebb57322fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the device registry presence touch interval from one minute to five minutes, cutting the steady `devices` upsert rate fivefold in production.

**New Features**
- Adds route-level tests that pin the interval as the write budget: an identical poll inside the interval writes nothing, and a poll past it refreshes presence.

**Migration**
- `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS` overrides the new default without a deploy; no data migration or client change is needed.

<sup>Written for commit c15fe541f505fbf6eb224e6b742ae8c5d4e60dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production write behavior and coarsens device-list `last_seen_at` ordering; tunable via env and does not affect auth or liveness signals.
> 
> **Overview**
> Raises the default **presence touch interval** for identical device re-registrations from **one minute to five minutes** in `registrationNoOp.ts`, so the no-op short-circuit can skip DB upserts for longer when a client keeps POSTing the same row.
> 
> The interval caps steady registry writes at roughly **live devices / interval**; the PR documents that tradeoff and notes **`CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS`** still overrides without a deploy. **`last_seen_at`** is only used for device-list ordering/display, not liveness (presence service owns online/offline).
> 
> Tests follow the new default: unit cases for stale/fresh boundaries (including **four minutes still fresh**), and a route-level DB test that identical polls after a **4-minute** backdate do not bump `updated_at`, while **6 minutes** does refresh presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15fe541f505fbf6eb224e6b742ae8c5d4e60dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Device presence updates now use a five-minute default interval, reducing unnecessary refreshes during frequent polling.
  - Re-registrations within the configured interval no longer refresh device presence unnecessarily.
  - Presence is refreshed once the configured interval has elapsed.
  - The interval remains configurable through the existing environment-variable override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->