### PR TITLE
web: keep iroh retention deletes off the discovery request path

### DIFF
--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -1006,87 +1006,12 @@ function makeLiveRepository(): IrohRepositoryShape {
           await advanceRouteRevision(tx, input.userId, input.now);
         }
 
-        const challengeRetentionCutoff = new Date(input.now.getTime() - IROH_EXPIRED_CHALLENGE_RETENTION_MS);
-        const auditRetentionCutoff = new Date(input.now.getTime() - 30 * 24 * 60 * 60 * 1_000);
-        await tx.execute(sql`
-          with candidates as materialized (
-            select id
-            from iroh_registration_challenges
-            where user_id = ${input.userId}
-              and expires_at < ${challengeRetentionCutoff.toISOString()}::timestamptz
-            order by expires_at, id
-            limit ${IROH_RETENTION_BATCH_SIZE}
-            for update skip locked
-          )
-          delete from iroh_registration_challenges as challenge
-          using candidates
-          where challenge.id = candidates.id
-        `);
-        await tx.execute(sql`
-          with candidates as materialized (
-            select id
-            from iroh_registration_challenges
-            where user_id = ${input.userId}
-              and consumed_at is not null
-            order by consumed_at, id
-            limit ${IROH_RETENTION_BATCH_SIZE}
-            for update skip locked
-          )
-          delete from iroh_registration_challenges as challenge
-          using candidates
-          where challenge.id = candidates.id
-        `);
-        await tx.execute(sql`
-          with candidates as materialized (
-            select id
-            from iroh_relay_token_issuances
-            where user_id = ${input.userId}
-              and requested_at < ${auditRetentionCutoff.toISOString()}::timestamptz
-            order by requested_at, id
-            limit ${IROH_RETENTION_BATCH_SIZE}
-            for update skip locked
-          )
-          delete from iroh_relay_token_issuances as issuance
-          using candidates
-          where issuance.id = candidates.id
-        `);
-        await tx.execute(sql`
-          with candidates as materialized (
-            select id
-            from iroh_pair_grant_issuances
-            where user_id = ${input.userId}
-              and expires_at < ${auditRetentionCutoff.toISOString()}::timestamptz
-            order by expires_at, id
-            limit ${IROH_RETENTION_BATCH_SIZE}
-            for update skip locked
-          )
-          delete from iroh_pair_grant_issuances as issuance
-          using candidates
-          where issuance.id = candidates.id
-        `);
-        await tx.execute(sql`
-          with candidates as materialized (
-            select binding.id
-            from iroh_endpoint_bindings as binding
-            where binding.user_id = ${input.userId}
-              and binding.revoked_at < ${auditRetentionCutoff.toISOString()}::timestamptz
-            and not exists (
-              select 1 from iroh_pair_grant_issuances as pair_grant
-              where pair_grant.initiator_binding_id = binding.id
-                or pair_grant.acceptor_binding_id = binding.id
-            )
-            and not exists (
-              select 1 from iroh_relay_token_issuances as issuance
-              where issuance.binding_id = binding.id
-            )
-            order by binding.revoked_at, binding.id
-            limit ${IROH_RETENTION_BATCH_SIZE}
-            for update skip locked
-          )
-          delete from iroh_endpoint_bindings as binding
-          using candidates
-          where binding.id = candidates.id
-        `);
+        // Retention deletes for challenges, relay and pair-grant audit rows,
+        // and old revoked bindings run in the scheduled global drain
+        // (`pruneExpiredStateGlobally`). They used to run here on every
+        // discovery call as well, which cost three to five statements per
+        // heartbeat fleet-wide for rows that the drain removes within minutes.
+        // This path keeps only the route-affecting work: expiring path hints.
       });
     }),
 

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -2243,6 +2243,8 @@ describe("Iroh trust broker database behavior", () => {
         ${new Date(NOW.getTime() - 2 * 24 * 60 * 60 * 1_000)}
       from generate_series(1, ${IROH_RETENTION_BATCH_SIZE + 1}) as values(value)
     `;
+    // The per-user prune on the request path no longer deletes retention
+    // rows; the scheduled global drain owns that work.
     await Effect.runPromise(requiredRepository().pruneExpiredState({
       userId: "user-retention-scoped",
       now: NOW,
@@ -2252,7 +2254,14 @@ describe("Iroh trust broker database behavior", () => {
       from iroh_registration_challenges
       where user_id = 'user-retention-scoped'
     `;
-    expect(scopedRemaining).toBe("1");
+    expect(scopedRemaining).toBe(String(IROH_RETENTION_BATCH_SIZE + 1));
+    await Effect.runPromise(requiredRepository().pruneExpiredStateGlobally({ now: NOW }));
+    const [{ scopedAfterDrain }] = await requiredSql()<Array<{ scopedAfterDrain: string }>>`
+      select count(*)::text as "scopedAfterDrain"
+      from iroh_registration_challenges
+      where user_id = 'user-retention-scoped'
+    `;
+    expect(scopedAfterDrain).toBe("0");
   });
 
   dbTest("global retention reports backlog when its row budget is exhausted", async () => {


### PR DESCRIPTION
Second backend PR from the PlanetScale Insights review of cmux-prod (3h window).

The per-user `pruneExpiredState` runs on every discovery call, which is every heartbeat. Besides expiring path hints, it issued up to five retention delete statements per call: expired challenges, consumed challenges, relay token audit rows, pair-grant audit rows, and old revoked bindings. Insights counted 1,076,922 of those statements per three hours. The scheduled global drain (`/api/internal/iroh/retention`, every ten minutes since PR 12209) already performs the same deletes with a row budget.

This PR removes the five deletes from the request path and keeps the route-affecting work there: expiring path hints and advancing the route revision when a hint set changes. Retention is owned by the drain alone.

Commits: test first (fails on main), then the change. Verified against a local Postgres: 37 iroh behavior tests, 74 trust broker and route tests, typecheck, complexity gate at baseline.

Not in this PR, by agreement with the owners of PR 12211 (mint-time spacing, no-op heartbeat detection) and PR 12212 (device poll freshness window). The tombstone checks and advisory locks on discovery stay, because the deletion-fencing test requires discovery to refuse an account under deletion.

https://claude.ai/code/session_01GDMKMnvdKKL4LHgACBmeNC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534714&installation_model_id=21920&pr_number=12213&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12213&signature=b1a4f1cc319019de99ecb0900c7df623945c96fe0a55d0531651c15bedbca94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: expired audit/challenge rows may linger until the ~10-minute global drain instead of every heartbeat, though semantics match the existing scheduled job; discovery still does route-affecting path-hint pruning.
> 
> **Overview**
> **Removes duplicate retention deletes from the iroh discovery/heartbeat path** so per-user `pruneExpiredState` no longer runs up to five batched SQL deletes (expired/consumed challenges, relay and pair-grant audit rows, old revoked bindings) on every call.
> 
> That cleanup now lives only in the scheduled **`pruneExpiredStateGlobally`** drain (`drainIrohRetention`). The request path still expires **path hints** on active bindings and advances **route revision** when hints change.
> 
> Tests are updated: `pruneExpiredState` leaves retention rows in place; **`pruneExpiredStateGlobally`** clears them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b225d2327e9340a2dbc34944bc49c2e6b3d94793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the five retention delete statements from the per-user discovery path, so each heartbeat no longer issues up to five deletes that the scheduled global drain (every ten minutes) already handles. Discovery now keeps only the route-affecting work: expiring path hints and advancing route revision.

- Updates the retention behavior test to verify the scoped prune leaves rows and the global drain removes them.

<sup>Written for commit b225d2327e9340a2dbc34944bc49c2e6b3d94793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data-retention cleanup reliability by moving expired-account record cleanup to a scheduled background process.
  - Cleanup now handles multiple batches consistently, including records beyond the first batch.
  - Discovery requests continue to remove expired path hints while avoiding unnecessary retention cleanup work during those requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->