### PR TITLE
iroh: coalesce direct-address churn into spaced registrations

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
@@ -307,6 +307,7 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
         case discoveryComplete = "discovery_complete"
         case discoveryScope = "discovery_scope"
         case discoveryScopeComplete = "discovery_scope_complete"
+        case minimumPublicationSpacingSeconds = "minimum_publication_spacing_seconds"
     }
 
     /// Monotonic account route revision after this registration commit.
@@ -323,6 +324,9 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
     public let discoveryScope: CmxConnectivityDiscoveryScope?
     /// True only when embedded discovery covers every binding in its scope.
     public let discoveryScopeComplete: Bool?
+    /// The broker's floor between two reachability-driven publications for
+    /// this binding. Older brokers omit it; the client default applies.
+    public let minimumPublicationSpacingSeconds: Double?
 
     /// Whether the embedded discovery is proven complete globally or for its
     /// validated scoped-registration request.
@@ -340,7 +344,8 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
         discovery: CmxIrohDiscoveryResponse? = nil,
         discoveryComplete: Bool? = nil,
         discoveryScope: CmxConnectivityDiscoveryScope? = nil,
-        discoveryScopeComplete: Bool? = nil
+        discoveryScopeComplete: Bool? = nil,
+        minimumPublicationSpacingSeconds: Double? = nil
     ) {
         self.revision = revision
         self.binding = binding
@@ -349,6 +354,7 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
         self.discoveryComplete = discoveryComplete
         self.discoveryScope = discoveryScope
         self.discoveryScopeComplete = discoveryScopeComplete
+        self.minimumPublicationSpacingSeconds = minimumPublicationSpacingSeconds
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
@@ -260,7 +260,7 @@ extension CmxIrohClientRuntime {
         _ state: CmxIrohRegistrationPublicationState,
         at now: Date
     ) -> Bool {
-        !state.requiresPublication(after: lastRegistrationRefreshState, now: now)
+        state.publicationDecision(after: lastRegistrationRefreshState, now: now) == .unchanged
     }
 
     func registrationRefreshState(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
@@ -85,10 +85,12 @@ extension CmxIrohClientRuntime {
                 let state = try await registrationRefreshState(
                     expectedEndpointID: endpointID
                 )
-                guard state.requiresPublication(
+                // The spacing floor is a Mac host concern; a phone publishes
+                // every reachability change immediately.
+                guard state.publicationDecision(
                     after: lastRegistrationRefreshState,
                     now: now()
-                ) else { return .refreshed }
+                ) != .unchanged else { return .refreshed }
             }
             let policy = try await resolvePolicy(
                 expectedEndpointID: endpointID,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -196,7 +196,9 @@ extension CmxIrohHostRuntime {
         try requireCurrent(revision)
         lastRegistrationRefreshState = CmxIrohRegistrationPublicationState(
             payload: payload,
-            now: now()
+            now: now(),
+            minimumPublicationSpacing: registration.minimumPublicationSpacingSeconds
+                ?? CmxIrohRegistrationPublicationState.defaultMinimumPublicationSpacing
         )
         return ResolvedPolicy(
             registration: registration,
@@ -446,6 +448,38 @@ extension CmxIrohHostRuntime {
         }
     }
 
+    /// Arms one refresh at the end of the publication spacing window. The
+    /// renewal task slot is reused: a later successful publication replaces
+    /// the deferral with a normal renewal, and sign-out cancels both.
+    func scheduleDeferredPublication(at deadline: Date, revision: UInt64) {
+        registrationRenewalTask?.cancel()
+        registrationRenewalTask = nil
+        guard lifecyclePhase.ownsNetworkOperation,
+              lifecycleRevision == revision else { return }
+        registrationRenewalTask = Task { [weak self] in
+            await self?.runDeferredPublication(
+                revision: revision,
+                deadline: deadline
+            )
+        }
+    }
+
+    private func runDeferredPublication(
+        revision: UInt64,
+        deadline: Date
+    ) async {
+        do {
+            try await registrationClock.sleep(until: deadline)
+        } catch {
+            return
+        }
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        scheduleRegistrationRefresh(revision: revision)
+        await registrationRefreshTask?.value
+    }
+
     private func runRegistrationRenewal(
         revision: UInt64,
         firstDeadline: Date
@@ -546,10 +580,20 @@ extension CmxIrohHostRuntime {
                     engine: connectivityEngine,
                     expectedEndpointID: endpointID
                 )
-                guard state.requiresPublication(
+                switch state.publicationDecision(
                     after: lastRegistrationRefreshState,
                     now: now()
-                ) else {
+                ) {
+                case .publish:
+                    break
+                case .unchanged:
+                    completedSuccessfully = true
+                    return
+                case let .deferred(until):
+                    // Reachability changed inside the spacing window. Publish
+                    // the latest snapshot once the window closes instead of
+                    // on every observed-address change.
+                    scheduleDeferredPublication(at: until, revision: revision)
                     completedSuccessfully = true
                     return
                 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistrationPublicationState.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistrationPublicationState.swift
@@ -4,12 +4,33 @@ import Foundation
 /// Identifies the externally visible reachability state last published to the broker.
 struct CmxIrohRegistrationPublicationState: Equatable, Sendable {
     private struct Fingerprint: Equatable, Sendable {
-        let routeKeys: [String]
+        /// Reachability facts whose change must publish at once: relay URLs,
+        /// signed direct ports, and whether any direct address exists at all.
+        /// A peer that cannot reach the host through these is offline until
+        /// the broker learns the new value.
+        let stableKeys: [String]
         let directPorts: CmxIrohDirectPorts?
+        let hasDirectAddresses: Bool
+        /// Observed direct addresses. A NAT rebinding changes these every few
+        /// seconds on some networks while the relay path stays valid, so a
+        /// change here is coalesced by the spacing window.
+        let volatileKeys: [String]
 
         init(payload: CmxIrohRegistrationPayload) {
-            routeKeys = payload.pathHints.map(Self.routeKey).sorted()
+            let direct = payload.pathHints.filter { $0.kind == .directAddress }
+            stableKeys = payload.pathHints
+                .filter { $0.kind != .directAddress }
+                .map(Self.routeKey)
+                .sorted()
+            volatileKeys = direct.map(Self.routeKey).sorted()
+            hasDirectAddresses = !direct.isEmpty
             directPorts = payload.directPorts
+        }
+
+        func stablePartEquals(_ other: Fingerprint) -> Bool {
+            stableKeys == other.stableKeys
+                && directPorts == other.directPorts
+                && hasDirectAddresses == other.hasDirectAddresses
         }
 
         private static func routeKey(_ hint: CmxIrohPathHint) -> String {
@@ -24,13 +45,41 @@ struct CmxIrohRegistrationPublicationState: Equatable, Sendable {
         }
     }
 
+    /// What a runtime should do with a freshly computed publication state.
+    enum Decision: Equatable, Sendable {
+        /// Publish now: first registration, changed reachability past the
+        /// spacing window, or a scheduled renewal.
+        case publish
+        /// Reachability is unchanged and no renewal is due.
+        case unchanged
+        /// Reachability changed inside the spacing window. Publish at `until`
+        /// unless a later snapshot supersedes this one first.
+        case deferred(until: Date)
+    }
+
     private static let maximumPublicationInterval: TimeInterval = 50 * 60
     private static let hintRefreshLeadTime: TimeInterval = 5 * 60
+    /// The shortest gap between two publications driven only by observed
+    /// direct-address churn, when the broker has not advertised one.
+    ///
+    /// Observed addresses on a Mac behind a NAT can change every few seconds.
+    /// Without a floor, every change became a signed registration round trip
+    /// and a broker write; the fleet measured a median of 46 seconds between
+    /// registrations per device. Changes inside the window are coalesced into
+    /// one publication at the end of it. Renewals and forced publications are
+    /// not subject to the floor.
+    static let defaultMinimumPublicationSpacing: TimeInterval = 60
 
     private let fingerprint: Fingerprint
     private let refreshAfter: Date
+    private let publishedAt: Date
+    private let minimumSpacing: TimeInterval
 
-    init(payload: CmxIrohRegistrationPayload, now: Date) {
+    init(
+        payload: CmxIrohRegistrationPayload,
+        now: Date,
+        minimumPublicationSpacing: TimeInterval = Self.defaultMinimumPublicationSpacing
+    ) {
         let hintRefreshAfter = payload.pathHints.compactMap(\.expiresAt).min()
             .map { $0.addingTimeInterval(-Self.hintRefreshLeadTime) }
         let intervalRefreshAfter = now.addingTimeInterval(
@@ -41,14 +90,28 @@ struct CmxIrohRegistrationPublicationState: Equatable, Sendable {
             hintRefreshAfter ?? intervalRefreshAfter,
             intervalRefreshAfter
         )
+        publishedAt = now
+        minimumSpacing = max(0, minimumPublicationSpacing)
+    }
+
+    /// The spacing floor is a property of the last publication: the broker
+    /// advertises it on the register response that created `previous`.
+    func publicationDecision(
+        after previous: CmxIrohRegistrationPublicationState?,
+        now: Date
+    ) -> Decision {
+        guard let previous else { return .publish }
+        if now >= previous.refreshAfter { return .publish }
+        guard previous.fingerprint.stablePartEquals(fingerprint) else { return .publish }
+        guard previous.fingerprint != fingerprint else { return .unchanged }
+        let earliest = previous.publishedAt.addingTimeInterval(previous.minimumSpacing)
+        return now >= earliest ? .publish : .deferred(until: earliest)
     }
 
     func requiresPublication(
         after previous: CmxIrohRegistrationPublicationState?,
         now: Date
     ) -> Bool {
-        guard let previous,
-              previous.fingerprint == fingerprint else { return true }
-        return now >= previous.refreshAfter
+        publicationDecision(after: previous, now: now) == .publish
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistrationPublicationStateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistrationPublicationStateTests.swift
@@ -7,20 +7,21 @@ import Testing
 struct CmxIrohRegistrationPublicationStateTests {
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
-    @Test("path addition removal and replacement require publication")
+    @Test("relay path addition removal and replacement require publication at once")
     func changedPathsRequirePublication() throws {
         let first = try state(hints: [hint("https://relay-a.example/")])
+        let spaced = now
 
-        #expect(try state(hints: []).requiresPublication(after: first, now: now))
+        #expect(try state(hints: []).requiresPublication(after: first, now: spaced))
         #expect(
             try state(hints: [
                 hint("https://relay-a.example/"),
                 hint("https://relay-b.example/"),
-            ]).requiresPublication(after: first, now: now)
+            ]).requiresPublication(after: first, now: spaced)
         )
         #expect(
             try state(hints: [hint("https://relay-b.example/")])
-                .requiresPublication(after: first, now: now)
+                .requiresPublication(after: first, now: spaced)
         )
     }
 
@@ -50,6 +51,102 @@ struct CmxIrohRegistrationPublicationStateTests {
             after: first,
             now: now.addingTimeInterval(60)
         ))
+    }
+
+    @Test("relay changes and direct address appearance publish at once; address churn is spaced")
+    func stableChangesBypassSpacing() throws {
+        let relayOnly = try state(hints: [hint("https://relay-a.example/")])
+        let relayChanged = try state(
+            hints: [hint("https://relay-b.example/")],
+            payloadNow: now.addingTimeInterval(1)
+        )
+        #expect(relayChanged.publicationDecision(after: relayOnly, now: now.addingTimeInterval(1)) == .publish)
+        let firstDirect = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.8.8:4433")],
+            payloadNow: now.addingTimeInterval(1)
+        )
+        #expect(firstDirect.publicationDecision(after: relayOnly, now: now.addingTimeInterval(1)) == .publish)
+        let churned = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.4.4:4433")],
+            payloadNow: now.addingTimeInterval(2)
+        )
+        #expect(
+            churned.publicationDecision(after: firstDirect, now: now.addingTimeInterval(2))
+                == .deferred(until: now.addingTimeInterval(61))
+        )
+        let portsChanged = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.4.4:4433")],
+            ipv4Port: 50_001,
+            payloadNow: now.addingTimeInterval(3)
+        )
+        #expect(portsChanged.publicationDecision(after: firstDirect, now: now.addingTimeInterval(3)) == .publish)
+    }
+
+    @Test("a changed path inside the spacing window is deferred to the end of the window")
+    func changedPathsAreSpacedOut() throws {
+        let published = try state(hints: [hint("https://relay-a.example/"), directHint("8.8.8.8:4433")])
+        let changed = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.4.4:4433")],
+            payloadNow: now.addingTimeInterval(5)
+        )
+        #expect(
+            changed.publicationDecision(after: published, now: now.addingTimeInterval(5))
+                == .deferred(until: now.addingTimeInterval(60))
+        )
+        #expect(!changed.requiresPublication(after: published, now: now.addingTimeInterval(5)))
+        #expect(
+            changed.publicationDecision(after: published, now: now.addingTimeInterval(60))
+                == .publish
+        )
+        #expect(changed.requiresPublication(after: published, now: now.addingTimeInterval(60)))
+    }
+
+    @Test("the broker-advertised spacing on the last publication wins over the default")
+    func brokerSpacingApplies() throws {
+        let published = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.8.8:4433")],
+            minimumPublicationSpacing: 120
+        )
+        let changed = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.4.4:4433")],
+            payloadNow: now.addingTimeInterval(90)
+        )
+        #expect(
+            changed.publicationDecision(after: published, now: now.addingTimeInterval(90))
+                == .deferred(until: now.addingTimeInterval(120))
+        )
+        let zeroSpacing = try state(
+            hints: [hint("https://relay-a.example/"), directHint("8.8.8.8:4433")],
+            minimumPublicationSpacing: 0
+        )
+        #expect(
+            changed.publicationDecision(after: zeroSpacing, now: now.addingTimeInterval(1))
+                == .publish
+        )
+    }
+
+    @Test("first publication, renewals, and unchanged paths ignore the spacing window")
+    func spacingDoesNotDelayRenewalOrFirstPublication() throws {
+        let fresh = try state(hints: [hint("https://relay-a.example/")])
+        #expect(fresh.publicationDecision(after: nil, now: now) == .publish)
+        let unchanged = try state(hints: [hint("https://relay-a.example/")])
+        #expect(
+            unchanged.publicationDecision(after: fresh, now: now.addingTimeInterval(5))
+                == .unchanged
+        )
+        let expiring = try state(hints: [
+            hint("https://relay-a.example/", expiresAt: now.addingTimeInterval(320)),
+        ])
+        let changedAtRenewal = try state(
+            hints: [hint("https://relay-a.example/", expiresAt: now.addingTimeInterval(320)), directHint("8.8.4.4:4433")],
+            payloadNow: now.addingTimeInterval(20)
+        )
+        // Renewal is due at expiry minus the five-minute lead time, which is
+        // inside the spacing window here; renewal still wins.
+        #expect(
+            changedAtRenewal.publicationDecision(after: expiring, now: now.addingTimeInterval(20))
+                == .publish
+        )
     }
 
     @Test("unchanged paths renew before expiry and within fifty minutes")
@@ -93,6 +190,7 @@ struct CmxIrohRegistrationPublicationStateTests {
         let ipv4Changed = try state(hints: [], ipv4Port: 50_001, ipv6Port: 50_000)
         let ipv6Changed = try state(hints: [], ipv4Port: 50_000, ipv6Port: 50_001)
 
+        // Signed direct ports are reachability facts: a change publishes at once.
         #expect(ipv4Changed.requiresPublication(after: first, now: now))
         #expect(ipv6Changed.requiresPublication(after: first, now: now))
         #expect(!first.requiresPublication(after: first, now: now))
@@ -102,7 +200,9 @@ struct CmxIrohRegistrationPublicationStateTests {
         hints: [CmxIrohPathHint],
         ipv4Port: UInt16? = nil,
         ipv6Port: UInt16? = nil,
-        payloadNow: Date? = nil
+        payloadNow: Date? = nil,
+        minimumPublicationSpacing: TimeInterval =
+            CmxIrohRegistrationPublicationState.defaultMinimumPublicationSpacing
     ) throws -> CmxIrohRegistrationPublicationState {
         let payloadNow = payloadNow ?? now
         let payload = try CmxIrohRegistrationPayload(
@@ -120,7 +220,22 @@ struct CmxIrohRegistrationPublicationStateTests {
                 : try CmxIrohDirectPorts(ipv4: ipv4Port, ipv6: ipv6Port),
             now: payloadNow
         )
-        return CmxIrohRegistrationPublicationState(payload: payload, now: payloadNow)
+        return CmxIrohRegistrationPublicationState(
+            payload: payload,
+            now: payloadNow,
+            minimumPublicationSpacing: minimumPublicationSpacing
+        )
+    }
+
+    private func directHint(_ value: String) throws -> CmxIrohPathHint {
+        try CmxIrohPathHint(
+            kind: .directAddress,
+            value: value,
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: now,
+            expiresAt: now.addingTimeInterval(3_600)
+        )
     }
 
     private func hint(


### PR DESCRIPTION
Client half of the heartbeat write-rate fix. Server half: PR 12209 (merged), PR 12211 (mint-time spacing and no-op detection), PR 12213 (retention off the request path).

Measured on cmux-prod after the PlanetScale move: 3,978 Macs registering with a median gap of 46 seconds and a 10th percentile of 5.5 seconds, 99 percent of consecutive registrations with a changed payload, about 2,000 challenge rows a minute. The driver is `CmxIrohLibEndpoint` yielding `.networkChanged` on every observed-address snapshot from iroh, which `CmxIrohHostRuntime` turns into a registration whenever the hint fingerprint differs. There was no floor between publications.

`CmxIrohRegistrationPublicationState` now splits the fingerprint. The stable part, relay URLs, signed direct ports, and whether any direct address exists, publishes at once as before: these decide whether a peer can reach the host. The volatile part, observed direct-address values, is subject to a spacing window: a change inside the window returns `.deferred(until:)`, and the host runtime arms one refresh at that moment through the renewal task slot, so the latest snapshot is published exactly once when the window closes. Renewals, forced publications, and the first publication bypass the window. The window comes from `minimum_publication_spacing_seconds` on the register response that created the last publication state (contract agreed with PR 12211), defaulting to 60 seconds when absent. The iOS client runtime keeps publishing every change.

Tests: new state tests for deferral, broker-advertised spacing, and the stable-versus-volatile split; the host runtime test that asserted immediate publication on an address change now asserts the first address publishes at once and a later change is deferred to the window and then published, with the recording clock proving the deadline. Full CmuxIrohTransport package suite: 641 tests pass.

https://claude.ai/code/session_01GDMKMnvdKKL4LHgACBmeNC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534742&installation_model_id=21920&pr_number=12214&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12214&signature=57d3123d763c6ff1db22356fac11d5e4d6befa2cb379fe0924bb8ed11ced98a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mac host reachability publication timing and broker write rate; incorrect deferral could delay peers seeing updated direct addresses, though stable path changes still publish immediately.
> 
> **Overview**
> **Mac Iroh hosts** now coalesce rapid **observed direct-address** churn into a single broker registration instead of signing and publishing on every network snapshot.
> 
> `CmxIrohRegistrationPublicationState` replaces the single path fingerprint with **stable** reachability (relay URLs, direct ports, presence of direct addresses) vs **volatile** direct-address values. `publicationDecision` returns **publish**, **unchanged**, or **deferred(until:)**; renewals, first registration, and stable changes still publish immediately. The spacing floor comes from **`minimum_publication_spacing_seconds`** on the register response (default **60s** when omitted), stored on the last publication state.
> 
> The **host runtime** applies broker spacing after successful registration, and when only volatile fields change inside the window it arms **one** deferred refresh via the existing renewal task slot. The **iOS client** still treats any non-unchanged reachability as worth refreshing (spacing is documented as a Mac host concern). Registration response models decode the new optional field; tests cover deferral, broker spacing, and stable vs volatile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb572e0e4ae0ecffdc2a8ff462911ab029397f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces Mac host registrations so observed direct-address churn no longer produces a signed registration per iroh snapshot. Previously any hint-fingerprint change published immediately (cmux-prod measured a median 46-second gap per device); now the host publishes stable reachability facts — relay URLs, signed direct ports, and whether any direct address exists — at once and defers direct-address value changes to the end of a spacing window. Renewals, forced publications, and the first publication bypass the window; the iOS client runtime still publishes every change.

**Spacing window**
- The window is the broker's `minimum_publication_spacing_seconds` from the register response that created the last publication state, defaulting to 60 seconds when the broker omits it.
- A deferred publication is armed through the renewal task slot, so the latest snapshot publishes exactly once when the window closes; a later successful publication replaces the deferral with a normal renewal, and sign-out cancels both.

<sup>Written for commit eb572e0e4ae0ecffdc2a8ff462911ab029397f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Registration updates now publish immediately for meaningful connectivity changes, including relay or direct-address changes.
  - Minor direct-address changes may be briefly deferred to reduce unnecessary updates.
  - Renewal and first-time registration continue to take priority over spacing rules.
  - Publication timing can now be configured by the broker, with a default spacing interval when no value is provided.

- **Bug Fixes**
  - Refresh decisions now correctly distinguish unchanged, immediate, and deferred registration updates.
  - Deferred updates are scheduled and canceled safely according to connection lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->