### PR TITLE
web: tag every Cloud DB statement with SQLCommenter attribution

### DIFF
--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -7,6 +7,7 @@ import { Client, Pool, Query as PgQuery } from "pg";
 import postgres, { type Sql } from "postgres";
 import { cloudDbConfig, cloudDbConfigKey, type CloudDbAwsRdsIamConfig } from "./config";
 import { currentCloudDbQuerySignal } from "./queryScope";
+import { tagCloudDbQuery } from "./queryTags";
 import * as schema from "./schema";
 
 function createPostgresJsDb(sql: Sql) {
@@ -46,7 +47,11 @@ function installPostgresJsQueryCancellation(sql: Sql): void {
   const originalUnsafe = sql.unsafe;
   let currentUnsafe = originalUnsafe;
   const wrappedUnsafe = (...args: Parameters<typeof originalUnsafe>) => {
-    const query = currentUnsafe(...args) as unknown as CancellablePostgresQuery;
+    // Every statement carries the SQLCommenter tags for its request or job,
+    // so Insights attributes load to a route instead of to `postgres.js`.
+    const [statement, ...rest] = args;
+    const tagged = [tagCloudDbQuery(statement), ...rest] as Parameters<typeof originalUnsafe>;
+    const query = currentUnsafe(...tagged) as unknown as CancellablePostgresQuery;
     const signal = currentCloudDbQuerySignal();
     if (signal) watchPostgresJsQuery(query, signal);
     return query;

--- a/web/db/queryTags.ts
+++ b/web/db/queryTags.ts
@@ -1,0 +1,98 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * SQLCommenter-style tags appended to every statement the Cloud DB client
+ * sends, so PlanetScale Insights can attribute load to a route, a cron, or a
+ * script instead of showing one anonymous `postgres.js` application.
+ *
+ * Keys are bounded on purpose. Never add ids, emails, tokens, or raw URLs:
+ * Insights groups by tag value, and unbounded values make every pattern its
+ * own bucket. `route` must be the route template (`/api/vm/[id]`), never the
+ * concrete path.
+ */
+export type CloudDbQueryTags = {
+  /** app | cron | script | agent */
+  readonly source: string;
+  /** Route template for request-driven work, for example `/api/devices/iroh/register`. */
+  readonly route?: string;
+  /** Cron or script name for scheduled and operator work. */
+  readonly job?: string;
+};
+
+const tagStorage = new AsyncLocalStorage<CloudDbQueryTags>();
+
+export function runWithCloudDbQueryTags<T>(
+  tags: CloudDbQueryTags,
+  fn: () => T,
+): T {
+  return tagStorage.run(tags, fn);
+}
+
+/**
+ * The active tags: an explicit context wins; otherwise a script or cron can
+ * name itself through the environment (`CMUX_DB_QUERY_SOURCE`,
+ * `CMUX_DB_QUERY_JOB`), which is how the operator backfills and the Vercel
+ * cron routes identify themselves without a request wrapper.
+ */
+export function currentCloudDbQueryTags(): CloudDbQueryTags | undefined {
+  const stored = tagStorage.getStore();
+  if (stored) return stored;
+  const source = process.env.CMUX_DB_QUERY_SOURCE?.trim();
+  const job = process.env.CMUX_DB_QUERY_JOB?.trim();
+  if (!source && !job) return undefined;
+  return { source: source || "script", ...(job ? { job } : {}) };
+}
+
+const APPLICATION = "cmux-web";
+const MAX_VALUE_LENGTH = 120;
+
+function releaseTag(): string | undefined {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA?.trim();
+  if (sha && /^[0-9a-f]{7,40}$/i.test(sha)) return sha.slice(0, 12);
+  return undefined;
+}
+
+/**
+ * Percent-encode a value the way SQLCommenter specifies: the value is
+ * URL-encoded, then single quotes and backslashes are escaped so the comment
+ * cannot terminate early or carry statement text.
+ */
+function encodeValue(value: string): string {
+  return encodeURIComponent(value.slice(0, MAX_VALUE_LENGTH))
+    .replace(/'/g, "%27")
+    .replace(/\\/g, "%5C");
+}
+
+const SAFE_KEY = /^[a-z_]{1,32}$/;
+
+/** The comment for the current context, or an empty string when nothing applies. */
+export function formatCloudDbQueryComment(
+  tags: CloudDbQueryTags | undefined = currentCloudDbQueryTags(),
+  release: string | undefined = releaseTag(),
+): string {
+  const pairs: [string, string][] = [["application", APPLICATION]];
+  if (release) pairs.push(["release", release]);
+  pairs.push(["source", tags?.source ?? "app"]);
+  if (tags?.route) pairs.push(["route", tags.route]);
+  if (tags?.job) pairs.push(["job", tags.job]);
+  const rendered = pairs
+    .filter(([key, value]) => SAFE_KEY.test(key) && value.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}='${encodeValue(value)}'`)
+    .join(",");
+  return rendered ? `/*${rendered}*/` : "";
+}
+
+/**
+ * Append the comment to a statement. SQLCommenter puts the comment last so
+ * the statement text, which drivers use for prepared-statement identity,
+ * stays at the front. A statement that already carries a SQLCommenter
+ * comment is left alone.
+ */
+export function tagCloudDbQuery(query: string): string {
+  if (/\/\*[a-z_]+='/.test(query)) return query;
+  const comment = formatCloudDbQueryComment();
+  if (!comment) return query;
+  const trimmed = query.replace(/\s+$/, "");
+  return `${trimmed} ${comment}`;
+}

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -1,3 +1,4 @@
+import { runWithCloudDbQueryTags } from "../db/queryTags";
 import {
   context as otelContext,
   SpanStatusCode,
@@ -114,7 +115,10 @@ export async function withApiRouteSpan<T extends Response>(
       ...(options.priority === undefined ? {} : { "cmux.priority": options.priority }),
     },
     async (span) => {
-      const response = await fn(span);
+      const source = route.startsWith("/api/cron/") || route.startsWith("/api/internal/")
+        ? "cron"
+        : "app";
+      const response = await runWithCloudDbQueryTags({ source, route }, () => fn(span));
       span.setAttribute("http.response.status_code", response.status);
       span.setAttribute("cmux.http.response_error", response.status >= 400);
       if (response.status >= 500) {

--- a/web/tests/db-query-tags-behavior.test.ts
+++ b/web/tests/db-query-tags-behavior.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { cloudDb } from "../db/client";
+import { runWithCloudDbQueryTags } from "../db/queryTags";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+describe("cloud db query tags on the wire", () => {
+  dbTest("every statement the client sends carries the SQLCommenter comment", async () => {
+    const db = cloudDb();
+    const [outside] = await db.execute<{ q: string }>(sql`select current_query() as q`);
+    expect(outside?.q).toContain("/*application='cmux-web'");
+    // Drizzle issues the statement when the query is awaited, so the await
+    // must happen inside the tag context, as it does inside a route handler.
+    const [inside] = await runWithCloudDbQueryTags(
+      { source: "app", route: "/api/devices/iroh/register" },
+      async () => await db.execute<{ q: string }>(sql`select current_query() as q`),
+    );
+    expect(inside?.q).toContain("route='%2Fapi%2Fdevices%2Firoh%2Fregister'");
+    expect(inside?.q).toContain("source='app'");
+    // The comment is a suffix; the statement text is still first.
+    expect(inside?.q?.startsWith("select current_query()")).toBe(true);
+  });
+});

--- a/web/tests/db-query-tags.test.ts
+++ b/web/tests/db-query-tags.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  currentCloudDbQueryTags,
+  formatCloudDbQueryComment,
+  runWithCloudDbQueryTags,
+  tagCloudDbQuery,
+} from "../db/queryTags";
+
+const savedEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+});
+
+describe("cloud db query tags", () => {
+  test("renders bounded SQLCommenter keys in sorted order with encoded values", () => {
+    const comment = formatCloudDbQueryComment(
+      { source: "app", route: "/api/devices/iroh/register" },
+      "abcdef123456",
+    );
+    expect(comment).toBe(
+      "/*application='cmux-web',release='abcdef123456',route='%2Fapi%2Fdevices%2Firoh%2Fregister',source='app'*/",
+    );
+  });
+
+  test("escapes quotes and comment terminators so a value cannot end the comment", () => {
+    const comment = formatCloudDbQueryComment({ source: "app", job: "x'*/; drop" }, undefined);
+    expect(comment).not.toContain("*/;");
+    expect(comment).toBe("/*application='cmux-web',job='x%27*%2F%3B%20drop',source='app'*/");
+  });
+
+  test("appends the comment to a statement once and leaves tagged statements alone", () => {
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    const tagged = runWithCloudDbQueryTags({ source: "app", route: "/api/vm" }, () =>
+      tagCloudDbQuery("select 1 \n"),
+    );
+    expect(tagged).toBe("select 1 /*application='cmux-web',route='%2Fapi%2Fvm',source='app'*/");
+    expect(tagCloudDbQuery(tagged)).toBe(tagged);
+  });
+
+  test("scripts and crons identify themselves through the environment when no context is set", () => {
+    process.env.CMUX_DB_QUERY_SOURCE = "script";
+    process.env.CMUX_DB_QUERY_JOB = "stripe-backfill";
+    expect(currentCloudDbQueryTags()).toEqual({ source: "script", job: "stripe-backfill" });
+    // An explicit context still wins.
+    expect(runWithCloudDbQueryTags({ source: "app", route: "/x" }, () => currentCloudDbQueryTags()))
+      .toEqual({ source: "app", route: "/x" });
+  });
+
+  test("defaults to the application and source when nothing else is known", () => {
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    delete process.env.CMUX_DB_QUERY_SOURCE;
+    delete process.env.CMUX_DB_QUERY_JOB;
+    expect(formatCloudDbQueryComment(undefined, undefined)).toBe("/*application='cmux-web',source='app'*/");
+  });
+});


### PR DESCRIPTION
From the PlanetScale Insights review of cmux-prod: every pattern showed under the single application name `postgres.js`, and the only tags were the system ones (application_name, remote_address, username, catalog). Attributing the heartbeat load to `/api/devices/iroh/register` meant reading source.

Every statement the postgres.js client sends now ends with a SQLCommenter comment, for example `select ... /*application='cmux-web',release='4df1657ef510',route='%2Fapi%2Fdevices%2Firoh%2Fregister',source='app'*/`. Keys are bounded: `application`, `release`, `source` (app, cron, script), `route` (the route template), `job`. No ids, emails, or raw paths. Values are percent-encoded and quote-escaped so a value cannot terminate the comment.

Where the context comes from: `withApiRouteSpan` in `services/telemetry.ts` sets `route` and `source` for every API route that uses it; routes under `/api/cron/` and `/api/internal/` are tagged `cron`. Scripts and any route without the span wrapper can set `CMUX_DB_QUERY_SOURCE` and `CMUX_DB_QUERY_JOB`. The comment is appended in the existing `unsafe` wrapper in `db/client.ts`, which already intercepts every drizzle statement for cancellation, so no query path is missed. Statements that already carry a SQLCommenter comment are left alone.

Insights then supports `/insights/tags/summaries?tags=route` for per-route load, which is the precondition for any Traffic Control budget.

Tests: unit tests for formatting, encoding, env fallback, and idempotence; a database behavior test that reads `current_query()` inside and outside a tag context. Full web suite 2,911 tests, typecheck, complexity gate at baseline.

https://claude.ai/code/session_01GDMKMnvdKKL4LHgACBmeNC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791535004&installation_model_id=21920&pr_number=12215&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12215&signature=cf2b082628a9697a6faf5ac5403705986009053326d5a927f8635a7ee9d2cf79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every postgres.js query string is modified at the driver boundary; mistakes could affect prepared-statement identity or comment safety, though values are bounded and escaped and comments are appended as suffixes.
> 
> **Overview**
> **Adds SQLCommenter-style comments to Cloud DB queries** so PlanetScale Insights can attribute load by route, job, or source instead of lumping everything under `postgres.js`.
> 
> A new `queryTags` module builds bounded, encoded comment suffixes (`application`, `release`, `source`, `route`, `job`) from `AsyncLocalStorage` or from `CMUX_DB_QUERY_SOURCE` / `CMUX_DB_QUERY_JOB` for scripts and crons. The existing postgres.js `unsafe` wrapper in `db/client.ts` now runs every statement through `tagCloudDbQuery` before execution (alongside query cancellation), so Drizzle-issued SQL picks up tags without touching each call site.
> 
> API routes wrapped by `withApiRouteSpan` run their handlers inside `runWithCloudDbQueryTags`, setting `route` to the route template and `source` to `cron` for `/api/cron/` and `/api/internal/`, otherwise `app`. Unit tests cover comment formatting, escaping, env fallback, and idempotence; an optional integration test asserts `current_query()` on the wire when `CMUX_DB_TEST=1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d1d9ae2cd07568cb3c4eb0c209ba29c6297e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags every Cloud DB statement with SQLCommenter attribution so PlanetScale Insights can attribute load to a route, cron, or script instead of grouping all traffic under `postgres.js`.

- Appends a comment with bounded keys (`application`, `release`, `source`, `route`, `job`) to every statement the `postgres.js` client sends.
- `withApiRouteSpan` sets the route and source context; cron and internal routes are tagged as `cron`.
- Scripts and routes without the span wrapper can set `CMUX_DB_QUERY_SOURCE` and `CMUX_DB_QUERY_JOB` to identify themselves.
- Values are percent-encoded and quote-escaped so they cannot end the comment, and statements already carrying a SQLCommenter comment are left unchanged.

<sup>Written for commit 73d1d9ae2cd07568cb3c4eb0c209ba29c6297e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud database query insights now identify the originating application route.
  - Queries from scheduled and internal processes are labeled with their relevant execution context.
  - Existing query annotations are preserved, with consistent and safely formatted metadata.

- **Bug Fixes**
  - Improved attribution prevents database activity from being grouped generically under the database client, making performance analysis more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->