### PR TITLE
irx: honor the broker Retry-After floor on activation retries

### DIFF
--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -32,6 +32,31 @@ final class MobileHostIrxRuntime {
         return true
     }
 
+    /// Longest wait between two activation attempts on the doubling ladder.
+    nonisolated static let maximumActivationRetryDelay: TimeInterval = 5 * 60
+
+    /// Delay before the next activation attempt after `error`.
+    ///
+    /// The ladder starts at 5 s and doubles per consecutive failure up to
+    /// `maximumActivationRetryDelay`. A broker `Retry-After` is a floor that
+    /// wins over the ladder, and `jitterUnitInterval` (0...1) adds up to a
+    /// quarter of the resulting delay so a fleet told to wait the same window
+    /// does not re-mint in lockstep.
+    nonisolated static func activationRetryDelay(
+        after error: any Error,
+        failureCount: Int,
+        jitterUnitInterval: Double
+    ) -> TimeInterval {
+        let exponent = min(max(failureCount, 0), 16)
+        let ladder = min(5 * pow(2, Double(exponent)), maximumActivationRetryDelay)
+        let serverFloor = TimeInterval(
+            max(0, (error as? any CmxRetryAfterProviding)?.retryAfterSeconds ?? 0)
+        )
+        let base = max(ladder, serverFloor)
+        let jitter = min(max(jitterUnitInterval, 0), 1) * base * 0.25
+        return base + jitter
+    }
+
     nonisolated static var forceRelayOnly: Bool {
         if ProcessInfo.processInfo.environment["CMUX_IRX_FORCE_RELAY"] == "1" {
             UserDefaults.standard.set(true, forKey: forceRelayDefaultsKey)
@@ -145,6 +170,9 @@ final class MobileHostIrxRuntime {
     private var managedNetworkingTask: Task<Void, Never>?
     /// Changes on every (de)activation; per-connection supervisors compare it.
     private var generationToken = UUID()
+    /// Consecutive activation failures since the last successful activation.
+    /// Drives the doubling retry ladder; reset on success and on transition.
+    private var activationFailureCount = 0
 
     /// Coarse lifecycle mirror for the Settings Networking section (see
     /// `MobileHostIrxRuntime+SettingsControl`). `failed` means the last
@@ -238,6 +266,7 @@ final class MobileHostIrxRuntime {
         }
         await deactivate()
         activeAccountID = accountID
+        activationFailureCount = 0
         guard let accountID else { return }
         Self.journal.record("host-runtime", "activating", ["account": accountID])
         setSettingsPhase(.activating)
@@ -546,6 +575,7 @@ final class MobileHostIrxRuntime {
                 ]
             )
             setSettingsPhase(.active)
+            activationFailureCount = 0
         } catch {
             guard !Task.isCancelled, generationToken == token else { return }
             Self.journal.record(
@@ -557,9 +587,27 @@ final class MobileHostIrxRuntime {
                 // flicker in Settings); success or an account change clears it.
                 setSettingsPhase(.failed)
             }
-            // One bounded retry ladder, reset by the auth observation loop on
-            // account change: retry activation after 5s while still desired.
-            try? await Task.sleep(for: .seconds(5))
+            // One bounded retry ladder, reset on success and by the auth
+            // observation loop on account change. The broker's Retry-After
+            // (429 on challenge/register under mint spacing) is a floor, so a
+            // rejected Mac never re-mints inside the window it was told to
+            // wait out; the doubling ladder covers every other failure.
+            let delay = Self.activationRetryDelay(
+                after: error,
+                failureCount: activationFailureCount,
+                jitterUnitInterval: Double.random(in: 0 ... 1)
+            )
+            activationFailureCount = min(activationFailureCount + 1, 20)
+            Self.journal.record(
+                "host-runtime", "activation-retry-scheduled",
+                [
+                    "delay_s": String(Int(delay)),
+                    "server_floor_s": (error as? any CmxRetryAfterProviding)?
+                        .retryAfterSeconds.map(String.init) ?? "-",
+                    "failure_count": String(activationFailureCount),
+                ]
+            )
+            try? await Task.sleep(for: .seconds(delay))
             if !Task.isCancelled, isNetworkingAllowed,
                generationToken == token, activeAccountID == accountID {
                 await activate(accountID: accountID)

--- a/cmuxTests/MobileHostIrxSettingsMappingTests.swift
+++ b/cmuxTests/MobileHostIrxSettingsMappingTests.swift
@@ -164,3 +164,46 @@ struct MobileHostIrxSettingsMappingTests {
         }
     }
 }
+
+/// The irx activation retry ladder must honor a broker `Retry-After` floor.
+/// Before this coverage, a 429 on `/api/devices/iroh/challenge` was retried on
+/// a fixed 5 s cadence (35 rejected mints in 3 minutes on one Mac).
+struct MobileHostIrxActivationRetryTests {
+    @Test func firstFailureWithoutServerFloorWaitsTheBaseDelay() {
+        let delay = MobileHostIrxRuntime.activationRetryDelay(
+            after: URLError(.notConnectedToInternet),
+            failureCount: 0,
+            jitterUnitInterval: 0
+        )
+        #expect(delay == 5)
+    }
+
+    @Test func retryAfterFloorWinsOverTheBaseDelay() {
+        let delay = MobileHostIrxRuntime.activationRetryDelay(
+            after: CmxRateLimitedError(retryAfterSeconds: 60),
+            failureCount: 0,
+            jitterUnitInterval: 0
+        )
+        #expect(delay == 60)
+    }
+
+    @Test func repeatedFailuresDoubleUpToTheCap() {
+        let third = MobileHostIrxRuntime.activationRetryDelay(
+            after: URLError(.timedOut), failureCount: 2, jitterUnitInterval: 0
+        )
+        let capped = MobileHostIrxRuntime.activationRetryDelay(
+            after: URLError(.timedOut), failureCount: 20, jitterUnitInterval: 0
+        )
+        #expect(third == 20)
+        #expect(capped == MobileHostIrxRuntime.maximumActivationRetryDelay)
+    }
+
+    @Test func jitterAddsAtMostAQuarterOfTheDelay() {
+        let delay = MobileHostIrxRuntime.activationRetryDelay(
+            after: CmxRateLimitedError(retryAfterSeconds: 60),
+            failureCount: 0,
+            jitterUnitInterval: 1
+        )
+        #expect(delay == 75)
+    }
+}


### PR DESCRIPTION
`MobileHostIrxRuntime.activate()` retried every failure on a fixed 5 s sleep. With mint-time spacing on the broker (https://github.com/manaflow-ai/cmux/pull/12216), a Mac rejected with 429 on `/api/devices/iroh/challenge` re-minted every 5 s for the whole window: 35 rejected mints in 3 minutes on one DEBUG build, measured by the PR 12216 owner on tag `irohhb`. The same fixed cadence hits cmux-staging today, which answers 503 on register, from every DEBUG and nightly Mac.

The retry now waits `max(doubling ladder, Retry-After)` plus up to 25% jitter, capped at 5 minutes. The ladder starts at 5 s, resets on a successful activation and on account transition, and the irx journal records `activation-retry-scheduled` with the delay, the server floor, and the failure count. `IrxPeerEngine.scheduleRedial` already applies the same floor to dials; this is the activation counterpart.

Commit 1 adds `MobileHostIrxActivationRetryTests` (fails: no `activationRetryDelay`), commit 2 adds the helper and wires it. Principled: the header is a contract the client already honors elsewhere. No user-facing strings.

Scope note: production stable Macs (4,112 active bindings) run the legacy `MobileHostIrohRuntime`, whose `registrationRetrySchedule` already honors Retry-After. irx is the default for DEBUG and nightly (`cmux.irx.enabled` defaults on), so this matters for nightly now and for stable once irx ships there.

https://claude.ai/code/session_01GDMKMnvdKKL4LHgACBmeNC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791537827&installation_model_id=21920&pr_number=12217&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12217&signature=77378b797a62447f7fd0fca73f98436b18cfa6567d6cf977f2288b0d14c3c8a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f3f2f7bae8ec1ce38c745ebf22474981bce7eb1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the broker's `Retry-After` header when scheduling activation retries, replacing the fixed 5 s sleep that caused repeated rejected mints on 429 during mint-time spacing.

- Retry delay is now max(doubling ladder starting at 5 s, server `Retry-After`) plus up to 25% jitter, capped at 5 minutes.
- The ladder resets on successful activation and on account transition; the irx journal records `activation-retry-scheduled` with the delay, server floor, and failure count.
- Adds `MobileHostIrxActivationRetryTests` covering the ladder, floor, cap, and jitter behavior.

<sup>Written for commit f3f2f7bae8ec1ce38c745ebf22474981bce7eb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation retry timing with progressively increasing delays, random jitter, and support for server-provided retry timing.
  * Retry delays are capped to prevent excessively long waits.
  * Retry timing resets after successful activation or an account transition.

* **Tests**
  * Added coverage for initial delays, server retry floors, delay growth, maximum limits, and jitter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->