### PR TITLE
docs: add protected-folder diagnostics for tmux sessions

### DIFF
--- a/docs/local-tmux.md
+++ b/docs/local-tmux.md
@@ -113,6 +113,8 @@ tmux -V
 binary currently on `PATH`. They can differ after a package upgrade. Record the
 server PID and start time as well as the cmux and macOS versions. On macOS, `ps`
 and `lsof` can help inspect the selected PID's start time and mapped executable.
+If the mapped executable path has been replaced or removed, record that too; it
+is a possible confounding factor, not proof of the permission failure's cause.
 
 Outside the pane, use `tmux -S <socket-path>` to query the same server, or
 `tmux -L <socket-name>` for an explicitly named server. A plain `tmux ls` does not
@@ -130,6 +132,8 @@ currently non-reproducible rather than permanently fixed.
 When reporting the problem, include:
 
 - Whether the session uses `cmux local-tmux` or an external launcher.
+- The tested app build/revision and whether newer relevant changes were tested;
+  a marketing version alone may not distinguish a release from a development build.
 - The affected server's version/start time and how its socket was selected.
 - The failing operation and the results of the same-file comparison.
 - Any available permission-denial record at the failure time, with private paths

--- a/docs/local-tmux.md
+++ b/docs/local-tmux.md
@@ -95,6 +95,51 @@ GUI/API operations still use cmux's authenticated control socket. Headless
 operations are limited by the operating-system user; do not share the state
 directory or socket with another Unix user.
 
+## Diagnosing protected-folder access errors
+
+If a shell in tmux reports `Operation not permitted` while reading a file in
+`~/Documents` or another protected folder, record the failure before restarting
+cmux, replacing the tmux server, or changing permissions. A live server and a
+successful attach do not establish that its child processes can read that file.
+
+First identify the affected server. Inside the affected tmux pane, run:
+
+```sh
+tmux display-message -p 'socket=#{socket_path} server_pid=#{pid} server_version=#{version}'
+tmux -V
+```
+
+`server_version` comes from the running server; `tmux -V` describes the client
+binary currently on `PATH`. They can differ after a package upgrade. Record the
+server PID and start time as well as the cmux and macOS versions. On macOS, `ps`
+and `lsof` can help inspect the selected PID's start time and mapped executable.
+
+Outside the pane, use `tmux -S <socket-path>` to query the same server, or
+`tmux -L <socket-name>` for an explicitly named server. A plain `tmux ls` does not
+list every server. For the cmux local-tmux profile, `cmux local-tmux list --json`
+includes `socket_path`; external tmux launchers may use a different socket.
+Do not infer that a session died from a query against another socket.
+
+Use one harmless, existing file to compare a direct shell and the affected pane.
+Record the exact command, time, and exit status without including private file
+contents. If a separate server succeeds, also record its version and launch
+context: that result alone does not isolate server age, TCC state, or cmux as the
+cause. If a later retry succeeds without intervention, report the failure as
+currently non-reproducible rather than permanently fixed.
+
+When reporting the problem, include:
+
+- Whether the session uses `cmux local-tmux` or an external launcher.
+- The affected server's version/start time and how its socket was selected.
+- The failing operation and the results of the same-file comparison.
+- Any available permission-denial record at the failure time, with private paths
+  and unrelated process details removed.
+
+`EPERM` is not specific to TCC, and a daemon's parent PID alone does not identify
+its responsible application. See Apple's [file-system permissions guidance](https://developer.apple.com/forums/thread/678819).
+The related [protected-folder report](https://github.com/manaflow-ai/cmux/issues/2866)
+is an investigation, not evidence that every similar failure has the same cause.
+
 ## Limitations
 
 - This slice requires a local `tmux` executable (or `CMUX_LOCAL_TMUX_BIN`).

--- a/docs/local-tmux.md
+++ b/docs/local-tmux.md
@@ -111,21 +111,26 @@ tmux -V
 
 `server_version` comes from the running server; `tmux -V` describes the client
 binary currently on `PATH`. They can differ after a package upgrade. Record the
-server PID and start time as well as the cmux and macOS versions. On macOS, `ps`
-and `lsof` can help inspect the selected PID's start time and mapped executable.
+server PID and start time as well as the cmux and macOS versions. On macOS,
+`ps`
+and `lsof` can help inspect the selected PID's start time and mapped
+executable.
 If the mapped executable path has been replaced or removed, record that too; it
 is a possible confounding factor, not proof of the permission failure's cause.
 
 Outside the pane, use `tmux -S <socket-path>` to query the same server, or
-`tmux -L <socket-name>` for an explicitly named server. A plain `tmux ls` does not
-list every server. For the cmux local-tmux profile, `cmux local-tmux list --json`
-includes `socket_path`; external tmux launchers may use a different socket.
+`tmux -L <socket-name>` for an explicitly named server. A plain `tmux ls`
+does not list every server. For the cmux local-tmux profile,
+`cmux local-tmux list --json` includes `socket_path`; external tmux launchers
+may use a different socket.
 Do not infer that a session died from a query against another socket.
 
-Use one harmless, existing file to compare a direct shell and the affected pane.
+Use one harmless, existing file to compare a direct shell and the affected
+pane.
 Record the exact command, time, and exit status without including private file
 contents. If a separate server succeeds, also record its version and launch
-context: that result alone does not isolate server age, TCC state, or cmux as the
+context: that result alone does not isolate server age, TCC state, or cmux as
+the
 cause. If a later retry succeeds without intervention, report the failure as
 currently non-reproducible rather than permanently fixed.
 
@@ -133,16 +138,22 @@ When reporting the problem, include:
 
 - Whether the session uses `cmux local-tmux` or an external launcher.
 - The tested app build/revision and whether newer relevant changes were tested;
-  a marketing version alone may not distinguish a release from a development build.
+  a marketing version alone may not distinguish a release from a development
+  build.
 - The affected server's version/start time and how its socket was selected.
 - The failing operation and the results of the same-file comparison.
-- Any available permission-denial record at the failure time, with private paths
+- Any available permission-denial record at the failure time, with private
+  paths
   and unrelated process details removed.
 
-`EPERM` is not specific to TCC, and a daemon's parent PID alone does not identify
-its responsible application. See Apple's [file-system permissions guidance](https://developer.apple.com/forums/thread/678819).
-The related [protected-folder report](https://github.com/manaflow-ai/cmux/issues/2866)
-is an investigation, not evidence that every similar failure has the same cause.
+`EPERM` is not specific to TCC, and a daemon's parent PID alone does not
+identify
+its responsible application. `Operation not permitted` (EPERM) and
+`Permission denied` (EACCES) are different errors; record the exact wording or
+errno rather than treating them as interchangeable. See
+[Apple's guidance](https://developer.apple.com/forums/thread/678819).
+The related [report](https://github.com/manaflow-ai/cmux/issues/2866) is an
+investigation, not evidence that every similar failure has the same cause.
 
 ## Limitations
 

--- a/docs/local-tmux.md
+++ b/docs/local-tmux.md
@@ -112,9 +112,14 @@ tmux -V
 `server_version` comes from the running server; `tmux -V` describes the client
 binary currently on `PATH`. They can differ after a package upgrade. Record the
 server PID and start time as well as the cmux and macOS versions. On macOS,
-`ps`
-and `lsof` can help inspect the selected PID's start time and mapped
-executable.
+substitute the reported server PID in these read-only commands:
+
+```sh
+ps -p <server-pid> -o pid=,ppid=,lstart=,command=
+lsof -a -p <server-pid> -d txt
+```
+
+The `txt` entries show mapped executable and code files.
 If the mapped executable path has been replaced or removed, record that too; it
 is a possible confounding factor, not proof of the permission failure's cause.
 
@@ -125,14 +130,43 @@ does not list every server. For the cmux local-tmux profile,
 may use a different socket.
 Do not infer that a session died from a query against another socket.
 
-Use one harmless, existing file to compare a direct shell and the affected
-pane.
-Record the exact command, time, and exit status without including private file
-contents. If a separate server succeeds, also record its version and launch
-context: that result alone does not isolate server age, TCC state, or cmux as
-the
-cause. If a later retry succeeds without intervention, report the failure as
-currently non-reproducible rather than permanently fixed.
+Compare the original failing operation in the affected pane, a direct cmux
+shell outside tmux, and a direct shell in the other terminal app. Use the same
+absolute path and record which app hosts each shell. For a directory-listing
+failure, run this POSIX-shell snippet in each context, replacing the example
+path with the affected directory:
+
+```sh
+diagnostic_dir="$HOME/Documents/path/to/affected-directory"
+date -u '+%Y-%m-%dT%H:%M:%SZ'
+/bin/ls -a "$diagnostic_dir" > /dev/null
+diagnostic_status=$?
+printf 'directory listing exit=%s\n' "$diagnostic_status"
+```
+
+Standard output is discarded to avoid printing directory entries; standard
+error remains visible so the exact error can be recorded. If the original
+failure used a relative path such as `ls .`, also record the working directory
+and repeat that exact command: a fresh lookup by absolute path may behave
+differently from access through an existing working directory.
+
+For a file-read failure, choose one harmless, existing regular file and use
+this additional check in the same shell contexts:
+
+```sh
+diagnostic_file="$HOME/Documents/path/to/harmless-file"
+date -u '+%Y-%m-%dT%H:%M:%SZ'
+cat "$diagnostic_file" > /dev/null
+diagnostic_status=$?
+printf 'file read exit=%s\n' "$diagnostic_status"
+```
+
+A successful file read does not establish that listing its directory works.
+Record each command, time, exact error, and exit status without including
+private contents. If a separate server succeeds, also record its version and
+launch context: that result alone does not isolate server age, TCC state, or
+cmux as the cause. If a later retry succeeds without intervention, report the
+failure as currently non-reproducible rather than permanently fixed.
 
 When reporting the problem, include:
 
@@ -141,13 +175,11 @@ When reporting the problem, include:
   a marketing version alone may not distinguish a release from a development
   build.
 - The affected server's version/start time and how its socket was selected.
-- The failing operation and the results of the same-file comparison.
+- The failing operation and the results for the same path in each shell context.
 - Any available permission-denial record at the failure time, with private
-  paths
-  and unrelated process details removed.
+  paths and unrelated process details removed.
 
-`EPERM` is not specific to TCC, and a daemon's parent PID alone does not
-identify
+`EPERM` is not specific to TCC, and a daemon's parent PID alone does not identify
 its responsible application. `Operation not permitted` (EPERM) and
 `Permission denied` (EACCES) are different errors; record the exact wording or
 errno rather than treating them as interchangeable. See


### PR DESCRIPTION
## Summary

Add a protected-folder troubleshooting section to the local tmux guide. It explains how to identify the affected socket and running server version, preserve the failure before restarting, and report a same-file comparison without assuming an EPERM root cause.

Related to #2866. The guide distinguishes the cmux local-tmux profile from externally managed tmux sessions and makes no runtime or permission-policy change.

## Testing

- Validated the documented `display-message` format for socket, server PID, and running-server version.
- Confirmed `local-tmux list --json` exposes `socket_path` in `CLI/CMUXCLI+LocalTmuxLifecycle.swift`.
- `git diff --check`.
- Localization audit: changed repository Markdown only; no app strings, web-rendered message keys, or localization catalogs changed. No localized counterpart to this Markdown page was found in the checkout.
- No app build: documentation-only change. This PR makes no claim to reproduce or fix a permission failure.

## Demo Video

Not applicable: no UI or runtime behavior change.

## Checklist

- [x] I tested the documented diagnostic command locally
- [x] I updated the relevant documentation
- [ ] Maintainer review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791541595&installation_model_id=21920&pr_number=12219&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12219&signature=6a48a9fc03cc0c7864a7354c8ec5fd75f246d368e66189c3eacfdc6d7aa9f1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a protected-folder troubleshooting section to the local tmux guide so `Operation not permitted` errors can be diagnosed reproducibly and reported without assuming an EPERM root cause. The docs show how to identify the affected socket and server version, preserve the failure before restarting, and run exact same-path commands in each shell context.

- Records the server PID, start time, and mapped executables via read-only commands.
- Includes repeatable POSIX-shell snippets for directory-listing and file-read checks that capture exit status and exact error text.
- Distinguishes EPERM from EACCES and notes when a failure should be reported as non-reproducible.
- Relates to the protected-folder investigation in #2866.
- Documentation-only change; no runtime or permission-policy behavior changes.

<sup>Written for commit 4f9db46ba1aef9f3d164e91dd23905733ffbd4cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for protected-folder access errors in local tmux environments.
  * Documented how to capture diagnostic details, identify the affected tmux server, and gather process information.
  * Added examples for investigating directory-listing and file-read failures across panes and terminal applications.
  * Clarified distinctions between permission errors and limitations of interpreting process ownership.
  * Included reporting recommendations and links to relevant Apple guidance and issue information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->