### PR TITLE
Fix Design Mode capture scroll limits at fractional zoom

### DIFF
--- a/Sources/Panels/BrowserScreenshotSnapshotter.swift
+++ b/Sources/Panels/BrowserScreenshotSnapshotter.swift
@@ -752,18 +752,12 @@ enum BrowserScreenshotWebViewSnapshotter {
     private static func scroll(_ webView: WKWebView, to point: NSPoint) async throws -> CGPoint {
         let value = try await webView.callAsyncJavaScript(
             """
-            const doc = document.documentElement;
-            const body = document.body;
-            const maximumX = Math.max(
-              0,
-              doc ? doc.scrollWidth - window.innerWidth : 0,
-              body ? body.scrollWidth - window.innerWidth : 0
-            );
-            const maximumY = Math.max(
-              0,
-              doc ? doc.scrollHeight - window.innerHeight : 0,
-              body ? body.scrollHeight - window.innerHeight : 0
-            );
+            const scrollingElement = document.scrollingElement || document.documentElement;
+            // Use the scroll container's client size for its scroll limits.
+            // At fractional page zoom, WebKit can round innerWidth/innerHeight
+            // differently; they also include scrollbars that cannot be scrolled.
+            const maximumX = Math.max(0, scrollingElement.scrollWidth - scrollingElement.clientWidth);
+            const maximumY = Math.max(0, scrollingElement.scrollHeight - scrollingElement.clientHeight);
             const expectedX = Math.min(Math.max(0, x), maximumX);
             const expectedY = Math.min(Math.max(0, y), maximumY);
             window.scrollTo({ left: x, top: y, behavior: "instant" });

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -488,7 +488,8 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
             """
             <!doctype html>
             <style>
-              html { scroll-behavior: smooth; }
+              html { scroll-behavior: smooth; overflow: scroll; }
+              ::-webkit-scrollbar { width: 16px; height: 16px; }
               body { margin: 0; width: 2100.5px; height: 2100.5px; background: red; }
               #target {
                 position: absolute; left: 1900px; top: 1900px;

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -475,6 +475,62 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         _ = navigationDelegate
     }
 
+    @Test(arguments: [1.0, 1.1, 1.2, 1.3, 1.5])
+    func fractionalZoomCapturesAtScrollLimitsAndRestoresOffset(zoom: Double) async throws {
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 704, height: 528))
+        let (loaded, loadedContinuation) = AsyncStream<Void>.makeStream()
+        let navigationDelegate = BrowserDesignModeTestNavigationDelegate {
+            loadedContinuation.yield()
+            loadedContinuation.finish()
+        }
+        webView.navigationDelegate = navigationDelegate
+        webView.loadHTMLString(
+            """
+            <!doctype html>
+            <style>
+              html { scroll-behavior: smooth; }
+              body { margin: 0; width: 2100.5px; height: 2100.5px; background: red; }
+              #target {
+                position: absolute; left: 1900px; top: 1900px;
+                width: 200.5px; height: 200.5px; background: blue;
+              }
+            </style>
+            <div id="target"></div>
+            """,
+            baseURL: nil
+        )
+        let didLoad = await Self.awaitPageLoad(loaded)
+        #expect(didLoad, "WebKit never finished loading the test page")
+        guard didLoad else { return }
+        webView.pageZoom = zoom
+        let initialOffset = try #require(
+            try await webView.evaluateJavaScript(
+                "window.scrollTo({left: 43, top: 67, behavior: 'instant'}); [scrollX, scrollY]"
+            ) as? [Double]
+        )
+
+        // This crop requires clamping both axes at their maximum scroll offset.
+        // Fractional zoom rounds innerWidth/innerHeight differently from the
+        // scrolling element's client size, especially with visible scrollbars.
+        let image = try await BrowserScreenshotWebViewSnapshotter.captureDocumentRect(
+            NSRect(x: 2000 * zoom, y: 2000 * zoom, width: 50 * zoom, height: 50 * zoom),
+            from: webView
+        )
+        let bitmap = try #require(NSBitmapImageRep(data: try #require(image.tiffRepresentation)))
+        let color = try #require(
+            bitmap.colorAt(x: bitmap.pixelsWide / 2, y: bitmap.pixelsHigh / 2)?.usingColorSpace(.deviceRGB)
+        )
+        let restoredOffset = try #require(
+            try await webView.evaluateJavaScript("[scrollX, scrollY]") as? [Double]
+        )
+
+        #expect(color.blueComponent > 0.9)
+        #expect(color.redComponent < 0.1)
+        #expect(abs(restoredOffset[0] - initialOffset[0]) <= 1)
+        #expect(abs(restoredOffset[1] - initialOffset[1]) <= 1)
+        _ = navigationDelegate
+    }
+
     @Test func synthesizedClickKeepsPageRuntimeOutOfTheNativeComposerInputPath() async throws {
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let controller = BrowserDesignModeController(


### PR DESCRIPTION
## Summary

Design Mode element capture can fail with “The page dimensions could not be read” at fractional page zoom. The screenshot scroller computes its maximum offset from `scrollHeight - innerHeight` (and the equivalent width calculation). WebKit rounds the window viewport differently from the scrolling element's client size; window dimensions also include scrollbars. In a standalone macOS 26.6.2 / cmux 0.64.22 reproduction at 120% zoom with both scrollbars, the old calculation expects `(1461, 1621)` while WebKit reaches `(1474, 1634)`, exceeding the existing one-pixel check. The corrected calculation matches `(1474, 1634)`. Zooming out avoids the reported failure.

Compute both scroll limits from `document.scrollingElement`'s `scrollWidth/clientWidth` and `scrollHeight/clientHeight`, with a document-element fallback. Keep instant scrolling, finite-value checks, the one-pixel tolerance, and restoration unchanged. This fixes the shared capture path used by Design Mode and tiled screenshots.

## Testing

- Reproduced the old scroll-limit mismatch in the installed WKWebView browser using a standalone page with fractional document height. The corrected calculation stays within the existing tolerance.
- Added a parameterized native capture regression for 100%, 110%, 120%, 130%, and 150% zoom. It samples the captured bottom-right target's color and verifies restoration of both scroll offsets. Test and fix are separate commits.
- `git diff --check` and `scripts/lint-pbxproj-test-wiring.sh` pass.
- Swift syntax parsing passes for both changed files.
- Tagged build attempted with checksum-verified prebuilt GhosttyKit and `CMUX_SKIP_ZIG_BUILD=1`. It reached `Build Diff Sidecar` and failed because `rustup` is not installed; no successful full app build is claimed. Native test execution is blocked: dispatching the project's hosted `test-e2e.yml` lane for this PR SHA returns HTTP 403 (upstream repository rights required). A maintainer can run it with `test_filter=cmuxTests/BrowserDesignModeScreenshotEvaluatorTests`. Keeping this draft pending native validation.

## Demo Video

Not recorded. Reproduction: open a tall page, zoom in, and copy a Design Mode element selection; the failure disappears when zooming out.

No user-facing strings changed. No localization changes are needed.
