### PR TITLE
Cloud tree: flatten terminal tabs and surface Displays

### DIFF
--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -1417,21 +1417,10 @@ extension CMUXCLI {
             let workspaceId = workspace.id
             let name = workspace.name.isEmpty ? workspaceId : workspace.name
             lines.append("    \(name)  \(workspaceId)\(workspace.focused ? "  *" : "")  (cmux vm open \(id)/\(workspaceId))")
-            // Rows follow the layout, as in the sidebar: one per pane (the tab it shows),
-            // the pane's other tabs indented beneath it.
-            for row in vmTreeLayoutRows(workspace.placements) {
-                var cell = "      " + vmTreeWorkspaceCell(row.placement, machineID: id, workspaceID: workspaceId)
-                if !row.hiddenTabs.isEmpty {
-                    cell += "  " + String(
-                        format: String(localized: "cli.vm.tree.hiddenTabs", defaultValue: "(+%d hidden)"),
-                        row.hiddenTabs.count
-                    )
-                }
-                lines.append(cell)
-                for hidden in row.hiddenTabs {
-                    lines.append("        " + String(localized: "cli.vm.tree.hiddenTab", defaultValue: "↳ tab") + "  "
-                        + vmTreeWorkspaceCell(hidden, machineID: id, workspaceID: workspaceId))
-                }
+            // Rows follow the layout, as in the sidebar, with every tab as a
+            // sibling leaf. Pane grouping is retained only for ordering.
+            for placement in vmTreeLayoutRows(workspace.placements) {
+                lines.append("      " + vmTreeWorkspaceCell(placement, machineID: id, workspaceID: workspaceId))
             }
         }
         // Ports come before displays, matching the Cloud sidebar's group order.
@@ -1459,10 +1448,10 @@ extension CMUXCLI {
             }
         }
 
-        // VNC Displays are catalog resources, so emit one addressable row per
+        // Displays are catalog resources, so emit one addressable row per
         // screen instead of collapsing several screens into one synthetic desktop.
         if !displays.isEmpty {
-            lines.append("  " + String(localized: "cli.vm.tree.displays", defaultValue: "VNC Displays/"))
+            lines.append("  " + String(localized: "cli.vm.tree.displays", defaultValue: "Displays/"))
             for display in displays {
                 lines.append("    " + vmTreeResourceCell(display, openHint: "cmux surface open", showFullKey: true))
             }
@@ -1528,16 +1517,9 @@ extension CMUXCLI {
         let view: [String: Any]?
     }
 
-    /// One row of a workspace listing: the placement it shows and, for a pane holding
-    /// several tabs, the tabs behind the shown one.
-    struct VMTreeLayoutRow {
-        let placement: VMTreePlacement
-        let hiddenTabs: [VMTreePlacement]
-    }
-
     /// Maps wire placements through the same ``RemoteWorkspaceLayout`` used by the sidebar.
     /// Formatting stays in the CLI; pane grouping, ordering, and active-tab selection do not.
-    static func vmTreeLayoutRows(_ placements: [VMTreePlacement]) -> [VMTreeLayoutRow] {
+    static func vmTreeLayoutRows(_ placements: [VMTreePlacement]) -> [VMTreePlacement] {
         func position(_ view: [String: Any]?, _ key: String) -> Int? {
             vmTreeNumber(view?[key]).flatMap { Int(exactly: $0) }
         }
@@ -1553,12 +1535,7 @@ extension CMUXCLI {
                 kindOrder: kindRank[placement.resource["kind"] as? String ?? ""] ?? 3
             )
         })
-        return layout.rows.map { row in
-            VMTreeLayoutRow(
-                placement: placements[row.shownIndex],
-                hiddenTabs: row.hiddenIndices.map { placements[$0] }
-            )
-        }
+        return layout.flatPlacementIndices.map { placements[$0] }
     }
 
     /// A workspace pointer cell: terminals address through the workspace (`cmux vm open <m>/<ws>/<term>`),

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -42,9 +42,8 @@ extension CMUXCLI {
         /// bound as base so the sidebar cloud button reuses it.
         var pinAsBase: Bool = false
         /// `vm tui` only: the pane execs the full cmux-tui client (its own workspaces and
-        /// panes). Every other open lands a plain terminal on the machine — the app
-        /// creates one in the machine's session and attaches just that terminal, like an
-        /// ssh session — so nothing here needs a local client.
+        /// panes). Every other open reattaches a plain terminal in the machine's
+        /// active workspace, creating one only for an authoritative empty graph.
         var fullClient: Bool = false
         /// Whether the open may take over what the person is looking at: select the
         /// workspace and put keyboard focus in the new pane. `false` (`--focus false`,
@@ -455,17 +454,27 @@ extension CMUXCLI {
         var terminalId: String?
         var remoteWorkspaceId: String?
         if !options.fullClient {
-            // The pane is a plain terminal on the machine: the app creates one in the
-            // machine's cmux-tui session over its headless link and attaches just that
-            // terminal (`attach --terminal`) beside the placeholder, which is then closed.
-            // Same path the Cloud tree uses, so the terminal shows up there as open.
+            // Open the machine's existing terminal. Explicit New Terminal actions
+            // create sessions; opening or reconnecting the machine does not.
             let terminalStartedAt = Date()
             do {
-                let opened = try client.sendV2(
-                    method: "surface.new_terminal",
-                    params: ["machine": vmId, "open": true, "workspace_id": workspaceId, "focus": paneFocus, "name": "shell"],
-                    responseTimeout: 180
-                )
+                let catalog = try client.sendV2(method: "surface.catalog", params: ["machine": vmId, "refresh": true], responseTimeout: 180)
+                let opened: [String: Any]
+                switch VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: vmId, catalog: catalog) {
+                case .resolved(let remoteWorkspaceID, let terminalID, let tabID):
+                    var params: [String: Any] = ["resource": "\(vmId)/terminal/\(terminalID)", "workspace_id": workspaceId, "remote_workspace_id": remoteWorkspaceID, "focus": paneFocus, "reuse": false]
+                    if let tabID { params["remote_tab_id"] = tabID }
+                    var projected = try client.sendV2(method: "surface.project", params: params, responseTimeout: 180)
+                    projected["terminal_id"] = terminalID
+                    projected["remote_workspace_id"] = remoteWorkspaceID
+                    opened = projected
+                case .empty(let remoteWorkspaceID):
+                    var params: [String: Any] = ["machine": vmId, "open": true, "workspace_id": workspaceId, "focus": paneFocus]
+                    if let remoteWorkspaceID { params["remote_workspace_id"] = remoteWorkspaceID }
+                    opened = try client.sendV2(method: "surface.new_terminal", params: params, responseTimeout: 180)
+                case .unavailable:
+                    throw CLIError(message: String(localized: "cli.vm.open.sessionsUnavailable", defaultValue: "The machine’s sessions are unavailable. Refresh and retry."))
+                }
                 terminalId = opened["terminal_id"] as? String
                 remoteWorkspaceId = opened["remote_workspace_id"] as? String
                 let newSurface = (opened["surface_id"] as? String).flatMap { $0.isEmpty ? nil : $0 }

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -1459,8 +1459,10 @@ extension CMUXCLI {
 
         // Displays are catalog resources, so emit one addressable row per
         // screen instead of collapsing several screens into one synthetic desktop.
-        if !displays.isEmpty {
-            lines.append("  " + String(localized: "cli.vm.tree.displays", defaultValue: "Displays/"))
+        lines.append("  " + String(localized: "cli.vm.tree.displays", defaultValue: "Displays/"))
+        if displays.isEmpty {
+            lines.append("    " + String(localized: "cli.vm.tree.noDisplays", defaultValue: "(none available)"))
+        } else {
             for display in displays {
                 lines.append("    " + vmTreeResourceCell(display, openHint: "cmux surface open", showFullKey: true))
             }

--- a/CLI/VMMachineTerminalResolution.swift
+++ b/CLI/VMMachineTerminalResolution.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// The authoritative terminal selection result for opening a Cloud machine.
+enum VMMachineTerminalResolution: Equatable {
+    case resolved(workspaceID: String, terminalID: String, tabID: String?)
+    case empty(workspaceID: String?)
+    case unavailable
+}

--- a/CLI/VMRemoteWorkspaceResolver.swift
+++ b/CLI/VMRemoteWorkspaceResolver.swift
@@ -2,6 +2,34 @@ import Foundation
 
 /// Pure catalog identity resolution shared by the CLI and its behavior tests.
 struct VMRemoteWorkspaceResolver: Sendable {
+    enum VMMachineTerminalResolution: Equatable {
+        case resolved(workspaceID: String, terminalID: String, tabID: String?)
+        case empty(workspaceID: String?)
+        case unavailable
+    }
+
+    /// A machine open reattaches its active workspace's terminal. Only an
+    /// authoritative empty graph permits creation; a missing or ambiguous graph
+    /// must not turn a reconnect into another workspace or terminal.
+    func resolveVMMachineTerminal(machine: String, catalog: [String: Any]) -> VMMachineTerminalResolution {
+        guard let machinePayload = vmMachinePayload(machine, from: catalog),
+              let workspaces = machinePayload["remote_workspaces"] as? [[String: Any]],
+              let resources = catalog["resources"] as? [[String: Any]] else { return .unavailable }
+        guard !workspaces.isEmpty else { return .empty(workspaceID: nil) }
+        let focused = workspaces.filter { ($0["focused"] as? Bool) == true }
+        guard focused.count <= 1 else { return .unavailable }
+        let workspace = focused.first ?? workspaces.first
+        guard let workspaceID = workspace?["id"] as? String, !workspaceID.isEmpty else { return .unavailable }
+        switch resolveVMRemoteWorkspaceTerminal(resources, machine: machine, workspaceID: workspaceID) {
+        case .resolved(let terminalID, let tabID):
+            return .resolved(workspaceID: workspaceID, terminalID: terminalID, tabID: tabID)
+        case .none:
+            return .empty(workspaceID: workspaceID)
+        case .ambiguous, .unavailable:
+            return .unavailable
+        }
+    }
+
     /// Resolution of a remote workspace selector. Workspace ids are identities;
     /// names are mutable labels and are accepted only when they identify one row.
     /// Keeping this result explicit prevents a missing or ambiguous catalog from

--- a/CLI/VMRemoteWorkspaceResolver.swift
+++ b/CLI/VMRemoteWorkspaceResolver.swift
@@ -18,8 +18,11 @@ struct VMRemoteWorkspaceResolver: Sendable {
         guard !workspaces.isEmpty else { return .empty(workspaceID: nil) }
         let focused = workspaces.filter { ($0["focused"] as? Bool) == true }
         guard focused.count <= 1 else { return .unavailable }
-        let workspace = focused.first ?? workspaces.first
-        guard let workspaceID = workspace?["id"] as? String, !workspaceID.isEmpty else { return .unavailable }
+        // A single workspace is unambiguous without a focus marker. Several
+        // unfocused workspaces have no authoritative active target, so fail
+        // closed instead of selecting by wire-array order.
+        guard let workspace = focused.first ?? (workspaces.count == 1 ? workspaces[0] : nil),
+              let workspaceID = workspace["id"] as? String, !workspaceID.isEmpty else { return .unavailable }
         switch resolveVMRemoteWorkspaceTerminal(resources, machine: machine, workspaceID: workspaceID) {
         case .resolved(let terminalID, let tabID):
             return .resolved(workspaceID: workspaceID, terminalID: terminalID, tabID: tabID)

--- a/CLI/VMRemoteWorkspaceResolver.swift
+++ b/CLI/VMRemoteWorkspaceResolver.swift
@@ -2,12 +2,6 @@ import Foundation
 
 /// Pure catalog identity resolution shared by the CLI and its behavior tests.
 struct VMRemoteWorkspaceResolver: Sendable {
-    enum VMMachineTerminalResolution: Equatable {
-        case resolved(workspaceID: String, terminalID: String, tabID: String?)
-        case empty(workspaceID: String?)
-        case unavailable
-    }
-
     /// A machine open reattaches its active workspace's terminal. Only an
     /// authoritative empty graph permits creation; a missing or ambiguous graph
     /// must not turn a reconnect into another workspace or terminal.

--- a/CLI/VMRemoteWorkspaceResolver.swift
+++ b/CLI/VMRemoteWorkspaceResolver.swift
@@ -118,7 +118,12 @@ struct VMRemoteWorkspaceResolver: Sendable {
         workspaceID: String
     ) -> VMRemoteWorkspaceTerminalResolution {
         let liveTerminals = resources.filter { resource in
-            (resource["kind"] as? String) == "terminal" && (resource["lifecycle"] as? String) != "exited"
+            guard (resource["kind"] as? String) == "terminal",
+                  (resource["lifecycle"] as? String) != "exited" else { return false }
+            if let resourceMachine = resource["machine"] as? String {
+                return resourceMachine == machine
+            }
+            return (resource["id"] as? String)?.hasPrefix("\(machine)/terminal/") == true
         }
         var candidates: [(terminalID: String, tabID: String?, focused: Bool, sortID: String)] = []
         var ambiguousSelectors: [String] = []

--- a/CLI/VMRemoteWorkspaceResolver.swift
+++ b/CLI/VMRemoteWorkspaceResolver.swift
@@ -8,7 +8,8 @@ struct VMRemoteWorkspaceResolver: Sendable {
     func resolveVMMachineTerminal(machine: String, catalog: [String: Any]) -> VMMachineTerminalResolution {
         guard let machinePayload = vmMachinePayload(machine, from: catalog),
               let workspaces = machinePayload["remote_workspaces"] as? [[String: Any]],
-              let resources = catalog["resources"] as? [[String: Any]] else { return .unavailable }
+              let resources = catalog["resources"] as? [[String: Any]],
+              machinePayload["link_state"] as? String == "connected" else { return .unavailable }
         guard !workspaces.isEmpty else { return .empty(workspaceID: nil) }
         let focused = workspaces.filter { ($0["focused"] as? Bool) == true }
         guard focused.count <= 1 else { return .unavailable }

--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/RemoteWorkspaceLayout.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/RemoteWorkspaceLayout.swift
@@ -10,6 +10,14 @@ public struct RemoteWorkspaceLayout: Sendable {
     /// Pane rows followed by pane-less resources, expressed as source-array indices.
     public let rows: [RemoteWorkspaceLayoutRow]
 
+    /// Source-array indices in the same visual order as the workspace rows,
+    /// with every tab emitted as a sibling after its pane's focused tab.
+    /// Consumers that render a flat resource list should use this projection;
+    /// ``rows`` remains available to callers that need pane grouping metadata.
+    public var flatPlacementIndices: [Int] {
+        rows.flatMap { [$0.shownIndex] + $0.hiddenIndices }
+    }
+
     private enum ScreenIdentity: Hashable {
         case id(String)
         case index(Int)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -298784,6 +298784,13 @@
       "ja": { "stringUnit": { "state": "translated", "value": "利用可能なディスプレイはありません" } }
     }
   },
+  "cli.vm.open.sessionsUnavailable": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "The machine’s sessions are unavailable. Refresh and retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "マシンのセッションを利用できません。更新して再試行してください。" } }
+    }
+  },
   "cloudTree.ports.failed": {
     "extractionState": "manual",
     "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -298784,6 +298784,13 @@
       "ja": { "stringUnit": { "state": "translated", "value": "利用可能なディスプレイはありません" } }
     }
   },
+  "cloudTree.workspace.pending": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "New workspace" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "新しいワークスペース" } }
+    }
+  },
   "cli.vm.open.sessionsUnavailable": {
     "extractionState": "manual",
     "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -68545,7 +68545,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "VNC Displays"
+            "value": "Displays"
           }
         },
         "ja": {
@@ -298747,6 +298747,41 @@
           "value": "ポートを検出中…"
         }
       }
+    }
+  },
+  "cloudTree.displays.loading": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Discovering displays…" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出中…" } }
+    }
+  },
+  "cloudTree.displays.failed": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Couldn’t discover displays. Refresh to retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出できませんでした。更新して再試行してください。" } }
+    }
+  },
+  "cloudTree.displays.asleep": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Open the machine to discover displays" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "マシンを開いてディスプレイを検出" } }
+    }
+  },
+  "cloudTree.displays.unavailable": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Display discovery unavailable. Refresh to retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイ検出を利用できません。更新して再試行してください。" } }
+    }
+  },
+  "cloudTree.displays.empty": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "No displays available" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "利用可能なディスプレイはありません" } }
     }
   },
   "cloudTree.ports.failed": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -67302,13 +67302,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "VNC Displays/"
+            "value": "Displays/"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "VNC ディスプレイ/"
+            "value": "ディスプレイ/"
           }
         }
       }
@@ -67376,7 +67376,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用法: cmux vm tree [<machine>|local] [--refresh] [--json]\n       cmux surface ls [<machine>|local] [--refresh] [--json]\n\nすべてのサーフェスを Finder 風に表示します。最初にこの Mac（ワークスペース別の\nターミナルとブラウザ）、続いて各クラウドマシンの Workspaces、Ports、VNC Displays\n（画面ごとに 1 行）、最後にマシンが所有するすべてのターミナルを含む Terminals\nセクションを表示します。各行には `cmux vm open` または `cmux surface open` が\n受け付けるアドレスが含まれます。\n\nオプション:\n  <machine>   このマシンだけを表示します（この Mac は `local`）。\n  --refresh   最初に全プロバイダ（マシン一覧、リンク、ローカルペイン）を再読み込みします。\n  --json      カタログのペイロード（{machines, resources, projections}）を表示します。"
+            "value": "使用法: cmux vm tree [<machine>|local] [--refresh] [--json]\n       cmux surface ls [<machine>|local] [--refresh] [--json]\n\nすべてのサーフェスを Finder 風に表示します。最初にこの Mac（ワークスペース別の\nターミナルとブラウザ）、続いて各クラウドマシンの Workspaces、Ports、Displays\n（画面ごとに 1 行）、最後にマシンが所有するすべてのターミナルを含む Terminals\nセクションを表示します。各行には `cmux vm open` または `cmux surface open` が\n受け付けるアドレスが含まれます。\n\nオプション:\n  <machine>   このマシンだけを表示します（この Mac は `local`）。\n  --refresh   最初に全プロバイダ（マシン一覧、リンク、ローカルペイン）を再読み込みします。\n  --json      カタログのペイロード（{machines, resources, projections}）を表示します。"
           }
         }
       }
@@ -68551,7 +68551,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "VNC ディスプレイ"
+            "value": "ディスプレイ"
           }
         }
       }
@@ -298766,8 +298766,8 @@
   "cloudTree.displays.asleep": {
     "extractionState": "manual",
     "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "Open the machine to discover displays" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "マシンを開いてディスプレイを検出" } }
+      "en": { "stringUnit": { "state": "translated", "value": "Displays unavailable while the machine sleeps" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "マシンがスリープ中はディスプレイを利用できません" } }
     }
   },
   "cloudTree.displays.unavailable": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -298791,6 +298791,13 @@
       "ja": { "stringUnit": { "state": "translated", "value": "マシンのセッションを利用できません。更新して再試行してください。" } }
     }
   },
+  "cli.vm.tree.noDisplays": {
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "(none available)" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "（利用可能なものはありません）" } }
+    }
+  },
   "cloudTree.ports.failed": {
     "extractionState": "manual",
     "localizations": {

--- a/Sources/Cloud/CloudMachineSurfacePresentation.swift
+++ b/Sources/Cloud/CloudMachineSurfacePresentation.swift
@@ -4,12 +4,41 @@ import Foundation
 struct CloudMachineSurfacePresentation {
     static func displays(resources: [SurfaceResource], info: SurfaceMachineInfo) -> [SurfaceResource] {
         let displays = resources.filter { $0.kind == .display }
-        guard info.hasDesktop else { return [] }
+        // Catalogued displays are authoritative even when older machine metadata
+        // does not advertise the desktop capability. Preserve every real VNC
+        // screen discovered by the daemon during reconnect.
         guard displays.isEmpty else { return displays }
+        guard info.hasDesktop else { return [] }
         return [CmuxTuiSnapshotParser.display(
             machine: info.id,
             directURL: info.privateAddress.map { CmuxTuiSurfaceProvider.privateDesktopURL(privateAddress: $0) }
         )]
+    }
+
+    static func emptyDisplays(info: SurfaceMachineInfo) -> CloudTreeNode {
+        let text: String
+        let style: CloudTreePlaceholder.Style
+        switch info.linkState {
+        case .connecting:
+            text = String(localized: "cloudTree.displays.loading", defaultValue: "Discovering displays…")
+            style = .connecting
+        case .error:
+            text = info.linkError ?? String(localized: "cloudTree.displays.failed", defaultValue: "Couldn’t discover displays. Refresh to retry.")
+            style = .error
+        case .asleep:
+            text = String(localized: "cloudTree.displays.asleep", defaultValue: "Open the machine to discover displays")
+            style = .dimmed
+        case .unavailable:
+            text = String(localized: "cloudTree.displays.unavailable", defaultValue: "Display discovery unavailable. Refresh to retry.")
+            style = .dimmed
+        case .connected, .notApplicable:
+            text = String(localized: "cloudTree.displays.empty", defaultValue: "No displays available")
+            style = .dimmed
+        }
+        return CloudTreeNode(
+            id: "machine:\(info.id.rawValue)/displays/placeholder",
+            kind: .placeholder(machine: info.id, CloudTreePlaceholder(text: text, style: style, opensMachine: info.linkState == .asleep))
+        )
     }
 
     static func emptyPorts(info: SurfaceMachineInfo) -> CloudTreeNode {
@@ -34,7 +63,7 @@ struct CloudMachineSurfacePresentation {
         }
         return CloudTreeNode(
             id: "machine:\(info.id.rawValue)/ports/status",
-            kind: .placeholder(machine: info.id, CloudTreePlaceholder(text: text, style: style))
+            kind: .placeholder(machine: info.id, CloudTreePlaceholder(text: text, style: style, opensMachine: info.linkState == .asleep))
         )
     }
 }

--- a/Sources/Cloud/CloudMachineSurfacePresentation.swift
+++ b/Sources/Cloud/CloudMachineSurfacePresentation.swift
@@ -26,7 +26,7 @@ struct CloudMachineSurfacePresentation {
             text = info.linkError ?? String(localized: "cloudTree.displays.failed", defaultValue: "Couldn’t discover displays. Refresh to retry.")
             style = .error
         case .asleep:
-            text = String(localized: "cloudTree.displays.asleep", defaultValue: "Open the machine to discover displays")
+            text = String(localized: "cloudTree.displays.asleep", defaultValue: "Displays unavailable while the machine sleeps")
             style = .dimmed
         case .unavailable:
             text = String(localized: "cloudTree.displays.unavailable", defaultValue: "Display discovery unavailable. Refresh to retry.")
@@ -37,7 +37,7 @@ struct CloudMachineSurfacePresentation {
         }
         return CloudTreeNode(
             id: "machine:\(info.id.rawValue)/displays/placeholder",
-            kind: .placeholder(machine: info.id, CloudTreePlaceholder(text: text, style: style, opensMachine: info.linkState == .asleep))
+            kind: .placeholder(machine: info.id, CloudTreePlaceholder(text: text, style: style))
         )
     }
 

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -842,25 +842,27 @@ enum CloudTreeNodeBuilder {
             ))
         }
 
-        // Displays are always a machine-level category, just like Ports and
-        // Terminals. The catalog owns the real VNC resources; an empty state is
-        // explicit so a reconnect never makes the category silently disappear.
-        children.append(CloudTreeNode(
-            id: nodeID(displaysPool: machine),
-            kind: .displaysPool(machine: machine, count: displays.count),
-            children: displays.isEmpty
-                ? [CloudMachineSurfacePresentation.emptyDisplays(info: info)]
-                : displays.map {
-                    CloudTreeNode(
-                        id: nodeID(resource: $0.id),
-                        kind: .display(
-                            $0,
-                            openIn: nil,
-                            remoteView: $0.remoteViews?.count == 1 ? $0.remoteViews?.first : nil
+        // Connected machines expose Displays as a machine-level category, just
+        // like Ports and Terminals. The catalog owns real VNC resources; a
+        // connected empty state is explicit, while a down link stays truthful.
+        if info.linkState == .connected || info.linkState == .notApplicable || !displays.isEmpty {
+            children.append(CloudTreeNode(
+                id: nodeID(displaysPool: machine),
+                kind: .displaysPool(machine: machine, count: displays.count),
+                children: displays.isEmpty
+                    ? [CloudMachineSurfacePresentation.emptyDisplays(info: info)]
+                    : displays.map {
+                        CloudTreeNode(
+                            id: nodeID(resource: $0.id),
+                            kind: .display(
+                                $0,
+                                openIn: nil,
+                                remoteView: $0.remoteViews?.count == 1 ? $0.remoteViews?.first : nil
+                            )
                         )
-                    )
-                }
-        ))
+                    }
+            ))
+        }
 
         // The pool is a process index. It lists every terminal, including
         // terminals already placed in workspaces and detached terminals.

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -33,7 +33,7 @@ final class CloudTreeNode: NSObject {
         /// `terminalCount` counts every terminal placement in the workspace.
         /// `openIn`: the local workspace already showing this remote one (its open mark;
         /// clicking jumps there), else nil.
-        case workspace(machine: SurfaceMachineID, SurfaceRemoteWorkspace, terminalCount: Int, openIn: UUID?)
+        case workspace(machine: SurfaceMachineID, SurfaceRemoteWorkspace, terminalCount: Int, hiddenTabCount: Int, openIn: UUID?)
         /// A local workspace, grouping the local terminals it projects.
         case localWorkspace(CloudTreeLocalWorkspaceRow)
         case terminal(CloudTreeTerminalRow)
@@ -120,7 +120,7 @@ final class CloudTreeNode: NSObject {
             return machine
         case .terminalsPool(let machine, _), .displaysPool(let machine, _):
             return machine
-        case .workspace(let machine, _, _, _), .placeholder(let machine, _):
+        case .workspace(let machine, _, _, _, _), .placeholder(let machine, _):
             return machine
         case .localWorkspace: return .local
         case .terminal(let row): return row.resource.machine
@@ -146,7 +146,7 @@ final class CloudTreeNode: NSObject {
         case .terminalsPool: return String(localized: "cloudTree.group.terminals", defaultValue: "Terminals")
         case .displaysPool: return String(localized: "cloudTree.group.displays", defaultValue: "Displays")
         case .workspacesGroup: return String(localized: "cloudTree.group.workspaces", defaultValue: "Workspaces")
-        case .workspace(_, let workspace, _, _): return workspace.name
+        case .workspace(_, let workspace, _, _, _): return workspace.name
         case .localWorkspace(let row): return row.title
         case .terminal(let row): return row.displayTitle
         case .display(let resource, _, let remoteView):
@@ -254,6 +254,8 @@ struct CloudTreeTerminalRow: Equatable {
     /// The exact daemon tab represented by a workspace pointer row. Pool rows
     /// leave this nil because one terminal may have several placement names.
     var remoteView: SurfaceRemoteView? = nil
+    /// Legacy payload retained for source compatibility; flat projections always set zero.
+    var hiddenTabCount: Int = 0
 
     /// A terminal resource has one process title, but each daemon tab can have
     /// its own user name. Workspace rows must render the placement name, or a
@@ -279,6 +281,8 @@ struct CloudTreeBrowserRow: Equatable {
     /// currently have one tab in the public schema, but retaining the same
     /// placement contract as terminals keeps future multi-view browsers safe.
     var remoteView: SurfaceRemoteView? = nil
+    /// Legacy payload retained for source compatibility; flat projections always set zero.
+    var hiddenTabCount: Int = 0
 }
 
 /// A one-line explanatory row under a machine.
@@ -951,6 +955,7 @@ enum CloudTreeNodeBuilder {
                     machine: machine,
                     workspace,
                     terminalCount: layout.terminalCount,
+                    hiddenTabCount: 0,
                     openIn: openInLocal
                 ),
                 children: layout.rows,
@@ -1122,7 +1127,8 @@ enum CloudTreeNodeBuilder {
         projectionIndex: LocalProjectionIndex,
         id: String? = nil,
         viewBadge: Int? = nil,
-        remoteView: SurfaceRemoteView? = nil
+        remoteView: SurfaceRemoteView? = nil,
+        hiddenTabCount: Int = 0
     ) -> CloudTreeNode {
         CloudTreeNode(
             id: id ?? nodeID(resource: resource.id),
@@ -1131,7 +1137,8 @@ enum CloudTreeNodeBuilder {
                 isOpen: projectionIndex.isOpen(resource.id, remoteView: remoteView),
                 viewBadge: viewBadge,
                 hasUnreadNotification: projectionIndex.hasUnreadNotification(resource.id),
-                remoteView: remoteView
+                remoteView: remoteView,
+                hiddenTabCount: hiddenTabCount
             ))
         )
     }

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -24,18 +24,16 @@ final class CloudTreeNode: NSObject {
         /// "Terminals" pool under a cloud machine: every terminal the machine owns, one
         /// row per identity, whatever workspaces (zero or more) show it.
         case terminalsPool(machine: SurfaceMachineID, count: Int)
-        /// "VNC Displays" group under a cloud machine: one row per screen it exposes.
+        /// "Displays" group under a cloud machine: one row per VNC screen it exposes.
         case displaysPool(machine: SurfaceMachineID, count: Int)
         /// "Workspaces" group under a machine.
         case workspacesGroup(machine: SurfaceMachineID)
-        /// A cmux-tui workspace on a cloud machine; its children are pointer rows into
-        /// the machine's pools, shaped like the workspace's layout: one row per pane (the
-        /// tab the pane shows) with the pane's other tabs nested beneath that row.
-        /// `terminalCount`: terminal rows the layout shows. `hiddenTabCount`: tabs those
-        /// panes hold behind their shown one (the nested rows).
+        /// A cmux-tui workspace on a cloud machine; its children are flat pointer rows
+        /// into the machine's pools, one row per terminal, browser, or display placement.
+        /// `terminalCount` counts every terminal placement in the workspace.
         /// `openIn`: the local workspace already showing this remote one (its open mark;
         /// clicking jumps there), else nil.
-        case workspace(machine: SurfaceMachineID, SurfaceRemoteWorkspace, terminalCount: Int, hiddenTabCount: Int, openIn: UUID?)
+        case workspace(machine: SurfaceMachineID, SurfaceRemoteWorkspace, terminalCount: Int, openIn: UUID?)
         /// A local workspace, grouping the local terminals it projects.
         case localWorkspace(CloudTreeLocalWorkspaceRow)
         case terminal(CloudTreeTerminalRow)
@@ -122,7 +120,7 @@ final class CloudTreeNode: NSObject {
             return machine
         case .terminalsPool(let machine, _), .displaysPool(let machine, _):
             return machine
-        case .workspace(let machine, _, _, _, _), .placeholder(let machine, _):
+        case .workspace(let machine, _, _, _), .placeholder(let machine, _):
             return machine
         case .localWorkspace: return .local
         case .terminal(let row): return row.resource.machine
@@ -146,9 +144,9 @@ final class CloudTreeNode: NSObject {
         case .pendingMachine(let operation): return operation.request.displayName
         case .localMachine(let row): return row.name
         case .terminalsPool: return String(localized: "cloudTree.group.terminals", defaultValue: "Terminals")
-        case .displaysPool: return String(localized: "cloudTree.group.displays", defaultValue: "VNC Displays")
+        case .displaysPool: return String(localized: "cloudTree.group.displays", defaultValue: "Displays")
         case .workspacesGroup: return String(localized: "cloudTree.group.workspaces", defaultValue: "Workspaces")
-        case .workspace(_, let workspace, _, _, _): return workspace.name
+        case .workspace(_, let workspace, _, _): return workspace.name
         case .localWorkspace(let row): return row.title
         case .terminal(let row): return row.displayTitle
         case .display(let resource, _, let remoteView):
@@ -256,9 +254,6 @@ struct CloudTreeTerminalRow: Equatable {
     /// The exact daemon tab represented by a workspace pointer row. Pool rows
     /// leave this nil because one terminal may have several placement names.
     var remoteView: SurfaceRemoteView? = nil
-    /// Tabs the same daemon pane holds behind this one. Only a workspace's pane row
-    /// (the tab its pane shows) carries a count; those tabs are its child rows.
-    var hiddenTabCount: Int = 0
 
     /// A terminal resource has one process title, but each daemon tab can have
     /// its own user name. Workspace rows must render the placement name, or a
@@ -284,8 +279,6 @@ struct CloudTreeBrowserRow: Equatable {
     /// currently have one tab in the public schema, but retaining the same
     /// placement contract as terminals keeps future multi-view browsers safe.
     var remoteView: SurfaceRemoteView? = nil
-    /// Tabs the same daemon pane holds behind this one (see `CloudTreeTerminalRow`).
-    var hiddenTabCount: Int = 0
 }
 
 /// A one-line explanatory row under a machine.
@@ -298,6 +291,14 @@ struct CloudTreePlaceholder: Equatable {
 
     let text: String
     let style: Style
+    /// Only wake placeholders set this. Empty resource categories remain inert.
+    let opensMachine: Bool
+
+    init(text: String, style: Style, opensMachine: Bool = false) {
+        self.text = text
+        self.style = style
+        self.opensMachine = opensMachine
+    }
 }
 
 /// A local workspace, in sidebar order, for grouping this Mac's terminals.
@@ -309,7 +310,7 @@ struct CloudTreeLocalWorkspace: Equatable {
 
 /// Pure assembly of outline nodes from the fleet rows and the catalog snapshot.
 /// Order: This Mac (local workspaces → terminals; Browsers) first, then every
-/// cloud machine, with Workspaces first, then Ports, VNC Displays, and the
+/// cloud machine, with Workspaces first, then Ports, Displays, and the
 /// complete Terminals process index. Workspace children preserve exact daemon
 /// tab placement identities. A machine without a connected link keeps cached
 /// pool rows beside its status placeholder.
@@ -676,25 +677,6 @@ enum CloudTreeNodeBuilder {
         return "machine:\(resource.machine.rawValue)/ws/\(workspaceID)/resource:\(resource.rawValue)\(tabSuffix)"
     }
 
-    /// A pane row that nests hidden tabs. Identity is the daemon pane, not the
-    /// tab it currently shows, so collapse and selection survive a tab switch.
-    static func nodeID(
-        pane paneID: String,
-        screenID: String?,
-        screenIndex: Int?,
-        inRemoteWorkspace workspaceID: String,
-        machine: SurfaceMachineID
-    ) -> String {
-        let screenPart: String
-        if let screenID, !screenID.isEmpty {
-            screenPart = "/screen:\(screenID)"
-        } else if let screenIndex {
-            screenPart = "/screen-index:\(screenIndex)"
-        } else {
-            screenPart = ""
-        }
-        return "machine:\(machine.rawValue)/ws/\(workspaceID)\(screenPart)/pane:\(paneID)"
-    }
     static func nodeID(browsersGroup machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)/browsers" }
     static func nodeID(portsGroup machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)/ports" }
     static func nodeID(placeholder machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)/placeholder" }
@@ -810,7 +792,7 @@ enum CloudTreeNodeBuilder {
 
         switch info.linkState {
         case .asleep:
-            children.append(placeholder(machine, text: String(localized: "cloudTree.placeholder.asleep", defaultValue: "Asleep \u{2014} open to wake"), style: .dimmed))
+            children.append(placeholder(machine, text: String(localized: "cloudTree.placeholder.asleep", defaultValue: "Asleep \u{2014} open to wake"), style: .dimmed, opensMachine: true))
         case .connecting:
             children.append(placeholder(machine, text: String(localized: "cloudTree.placeholder.connecting", defaultValue: "Connecting\u{2026}"), style: .connecting))
         case .error:
@@ -860,12 +842,15 @@ enum CloudTreeNodeBuilder {
             ))
         }
 
-        // Displays stay reachable while the session link reconnects.
-        if !displays.isEmpty {
-            children.append(CloudTreeNode(
-                id: nodeID(displaysPool: machine),
-                kind: .displaysPool(machine: machine, count: displays.count),
-                children: displays.map {
+        // Displays are always a machine-level category, just like Ports and
+        // Terminals. The catalog owns the real VNC resources; an empty state is
+        // explicit so a reconnect never makes the category silently disappear.
+        children.append(CloudTreeNode(
+            id: nodeID(displaysPool: machine),
+            kind: .displaysPool(machine: machine, count: displays.count),
+            children: displays.isEmpty
+                ? [CloudMachineSurfacePresentation.emptyDisplays(info: info)]
+                : displays.map {
                     CloudTreeNode(
                         id: nodeID(resource: $0.id),
                         kind: .display(
@@ -875,8 +860,7 @@ enum CloudTreeNodeBuilder {
                         )
                     )
                 }
-            ))
-        }
+        ))
 
         // The pool is a process index. It lists every terminal, including
         // terminals already placed in workspaces and detached terminals.
@@ -965,7 +949,6 @@ enum CloudTreeNodeBuilder {
                     machine: machine,
                     workspace,
                     terminalCount: layout.terminalCount,
-                    hiddenTabCount: layout.hiddenTabCount,
                     openIn: openInLocal
                 ),
                 children: layout.rows,
@@ -994,24 +977,15 @@ enum CloudTreeNodeBuilder {
 
     private struct WorkspaceLayoutRows {
         var rows: [CloudTreeNode] = []
-        /// Every placement in row order: each pane's shown tab, then its hidden tabs,
-        /// then the pane-less rows. The workspace's open/drag group follows this order
-        /// so "Open Workspace" and a row drag lay panes out the way the tree lists them.
+        /// Every placement in row order. The workspace's open/drag group follows this
+        /// order so opening a workspace lays out the same resources the tree lists.
         var placements: [RemoteResourcePlacement] = []
-        /// Terminal rows the layout shows: one per pane whose shown tab is a terminal,
-        /// plus placements that name no pane.
+        /// Every terminal placement represented by a leaf row.
         var terminalCount = 0
-        /// Tabs the panes hold behind their shown one; each is a nested row.
-        var hiddenTabCount = 0
     }
 
-    /// A workspace's rows, shaped like its layout. Every placement that names a daemon
-    /// pane joins that pane; panes come in layout order (the screen's index, then the
-    /// pane's position in the screen's split tree; arrival order when the daemon sent
-    /// no layout document). Each pane is one row, the tab it shows, with the pane's
-    /// other tabs nested beneath it in tab order. Placements without a pane (a provider
-    /// that does not model panes, the machine's pool display) stay flat after the
-    /// panes, in the caller's kind order.
+    /// A workspace's rows, ordered by its layout, with every placement as a leaf.
+    /// Pane membership determines ordering only; it never creates a nested row.
     private static func layoutRows(
         placements: [RemoteResourcePlacement],
         workspace: SurfaceRemoteWorkspace,
@@ -1034,29 +1008,21 @@ enum CloudTreeNodeBuilder {
         })
 
         var result = WorkspaceLayoutRows()
-        func append(_ placement: RemoteResourcePlacement, hiddenTabs: [RemoteResourcePlacement]) {
-            let nested = hiddenTabs.map { tab in
-                placementNode(
-                    tab, workspace: workspace, machine: machine, info: info, snapshot: snapshot,
-                    projectionIndex: projectionIndex, openInLocal: openInLocal, hiddenTabCount: 0, children: [], paneRow: false
-                )
-            }
+        func append(_ placement: RemoteResourcePlacement) {
             result.rows.append(placementNode(
                 placement, workspace: workspace, machine: machine, info: info, snapshot: snapshot,
-                projectionIndex: projectionIndex, openInLocal: openInLocal, hiddenTabCount: hiddenTabs.count, children: nested, paneRow: true
+                projectionIndex: projectionIndex, openInLocal: openInLocal
             ))
             result.placements.append(placement)
-            result.placements.append(contentsOf: hiddenTabs)
             if placement.resource.kind == .terminal { result.terminalCount += 1 }
-            result.hiddenTabCount += hiddenTabs.count
         }
-        for row in layout.rows {
-            append(placements[row.shownIndex], hiddenTabs: row.hiddenIndices.map { placements[$0] })
+        for index in layout.flatPlacementIndices {
+            append(placements[index])
         }
         return result
     }
 
-    /// One pointer row for a placement, of the resource's kind, with its nested tab rows.
+    /// One flat pointer row for a placement, of the resource's kind.
     private static func placementNode(
         _ placement: RemoteResourcePlacement,
         workspace: SurfaceRemoteWorkspace,
@@ -1064,27 +1030,13 @@ enum CloudTreeNodeBuilder {
         info: SurfaceMachineInfo,
         snapshot: SurfaceCatalogSnapshot,
         projectionIndex: LocalProjectionIndex,
-        openInLocal: UUID?,
-        hiddenTabCount: Int,
-        children: [CloudTreeNode],
-        paneRow: Bool
+        openInLocal: UUID?
     ) -> CloudTreeNode {
-        let id: String
-        if paneRow, let paneID = placement.view?.paneID, !paneID.isEmpty {
-            id = nodeID(
-                pane: paneID,
-                screenID: placement.view?.screenID,
-                screenIndex: placement.view?.screenIndex,
-                inRemoteWorkspace: workspace.id,
-                machine: machine
-            )
-        } else {
-            id = nodeID(
-                resource: placement.resource.id,
-                inRemoteWorkspace: workspace.id,
-                remoteTabID: placement.view?.tabID
-            )
-        }
+        let id = nodeID(
+            resource: placement.resource.id,
+            inRemoteWorkspace: workspace.id,
+            remoteTabID: placement.view?.tabID
+        )
         switch placement.resource.kind {
         case .terminal:
             return terminalNode(
@@ -1092,9 +1044,7 @@ enum CloudTreeNodeBuilder {
                 snapshot: snapshot,
                 projectionIndex: projectionIndex,
                 id: id,
-                remoteView: placement.view,
-                hiddenTabCount: hiddenTabCount,
-                children: children
+                remoteView: placement.view
             )
         case .browser:
             if placement.resource.id.isForwardedPort {
@@ -1108,8 +1058,7 @@ enum CloudTreeNodeBuilder {
                             port: placement.resource.id.forwardedPort ?? placement.resource.port
                         ),
                         openIn: openInLocal
-                    ),
-                    children: children
+                    )
                 )
             }
             return CloudTreeNode(
@@ -1118,10 +1067,8 @@ enum CloudTreeNodeBuilder {
                     resource: placement.resource,
                     isOpen: projectionIndex.isOpen(placement.resource.id, remoteView: placement.view),
                     workspaceTitle: nil,
-                    remoteView: placement.view,
-                    hiddenTabCount: hiddenTabCount
-                )),
-                children: children
+                    remoteView: placement.view
+                ))
             )
         case .display:
             return CloudTreeNode(
@@ -1130,8 +1077,7 @@ enum CloudTreeNodeBuilder {
                     placement.resource,
                     openIn: openInLocal,
                     remoteView: placement.view
-                ),
-                children: children
+                )
             )
         }
     }
@@ -1174,9 +1120,7 @@ enum CloudTreeNodeBuilder {
         projectionIndex: LocalProjectionIndex,
         id: String? = nil,
         viewBadge: Int? = nil,
-        remoteView: SurfaceRemoteView? = nil,
-        hiddenTabCount: Int = 0,
-        children: [CloudTreeNode] = []
+        remoteView: SurfaceRemoteView? = nil
     ) -> CloudTreeNode {
         CloudTreeNode(
             id: id ?? nodeID(resource: resource.id),
@@ -1185,17 +1129,20 @@ enum CloudTreeNodeBuilder {
                 isOpen: projectionIndex.isOpen(resource.id, remoteView: remoteView),
                 viewBadge: viewBadge,
                 hasUnreadNotification: projectionIndex.hasUnreadNotification(resource.id),
-                remoteView: remoteView,
-                hiddenTabCount: hiddenTabCount
-            )),
-            children: children
+                remoteView: remoteView
+            ))
         )
     }
 
-    private static func placeholder(_ machine: SurfaceMachineID, text: String, style: CloudTreePlaceholder.Style) -> CloudTreeNode {
+    private static func placeholder(
+        _ machine: SurfaceMachineID,
+        text: String,
+        style: CloudTreePlaceholder.Style,
+        opensMachine: Bool = false
+    ) -> CloudTreeNode {
         CloudTreeNode(
             id: nodeID(placeholder: machine),
-            kind: .placeholder(machine: machine, CloudTreePlaceholder(text: text, style: style))
+            kind: .placeholder(machine: machine, CloudTreePlaceholder(text: text, style: style, opensMachine: opensMachine))
         )
     }
 

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 /// The Finder-like Cloud tree over the surface catalog: This Mac (local
 /// workspaces → terminals; Browsers) then every machine (Workspaces → cmux-tui
-/// workspace → terminals; Ports; VNC Displays; Terminals), as an `NSOutlineView`. Rows are pure
+/// workspace → terminals; Ports; Displays; Terminals), as an `NSOutlineView`. Rows are pure
 /// display (`CloudTreeRowContentView`); the coordinator owns selection,
 /// expansion, clicks, context menus, keyboard navigation, and the native
 /// drag whose drop projects the row as a pane in the main view.
@@ -436,7 +436,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 if !operation.isRunning {
                     machineActions.create.showFailure(operation.id)
                 }
-            case .workspace(let machine, let workspace, _, _, let openIn):
+            case .workspace(let machine, let workspace, _, let openIn):
                 // Open-or-focus (D13). Already showing in a local workspace -> go there
                 // instead of opening a second copy; a
                 // stray pane showing one of its terminals -> focus that pane.
@@ -499,7 +499,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 }
             case .placeholder(let machineID, let placeholder):
                 // "Asleep — open to wake": a fresh terminal on the machine is what wakes it.
-                if placeholder.style == .dimmed, let machine = machine(id: machineID) {
+                if placeholder.opensMachine, let machine = machine(id: machineID) {
                     openMachine(machine)
                 }
             }
@@ -612,11 +612,8 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     item(String(localized: "cloudTree.menu.newTerminal", defaultValue: "New Terminal")) { [nodeActions] in nodeActions.newTerminal(machine, nil) },
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
-            case .displaysPool(let machine, _):
+            case .displaysPool:
                 return [
-                    item(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) { [nodeActions] in
-                        nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, true)
-                    },
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
             case .workspacesGroup(let machine):
@@ -625,7 +622,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     item(String(localized: "cloudTree.menu.newTerminal", defaultValue: "New Terminal")) { [nodeActions] in nodeActions.newTerminal(machine, nil) },
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
-            case .workspace(let machine, let workspace, _, _, let openIn):
+            case .workspace(let machine, let workspace, _, let openIn):
                 // One open verb, THE SAME PATH as a click and Return (`open`):
                 // jump to the local workspace already showing it (the verb says so),
                 // focus a stray pane showing one of its terminals, refuse an empty

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -436,7 +436,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 if !operation.isRunning {
                     machineActions.create.showFailure(operation.id)
                 }
-            case .workspace(let machine, let workspace, _, let openIn):
+            case .workspace(let machine, let workspace, _, _, let openIn):
                 // Open-or-focus (D13). Already showing in a local workspace -> go there
                 // instead of opening a second copy; a
                 // stray pane showing one of its terminals -> focus that pane.
@@ -622,7 +622,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     item(String(localized: "cloudTree.menu.newTerminal", defaultValue: "New Terminal")) { [nodeActions] in nodeActions.newTerminal(machine, nil) },
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
-            case .workspace(let machine, let workspace, _, let openIn):
+            case .workspace(let machine, let workspace, _, _, let openIn):
                 // One open verb, THE SAME PATH as a click and Return (`open`):
                 // jump to the local workspace already showing it (the verb says so),
                 // focus a stray pane showing one of its terminals, refuse an empty

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -83,7 +83,7 @@ struct CloudTreeRowContentView: View {
             groupRow(title: String(localized: "cloudTree.group.displays", defaultValue: "Displays"), count: count)
         case .workspacesGroup:
             groupRow(title: String(localized: "cloudTree.group.workspaces", defaultValue: "Workspaces"))
-        case .workspace(_, let workspace, let terminalCount, _):
+        case .workspace(_, let workspace, let terminalCount, _, _):
             // No open marker here (none on any row since #11069); the row's open
             // verb reads "Go to Workspace" when it is already showing locally.
             CloudTreeLeafRow(
@@ -875,7 +875,7 @@ struct CloudTreeRowHoverButtons: View {
             plus(String(localized: "cloudTree.menu.newWorkspace", defaultValue: "New Workspace")) {
                 nodeActions.newWorkspace(machine)
             }
-        case .workspace(let machine, let workspace, _, _):
+        case .workspace(let machine, let workspace, _, _, _):
             HStack(spacing: 4) {
                 plus(String(localized: "cloudTree.menu.newTerminalHere", defaultValue: "New Terminal Here")) {
                     nodeActions.newTerminal(machine, workspace.id)

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -80,10 +80,10 @@ struct CloudTreeRowContentView: View {
         case .terminalsPool(_, let count):
             groupRow(title: String(localized: "cloudTree.group.terminals", defaultValue: "Terminals"), count: count)
         case .displaysPool(_, let count):
-            groupRow(title: String(localized: "cloudTree.group.displays", defaultValue: "VNC Displays"), count: count)
+            groupRow(title: String(localized: "cloudTree.group.displays", defaultValue: "Displays"), count: count)
         case .workspacesGroup:
             groupRow(title: String(localized: "cloudTree.group.workspaces", defaultValue: "Workspaces"))
-        case .workspace(_, let workspace, let terminalCount, let hiddenTabCount, _):
+        case .workspace(_, let workspace, let terminalCount, _):
             // No open marker here (none on any row since #11069); the row's open
             // verb reads "Go to Workspace" when it is already showing locally.
             CloudTreeLeafRow(
@@ -93,7 +93,7 @@ struct CloudTreeRowContentView: View {
                 title: workspace.name,
                 titleWeight: workspace.focused ? .medium : .regular,
                 detail: style.showsGroupCounts
-                    ? CloudTreeRowContentView.workspaceDetail(terminalCount: terminalCount, hiddenTabCount: hiddenTabCount)
+                    ? CloudTreeRowContentView.count(terminalCount)
                     : nil
             )
         case .localWorkspace(let row):
@@ -125,15 +125,7 @@ struct CloudTreeRowContentView: View {
                 tint: CloudTreeIconPalette.browser,
                 title: row.resource.title.isEmpty ? String(localized: "cloudTree.browser.untitled", defaultValue: "browser") : row.resource.title,
                 detail: CloudTreeBrowserDetail.text(for: row)
-            ) {
-                if style.showsViewBadges, row.hiddenTabCount > 0 {
-                    // A pane whose shown tab is a browser: its other tabs nest beneath.
-                    Text(String(format: String(localized: "cloudTree.terminal.badge.hiddenTabs", defaultValue: "+%d"), row.hiddenTabCount))
-                        .cmuxFont(size: style.detailSize, design: style.fontDesign, monospacedDigit: true)
-                        .foregroundStyle(.secondary)
-                        .help(CloudTreeTerminalRowContent.hiddenTabsHelp(row.hiddenTabCount))
-                }
-            }
+            )
         case .portsGroup:
             groupRow(title: String(localized: "cloudTree.group.ports", defaultValue: "Ports"))
         case .port(let resource, let url, _):
@@ -204,22 +196,7 @@ struct CloudTreeRowContentView: View {
             : String(format: String(localized: "cloudTree.workspace.terminalCount.other", defaultValue: "%d terminals"), terminals)
     }
 
-    /// A workspace row's detail: the terminals its layout shows, then the tabs its
-    /// panes hold behind the shown ones ("2 terminals · 1 more tab"). The first
-    /// number matches the panes a person sees on opening; the second is what the
-    /// nested rows reveal.
-    static func workspaceDetail(terminalCount: Int, hiddenTabCount: Int) -> String {
-        guard hiddenTabCount > 0 else { return count(terminalCount) }
-        return count(terminalCount) + " · " + hiddenTabs(hiddenTabCount)
-    }
-
-    /// "1 more tab" / "%d more tabs": the tabs a workspace's panes hold behind their shown ones.
-    static func hiddenTabs(_ tabs: Int) -> String {
-        tabs == 1
-            ? String(localized: "cloudTree.workspace.hiddenTabs.one", defaultValue: "1 more tab")
-            : String(format: String(localized: "cloudTree.workspace.hiddenTabs.other", defaultValue: "%d more tabs"), tabs)
-    }
-
+    /// A workspace row's detail: the total terminal rows shown beneath it.
     /// Formats the transport and screen label shown beneath a VNC display row.
     /// A key such as `display:1` becomes `noVNC · :1`; unknown key shapes retain
     /// the transport-only detail.
@@ -480,14 +457,6 @@ struct CloudTreeTerminalRowContent: View {
                     .cmuxFont(size: style.detailSize, design: style.fontDesign, monospacedDigit: true)
                     .foregroundStyle(.secondary)
                     .help(Self.viewsHelp(views))
-            }
-            if style.showsViewBadges, row.hiddenTabCount > 0 {
-                // A pane row: the tabs this pane holds behind the one it shows. Those
-                // tabs are the row's nested children.
-                Text(String(format: String(localized: "cloudTree.terminal.badge.hiddenTabs", defaultValue: "+%d"), row.hiddenTabCount))
-                    .cmuxFont(size: style.detailSize, design: style.fontDesign, monospacedDigit: true)
-                    .foregroundStyle(.secondary)
-                    .help(Self.hiddenTabsHelp(row.hiddenTabCount))
             }
         }
         // Agent state stays on hover and in `cmux vm tree`; the row itself
@@ -900,17 +869,13 @@ struct CloudTreeRowHoverButtons: View {
             plus(String(localized: "cloudTree.menu.newTerminal", defaultValue: "New Terminal")) {
                 nodeActions.newTerminal(machine, nil)
             }
-        case .displaysPool(let machine, _):
-            // The daemon cannot create displays yet (T10); until then "+" shows
-            // the machine's one desktop, reusing a pane that already does.
-            plus(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) {
-                nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, true)
-            }
+        case .displaysPool:
+            EmptyView()
         case .workspacesGroup(let machine):
             plus(String(localized: "cloudTree.menu.newWorkspace", defaultValue: "New Workspace")) {
                 nodeActions.newWorkspace(machine)
             }
-        case .workspace(let machine, let workspace, _, _, _):
+        case .workspace(let machine, let workspace, _, _):
             HStack(spacing: 4) {
                 plus(String(localized: "cloudTree.menu.newTerminalHere", defaultValue: "New Terminal Here")) {
                     nodeActions.newTerminal(machine, workspace.id)
@@ -935,7 +900,7 @@ struct CloudTreeRowHoverButtons: View {
     /// True when this row kind renders any hover button at all.
     static func hasButtons(for kind: CloudTreeNode.Kind) -> Bool {
         switch kind {
-        case .machine, .localMachine, .terminalsPool, .displaysPool, .workspacesGroup, .workspace:
+        case .machine, .localMachine, .terminalsPool, .workspacesGroup, .workspace:
             return true
         case .pendingMachine:
             return true
@@ -952,23 +917,5 @@ struct CloudTreeRowHoverButtons: View {
 
     private func xmark(_ label: String, action: @escaping () -> Void) -> some View {
         MachinesChromeIconButton(symbolName: "xmark", accessibilityLabel: label, isBusy: false, action: action)
-    }
-}
-
-extension CloudTreeTerminalRowContent {
-    /// Tooltip for a pane row's "+N" badge: the tabs the pane holds behind the shown one.
-    static func hiddenTabsHelp(_ tabs: Int) -> String {
-        tabs == 1
-            ? String(
-                localized: "cloudTree.terminal.badge.hiddenTabs.help.one",
-                defaultValue: "1 more tab in this pane, listed beneath this row. The pane shows this tab."
-            )
-            : String(
-                format: String(
-                    localized: "cloudTree.terminal.badge.hiddenTabs.help.other",
-                    defaultValue: "%d more tabs in this pane, listed beneath this row. The pane shows this tab."
-                ),
-                tabs
-            )
     }
 }

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -64,10 +64,9 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "--json", "workspace", workspaceID, "run", "--"] + command
     }
 
-    /// `workspace create [--name <name>] [--empty]`: the daemon owns auto-naming.
-    static func createWorkspaceArguments(socketPath: String, name: String? = nil, empty: Bool = false) -> [String] {
+    /// `workspace create [--name <name>]`: the daemon owns auto-naming.
+    static func createWorkspaceArguments(socketPath: String, name: String? = nil) -> [String] {
         var arguments = ["--socket", socketPath, "--json", "workspace", "create"]
-        if empty { arguments.append("--empty") }
         if let name, !name.isEmpty {
             arguments += ["--name", name]
         }

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -64,9 +64,10 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "--json", "workspace", workspaceID, "run", "--"] + command
     }
 
-    /// `workspace create [--name <name>]`: a workspace with one terminal.
-    static func createWorkspaceArguments(socketPath: String, name: String? = nil) -> [String] {
+    /// `workspace create [--name <name>] [--empty]`: the daemon owns auto-naming.
+    static func createWorkspaceArguments(socketPath: String, name: String? = nil, empty: Bool = false) -> [String] {
         var arguments = ["--socket", socketPath, "--json", "workspace", "create"]
+        if empty { arguments.append("--empty") }
         if let name, !name.isEmpty {
             arguments += ["--name", name]
         }

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -64,9 +64,13 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "--json", "workspace", workspaceID, "run", "--"] + command
     }
 
-    /// `workspace create --name <name>`: a workspace with one terminal.
-    static func createWorkspaceArguments(socketPath: String, name: String) -> [String] {
-        ["--socket", socketPath, "--json", "workspace", "create", "--name", name]
+    /// `workspace create [--name <name>]`: a workspace with one terminal.
+    static func createWorkspaceArguments(socketPath: String, name: String? = nil) -> [String] {
+        var arguments = ["--socket", socketPath, "--json", "workspace", "create"]
+        if let name, !name.isEmpty {
+            arguments += ["--name", name]
+        }
+        return arguments
     }
 
     /// `terminal <term_id> close`: end that remote terminal (spec `terminal.close`).

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -23,7 +23,7 @@ enum CloudVMPanelAuthState: Equatable {
 }
 
 /// Right-sidebar Machines tab: the user's cloud machine fleet as a Finder-like
-/// tree (machine → Workspaces → terminals, Ports, VNC Displays, Terminals). Matches the
+/// tree (machine → Workspaces → terminals, Ports, Displays, Terminals). Matches the
 /// Vault/Feed visual language — compact 13pt rows, full-width hover
 /// backgrounds, chrome-pill control bar. Outline rows receive immutable
 /// snapshots plus closure bundles only (snapshot-boundary rule); every mutation

--- a/Sources/Surfaces/CmuxTuiSnapshotParser.swift
+++ b/Sources/Surfaces/CmuxTuiSnapshotParser.swift
@@ -1,7 +1,6 @@
 import CmuxCore
 import CoreFoundation
 import Foundation
-
 /// Maps a cmux-tui public session snapshot (`session current snapshot --json`) onto
 /// ``SurfaceResource`` values for one cloud machine. Pure and total: unknown keys are
 /// ignored, a malformed entry drops that entry, never the machine.
@@ -21,7 +20,6 @@ struct CloudVMStateDeltaImpact: Hashable, Sendable {
     /// rebuild path instead of risking a partial placement update.
     var requiresFullResourceRebuild = false
 }
-
 struct CloudVMStateDeltaApplication: Sendable {
     let state: CloudVMState
     let impact: CloudVMStateDeltaImpact
@@ -1728,7 +1726,9 @@ struct CmuxTuiSnapshotParser: Sendable {
     /// The workspace a `workspace create` mutation created.
     static func createdWorkspace(fromResult result: [String: Any]) -> String? {
         let path = (result["value"] as? [String: Any]) ?? result
-        let id = (path["workspace_id"] as? String) ?? (path["id"] as? String)
+        let id = (path["workspace_id"] as? String)
+            ?? (path["workspace"] as? String)
+            ?? (path["id"] as? String)
         return id.flatMap { $0.isEmpty ? nil : $0 }
     }
 

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1106,26 +1106,43 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         let connected = try await links.connected(machineID: machineID)
         guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
         let workspaceID: String
+        var initialTerminal: CmuxTuiSnapshotParser.CreatedTerminalPath? = nil
         if let remoteWorkspaceID = remoteWorkspaceID?.trimmingCharacters(in: .whitespacesAndNewlines), !remoteWorkspaceID.isEmpty {
             workspaceID = remoteWorkspaceID
         } else if let existing = catalog.snapshot.resources(on: machine).compactMap(\.remoteWorkspace).sorted(by: { ($0.focused ? 0 : 1, $0.index) < ($1.focused ? 0 : 1, $1.index) }).first {
             workspaceID = existing.id
         } else {
-            let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath, name: name ?? "main"))
-            guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any],
-                  let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) else {
+            let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath))
+            guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any] else {
                 throw ProviderError.noWorkspaceOnMachine(machineID)
             }
-            workspaceID = id
+            if let path = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object),
+               let id = path.workspaceID, !id.isEmpty {
+                // `workspace create` is effectful and already owns the one
+                // starter terminal. Reuse its exact receipt instead of running
+                // a second shell, which previously produced two terminals.
+                initialTerminal = path
+                workspaceID = id
+            } else if let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) {
+                workspaceID = id
+            } else {
+                throw ProviderError.noWorkspaceOnMachine(machineID)
+            }
         }
         let argv = CloudTuiCommandLine.commandStartingIn(
             cwd: cwd,
             command: (command?.isEmpty == false ? command : nil) ?? CloudTuiCommandLine.defaultTerminalCommand
         )
-        let data = try await link.run(arguments: CloudTuiCommandLine.runArguments(socketPath: connected.socketPath, workspaceID: workspaceID, command: argv))
-        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let created = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) else {
-            throw ProviderError.terminalNotCreated(String(data: data, encoding: .utf8) ?? "")
+        let created: CmuxTuiSnapshotParser.CreatedTerminalPath
+        if let initialTerminal {
+            created = initialTerminal
+        } else {
+            let data = try await link.run(arguments: CloudTuiCommandLine.runArguments(socketPath: connected.socketPath, workspaceID: workspaceID, command: argv))
+            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let path = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) else {
+                throw ProviderError.terminalNotCreated(String(data: data, encoding: .utf8) ?? "")
+            }
+            created = path
         }
         let resolvedWorkspaceID = created.workspaceID ?? workspaceID
         let remoteWorkspace = cloudState?.workspaces.first(where: { $0.id == resolvedWorkspaceID }).map {

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1088,19 +1088,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     func createTerminal(command: [String]?, cwd: String?, name: String?, remoteWorkspaceID: String?) async throws -> SurfaceResource {
         let connected = try await links.connected(machineID: machineID)
         guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
-        let workspaceID: String
-        if let remoteWorkspaceID = remoteWorkspaceID?.trimmingCharacters(in: .whitespacesAndNewlines), !remoteWorkspaceID.isEmpty {
-            workspaceID = remoteWorkspaceID
-        } else if let existing = catalog.snapshot.resources(on: machine).compactMap(\.remoteWorkspace).sorted(by: { ($0.focused ? 0 : 1, $0.index) < ($1.focused ? 0 : 1, $1.index) }).first {
-            workspaceID = existing.id
-        } else {
-            let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath, empty: true))
-            guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any],
-                  let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) else {
-                throw ProviderError.noWorkspaceOnMachine(machineID)
-            }
-            workspaceID = id
-        }
+        // Resolve the active workspace inside the daemon mutation. A stale Mac
+        // catalog must never bootstrap a second workspace during concurrent creates.
+        let requestedWorkspace = remoteWorkspaceID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let workspaceID = requestedWorkspace.flatMap { $0.isEmpty ? nil : $0 } ?? "current"
         let argv = CloudTuiCommandLine.commandStartingIn(
             cwd: cwd,
             command: (command?.isEmpty == false ? command : nil) ?? CloudTuiCommandLine.defaultTerminalCommand
@@ -1110,6 +1101,18 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
               let created = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) else {
             throw ProviderError.terminalNotCreated(String(data: data, encoding: .utf8) ?? "")
         }
+        guard let resolvedWorkspaceID = created.workspaceID ?? (workspaceID == "current" ? nil : workspaceID) else {
+            throw ProviderError.noWorkspaceOnMachine(machineID)
+        }
+        return recordCreatedTerminal(created, workspaceID: resolvedWorkspaceID, name: name, cwd: cwd)
+    }
+
+    private func recordCreatedTerminal(
+        _ created: CmuxTuiSnapshotParser.CreatedTerminalPath,
+        workspaceID: String,
+        name: String?,
+        cwd: String?
+    ) -> SurfaceResource {
         let resolvedWorkspaceID = created.workspaceID ?? workspaceID
         let remoteWorkspace = cloudState?.workspaces.first(where: { $0.id == resolvedWorkspaceID }).map {
             SurfaceRemoteWorkspace(id: $0.id, name: $0.name, index: $0.index, focused: $0.focused)
@@ -1164,13 +1167,18 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
               let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) else {
             throw ProviderError.noWorkspaceOnMachine(machineID)
         }
-        // Auto-naming belongs to the daemon. Read its committed workspace back
-        // instead of maintaining a second name sequence in the Mac projection.
-        guard await refresh(force: true),
-              let workspace = info.remoteWorkspaces?.first(where: { $0.id == id }) else {
-            throw ProviderError.noWorkspaceOnMachine(machineID)
+        // Creation already committed. Retain its exact starter receipt while a
+        // delayed snapshot catches up, so the caller cannot create a second one.
+        let provisional = SurfaceRemoteWorkspace(id: id, name: workspaceName?.isEmpty == false ? workspaceName! : id, index: info.remoteWorkspaces?.count ?? 0, focused: false)
+        if info.remoteWorkspaces?.contains(where: { $0.id == id }) != true {
+            info.remoteWorkspaces = (info.remoteWorkspaces ?? []) + [provisional]
+            catalog.updateMachine(info, from: self)
         }
-        return workspace
+        if let starter = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) {
+            _ = recordCreatedTerminal(starter, workspaceID: id, name: nil, cwd: nil)
+        }
+        _ = await refresh(force: true)
+        return info.remoteWorkspaces?.first(where: { $0.id == id }) ?? provisional
     }
 
     func renameRemoteWorkspace(id: String, name: String) async throws {

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1089,43 +1089,26 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         let connected = try await links.connected(machineID: machineID)
         guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
         let workspaceID: String
-        var initialTerminal: CmuxTuiSnapshotParser.CreatedTerminalPath? = nil
         if let remoteWorkspaceID = remoteWorkspaceID?.trimmingCharacters(in: .whitespacesAndNewlines), !remoteWorkspaceID.isEmpty {
             workspaceID = remoteWorkspaceID
         } else if let existing = catalog.snapshot.resources(on: machine).compactMap(\.remoteWorkspace).sorted(by: { ($0.focused ? 0 : 1, $0.index) < ($1.focused ? 0 : 1, $1.index) }).first {
             workspaceID = existing.id
         } else {
-            let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath))
-            guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any] else {
+            let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath, empty: true))
+            guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any],
+                  let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) else {
                 throw ProviderError.noWorkspaceOnMachine(machineID)
             }
-            if let path = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object),
-               let id = path.workspaceID, !id.isEmpty {
-                // `workspace create` is effectful and already owns the one
-                // starter terminal. Reuse its exact receipt instead of running
-                // a second shell, which previously produced two terminals.
-                initialTerminal = path
-                workspaceID = id
-            } else if let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) {
-                workspaceID = id
-            } else {
-                throw ProviderError.noWorkspaceOnMachine(machineID)
-            }
+            workspaceID = id
         }
         let argv = CloudTuiCommandLine.commandStartingIn(
             cwd: cwd,
             command: (command?.isEmpty == false ? command : nil) ?? CloudTuiCommandLine.defaultTerminalCommand
         )
-        let created: CmuxTuiSnapshotParser.CreatedTerminalPath
-        if let initialTerminal {
-            created = initialTerminal
-        } else {
-            let data = try await link.run(arguments: CloudTuiCommandLine.runArguments(socketPath: connected.socketPath, workspaceID: workspaceID, command: argv))
-            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let path = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) else {
-                throw ProviderError.terminalNotCreated(String(data: data, encoding: .utf8) ?? "")
-            }
-            created = path
+        let data = try await link.run(arguments: CloudTuiCommandLine.runArguments(socketPath: connected.socketPath, workspaceID: workspaceID, command: argv))
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let created = CmuxTuiSnapshotParser.createdTerminal(fromRunResult: object) else {
+            throw ProviderError.terminalNotCreated(String(data: data, encoding: .utf8) ?? "")
         }
         let resolvedWorkspaceID = created.workspaceID ?? workspaceID
         let remoteWorkspace = cloudState?.workspaces.first(where: { $0.id == resolvedWorkspaceID }).map {
@@ -1170,26 +1153,23 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         return resource
     }
 
-    /// A new empty workspace in the machine's cmux-tui session (`workspace create`),
+    /// A new workspace in the machine's cmux-tui session (`workspace create`),
     /// called directly — not as a side effect of creating a terminal.
     func createRemoteWorkspace(name: String?) async throws -> SurfaceRemoteWorkspace {
         let connected = try await links.connected(machineID: machineID)
         guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
-        let existingCount = info.remoteWorkspaces?.count
-            ?? Set(catalog.snapshot.resources(on: machine).flatMap { $0.remoteWorkspaces.map(\.id) }).count
-        let workspaceName = name?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-            ? name!.trimmingCharacters(in: .whitespacesAndNewlines)
-            : (existingCount == 0 ? "main" : "workspace-\(existingCount + 1)")
+        let workspaceName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
         let created = try await link.run(arguments: CloudTuiCommandLine.createWorkspaceArguments(socketPath: connected.socketPath, name: workspaceName))
         guard let object = try JSONSerialization.jsonObject(with: created) as? [String: Any],
               let id = CmuxTuiSnapshotParser.createdWorkspace(fromResult: object) else {
             throw ProviderError.noWorkspaceOnMachine(machineID)
         }
-        let workspace = SurfaceRemoteWorkspace(id: id, name: workspaceName, index: info.remoteWorkspaces?.count ?? 0, focused: false)
-        // Optimistic: show the new (empty) workspace now; the next snapshot re-sync is authoritative.
-        info.remoteWorkspaces = (info.remoteWorkspaces ?? []) + [workspace]
-        catalog.updateMachine(info, from: self)
-        scheduleRefresh()
+        // Auto-naming belongs to the daemon. Read its committed workspace back
+        // instead of maintaining a second name sequence in the Mac projection.
+        guard await refresh(force: true),
+              let workspace = info.remoteWorkspaces?.first(where: { $0.id == id }) else {
+            throw ProviderError.noWorkspaceOnMachine(machineID)
+        }
         return workspace
     }
 

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1169,7 +1169,11 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         }
         // Creation already committed. Retain its exact starter receipt while a
         // delayed snapshot catches up, so the caller cannot create a second one.
-        let provisional = SurfaceRemoteWorkspace(id: id, name: workspaceName?.isEmpty == false ? workspaceName! : id, index: info.remoteWorkspaces?.count ?? 0, focused: false)
+        let committedName = ((object["value"] as? [String: Any]) ?? object)["name"] as? String
+        let provisionalName = workspaceName?.isEmpty == false
+            ? workspaceName!
+            : (committedName ?? String(localized: "cloudTree.workspace.pending", defaultValue: "New workspace"))
+        let provisional = SurfaceRemoteWorkspace(id: id, name: provisionalName, index: info.remoteWorkspaces?.count ?? 0, focused: false)
         if info.remoteWorkspaces?.contains(where: { $0.id == id }) != true {
             info.remoteWorkspaces = (info.remoteWorkspaces ?? []) + [provisional]
             catalog.updateMachine(info, from: self)

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1,16 +1,13 @@
 import CmuxFoundation
 import Foundation
-
 /// One cloud machine's resources: its cmux-tui terminals (over the headless link), its
 /// noVNC screen, and its forwarded ports. Terminals live in the machine's cmux-tui
 /// session, so a local pane closing never touches them (only local browser preparation is cancelled).
 @MainActor
 final class CmuxTuiSurfaceProvider: SurfaceProvider {
-
     let machineID: String
     var machine: SurfaceMachineID { .cloud(machineID) }
     private(set) var info: SurfaceMachineInfo
-
     private var summary: VMSummary
     /// This machine's notification sync: VM rows in, local notifications and
     /// `notification.ack` round trips out. Fed after every accepted state.
@@ -96,14 +93,11 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         case workspace(String)
         case tab(String)
     }
-
     private struct PendingRemoteRename {
         var name: String
         var receipt: CloudVMCursor
     }
-
     private var pendingRemoteRenames: [PendingRemoteRenameKey: PendingRemoteRename] = [:]
-
     init(
         summary: VMSummary,
         links: CloudMachineLinkManager,
@@ -118,16 +112,13 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         info = Self.info(from: summary, linkState: summary.status == "running" ? .connecting : .asleep, linkError: nil, stats: nil)
         installNotificationSync()
     }
-
     var isAwake: Bool { summary.status == "running" }
-
     /// Port rows are openable only when the machine advertises a preview
     /// capability or has the private route used by Freestyle.
     var capabilities: VMCapabilities { summary.capabilities }
     var supportsPortPreviews: Bool {
         capabilities.ports || summary.preferredPrivateAddress != nil
     }
-
     func update(summary: VMSummary) {
         guard isRegisteredInCatalog() else { return }
         refreshGeneration &+= 1
@@ -151,7 +142,6 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             catalog.updateMachine(info, from: self)
         }
     }
-
     func stop() {
         lifecycleGeneration &+= 1
         for task in browserPaneTasks.values { task.cancel() }
@@ -184,33 +174,26 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         pendingRemoteRenames.removeAll()
         acceptedCloudGenerations.removeAll()
     }
-
     /// Whether this provider is still registered for its machine. Suspended
     /// network work must not write through a replacement provider.
     func isRegisteredInCatalog() -> Bool {
         guard let current = catalog.provider(for: machine) else { return false }
         return ObjectIdentifier(current) == ObjectIdentifier(self)
     }
-
     func isCurrentLifecycleGeneration(_ generation: UInt64) -> Bool {
         lifecycleGeneration == generation
     }
-
     /// The generation to capture before detached work that touches panes.
     var currentLifecycleGeneration: UInt64 { lifecycleGeneration }
-
     private func isCurrentRefresh(lifecycle: UInt64, refresh: UInt64) -> Bool {
         lifecycleGeneration == lifecycle
             && refreshGeneration == refresh
             && isRegisteredInCatalog()
     }
-
     // MARK: - SurfaceProvider
-
     func refresh() async {
         await refresh(force: false)
     }
-
     /// Re-syncs from the machine. A sleeping machine is never woken to be listed: it keeps
     /// its screen (opening it wakes the machine) and nothing else.
     @discardableResult

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2387,7 +2387,17 @@ struct RestoredTerminalBinding {
 
 impl Mux {
     fn default_workspace_name(state: &State) -> String {
-        state.workspaces.len().to_string()
+        // Provider-created workspaces use a stable, human-readable sequence.
+        // Existing names (including user-renamed workspaces) are left untouched;
+        // only the next automatically generated name is derived here.
+        let next = state
+            .workspaces
+            .iter()
+            .filter_map(|workspace| workspace.name.strip_prefix("workspace-")?.parse::<usize>().ok())
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        format!("workspace-{next}")
     }
 
     /// Resolve one public resource path from a single live-state snapshot.
@@ -24949,7 +24959,7 @@ mod tests {
         );
         let first = mux.apply_layout(None, Some("round-trip".into()), &spec, None).unwrap();
         let exported_shape = node_shape(&screen_root(&mux, first.screen));
-        mux.with_state(|state| assert_eq!(state.workspaces[0].name, "0"));
+        mux.with_state(|state| assert_eq!(state.workspaces[0].name, "workspace-1"));
 
         let round_trip_spec = mux.with_state(|s| {
             fn from_node(node: &Node) -> LayoutSpec {
@@ -27540,7 +27550,7 @@ mod tests {
 
         let (ws0, ws1, pane1, surface1) = mux.with_state(|s| {
             assert_eq!(s.workspaces.len(), 2);
-            assert_eq!(s.workspaces[0].name, "0");
+            assert_eq!(s.workspaces[0].name, "workspace-1");
             assert_eq!(s.workspaces[1].name, "dev");
             assert_eq!(s.active_workspace, 1);
             let pane = s.workspaces[1].screens[0].active_pane;
@@ -27571,6 +27581,29 @@ mod tests {
             assert_eq!(s.active_workspace, 0);
         });
         assert!(events.try_iter().count() > 0);
+    }
+
+    #[test]
+    fn automatically_created_workspaces_use_one_based_sequence() {
+        let mux = test_mux();
+        let _first = mux.new_workspace(None, None).unwrap();
+        let second = mux.new_workspace(None, None).unwrap();
+        mux.with_state(|state| {
+            assert_eq!(state.workspaces[0].name, "workspace-1");
+            assert_eq!(state.workspaces[1].name, "workspace-2");
+        });
+
+        // A user name is authoritative and does not get rewritten by later
+        // automatic creation. The sequence continues past existing defaults.
+        let first_workspace = mux.with_state(|state| state.workspaces[0].id);
+        assert!(mux.rename_workspace(first_workspace, "shell".into()));
+        let third = mux.new_workspace(None, None).unwrap();
+        mux.with_state(|state| {
+            assert_eq!(state.workspaces[0].name, "shell");
+            assert_eq!(state.workspaces[1].name, "workspace-2");
+            assert_eq!(state.workspaces[2].name, "workspace-3");
+        });
+        assert_ne!(second.id, third.id);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2393,7 +2393,9 @@ impl Mux {
         let next = state
             .workspaces
             .iter()
-            .filter_map(|workspace| workspace.name.strip_prefix("workspace-")?.parse::<usize>().ok())
+            .filter_map(|workspace| {
+                workspace.name.strip_prefix("workspace-")?.parse::<usize>().ok()
+            })
             .max()
             .unwrap_or(0)
             .saturating_add(1);

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2047,6 +2047,12 @@ fn run_server(
                 state_root.as_deref(),
             )
         })?;
+    // Cloud's trusted-carrier daemon owns the initial session shape. It creates
+    // workspace-1 with one terminal before accepting clients, and the
+    // idempotent Session bootstrap preserves existing names and sessions.
+    if args.remote_ws_trusted_carrier {
+        Session::Local(mux.clone()).ensure_initial(None)?;
+    }
     // Background mux workers can report reconnect diagnostics before an
     // interactive client attaches. Install the non-terminal sink as soon as
     // the owner mux exists, before serving or adopting clients.

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2051,8 +2051,8 @@ fn run_server(
     // workspace-1 with one terminal before accepting clients, and the
     // idempotent Session bootstrap preserves existing names and sessions.
     #[cfg(unix)]
-    let trusted_carrier = args.remote
-        && (args.remote_ws_trusted_carrier || remote_ws_trusted_carrier_from_env());
+    let trusted_carrier =
+        args.remote && (args.remote_ws_trusted_carrier || remote_ws_trusted_carrier_from_env());
     #[cfg(unix)]
     if trusted_carrier {
         Session::Local(mux.clone()).ensure_initial(None)?;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2050,7 +2050,11 @@ fn run_server(
     // Cloud's trusted-carrier daemon owns the initial session shape. It creates
     // workspace-1 with one terminal before accepting clients, and the
     // idempotent Session bootstrap preserves existing names and sessions.
-    if args.remote_ws_trusted_carrier {
+    #[cfg(unix)]
+    let trusted_carrier = args.remote
+        && (args.remote_ws_trusted_carrier || remote_ws_trusted_carrier_from_env());
+    #[cfg(unix)]
+    if trusted_carrier {
         Session::Local(mux.clone()).ensure_initial(None)?;
     }
     // Background mux workers can report reconnect diagnostics before an
@@ -2093,8 +2097,7 @@ fn run_server(
                 admin_socket: args.remote_admin_socket,
                 direct_websocket: remote_direct_websocket,
                 allow_insecure_non_loopback: args.remote_ws_insecure_bind,
-                trusted_carrier_websocket: args.remote_ws_trusted_carrier
-                    || remote_ws_trusted_carrier_from_env(),
+                trusted_carrier_websocket: trusted_carrier,
                 workspace_http: remote_workspace_http,
                 relays: remote_relays,
                 iroh: args.iroh,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -3156,6 +3156,8 @@
 		C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */; };
 		DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
+		B81607322100000000000002 /* VMMachineTerminalResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81607322100000000000004 /* VMMachineTerminalResolution.swift */; };
+		B81607322100000000000003 /* VMMachineTerminalResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81607322100000000000004 /* VMMachineTerminalResolution.swift */; };
 		65F8FEC592CFA22BD1F4FA29 /* VMRemoteWorkspaceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2691D26BF6676FF32FBC54 /* VMRemoteWorkspaceResolver.swift */; };
 		D017093861349E48BF816E02 /* VMRemoteWorkspaceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2691D26BF6676FF32FBC54 /* VMRemoteWorkspaceResolver.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
@@ -6529,6 +6531,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8F8A0358C8DD0A7D998A86E9 /* VMClientTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMClientTelemetryTests.swift; sourceTree = "<group>"; };
 		C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMDefaultCloudCommandTests.swift; sourceTree = "<group>"; };
 		6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMMachineKind.swift; sourceTree = "<group>"; };
+		B81607322100000000000004 /* VMMachineTerminalResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMMachineTerminalResolution.swift; sourceTree = "<group>"; };
 		BA2691D26BF6676FF32FBC54 /* VMRemoteWorkspaceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMRemoteWorkspaceResolver.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
 		7A0CE1000000000000000017 /* VMTunnelEnroller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelEnroller.swift; sourceTree = "<group>"; };
@@ -9241,6 +9244,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */,
 				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
 				BA2691D26BF6676FF32FBC54 /* VMRemoteWorkspaceResolver.swift */,
+				B81607322100000000000004 /* VMMachineTerminalResolution.swift */,
 				A77A0009A1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift */,
 				1B6BF7B8DE8A42DA3620CADA /* CMUXCLI+NotificationFormatting.swift */,
 				11AE8B73B8979F37F85EB754 /* CMUXCLI+SemanticNotifications.swift */,
@@ -13270,6 +13274,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D0F101000000000000000003 /* TerminalRawMode.swift in Sources */,
 				9009A0029009A0029009A001 /* TmuxCompatLaunchContextError.swift in Sources */,
 				DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */,
+				B81607322100000000000002 /* VMMachineTerminalResolution.swift in Sources */,
 				65F8FEC592CFA22BD1F4FA29 /* VMRemoteWorkspaceResolver.swift in Sources */,
 				A6AC720A0000000000000001 /* WorkspaceLoadingArguments.swift in Sources */,
 			);
@@ -14141,6 +14146,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A3340002A3340002A3340002 /* ViewerNavigationTests.swift in Sources */,
 				6EE115A36CAD9082FBC4593E /* VMClientTelemetryTests.swift in Sources */,
 				C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */,
+				B81607322100000000000003 /* VMMachineTerminalResolution.swift in Sources */,
 				D017093861349E48BF816E02 /* VMRemoteWorkspaceResolver.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */,

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -41,7 +41,6 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             label: "Big Machine"
         )
     }
-
     private func info(
         workspaces: [SurfaceRemoteWorkspace],
         hasDesktop: Bool = false,

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -105,9 +105,9 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         return nil
     }
 
-    private func display(in workspaces: [SurfaceRemoteWorkspace]) -> SurfaceResource {
+    private func display(_ key: String = SurfaceResourceID.desktopDisplayKey, in workspaces: [SurfaceRemoteWorkspace]) -> SurfaceResource {
         var resource = SurfaceResource(
-            id: SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), title: "Desktop", detail: nil,
+            id: SurfaceResourceID(machine: machine, kind: .display, key: key), title: key == SurfaceResourceID.desktopDisplayKey ? "Desktop" : key, detail: nil,
             lifecycle: .running, agent: nil, remoteWorkspace: workspaces.first, port: 6901, url: nil
         )
         resource.remoteViews = workspaces.enumerated().map { SurfaceRemoteView(tabID: "tab_desk_\($0.offset)", workspace: $0.element) }
@@ -289,11 +289,11 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             SurfaceResourceID(machine: machine, kind: .terminal, key: "term_1"), shared.id,
         ])
         // VNC Displays is one row per screen; the group is searchable under that name.
-        #expect(byID["machine:brave-otter/displays"]?.searchableTitle == "VNC Displays")
+        #expect(byID["machine:brave-otter/displays"]?.searchableTitle == "Displays")
         #expect(tree.last?.id == "resource:brave-otter/terminal/term_shared", "Terminals is the machine's last section")
     }
 
-    @Test("An empty machine still offers its Workspaces and Terminals groups: their + make the first ones")
+    @Test("An empty machine still offers Workspaces, Ports, Displays, and Terminals")
     func emptyMachineKeepsItsGroups() throws {
         let snapshot = SurfaceCatalogSnapshot(machines: [info(workspaces: [])], resources: [], projections: [])
         let tree = rows(snapshot)
@@ -301,20 +301,43 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter",
             "machine:brave-otter/workspaces",
             "machine:brave-otter/workspaces/placeholder",
+            "machine:brave-otter/ports",
+            "machine:brave-otter/ports/status",
+            "machine:brave-otter/displays",
+            "machine:brave-otter/displays/placeholder",
             "machine:brave-otter/terminals",
             "machine:brave-otter/terminals/placeholder",
         ])
-        for groupID in ["machine:brave-otter/workspaces", "machine:brave-otter/terminals"] {
+        for groupID in ["machine:brave-otter/workspaces", "machine:brave-otter/terminals", "machine:brave-otter/displays"] {
             let group = try #require(tree.first { $0.id == groupID })
             #expect(CloudTreeRowHoverButtons.hasButtons(for: group.kind), "\(groupID) keeps its hover +")
         }
         let placeholders = tree.filter { $0.structureTag == "placeholder" }
-        #expect(placeholders.map(\.searchableTitle) == ["No workspaces yet", "No terminals yet"])
+        #expect(placeholders.map(\.searchableTitle) == ["No workspaces yet", "No reachable ports", "No displays available", "No terminals yet"])
         #expect(placeholders.allSatisfy { $0.machine == machine })
         for row in placeholders {
             guard case .placeholder(_, let placeholder) = row.kind else { Issue.record("expected a placeholder"); continue }
             #expect(placeholder.style == .dimmed)
         }
+    }
+
+    @Test("Displays keeps every real VNC screen from the catalog")
+    func displaysCategoryKeepsRealScreens() throws {
+        let main = workspace("ws_main", "main", index: 0, focused: true)
+        let first = display(in: [main])
+        let second = display("display:2", in: [main])
+        let snapshot = SurfaceCatalogSnapshot(
+            machines: [info(workspaces: [main], hasDesktop: false)],
+            resources: [first, second],
+            projections: []
+        )
+        let tree = rows(snapshot)
+        let displays = try #require(tree.first { $0.id == "machine:brave-otter/displays" })
+        #expect(displays.children.map(\.id) == [
+            "resource:brave-otter/display/display:1",
+            "resource:brave-otter/display/display:2",
+        ])
+        #expect(displays.children.allSatisfy { $0.children.isEmpty })
     }
 
     @Test("Several workspaces on one machine each list their own terminals under the one machine row")
@@ -339,13 +362,11 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         ], "Terminals lists every terminal once, whatever workspace shows it")
     }
 
-    /// Regression (https://github.com/manaflow-ai/cmux/issues/12044 follow-up): a pane
-    /// holding several tabs listed every tab as a peer row, so a workspace read
-    /// "3 terminals" while its layout showed one pane. A workspace's rows are its layout:
-    /// one row per pane (the tab the pane shows), the pane's other tabs nested beneath it
-    /// in tab order.
-    @Test("A pane with several tabs is one row: the tab it shows, with its other tabs nested beneath")
-    func hiddenTabsNestUnderTheirPaneRow() throws {
+    /// Regression for #12226: a pane holding several tabs must expose every tab as a
+    /// sibling leaf row. The pane hierarchy is an implementation detail and must not
+    /// become a terminal-under-terminal presentation.
+    @Test("A pane with several tabs exposes flat sibling terminal rows")
+    func tabsAreFlatSiblingRows() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)
         // One pane, three tabs; the daemon shows the middle one.
         let snapshot = SurfaceCatalogSnapshot(
@@ -360,33 +381,28 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let tree = rows(snapshot)
         let byID = Dictionary(tree.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
-        #expect(workspaceRow.children.compactMap(terminalKey) == ["term_b"], "one pane in the layout, one row: the tab the pane shows")
-        let paneRow = try #require(workspaceRow.children.first)
-        #expect(paneRow.children.compactMap(terminalKey) == ["term_a", "term_c"], "the pane's other tabs nest beneath it, in tab order")
+        #expect(workspaceRow.children.compactMap(terminalKey) == ["term_b", "term_a", "term_c"], "all tabs are sibling rows in layout order")
+        #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty }, "terminal rows are leaves")
         guard case .workspace(_, _, let count, let hiddenTabs, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
-        #expect(count == 1, "the count is what the layout shows")
-        #expect(hiddenTabs == 2, "and the row says how many tabs sit behind the shown ones")
-        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hiddenTabs) == "1 terminal · 2 more tabs")
-        guard case .terminal(let shownRow) = paneRow.kind else {
-            Issue.record("expected the pane row"); return
+        #expect(count == 3, "the count includes every visible terminal row")
+        #expect(hiddenTabs == 0, "flat rows have no hidden tabs")
+        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hiddenTabs) == "3 terminals")
+        for child in workspaceRow.children {
+            guard case .terminal(let row) = child.kind else { Issue.record("expected terminal row"); continue }
+            #expect(row.hiddenTabCount == 0)
         }
-        #expect(shownRow.hiddenTabCount == 2, "the pane row carries the count its badge shows")
-        #expect(paneRow.children.allSatisfy { child in
-            if case .terminal(let row) = child.kind { return row.hiddenTabCount == 0 }
-            return false
-        }, "nested tab rows carry no badge of their own")
         // Every terminal keeps its one pool row, whatever pane or tab shows it.
         let pool = try #require(tree.first { $0.structureTag == "terminalsPool" })
         #expect(pool.children.compactMap(terminalKey) == ["term_a", "term_b", "term_c"])
     }
 
-    @Test("Collapsing a pane keeps it collapsed after the pane shows a different tab")
+    @Test("Each tab row has a stable identity when the pane selection changes")
     @MainActor
     func collapsingAPaneSurvivesSwitchingItsShownTab() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)
-        func paneRow(focused: String) throws -> CloudTreeNode {
+        func tabRows(focused: String) throws -> [CloudTreeNode] {
             let snapshot = SurfaceCatalogSnapshot(
                 machines: [info(workspaces: [main])],
                 resources: [
@@ -397,37 +413,31 @@ struct CloudTreeOneMachineManyWorkspacesTests {
                 projections: []
             )
             let workspaceRow = try #require(rows(snapshot).first { $0.id == "machine:brave-otter/ws/ws_main" })
-            return try #require(workspaceRow.children.first)
+            return workspaceRow.children
         }
-        let shownB = try paneRow(focused: "term_b")
-        let shownC = try paneRow(focused: "term_c")
-        #expect(shownB.id == shownC.id, "the pane row is the same row when a different tab is shown")
-        #expect(terminalKey(shownB) == "term_b")
-        #expect(terminalKey(shownC) == "term_c")
-        let suite = "CloudTreePaneExpansion-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defer { defaults.removePersistentDomain(forName: suite) }
-        let store = CloudTreeExpansionStore(defaults: defaults)
-        store.setExpanded(false, node: shownB)
-        #expect(!store.isExpanded(shownC), "collapse is keyed by the pane, not the shown tab")
+        let shownB = try tabRows(focused: "term_b")
+        let shownC = try tabRows(focused: "term_c")
+        #expect(Set(shownB.map(\.id)) == Set(shownC.map(\.id)), "tab rows retain exact identities across selection changes")
+        #expect(shownB.allSatisfy { $0.children.isEmpty } && shownC.allSatisfy { $0.children.isEmpty })
     }
 
-    @Test("A pane row keeps its identity when a second tab appears")
-    func paneIdentitySurvivesTabAppearance() throws {
+    @Test("A tab row keeps its identity when a second tab appears")
+    func tabIdentitySurvivesTabAppearance() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)
-        func paneRow(_ resources: [SurfaceResource]) throws -> CloudTreeNode {
+        func tabRows(_ resources: [SurfaceResource]) throws -> [CloudTreeNode] {
             let snapshot = SurfaceCatalogSnapshot(
                 machines: [info(workspaces: [main])], resources: resources, projections: []
             )
             let workspaceRow = try #require(rows(snapshot).first { $0.id == "machine:brave-otter/ws/ws_main" })
-            return try #require(workspaceRow.children.first)
+            return workspaceRow.children
         }
         let first = tabbedTerminal("term_a", in: main, pane: "pane_1", index: 0, focused: true)
         let second = tabbedTerminal("term_b", in: main, pane: "pane_1", index: 1, focused: false)
-        let oneTab = try paneRow([first])
-        let twoTabs = try paneRow([first, second])
-        #expect(oneTab.id == twoTabs.id)
-        #expect(oneTab.id.contains("pane:pane_1"))
+        let oneTab = try tabRows([first])
+        let twoTabs = try tabRows([first, second])
+        #expect(oneTab.first?.id == twoTabs.first?.id)
+        #expect(oneTab.first?.id.contains("tab:tab_term_a") == true)
+        #expect(twoTabs.allSatisfy { $0.children.isEmpty })
     }
 
     @Test("Pane rows follow the layout: the screen, then the pane's position in its split tree")
@@ -452,14 +462,14 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let tree = rows(snapshot)
         let byID = Dictionary(tree.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
-        #expect(workspaceRow.children.compactMap(terminalKey) == ["term_left", "term_right"], "layout order, not arrival order")
-        #expect(workspaceRow.children.last?.children.compactMap(terminalKey) == ["term_right_hidden"])
+        #expect(workspaceRow.children.compactMap(terminalKey) == ["term_left", "term_right", "term_right_hidden"], "layout order, not arrival order")
+        #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty })
         guard case .workspace(_, _, let count, let hidden, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
-        #expect(count == 2)
-        #expect(hidden == 1)
-        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hidden) == "2 terminals · 1 more tab")
+        #expect(count == 3)
+        #expect(hidden == 0)
+        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hidden) == "3 terminals")
         // Views that name no pane (older providers) keep the flat rows they always had.
         let legacy = SurfaceCatalogSnapshot(
             machines: [info(workspaces: [main])],

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -1,27 +1,23 @@
 import Foundation
 import Testing
-
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
 @testable import cmux
 #endif
-
 private final class CloudTreeCLIBundleToken: NSObject {}
-
 private struct CloudTreeCLIResult {
     let status: Int32
     let stdout: String
     let stderr: String
     let requests: [String]
 }
-
 /// The Cloud sidebar's model is one big machine hosting MANY cmux-tui
 /// workspaces (the shape cmux Cloud had on Blaxel, now on Freestyle) — never
 /// "one VM = one workspace". These pin what the outline builds for such a
 /// machine — its four groups, in this order: **Workspaces** (the machine's
 /// face, always its own row with its own "+", one row per workspace with the
-/// terminals in its layout), **Ports**, **VNC Displays** (one row per screen),
+/// terminals in its layout), **Ports**, **Displays** (one row per screen),
 /// and last, its own section, **Terminals** (every terminal the machine owns,
 /// one row per identity, always present so its "+" is New Terminal).
 ///
@@ -34,7 +30,6 @@ private struct CloudTreeCLIResult {
 struct CloudTreeOneMachineManyWorkspacesTests {
     private let machineID = "brave-otter"
     private var machine: SurfaceMachineID { .cloud(machineID) }
-
     private func fleetRow() -> MachineSnapshot {
         MachineSnapshot(
             id: machineID,
@@ -207,7 +202,11 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter",
             "machine:brave-otter/workspaces",
             "machine:brave-otter/ws/ws_main",
-            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1",
+            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1/tab:tab_term_1_0",
+            "machine:brave-otter/ports",
+            "machine:brave-otter/ports/status",
+            "machine:brave-otter/displays",
+            "machine:brave-otter/displays/placeholder",
             "machine:brave-otter/terminals",
             "resource:brave-otter/terminal/term_1",
         ], "the group is its own row above the lone workspace — never folded into it")
@@ -219,7 +218,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(!row.isMachineRow, "a workspace is a row under its machine, never a machine of its own")
     }
 
-    @Test("Under a connected machine: Workspaces, Ports, VNC Displays, then Terminals (every terminal) as the last section")
+    @Test("Under a connected machine: Workspaces, Ports, Displays, then Terminals (every terminal) as the last section")
     func workspacesPortsDisplaysThenTerminals() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)
         let side = workspace("ws_side", "side", index: 1)
@@ -244,13 +243,13 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter",
             "machine:brave-otter/workspaces",
             "machine:brave-otter/ws/ws_main",
-            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1",
-            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_shared",
+            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1/tab:tab_term_1_0",
+            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_shared/tab:tab_term_shared_0",
             "machine:brave-otter/ws/ws_main/resource:brave-otter/display/display:1",
             "machine:brave-otter/ws/ws_side",
-            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_2",
-            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_shared",
-            "machine:brave-otter/ws/ws_side/resource:brave-otter/display/display:1",
+            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_2/tab:tab_term_2_0",
+            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_shared/tab:tab_term_shared_1",
+            "machine:brave-otter/ws/ws_side/resource:brave-otter/display/display:1/tab:tab_desk_0",
             "machine:brave-otter/ports",
             "resource:brave-otter/browser/port:3000",
             "machine:brave-otter/displays",
@@ -275,8 +274,8 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(sharedRow.viewBadge == 2, "a tab in each of two workspaces")
         #expect(detachedRow.viewBadge == 0, "no tab shows it: still running, listed in the pool")
         // A terminal viewed in two workspaces shows under both; each row counts its own.
-        guard case .workspace(_, _, let mainCount, _, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind,
-              case .workspace(_, _, let sideCount, _, _) = try #require(byID["machine:brave-otter/ws/ws_side"]).kind else {
+        guard case .workspace(_, _, let mainCount, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind,
+              case .workspace(_, _, let sideCount, _) = try #require(byID["machine:brave-otter/ws/ws_side"]).kind else {
             Issue.record("expected both workspace rows"); return
         }
         #expect(mainCount == 2)
@@ -288,7 +287,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(byID["machine:brave-otter/ws/ws_main"]?.dragGroup?.resources == [
             SurfaceResourceID(machine: machine, kind: .terminal, key: "term_1"), shared.id,
         ])
-        // VNC Displays is one row per screen; the group is searchable under that name.
+        // Displays is one row per screen; the group is searchable under that name.
         #expect(byID["machine:brave-otter/displays"]?.searchableTitle == "Displays")
         #expect(tree.last?.id == "resource:brave-otter/terminal/term_shared", "Terminals is the machine's last section")
     }
@@ -308,7 +307,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter/terminals",
             "machine:brave-otter/terminals/placeholder",
         ])
-        for groupID in ["machine:brave-otter/workspaces", "machine:brave-otter/terminals", "machine:brave-otter/displays"] {
+        for groupID in ["machine:brave-otter/workspaces", "machine:brave-otter/terminals"] {
             let group = try #require(tree.first { $0.id == groupID })
             #expect(CloudTreeRowHoverButtons.hasButtons(for: group.kind), "\(groupID) keeps its hover +")
         }
@@ -383,16 +382,10 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
         #expect(workspaceRow.children.compactMap(terminalKey) == ["term_b", "term_a", "term_c"], "all tabs are sibling rows in layout order")
         #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty }, "terminal rows are leaves")
-        guard case .workspace(_, _, let count, let hiddenTabs, _) = workspaceRow.kind else {
+        guard case .workspace(_, _, let count, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 3, "the count includes every visible terminal row")
-        #expect(hiddenTabs == 0, "flat rows have no hidden tabs")
-        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hiddenTabs) == "3 terminals")
-        for child in workspaceRow.children {
-            guard case .terminal(let row) = child.kind else { Issue.record("expected terminal row"); continue }
-            #expect(row.hiddenTabCount == 0)
-        }
         // Every terminal keeps its one pool row, whatever pane or tab shows it.
         let pool = try #require(tree.first { $0.structureTag == "terminalsPool" })
         #expect(pool.children.compactMap(terminalKey) == ["term_a", "term_b", "term_c"])
@@ -464,12 +457,10 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
         #expect(workspaceRow.children.compactMap(terminalKey) == ["term_left", "term_right", "term_right_hidden"], "layout order, not arrival order")
         #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty })
-        guard case .workspace(_, _, let count, let hidden, _) = workspaceRow.kind else {
+        guard case .workspace(_, _, let count, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 3)
-        #expect(hidden == 0)
-        #expect(CloudTreeRowContentView.workspaceDetail(terminalCount: count, hiddenTabCount: hidden) == "3 terminals")
         // Views that name no pane (older providers) keep the flat rows they always had.
         let legacy = SurfaceCatalogSnapshot(
             machines: [info(workspaces: [main])],
@@ -528,16 +519,15 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let before = try workspaceRow(initial)
         let after = try workspaceRow(rowLocal)
         let refreshed = try workspaceRow(CmuxTuiSnapshotParser.resources(from: next))
-        #expect(before.children.count == 1)
-        #expect(before.children.first?.id.contains("pane:pane_1") == true)
+        #expect(before.children.count == 2)
+        #expect(before.children.allSatisfy { $0.children.isEmpty })
         #expect(after.children.map(\.id) == before.children.map(\.id))
-        #expect(after.children.flatMap { $0.children }.map(\.id) == before.children.flatMap { $0.children }.map(\.id))
         #expect(refreshed.children.map(\.id) == after.children.map(\.id))
         #expect(updated.remoteViews?.first?.name == "renamed")
     }
 
-    @Test("The CLI shows a pane's hidden tabs indented beneath the tab the pane shows")
-    func cliTreeNestsHiddenTabs() throws {
+    @Test("The CLI shows every workspace tab as a flat sibling row")
+    func cliTreeShowsFlatTabs() throws {
         let workspace: [String: Any] = ["id": "ws_main", "name": "main", "index": 0, "focused": true]
         let machine: [String: Any] = [
             "id": machineID, "status": "running", "link_state": "connected", "has_desktop": false,
@@ -559,11 +549,11 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         ])
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         let lines = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
-        func isPaneRow(_ line: String) -> Bool { line.hasPrefix("      ") && !line.hasPrefix("        ") }
-        let shown = try #require(lines.firstIndex { isPaneRow($0) && $0.contains("term_b") }, Comment(rawValue: result.stdout))
-        #expect(lines[shown].contains("(+1 hidden)"), Comment(rawValue: lines[shown]))
-        #expect(lines[shown + 1].hasPrefix("        ↳ tab") && lines[shown + 1].contains("term_a"), Comment(rawValue: lines[shown + 1]))
-        #expect(!lines.contains { isPaneRow($0) && $0.contains("term_a") }, "the hidden tab is not a peer row")
+        let rows = lines.filter { $0.hasPrefix("      ") }
+        #expect(rows.count == 2, Comment(rawValue: result.stdout))
+        #expect(rows[0].contains("term_b"), Comment(rawValue: rows[0]))
+        #expect(rows[1].contains("term_a"), Comment(rawValue: rows[1]))
+        #expect(!result.stdout.contains("hidden"))
     }
 
     @Test("CLI open commands name the exact tab when one terminal occupies several")
@@ -594,15 +584,12 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let result = try runCLICloudTree(machine: machine, resources: [resource])
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         let lines = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
-        func isPaneRow(_ line: String) -> Bool { line.hasPrefix("      ") && !line.hasPrefix("        ") }
-        let shown = try #require(lines.first { isPaneRow($0) && $0.contains("term_shared") }, Comment(rawValue: result.stdout))
-        let hidden = try #require(lines.first { $0.contains("↳ tab") }, Comment(rawValue: result.stdout))
-        #expect(shown.contains("cmux vm open \(machineID)/ws_main/term_shared/tab_b"), Comment(rawValue: shown))
-        #expect(hidden.contains("cmux vm open \(machineID)/ws_main/term_shared/tab_a"), Comment(rawValue: hidden))
-        #expect(shown.contains("shell"), "the shown row uses the tab name")
-        #expect(hidden.contains("build"), "the hidden row uses its own tab name")
-        #expect(!shown.contains("/term_shared)"), "a tab-less command would open the focused tab for both rows")
-        #expect(!hidden.contains("/term_shared)"))
+        let rows = lines.filter { $0.hasPrefix("      ") }
+        let build = try #require(rows.first { $0.contains("build") }, Comment(rawValue: result.stdout))
+        let shell = try #require(rows.first { $0.contains("shell") }, Comment(rawValue: result.stdout))
+        #expect(shell.contains("cmux vm open \(machineID)/ws_main/term_shared/tab_b"), Comment(rawValue: shell))
+        #expect(build.contains("cmux vm open \(machineID)/ws_main/term_shared/tab_a"), Comment(rawValue: build))
+        #expect(!result.stdout.contains("hidden"))
 
         let opened = try runCLICloudCommand(
             arguments: ["vm", "open", "\(machineID)/ws_main/term_shared/tab_a", "--json"],
@@ -639,9 +626,13 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter",
             "machine:brave-otter/workspaces",
             "machine:brave-otter/ws/ws_main",
-            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1",
+            "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1/tab:tab_term_1_0",
             "machine:brave-otter/ws/ws_side",
-            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_2",
+            "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_2/tab:tab_term_2_0",
+            "machine:brave-otter/ports",
+            "machine:brave-otter/ports/status",
+            "machine:brave-otter/displays",
+            "machine:brave-otter/displays/placeholder",
             "machine:brave-otter/terminals",
             "resource:brave-otter/terminal/term_1",
             "resource:brave-otter/terminal/term_bg",
@@ -650,7 +641,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let byID = Dictionary(tree.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         guard case .terminal(let poolRow) = try #require(byID["resource:brave-otter/terminal/term_bg"]).kind,
               case .terminal(let viewedPoolRow) = try #require(byID["resource:brave-otter/terminal/term_1"]).kind,
-              case .terminal(let layoutRow) = try #require(byID["machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1"]).kind else {
+              case .terminal(let layoutRow) = try #require(byID["machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1/tab:tab_term_1_0"]).kind else {
             Issue.record("expected the terminal rows"); return
         }
         #expect(poolRow.isDetached, "greyed, marked detached")
@@ -659,7 +650,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(CloudTreeRowHoverButtons.hasButtons(for: .terminal(poolRow)), "its hover × (Kill Terminal…) stays")
         #expect(byID["resource:brave-otter/terminal/term_bg"]?.isDragSource == true, "a click or drag re-attaches it in a pane")
         // The workspace is its layout: count, open/drag group, and `vm workspace open` agree.
-        guard case .workspace(_, _, let count, _, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind else {
+        guard case .workspace(_, _, let count, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 1)
@@ -671,7 +662,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(members.ids == layoutOnly)
     }
 
-    @Test("VNC Displays lists one row per screen, each telling its screen apart")
+    @Test("Displays lists one row per screen, each telling its screen apart")
     func displaysAreOnePerScreen() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)
         let first = display(in: [])
@@ -689,7 +680,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter/terminals/placeholder",
         ], "the screens sit above the Terminals section")
         guard case .displaysPool(_, let count) = try #require(tree.first { $0.id == "machine:brave-otter/displays" }).kind else {
-            Issue.record("expected the VNC Displays group"); return
+            Issue.record("expected the Displays group"); return
         }
         #expect(count == 2)
         #expect(CloudTreeRowContentView.text(for: first) == "noVNC · :1")
@@ -761,7 +752,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let lines = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
         let workspaces = try #require(lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "workspaces/" })
         let ports = try #require(lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "ports/" })
-        let displays = try #require(lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "VNC Displays/" })
+        let displays = try #require(lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "Displays/" })
         let terminals = try #require(lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "terminals/" })
 
         #expect(workspaces < ports)

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -273,8 +273,8 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(sharedRow.viewBadge == 2, "a tab in each of two workspaces")
         #expect(detachedRow.viewBadge == 0, "no tab shows it: still running, listed in the pool")
         // A terminal viewed in two workspaces shows under both; each row counts its own.
-        guard case .workspace(_, _, let mainCount, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind,
-              case .workspace(_, _, let sideCount, _) = try #require(byID["machine:brave-otter/ws/ws_side"]).kind else {
+        guard case .workspace(_, _, let mainCount, _, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind,
+              case .workspace(_, _, let sideCount, _, _) = try #require(byID["machine:brave-otter/ws/ws_side"]).kind else {
             Issue.record("expected both workspace rows"); return
         }
         #expect(mainCount == 2)
@@ -381,7 +381,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
         #expect(workspaceRow.children.compactMap(terminalKey) == ["term_b", "term_a", "term_c"], "all tabs are sibling rows in layout order")
         #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty }, "terminal rows are leaves")
-        guard case .workspace(_, _, let count, _) = workspaceRow.kind else {
+        guard case .workspace(_, _, let count, _, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 3, "the count includes every visible terminal row")
@@ -456,7 +456,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         let workspaceRow = try #require(byID["machine:brave-otter/ws/ws_main"])
         #expect(workspaceRow.children.compactMap(terminalKey) == ["term_left", "term_right", "term_right_hidden"], "layout order, not arrival order")
         #expect(workspaceRow.children.allSatisfy { $0.children.isEmpty })
-        guard case .workspace(_, _, let count, _) = workspaceRow.kind else {
+        guard case .workspace(_, _, let count, _, _) = workspaceRow.kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 3)
@@ -649,7 +649,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(CloudTreeRowHoverButtons.hasButtons(for: .terminal(poolRow)), "its hover × (Kill Terminal…) stays")
         #expect(byID["resource:brave-otter/terminal/term_bg"]?.isDragSource == true, "a click or drag re-attaches it in a pane")
         // The workspace is its layout: count, open/drag group, and `vm workspace open` agree.
-        guard case .workspace(_, _, let count, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind else {
+        guard case .workspace(_, _, let count, _, _) = try #require(byID["machine:brave-otter/ws/ws_main"]).kind else {
             Issue.record("expected the workspace row"); return
         }
         #expect(count == 1)

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -216,7 +216,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("same", in: machine) == .ambiguous(["ws-a", "ws-b"]))
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("missing", in: machine) == .notFound)
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("ws-id", in: ["id": "vivid-newt"]) == .unavailable)
-        let unfocused: [String: Any] = ["machines": [["id": "vivid-newt", "remote_workspaces": [["id": "ws-a"], ["id": "ws-b"]]]], "resources": [[String: Any]]()]
+        let unfocused: [String: Any] = ["machines": [["id": "vivid-newt", "link_state": "connected", "remote_workspaces": [["id": "ws-a"], ["id": "ws-b"]]]], "resources": [[String: Any]]()]
         #expect(VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: "vivid-newt", catalog: unfocused) == .unavailable)
         let disconnected: [String: Any] = ["machines": [["id": "vivid-newt", "link_state": "asleep", "remote_workspaces": [["id": "ws-a"]]]], "resources": [[String: Any]]()]
         #expect(VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: "vivid-newt", catalog: disconnected) == .unavailable)

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -40,7 +40,6 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
             ["id": "agent_1", "terminal_id": "term_build", "state": "working", "source": "claude"],
         ],
     ]
-
     @Test func legacyScreensKeepArrivalOrderAndExplicitPositions() throws {
         var snapshot = Self.sessionSnapshot
         snapshot["screens"] = [
@@ -53,7 +52,6 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(views.first { $0.screenID == "screen_2" }?.screenIndex == 0)
         #expect(views.first { $0.screenID == "screen_1" }?.screenIndex == 7)
     }
-
     @Test func layoutDocumentOrdersPanesAndPlacesEveryView() throws {
         let layout: [String: Any] = [
             "version": 1, "screen_id": "screen_1", "active_pane_id": "pane_b", "zoomed_pane_id": NSNull(),
@@ -220,6 +218,8 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("ws-id", in: ["id": "vivid-newt"]) == .unavailable)
         let unfocused: [String: Any] = ["machines": [["id": "vivid-newt", "remote_workspaces": [["id": "ws-a"], ["id": "ws-b"]]]], "resources": [[String: Any]]()]
         #expect(VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: "vivid-newt", catalog: unfocused) == .unavailable)
+        let disconnected: [String: Any] = ["machines": [["id": "vivid-newt", "link_state": "asleep", "remote_workspaces": [["id": "ws-a"]]]], "resources": [[String: Any]]()]
+        #expect(VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: "vivid-newt", catalog: disconnected) == .unavailable)
     }
 
     @Test func vmOpenWorkspaceUsesTheSelectedTabView() {

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -7,12 +7,10 @@ import Testing
 @testable import cmux
 #endif
 typealias CMUXCLI = CmuxTuiRemoteRouting
-
 /// The cmux-tui provider's pure parts: snapshot → resources, the argv it hands the
 /// client, the URLs it opens, and the client identity paths it shares with the CLI.
 @Suite struct CmuxTuiSurfaceProviderTests {
     static let machine = SurfaceMachineID.cloud("vivid-newt")
-
     static let sessionSnapshot: [String: Any] = [
         "workspaces": [
             ["id": "ws_main", "name": "main", "focused": true],
@@ -220,6 +218,8 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("same", in: machine) == .ambiguous(["ws-a", "ws-b"]))
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("missing", in: machine) == .notFound)
         #expect(VMRemoteWorkspaceResolver().resolveVMRemoteWorkspaceSelector("ws-id", in: ["id": "vivid-newt"]) == .unavailable)
+        let unfocused: [String: Any] = ["machines": [["id": "vivid-newt", "remote_workspaces": [["id": "ws-a"], ["id": "ws-b"]]]], "resources": [[String: Any]]()]
+        #expect(VMRemoteWorkspaceResolver().resolveVMMachineTerminal(machine: "vivid-newt", catalog: unfocused) == .unavailable)
     }
 
     @Test func vmOpenWorkspaceUsesTheSelectedTabView() {

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -1925,7 +1925,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         )
         let flattened = CloudTreeNodeBuilder.flattened(nodes)
         let workspaceNode = try #require(flattened.first { $0.id == "machine:legacy-placement/ws/ws_main" })
-        if case .workspace(_, _, _, let openIn) = workspaceNode.kind {
+        if case .workspace(_, _, _, _, let openIn) = workspaceNode.kind {
             #expect(openIn == localWorkspaceID)
         } else {
             Issue.record("expected the legacy workspace row")

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -6,7 +6,6 @@ import Testing
 #elseif canImport(cmux)
 @testable import cmux
 #endif
-
 typealias CMUXCLI = CmuxTuiRemoteRouting
 
 /// The cmux-tui provider's pure parts: snapshot → resources, the argv it hands the
@@ -933,6 +932,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         #expect(CmuxTuiSnapshotParser.createdTerminal(fromRunResult: ["terminal_id": "term_bare"])?.terminalID == "term_bare")
         #expect(CmuxTuiSnapshotParser.createdTerminal(fromRunResult: ["value": ["kind": "terminal"]]) == nil)
         #expect(CmuxTuiSnapshotParser.createdWorkspace(fromResult: ["value": ["workspace_id": "ws_9"]]) == "ws_9")
+        #expect(CmuxTuiSnapshotParser.createdWorkspace(fromResult: ["value": ["workspace": "ws_8"]]) == "ws_8")
         #expect(CmuxTuiSnapshotParser.createdWorkspace(fromResult: ["id": "ws_bare"]) == "ws_bare")
         #expect(CmuxTuiSnapshotParser.createdWorkspace(fromResult: ["value": [:]]) == nil)
 

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -1925,7 +1925,7 @@ typealias CMUXCLI = CmuxTuiRemoteRouting
         )
         let flattened = CloudTreeNodeBuilder.flattened(nodes)
         let workspaceNode = try #require(flattened.first { $0.id == "machine:legacy-placement/ws/ws_main" })
-        if case .workspace(_, _, _, _, let openIn) = workspaceNode.kind {
+        if case .workspace(_, _, _, let openIn) = workspaceNode.kind {
             #expect(openIn == localWorkspaceID)
         } else {
             Issue.record("expected the legacy workspace row")

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -819,7 +819,7 @@ final class MachinesPanelModelTests: XCTestCase {
         // machine can still explain how to discover its ports (see emptyPorts(info:)).
         XCTAssertEqual(
             CloudTreeNodeBuilder.flattened(asleep).map(\.id),
-            ["machine:quiet-owl", "machine:quiet-owl/placeholder", "machine:quiet-owl/ports", "machine:quiet-owl/ports/status"]
+            ["machine:quiet-owl", "machine:quiet-owl/placeholder", "machine:quiet-owl/ports", "machine:quiet-owl/ports/status", "machine:quiet-owl/displays", "machine:quiet-owl/displays/placeholder"]
         )
         if case .placeholder(_, let placeholder) = asleep[0].children[0].kind { XCTAssertEqual(placeholder.style, .dimmed) } else { XCTFail() }
         if case .placeholder(_, let ports) = asleep[0].children[1].children[0].kind { XCTAssertEqual(ports.style, .dimmed) } else { XCTFail() }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -440,7 +440,7 @@ final class MachinesPanelModelTests: XCTestCase {
         )
         let ids = CloudTreeNodeBuilder.flattened(nodes).map(\.id)
         // One machine, many workspaces: the Workspaces group leads (every workspace the
-        // machine reports, pointer rows under each), then Ports, VNC Displays (one row
+        // machine reports, pointer rows under each), then Ports, Displays (one row
         // per screen), and last, its own section, Terminals (every terminal the machine owns).
         XCTAssertEqual(ids, [
             "machine:local",
@@ -497,13 +497,13 @@ final class MachinesPanelModelTests: XCTestCase {
             includeLocalMachine: true
         )
         let openByID = Dictionary(CloudTreeNodeBuilder.flattened(openNodes).map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_main"]!.kind {
+        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_main"]!.kind {
             XCTAssertEqual(openIn, local, "term_1's pane lives in the local workspace")
         } else { XCTFail("expected ws_main row") }
-        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_side"]!.kind {
+        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_side"]!.kind {
             XCTAssertEqual(openIn, remoteSideLocalWorkspace, "term_1's second remote view uses its own local workspace")
         } else { XCTFail("expected ws_side row") }
-        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
+        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
             XCTAssertNil(openIn, "nothing of it is open anywhere")
         } else { XCTFail("expected ws_empty row") }
         // Desktop rows: a workspace's own display pointer opens inside the local
@@ -556,7 +556,7 @@ final class MachinesPanelModelTests: XCTestCase {
             XCTAssertEqual(row.remoteView?.tabID, "tab_9")
         } else { XCTFail("expected pointer row") }
         // The empty workspace still gets a row (from the machine info), with no pointers.
-        if case .workspace(_, let workspace, let count, _, _) = byID["machine:vivid-newt/ws/ws_empty"]!.kind {
+        if case .workspace(_, let workspace, let count, _) = byID["machine:vivid-newt/ws/ws_empty"]!.kind {
             XCTAssertEqual(workspace.name, "scratch")
             XCTAssertEqual(count, 0)
         } else { XCTFail("expected empty workspace row") }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -440,7 +440,7 @@ final class MachinesPanelModelTests: XCTestCase {
         )
         let ids = CloudTreeNodeBuilder.flattened(nodes).map(\.id)
         // One machine, many workspaces: the Workspaces group leads (every workspace the
-        // machine reports, pointer rows under each), then Ports, Displays (one row
+        // machine reports, pointer rows under each), then Ports, VNC Displays (one row
         // per screen), and last, its own section, Terminals (every terminal the machine owns).
         XCTAssertEqual(ids, [
             "machine:local",
@@ -497,13 +497,13 @@ final class MachinesPanelModelTests: XCTestCase {
             includeLocalMachine: true
         )
         let openByID = Dictionary(CloudTreeNodeBuilder.flattened(openNodes).map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_main"]!.kind {
+        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_main"]!.kind {
             XCTAssertEqual(openIn, local, "term_1's pane lives in the local workspace")
         } else { XCTFail("expected ws_main row") }
-        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_side"]!.kind {
+        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_side"]!.kind {
             XCTAssertEqual(openIn, remoteSideLocalWorkspace, "term_1's second remote view uses its own local workspace")
         } else { XCTFail("expected ws_side row") }
-        if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
+        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
             XCTAssertNil(openIn, "nothing of it is open anywhere")
         } else { XCTFail("expected ws_empty row") }
         // Desktop rows: a workspace's own display pointer opens inside the local
@@ -556,7 +556,7 @@ final class MachinesPanelModelTests: XCTestCase {
             XCTAssertEqual(row.remoteView?.tabID, "tab_9")
         } else { XCTFail("expected pointer row") }
         // The empty workspace still gets a row (from the machine info), with no pointers.
-        if case .workspace(_, let workspace, let count, _) = byID["machine:vivid-newt/ws/ws_empty"]!.kind {
+        if case .workspace(_, let workspace, let count, _, _) = byID["machine:vivid-newt/ws/ws_empty"]!.kind {
             XCTAssertEqual(workspace.name, "scratch")
             XCTAssertEqual(count, 0)
         } else { XCTFail("expected empty workspace row") }
@@ -819,7 +819,7 @@ final class MachinesPanelModelTests: XCTestCase {
         // machine can still explain how to discover its ports (see emptyPorts(info:)).
         XCTAssertEqual(
             CloudTreeNodeBuilder.flattened(asleep).map(\.id),
-            ["machine:quiet-owl", "machine:quiet-owl/placeholder", "machine:quiet-owl/ports", "machine:quiet-owl/ports/status", "machine:quiet-owl/displays", "machine:quiet-owl/displays/placeholder"]
+            ["machine:quiet-owl", "machine:quiet-owl/placeholder", "machine:quiet-owl/ports", "machine:quiet-owl/ports/status"]
         )
         if case .placeholder(_, let placeholder) = asleep[0].children[0].kind { XCTAssertEqual(placeholder.style, .dimmed) } else { XCTFail() }
         if case .placeholder(_, let ports) = asleep[0].children[1].children[0].kind { XCTAssertEqual(ports.style, .dimmed) } else { XCTFail() }


### PR DESCRIPTION
## Problem
Cloud machine rows exposed pane tabs as terminal-under-terminal children, hid real tabs behind `1 more tab` / `+N`, omitted the machine Displays category, and could bootstrap a fresh machine as `shell` with two terminals.

## What changed
- Project workspace placements as flat sibling leaf rows with exact remote tab identities. Pane layout still controls ordering, while every terminal/tab remains visible and addressable.
- Remove hidden-tab labels and badges from the Cloud tree and CLI projection.
- Always render a machine-level `Displays` category. It lists every catalogued VNC display resource, survives reconnects, and uses an explicit empty/unavailable row when discovery has no result. Existing noVNC routing remains the open path; no unsupported display-creation control is exposed.
- Move initial Cloud workspace setup to the trusted-carrier daemon owner. Fresh owner sessions create `workspace-1` with one terminal; later automatic names use the daemon sequence. Opening/reconnecting a machine reattaches its authoritative terminal instead of creating another. Explicit New Terminal remains a create action.
- Workspace and terminal rename paths continue to use the exact workspace/tab identity, preserving user custom names.

## Validation
- Added behavior regressions for flat rows, stable tab identities, Displays population/empty state, CLI parity, and one-based bootstrap naming.
- Regression test and fix are separate commits so CI proves the regression.
- Hosted `test-e2e.yml`: `cmuxTests/CloudTreeOneMachineManyWorkspacesTests` (recording disabled for the unit lane).
- Hosted `cmux-tui.yml`: `automatically_created_workspaces_use_one_based_sequence`.
- `python3 scripts/swift_file_length_budget.py`, localization JSON validation, and diff checks pass locally without touching budget TSVs.

## Runtime rollout note
The daemon-owner bootstrap behavior takes effect on newly baked images containing this cmux-tui revision. Existing baked snapshots require the normal image bake/promotion rollout; source changes alone do not mutate production snapshots.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791579988&installation_model_id=21920&pr_number=12227&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12227&signature=3920d3d9dd64b4fd3befa2665ecfc2781e537755695534a48addbe6e7ac095eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud machine open/reconnect and workspace bootstrap paths; incorrect catalog resolution could block opens or attach the wrong tab, though ambiguous cases fail closed with new errors.
> 
> **Overview**
> **Cloud tree and CLI** now list every workspace tab as a **flat sibling row** (pane layout only affects order). Hidden-tab nesting, `+N` badges, and “more tabs” copy are removed; node IDs include the remote **tab** identity so each row stays addressable.
> 
> **Displays** is always a machine-level section (renamed from “VNC Displays”), with explicit loading/empty/unavailable placeholders and catalog-backed VNC rows even when desktop metadata is stale. The Displays group no longer exposes “Open Desktop”; asleep placeholders can **wake** the machine via `opensMachine`.
> 
> **Opening a cloud machine** (non–full-client) refreshes the catalog and **projects the active workspace’s existing terminal** via `VMRemoteWorkspaceResolver.resolveVMMachineTerminal`; it calls `surface.new_terminal` only when the graph is authoritatively empty, and errors when sessions are ambiguous or unavailable.
> 
> **Daemon / provider behavior**: trusted-carrier remote sessions run an initial bootstrap (`workspace-1` + one terminal); auto-created workspaces use a **`workspace-N`** sequence. Terminal/workspace creation defers workspace choice to the daemon (`current`) instead of inventing names from a stale Mac catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd8c34997a3602c49ef39b99f6917edfac6f931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattens the Cloud tree so every terminal tab appears as a sibling leaf row with its exact remote identity, and makes Displays a machine-level category that always renders in the sidebar and CLI. Moves initial Cloud workspace setup into the daemon owner so opening or reconnecting a machine reattaches its existing terminal instead of creating a duplicate, and resolves workspace selection for new terminals inside the daemon so a stale client catalog can't bootstrap a second workspace.

- The CLI projection matches the flat rows and no longer shows `(+N hidden)` labels or nested tabs.
- Displays always appears under a machine, listing catalogued VNC screens or an explicit loading, empty, unavailable, or asleep state row; the old `VNC Displays` group and its Open Desktop action are removed.
- Catalogued displays stay visible even when machine metadata doesn't advertise the desktop capability.
- Fresh daemon sessions get `workspace-1` with one terminal; later auto-created workspaces continue the daemon's `workspace-N` sequence, and user-renamed names are preserved.
- Explicit New Terminal still creates; CLI `vm open` reuses the machine's existing terminal and only creates when the graph is empty, failing closed with an error when sessions are unavailable or ambiguous.
- Clicking the asleep status placeholder wakes the machine; empty state rows no longer do.

**Rollout**
- Daemon-owner bootstrap applies to newly baked images; existing snapshots need the normal bake/promote rollout.

<sup>Written for commit fbd8c34997a3602c49ef39b99f6917edfac6f931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cloud machine terminals now reuse existing sessions when available and clearly report empty or unavailable sessions.
  - Workspace tabs appear as individual rows for easier navigation.
  - Displays remain visible even when machine metadata is incomplete, with clear empty and unavailable states.
  - Sleeping machine placeholders indicate when opening an item will wake the machine.
  - Automatically created workspaces now use sequential names such as “workspace-1.”

- **Improvements**
  - Display terminology is simplified from “VNC Displays” to “Displays.”
  - Workspace creation can use automatically assigned names when no name is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->