### PR TITLE
Exempt authorized DEV clients from relay rate limits

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -24,6 +24,7 @@
 #   scripts/dev-setup.sh --tag grid --surface ios   # iOS only (needs Mac listener up)
 #   scripts/dev-setup.sh --tag grid --no-pair       # build both, skip auto-pair
 #   scripts/dev-setup.sh --tag grid --agent         # sign in as the agent account
+#   scripts/dev-setup.sh --tag grid --device        # physical iPhone, hosted DEV backend
 #
 # Flags:
 #   --tag <t>           required; tags the macOS + iOS dev builds.
@@ -131,6 +132,20 @@ if [[ -z "$AUTH_ACCOUNT" ]]; then
   exit 2
 fi
 echo "==> dev auth contract: $AUTH_PROFILE ($AUTH_ACCOUNT)"
+
+# A physical phone cannot reach the Mac's localhost API. Select the hosted DEV
+# backend for both tagged apps before either build starts, so a new teammate's
+# first device run does not depend on remembering two origin overrides. Keep
+# explicit caller values intact for controlled local or staging experiments.
+if [[ "$IOS_TARGET" == "device" && ( "$SURFACE" == "ios" || "$SURFACE" == "both" ) ]]; then
+  if [[ -z "${CMUX_DEV_API_BASE_URL:-}" ]]; then
+    export CMUX_DEV_API_BASE_URL="https://cmux-staging.vercel.app"
+  fi
+  if [[ -z "${CMUX_IROH_BROKER_BASE_URL:-}" ]]; then
+    export CMUX_IROH_BROKER_BASE_URL="https://cmux-staging.vercel.app"
+  fi
+  echo "==> physical-device dev backend: $CMUX_DEV_API_BASE_URL"
+fi
 
 # --- tag identity (delegated to scripts/lib/mobile-attach.sh) ----------------
 # slug -> socket path + DerivedData; tag-id -> bundle id. The shared lib owns the

--- a/scripts/setup-team-dev.sh
+++ b/scripts/setup-team-dev.sh
@@ -6,6 +6,9 @@
 # scripts/dev-setup.sh --tag <x> auto-signs-in as THEM and auto-attaches to
 # THEIR Mac, with zero manual steps. DEBUG-only and per-user: the file lives
 # outside the repo and is never committed.
+# Relay limiter access is team-based on the hosted DEV backend. There is no
+# per-user relay registration: membership in the configured Stack team is the
+# authorization source, and release namespaces never qualify.
 #
 # This script:
 #   1. If ~/.secrets/cmuxterm-dev.env already has a complete dogfood pair, prints
@@ -51,6 +54,10 @@ next_steps() {
     ${email}, enables the iOS pairing host, mints an attach
     ticket, and launches the iOS dev build auto-attached to your Mac.
     Mac-only: scripts/dev-setup.sh --tag <x> --surface mac
+
+    When the hosted DEV deployment's bypass is enabled, relay limits are
+    granted automatically to members of the cmux internal team. No user-id
+    registration is required.
 EOF
 }
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -132,6 +132,11 @@ CMUX_CONNECTIVITY_INVALIDATION_SECRET=
 CMUX_IROH_DEV_BINDING_OVERRIDE_ENABLED=0
 CMUX_IROH_DEV_BINDING_OVERRIDE_USER_IDS=
 CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS=
+# Hosted DEV relay limits stay enabled unless this is explicitly set to 1.
+# The bypass then requires the development Stack project, a tagged debug
+# namespace, and membership in one of these comma-separated Stack team IDs.
+CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED=0
+CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS=
 
 # Local/Postgres database. `bun db:*` derives the local port from CMUX_PORT by default:
 # DATABASE_URL uses localhost:${CMUX_PORT + 10000}. CI should set explicit URLs.

--- a/web/app/api/relay/preferences/route.ts
+++ b/web/app/api/relay/preferences/route.ts
@@ -28,6 +28,7 @@ import {
   type AuthedUser,
 } from "../../../../services/vms/auth";
 import { relayAuthenticationError } from "../../../../services/relay/errors";
+import { isAuthorizedDevRelayRateLimitBypass } from "../../../../services/relay/devRateLimitBypass";
 
 
 const MAX_BODY_BYTES = 32 * 1_024;
@@ -45,6 +46,11 @@ export interface RelayPreferenceDeps {
   readonly checkRateLimit: RelayRateLimitCheck;
   readonly rateLimitRuleId: () => string | undefined;
   readonly isVercel: () => boolean;
+  readonly isDevRateLimitBypassAllowed: (input: {
+    readonly request: Request;
+    readonly user: AuthedUser;
+    readonly clientNamespace: string;
+  }) => boolean | Promise<boolean>;
 }
 
 const productionDeps: RelayPreferenceDeps = {
@@ -59,6 +65,11 @@ const productionDeps: RelayPreferenceDeps = {
     process.env.CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID ??
     process.env.CMUX_RELAY_TOKEN_RATE_LIMIT_ID,
   isVercel: () => process.env.VERCEL === "1",
+  isDevRateLimitBypassAllowed: ({ clientNamespace, user }) =>
+    isAuthorizedDevRelayRateLimitBypass({
+      clientNamespace,
+      teamIds: user.teamIds,
+    }),
 };
 
 async function authenticatedAccount(
@@ -72,14 +83,30 @@ async function authenticatedAccount(
     throw relayAuthenticationError(error);
   }
   if (!user) return unauthorized();
-  await runRelayEffect(enforceRelayRateLimit({
-    request,
-    accountId: user.id,
-    ruleId: deps.rateLimitRuleId(),
-    check: deps.checkRateLimit,
-    isVercel: deps.isVercel(),
-    retryAfterSeconds: 60,
-  }));
+  const clientNamespace = request.headers.get("x-cmux-app-namespace") ?? "legacy";
+  let bypassRateLimit = false;
+  try {
+    bypassRateLimit = await deps.isDevRateLimitBypassAllowed({
+      request,
+      user,
+      clientNamespace,
+    });
+  } catch {
+    // A failed authorization lookup must retain the normal limiter.
+    bypassRateLimit = false;
+  }
+  if (bypassRateLimit) {
+    console.info("relay.rate_limit_bypassed", { reason: "authorized_dev_team" });
+  } else {
+    await runRelayEffect(enforceRelayRateLimit({
+      request,
+      accountId: user.id,
+      ruleId: deps.rateLimitRuleId(),
+      check: deps.checkRateLimit,
+      isVercel: deps.isVercel(),
+      retryAfterSeconds: 60,
+    }));
+  }
   return user;
 }
 

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -44,9 +44,14 @@ import {
 } from "../../../../services/iroh/routeHandler";
 import {
   unauthorized,
+  verifyRequestFromSnapshot,
   verifyRequestIdentity,
 } from "../../../../services/vms/auth";
 import { rateLimitDeploymentPartition } from "../../../../services/rateLimitPartition";
+import {
+  isAuthorizedDevRelayRateLimitBypass,
+  isDevelopmentRelayClientNamespace,
+} from "../../../../services/relay/devRateLimitBypass";
 
 
 const MAX_BODY_BYTES = 4 * 1_024;
@@ -85,6 +90,11 @@ export interface RelayTokenDeps {
   readonly rateLimitRuleId: () => string | undefined;
   readonly isVercel: () => boolean;
   readonly credentialSigningRequired: () => boolean;
+  readonly isDevRateLimitBypassAllowed: (input: {
+    readonly request: Request;
+    readonly userId: string;
+    readonly clientNamespace: string;
+  }) => boolean | Promise<boolean>;
 }
 
 const productionDeps: RelayTokenDeps = {
@@ -140,6 +150,20 @@ const productionDeps: RelayTokenDeps = {
   isVercel: () => process.env.VERCEL === "1",
   credentialSigningRequired: () =>
     process.env.VERCEL === "1" && process.env.VERCEL_ENV !== "preview",
+  isDevRateLimitBypassAllowed: async ({ request, userId, clientNamespace }) => {
+    if (!isDevelopmentRelayClientNamespace(clientNamespace)) return false;
+    try {
+      const user = await verifyRequestFromSnapshot(request);
+      return user?.id === userId && isAuthorizedDevRelayRateLimitBypass({
+        clientNamespace,
+        teamIds: user.teamIds,
+      });
+    } catch {
+      // Membership lookup is an authorization check. If Stack or the snapshot
+      // store is unavailable, retain the normal limiter instead of widening it.
+      return false;
+    }
+  },
 };
 
 export async function handleRelayTokenRequest(
@@ -165,8 +189,14 @@ export async function handleRelayTokenRequest(
     // Every request consumes quota before database/crypto work, even when
     // the binding lookup fails. Legacy admission cannot depend on the binding
     // result; its bootstrap and credential budgets remain separate below.
-    await checkTokenQuota(request, deps, user.id, clientNamespace, endpointId,
-      clientNamespace === "legacy" ? "admission" : "credential", requestId);
+    const bypassRateLimit = await checkTokenQuotaUnlessAuthorizedDev(
+      request,
+      deps,
+      user.id,
+      clientNamespace,
+      endpointId,
+      requestId,
+    );
     const isEndpointAuthorized = await deps.isEndpointAuthorized({
       accountId: user.id,
       endpointId,
@@ -184,7 +214,7 @@ export async function handleRelayTokenRequest(
     // A fresh endpoint must fetch policy before registration, then fetch its
     // bound credential immediately after registration. Keep bootstrap and
     // credential issuance in stable, separate partitions.
-    if (clientNamespace === "legacy") {
+    if (clientNamespace === "legacy" && !bypassRateLimit) {
       await checkTokenQuota(request, deps, user.id, clientNamespace, endpointId,
         isEndpointAuthorized ? "credential" : "bootstrap", requestId);
     }
@@ -232,6 +262,37 @@ export async function handleRelayTokenRequest(
   } catch (error) {
     return relayErrorResponse(error, errorContext);
   }
+}
+
+async function checkTokenQuotaUnlessAuthorizedDev(
+  request: Request,
+  deps: RelayTokenDeps,
+  userId: string,
+  clientNamespace: string,
+  endpointId: string,
+  requestId: string,
+): Promise<boolean> {
+  let bypassRateLimit = false;
+  try {
+    bypassRateLimit = await deps.isDevRateLimitBypassAllowed({
+      request,
+      userId,
+      clientNamespace,
+    });
+  } catch {
+    // A failed authorization lookup must retain the normal limiter.
+    bypassRateLimit = false;
+  }
+  if (bypassRateLimit) {
+    console.info("relay.rate_limit_bypassed", {
+      requestId,
+      reason: "authorized_dev_team",
+    });
+    return true;
+  }
+  await checkTokenQuota(request, deps, userId, clientNamespace, endpointId,
+    clientNamespace === "legacy" ? "admission" : "credential", requestId);
+  return false;
 }
 
 async function checkTokenQuota(

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -382,6 +382,11 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: z.string().max(256).optional(),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: irohBindingLimit.optional(),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: irohBindingLimit.optional(),
+    // Explicit opt-in for the hosted DEV relay limiter exemption. The route
+    // still requires the development Stack project, a tagged debug namespace,
+    // and membership in CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS.
+    CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED: z.enum(["0", "1"]).optional(),
+    CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS: z.string().max(8_192).optional(),
     // Self-hosted relay fleet. Preview and local builds remain credential-free,
     // while every deployed non-preview runtime must be able to mint endpoint-
     // bound credentials, sign the fleet policy, and enforce its account limit.
@@ -519,6 +524,12 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: trimEnv(process.env.CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_DEVICE_LIMIT),
+    CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED: trimEnv(
+      process.env.CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED,
+    ),
+    CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS: trimEnv(
+      process.env.CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS,
+    ),
     CMUX_RELAY_JWT_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_JWT_PRIVATE_KEY_PEM),
     CMUX_RELAY_POLICY_KEY_ID: trimEnv(process.env.CMUX_RELAY_POLICY_KEY_ID),
     CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_POLICY_PRIVATE_KEY_PEM),

--- a/web/services/auth/stackProject.ts
+++ b/web/services/auth/stackProject.ts
@@ -1,0 +1,2 @@
+/** Stack project used by cmux's local and hosted development builds. */
+export const DEVELOPMENT_STACK_PROJECT_ID = "454ecd03-1db2-4050-845e-4ce5b0cd9895";

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -25,6 +25,7 @@ import {
   withFreshAccountMetadataUser,
 } from
   "../account/metadataMutation";
+import { DEVELOPMENT_STACK_PROJECT_ID } from "../auth/stackProject";
 
 export const PRO_PLAN_ID = "pro";
 export const TEAM_PLAN_ID = "team";
@@ -34,8 +35,7 @@ export const TEAM_PLAN_ID = "team";
 // Existing operator grants may still use `cmuxVmPlan: "founders"`.
 export const FOUNDERS_PLAN_ID = "founders";
 export const FREE_PLAN_ID = "free";
-/** Stack project used by the local cmux development server. */
-export const DEVELOPMENT_STACK_PROJECT_ID = "454ecd03-1db2-4050-845e-4ce5b0cd9895";
+export { DEVELOPMENT_STACK_PROJECT_ID } from "../auth/stackProject";
 
 /**
  * Local development accounts are Pro by default. This is intentionally tied

--- a/web/services/iroh/README.md
+++ b/web/services/iroh/README.md
@@ -43,15 +43,13 @@ limit while upgraded clients traverse every page. Sign-out callers must invoke
 the authenticated revoke route with their captured binding id before discarding
 the Stack credential.
 
-There is no total active-binding limit per account or device. Postgres advisory
-locks keep request-rate limits concurrency-safe: six challenges per device per
-ten minutes, 32 outstanding challenges per account, 60 pair grants per account
-per hour, three relay mints per endpoint per ten minutes, 12 relay mints per
-endpoint per day, and 100 relay mints per account per day. A relay reservation
-remains active for 60 seconds, then the next account-scoped reservation marks it
-expired before applying those quotas. The optional Vercel Firewall rule is
-defense in depth. A tagged-build override widens challenge issuance only after
-an exact authenticated user-id and deployment-environment allowlist match.
+There is no total active-binding limit per account or device. Relay-token and
+relay-preference requests use the optional Vercel Firewall rules as their
+deployed ingress budget. A deliberate DEV-only bypass is available only when
+the deployment opts in, uses the development Stack project, presents a tagged
+debug namespace, and authenticates a member of the configured internal Stack
+team. Release and internal-beta namespaces never qualify, and a Stack or
+snapshot lookup failure falls back to the normal limiter.
 
 Registration bootstraps a relay credential only when it creates a binding.
 Signed refreshes of the same binding return `relay.status = "not_requested"`;

--- a/web/services/relay/devRateLimitBypass.ts
+++ b/web/services/relay/devRateLimitBypass.ts
@@ -1,0 +1,55 @@
+import { DEVELOPMENT_STACK_PROJECT_ID } from "../auth/stackProject";
+
+const IOS_DEVELOPMENT_NAMESPACE = /^dev\.cmux\.ios\.[A-Za-z0-9._-]+$/;
+const MAC_DEVELOPMENT_NAMESPACE = /^mac:com\.cmuxterm\.app\.debug\.[A-Za-z0-9._-]+$/;
+const STACK_TEAM_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+
+export { DEVELOPMENT_STACK_PROJECT_ID };
+
+export type DevRelayRateLimitBypassEnv = {
+  readonly CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED?: string;
+  readonly CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS?: string;
+  readonly NEXT_PUBLIC_STACK_PROJECT_ID?: string;
+};
+
+/**
+ * Only tagged debug bundle namespaces qualify. Release and internal beta
+ * bundles deliberately have different namespace prefixes and never match.
+ */
+export function isDevelopmentRelayClientNamespace(
+  clientNamespace: string,
+): boolean {
+  return IOS_DEVELOPMENT_NAMESPACE.test(clientNamespace) ||
+    MAC_DEVELOPMENT_NAMESPACE.test(clientNamespace);
+}
+
+/** Parse the server-owned Stack team allowlist without accepting blank entries. */
+export function parseDevRelayRateLimitBypassTeamIds(
+  raw: string | undefined,
+): ReadonlySet<string> {
+  const values = (raw ?? "").split(",").map((value) => value.trim().toLowerCase());
+  const ids = values.filter((value) => value.length > 0);
+  if (ids.some((value) => !STACK_TEAM_ID.test(value))) return new Set();
+  return new Set(ids);
+}
+
+/**
+ * A bypass is valid only when the deployment explicitly opts in, is running
+ * against the development Stack project, carries a tagged debug namespace,
+ * and the authenticated user belongs to an operator-selected team.
+ */
+export function isAuthorizedDevRelayRateLimitBypass(input: {
+  readonly clientNamespace: string;
+  readonly teamIds: readonly string[];
+  readonly env?: DevRelayRateLimitBypassEnv;
+}): boolean {
+  const env = input.env ?? process.env;
+  if (env.CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED !== "1") return false;
+  if (env.NEXT_PUBLIC_STACK_PROJECT_ID !== DEVELOPMENT_STACK_PROJECT_ID) return false;
+  if (!isDevelopmentRelayClientNamespace(input.clientNamespace)) return false;
+  const allowedTeamIds = parseDevRelayRateLimitBypassTeamIds(
+    env.CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS,
+  );
+  if (allowedTeamIds.size === 0) return false;
+  return input.teamIds.some((teamId) => allowedTeamIds.has(teamId.trim().toLowerCase()));
+}

--- a/web/tests/dev-rate-limit-bypass.test.ts
+++ b/web/tests/dev-rate-limit-bypass.test.ts
@@ -20,6 +20,7 @@ describe("authorized development relay rate-limit bypass", () => {
     expect([...parseDevRelayRateLimitBypassTeamIds(" team-a,TEAM-B ,, team-a ")])
       .toEqual(["team-a", "team-b"]);
     expect(parseDevRelayRateLimitBypassTeamIds(" , ").size).toBe(0);
+    expect(parseDevRelayRateLimitBypassTeamIds("team-a,not a team").size).toBe(0);
   });
 
   test("requires explicit enablement, the dev Stack project, a debug namespace, and membership", () => {

--- a/web/tests/dev-rate-limit-bypass.test.ts
+++ b/web/tests/dev-rate-limit-bypass.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEVELOPMENT_STACK_PROJECT_ID,
+  isAuthorizedDevRelayRateLimitBypass,
+  isDevelopmentRelayClientNamespace,
+  parseDevRelayRateLimitBypassTeamIds,
+} from "../services/relay/devRateLimitBypass";
+
+describe("authorized development relay rate-limit bypass", () => {
+  test("recognizes only tagged development namespaces", () => {
+    expect(isDevelopmentRelayClientNamespace("dev.cmux.ios.grid")).toBe(true);
+    expect(isDevelopmentRelayClientNamespace("mac:com.cmuxterm.app.debug.grid")).toBe(true);
+    expect(isDevelopmentRelayClientNamespace("dev.cmux.app.beta")).toBe(false);
+    expect(isDevelopmentRelayClientNamespace("mac:com.cmuxterm.app")).toBe(false);
+    expect(isDevelopmentRelayClientNamespace("legacy")).toBe(false);
+  });
+
+  test("parses and normalizes the configured team allowlist", () => {
+    expect([...parseDevRelayRateLimitBypassTeamIds(" team-a,TEAM-B ,, team-a ")])
+      .toEqual(["team-a", "team-b"]);
+    expect(parseDevRelayRateLimitBypassTeamIds(" , ").size).toBe(0);
+  });
+
+  test("requires explicit enablement, the dev Stack project, a debug namespace, and membership", () => {
+    const base = {
+      clientNamespace: "dev.cmux.ios.grid",
+      teamIds: ["team-a"],
+      env: {
+        CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED: "1",
+        CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS: "team-a,team-b",
+        NEXT_PUBLIC_STACK_PROJECT_ID: DEVELOPMENT_STACK_PROJECT_ID,
+      },
+    };
+    expect(isAuthorizedDevRelayRateLimitBypass(base)).toBe(true);
+    expect(isAuthorizedDevRelayRateLimitBypass({
+      ...base,
+      teamIds: ["team-c"],
+    })).toBe(false);
+    expect(isAuthorizedDevRelayRateLimitBypass({
+      ...base,
+      clientNamespace: "dev.cmux.app.beta",
+    })).toBe(false);
+    expect(isAuthorizedDevRelayRateLimitBypass({
+      ...base,
+      env: {
+        ...base.env,
+        CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED: "0",
+      },
+    })).toBe(false);
+    expect(isAuthorizedDevRelayRateLimitBypass({
+      ...base,
+      env: {
+        ...base.env,
+        NEXT_PUBLIC_STACK_PROJECT_ID: "production-stack-project",
+      },
+    })).toBe(false);
+  });
+});

--- a/web/tests/relay-preferences-route.test.ts
+++ b/web/tests/relay-preferences-route.test.ts
@@ -36,8 +36,12 @@ function deps(overrides: Partial<RelayPreferenceDeps> = {}): RelayPreferenceDeps
   };
 }
 
-function getRequest(): Request {
-  return new Request("https://cmux.dev/api/relay/preferences");
+function getRequest(clientNamespace?: string): Request {
+  return new Request("https://cmux.dev/api/relay/preferences", {
+    headers: clientNamespace
+      ? { "x-cmux-app-namespace": clientNamespace }
+      : undefined,
+  });
 }
 
 function putRequest(body: unknown): Request {
@@ -158,6 +162,26 @@ describe("/api/relay/preferences", () => {
     }));
     expect(limited.status).toBe(429);
     expect(await limited.json()).toEqual({ error: "rate_limited", source: "account_budget" });
+  });
+
+  test("skips preference limits for an authorized development team", async () => {
+    let checks = 0;
+    const response = await handleGetRelayPreference(
+      getRequest("dev.cmux.ios.grid"),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-preference",
+        checkRateLimit: async () => {
+          checks += 1;
+          return { rateLimited: true };
+        },
+        // This seam is added by the implementation. Keeping the test cast here
+        // makes this first commit the intentionally failing regression proof.
+        isDevRateLimitBypassAllowed: () => true,
+      } as Partial<RelayPreferenceDeps>),
+    );
+    expect(response.status).toBe(200);
+    expect(checks).toBe(0);
   });
 
   test("rejects unauthenticated callers", async () => {

--- a/web/tests/relay-preferences-route.test.ts
+++ b/web/tests/relay-preferences-route.test.ts
@@ -32,6 +32,7 @@ function deps(overrides: Partial<RelayPreferenceDeps> = {}): RelayPreferenceDeps
     checkRateLimit: async () => ({ rateLimited: false }),
     rateLimitRuleId: () => undefined,
     isVercel: () => false,
+    isDevRateLimitBypassAllowed: () => false,
     ...overrides,
   };
 }
@@ -175,10 +176,8 @@ describe("/api/relay/preferences", () => {
           checks += 1;
           return { rateLimited: true };
         },
-        // This seam is added by the implementation. Keeping the test cast here
-        // makes this first commit the intentionally failing regression proof.
         isDevRateLimitBypassAllowed: () => true,
-      } as Partial<RelayPreferenceDeps>),
+      }),
     );
     expect(response.status).toBe(200);
     expect(checks).toBe(0);

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -149,6 +149,44 @@ describe("POST /api/relay/token", () => {
     expect(policyReads).toBe(0);
   });
 
+  test("skips relay-token limits for an authorized development team", async () => {
+    let checks = 0;
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }, "dev.cmux.ios.grid", true),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => {
+          checks += 1;
+          return { rateLimited: true };
+        },
+        // This seam is added by the implementation. Keeping the test cast here
+        // makes this first commit the intentionally failing regression proof.
+        isDevRateLimitBypassAllowed: async () => true,
+      } as Partial<RelayTokenDeps>),
+    );
+    expect(response.status).toBe(200);
+    expect(checks).toBe(0);
+  });
+
+  test("keeps the relay-token limit for callers that are not authorized", async () => {
+    let checks = 0;
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }, "dev.cmux.ios.grid", true),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => {
+          checks += 1;
+          return { rateLimited: true };
+        },
+        isDevRateLimitBypassAllowed: async () => false,
+      } as Partial<RelayTokenDeps>),
+    );
+    expect(response.status).toBe(429);
+    expect(checks).toBe(1);
+  });
+
   test("keeps legacy token fields and adds policy plus separate preference metadata", async () => {
     const response = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -62,6 +62,7 @@ function deps(overrides: Partial<RelayTokenDeps> = {}): RelayTokenDeps {
     rateLimitRuleId: () => undefined,
     isVercel: () => false,
     credentialSigningRequired: () => false,
+    isDevRateLimitBypassAllowed: async () => false,
     ...overrides,
   };
 }
@@ -160,10 +161,8 @@ describe("POST /api/relay/token", () => {
           checks += 1;
           return { rateLimited: true };
         },
-        // This seam is added by the implementation. Keeping the test cast here
-        // makes this first commit the intentionally failing regression proof.
         isDevRateLimitBypassAllowed: async () => true,
-      } as Partial<RelayTokenDeps>),
+      }),
     );
     expect(response.status).toBe(200);
     expect(checks).toBe(0);
@@ -181,7 +180,7 @@ describe("POST /api/relay/token", () => {
           return { rateLimited: true };
         },
         isDevRateLimitBypassAllowed: async () => false,
-      } as Partial<RelayTokenDeps>),
+      }),
     );
     expect(response.status).toBe(429);
     expect(checks).toBe(1);


### PR DESCRIPTION
## Summary
- exempt only tagged macOS/iOS DEV relay-token and relay-preference requests from the hosted Vercel limiter
- require explicit opt-in, the development Stack project, an exact debug namespace, and membership in a configured Stack team
- use the existing identity snapshot for membership checks and fail closed to normal limits on lookup failure
- make physical-device `scripts/dev-setup.sh` select the shared staging backend automatically
- document team-based onboarding with no per-user relay registration

## Configuration
Set these server-side on the hosted DEV deployment:

```
CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED=1
CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS=<cmux-internal-stack-team-id>
```

Leave the flag at `0` or omit the team list to keep the normal limiter. Production Stack project IDs and release/internal-beta namespaces never qualify.

## Verification
- `bun run typecheck`
- `bun run lint:complexity`
- focused ESLint on changed TypeScript files
- `bun test --isolate tests/dev-rate-limit-bypass.test.ts tests/relay-token-route.test.ts tests/relay-preferences-route.test.ts`
- `bash -n scripts/dev-setup.sh scripts/setup-team-dev.sh`

The first commit is the failing regression coverage; the second contains the implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791580318&installation_model_id=21920&pr_number=12229&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12229&signature=82057c236cdeafb59eb3c55649bb0b07c8f2d6d1522952699d9e433a6a86695b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a relay rate-limit bypass on authenticated ingress routes; misconfigured env or team allowlists could widen quota, though multiple explicit gates and fail-closed error handling limit exposure to hosted DEV only.
> 
> **Overview**
> Adds an **opt-in hosted DEV bypass** for Vercel Firewall limits on **`/api/relay/token`** and **`/api/relay/preferences`**, so tagged debug builds stop hitting relay quotas during dogfood.
> 
> Bypass applies only when **`CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED=1`**, the deployment uses the **development Stack project**, the request carries a **tagged debug** `x-cmux-app-namespace` (iOS `dev.cmux.ios.*` or Mac `mac:com.cmuxterm.app.debug.*`), and the caller is in **`CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS`**. Release/beta namespaces and production Stack never qualify. **Stack/snapshot lookup failures keep normal limiting**; authorized bypasses log `relay.rate_limit_bypassed`.
> 
> **`scripts/dev-setup.sh`** now defaults **`CMUX_DEV_API_BASE_URL`** and **`CMUX_IROH_BROKER_BASE_URL`** to staging when **`--device`** is used (unless already set). Onboarding/docs note **team-based** relay access with no per-user registration. **`DEVELOPMENT_STACK_PROJECT_ID`** moves to **`web/services/auth/stackProject.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35fa3d17eedda4398a2e549d4bc40a5f58479b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempts tagged macOS/iOS DEV relay-token and relay-preference requests from the hosted Vercel rate limiter when the caller belongs to a configured Stack team.

- The bypass requires explicit opt-in, the development Stack project, an exact debug namespace, and membership in `CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS`.
- Membership checks reuse the identity snapshot and fail closed to normal limits when lookup fails.
- `scripts/dev-setup.sh --device` now selects the shared staging backend automatically.

**Configuration**
- Set `CMUX_IROH_DEV_RATE_LIMIT_BYPASS_ENABLED=1` and `CMUX_IROH_DEV_RATE_LIMIT_BYPASS_TEAM_IDS=<cmux-internal-stack-team-id>` on the hosted DEV deployment.
- Leaving the flag at `0` or omitting the team list keeps the normal limiter; production Stack projects and release/internal-beta namespaces never qualify.

<sup>Written for commit d54a525492f53ab36565d99dfe49bbcb7cd13a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional rate-limit bypasses for authorized development teams using hosted relay services.
  - Added configuration for enabling bypasses and specifying authorized team IDs.
  - Physical iPhone development builds now connect to the hosted staging backend instead of Mac-local services.

- **Documentation**
  - Updated setup guidance and environment examples for team-based relay access and development bypass behavior.

- **Bug Fixes**
  - Prevented physical-device builds from attempting to reach an inaccessible localhost backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->