### PR TITLE
Scope mobile Mac minimums by app build kind

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Requirement.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Requirement.swift
@@ -1,0 +1,18 @@
+/// Requirements for one iOS distribution build kind.
+extension MobileMacCompatPolicy {
+    public struct Requirement: Equatable, Sendable {
+        /// The inclusive minimum stable-channel Mac marketing version.
+        public let stableMinVersion: MobileMacAppVersion
+        /// The minimum nightly-channel Mac build, or `nil` when unconstrained.
+        public let nightly: NightlyRequirement?
+
+        /// Creates requirements for one build kind.
+        /// - Parameters:
+        ///   - stableMinVersion: The minimum stable-channel Mac version.
+        ///   - nightly: The minimum nightly-channel build, or `nil`.
+        public init(stableMinVersion: MobileMacAppVersion, nightly: NightlyRequirement? = nil) {
+            self.stableMinVersion = stableMinVersion
+            self.nightly = nightly
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Requirement.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Requirement.swift
@@ -1,5 +1,6 @@
 /// Requirements for one iOS distribution build kind.
 extension MobileMacCompatPolicy {
+    /// Stable and nightly Mac version floors for one iOS build kind.
     public struct Requirement: Equatable, Sendable {
         /// The inclusive minimum stable-channel Mac marketing version.
         public let stableMinVersion: MobileMacAppVersion

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Tier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Tier.swift
@@ -1,16 +1,6 @@
 /// An iOS-version range and its Mac compatibility requirements.
 extension MobileMacCompatPolicy {
     /// One iOS-version tier and the Mac minimums it demands.
-    public struct Requirement: Equatable, Sendable {
-        public let stableMinVersion: MobileMacAppVersion
-        public let nightly: NightlyRequirement?
-
-        public init(stableMinVersion: MobileMacAppVersion, nightly: NightlyRequirement? = nil) {
-            self.stableMinVersion = stableMinVersion
-            self.nightly = nightly
-        }
-    }
-
     public struct Tier: Equatable, Sendable {
         /// The inclusive minimum iOS marketing version this tier applies to.
         public let minIOSVersion: MobileMacAppVersion

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Tier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy+Tier.swift
@@ -1,6 +1,16 @@
 /// An iOS-version range and its Mac compatibility requirements.
 extension MobileMacCompatPolicy {
     /// One iOS-version tier and the Mac minimums it demands.
+    public struct Requirement: Equatable, Sendable {
+        public let stableMinVersion: MobileMacAppVersion
+        public let nightly: NightlyRequirement?
+
+        public init(stableMinVersion: MobileMacAppVersion, nightly: NightlyRequirement? = nil) {
+            self.stableMinVersion = stableMinVersion
+            self.nightly = nightly
+        }
+    }
+
     public struct Tier: Equatable, Sendable {
         /// The inclusive minimum iOS marketing version this tier applies to.
         public let minIOSVersion: MobileMacAppVersion
@@ -13,6 +23,8 @@ extension MobileMacCompatPolicy {
         public let stableMinVersion: MobileMacAppVersion
         /// The minimum nightly-channel build; `nil` leaves nightly unconstrained.
         public let nightly: NightlyRequirement?
+        /// Requirements keyed by ``MobileBuildType.token``.
+        public let buildKinds: [String: Requirement]
 
         /// Creates one tier of the policy.
         ///
@@ -25,12 +37,14 @@ extension MobileMacCompatPolicy {
             minIOSVersion: MobileMacAppVersion,
             maxIOSVersion: MobileMacAppVersion? = nil,
             stableMinVersion: MobileMacAppVersion,
-            nightly: NightlyRequirement?
+            nightly: NightlyRequirement?,
+            buildKinds: [String: Requirement] = [:]
         ) {
             self.minIOSVersion = minIOSVersion
             self.maxIOSVersion = maxIOSVersion
             self.stableMinVersion = stableMinVersion
             self.nightly = nightly
+            self.buildKinds = buildKinds
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -156,8 +156,13 @@ extension MobileMacCompatPolicy {
                     buildKinds[kind] = Requirement(stableMinVersion: stable, nightly: nightly)
                 }
             }
-            let stableMin = entry.stableMinVersion.flatMap(MobileMacAppVersion.init(parsing:))
-                ?? buildKinds[MobileBuildType.prod.token]?.stableMinVersion
+            let legacyStable = entry.stableMinVersion.flatMap(MobileMacAppVersion.init(parsing:))
+            if entry.buildKinds != nil,
+               let legacyStable,
+               legacyStable != buildKinds[MobileBuildType.prod.token]?.stableMinVersion {
+                return nil
+            }
+            let stableMin = legacyStable ?? buildKinds[MobileBuildType.prod.token]?.stableMinVersion
             guard let stableMin else { return nil }
             // The server publishes ascending, non-overwriting tiers. Reject
             // malformed responses at the trust boundary rather than caching a
@@ -177,6 +182,10 @@ extension MobileMacCompatPolicy {
             if let remoteNightly = entry.nightly {
                 guard let base = MobileMacAppVersion(parsing: remoteNightly.minBaseVersion), let build = UInt64(remoteNightly.minBuild) else { return nil }
                 nightly = NightlyRequirement(minBaseVersion: base, minBuild: build)
+            }
+            if entry.buildKinds != nil {
+                guard let prod = buildKinds[MobileBuildType.prod.token] else { return nil }
+                if let nightly, nightly != prod.nightly { return nil }
             }
             tiers.append(Tier(minIOSVersion: minIOS, maxIOSVersion: maxIOS, stableMinVersion: stableMin, nightly: nightly, buildKinds: buildKinds))
             previousMinIOSVersion = minIOS

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -1,3 +1,4 @@
+public import CmuxMobileShellModel
 public import Foundation
 
 /// The minimum Mac app versions one iOS build accepts, fetched from
@@ -40,7 +41,14 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 nightly: NightlyRequirement(
                     minBaseVersion: nightlyBase,
                     minBuild: 3_345_650_013_202
-                )
+                ),
+                buildKinds: [
+                    MobileBuildType.dev.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.0")!),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
+                    MobileBuildType.demo.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
+                    MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: NightlyRequirement(minBaseVersion: nightlyBase, minBuild: 3_345_650_013_202)),
+                ]
             ),
         ])
     }()
@@ -75,15 +83,18 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
     public func violation(
         iosVersion: String,
         channel: Channel,
-        macAppVersion: String?
+        macAppVersion: String?,
+        buildType: MobileBuildType = .prod
     ) -> Violation? {
         guard let tier = tier(forIOSVersion: iosVersion) else { return nil }
+        let requirement = tier.buildKinds[buildType.token]
+            ?? Requirement(stableMinVersion: tier.stableMinVersion, nightly: tier.nightly)
         let requirementDisplay: String
         switch channel {
         case .stable:
-            requirementDisplay = tier.stableMinVersion.description
+            requirementDisplay = requirement.stableMinVersion.description
         case .nightly:
-            guard let nightly = tier.nightly else { return nil }
+            guard let nightly = requirement.nightly else { return nil }
             requirementDisplay = "\(nightly.minBaseVersion)-nightly.\(nightly.minBuild)"
         }
         let reported = macAppVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -100,9 +111,9 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
             // A nightly stamp on the stable channel is a mislabeled build;
             // fail closed rather than guessing which rule it satisfies.
             guard stamp.nightlyBuild == nil else { return violation }
-            return stamp.base >= tier.stableMinVersion ? nil : violation
+            return stamp.base >= requirement.stableMinVersion ? nil : violation
         case .nightly:
-            guard let nightly = tier.nightly else { return nil }
+            guard let nightly = requirement.nightly else { return nil }
             guard let build = stamp.nightlyBuild else { return violation }
             if stamp.base > nightly.minBaseVersion { return nil }
             if stamp.base < nightly.minBaseVersion { return violation }
@@ -132,11 +143,22 @@ extension MobileMacCompatPolicy {
         tiers.reserveCapacity(payload.entries.count)
         var previousMinIOSVersion: MobileMacAppVersion?
         for entry in payload.entries {
-            guard let minIOS = MobileMacAppVersion(parsing: entry.minIOSVersion),
-                  let stableMin = MobileMacAppVersion(parsing: entry.stableMinVersion)
-            else {
-                return nil
+            guard let minIOS = MobileMacAppVersion(parsing: entry.minIOSVersion) else { return nil }
+            var buildKinds: [String: Requirement] = [:]
+            if let remoteKinds = entry.buildKinds {
+                for (kind, remote) in remoteKinds {
+                    guard let stable = MobileMacAppVersion(parsing: remote.stableMinVersion) else { return nil }
+                    var nightly: NightlyRequirement?
+                    if let value = remote.nightly {
+                        guard let base = MobileMacAppVersion(parsing: value.minBaseVersion), let build = UInt64(value.minBuild) else { return nil }
+                        nightly = NightlyRequirement(minBaseVersion: base, minBuild: build)
+                    }
+                    buildKinds[kind] = Requirement(stableMinVersion: stable, nightly: nightly)
+                }
             }
+            let stableMin = entry.stableMinVersion.flatMap(MobileMacAppVersion.init(parsing:))
+                ?? buildKinds[MobileBuildType.prod.token]?.stableMinVersion
+            guard let stableMin else { return nil }
             // The server publishes ascending, non-overwriting tiers. Reject
             // malformed responses at the trust boundary rather than caching a
             // range that could make an affected app version fail open.
@@ -153,19 +175,10 @@ extension MobileMacCompatPolicy {
             }
             var nightly: NightlyRequirement?
             if let remoteNightly = entry.nightly {
-                guard let base = MobileMacAppVersion(parsing: remoteNightly.minBaseVersion),
-                      let build = UInt64(remoteNightly.minBuild)
-                else {
-                    return nil
-                }
+                guard let base = MobileMacAppVersion(parsing: remoteNightly.minBaseVersion), let build = UInt64(remoteNightly.minBuild) else { return nil }
                 nightly = NightlyRequirement(minBaseVersion: base, minBuild: build)
             }
-            tiers.append(Tier(
-                minIOSVersion: minIOS,
-                maxIOSVersion: maxIOS,
-                stableMinVersion: stableMin,
-                nightly: nightly
-            ))
+            tiers.append(Tier(minIOSVersion: minIOS, maxIOSVersion: maxIOS, stableMinVersion: stableMin, nightly: nightly, buildKinds: buildKinds))
             previousMinIOSVersion = minIOS
         }
         self.init(tiers: tiers)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteEntry.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteEntry.swift
@@ -2,6 +2,14 @@
 struct MobileMacCompatRemoteEntry: Decodable {
     let minIOSVersion: String
     let maxIOSVersion: String?
+    let buildKinds: [String: MobileMacCompatRemoteRequirement]?
+    // Legacy fields are accepted so older policy fixtures and a staged server
+    // rollout remain readable. New payloads always use buildKinds.
+    let stableMinVersion: String?
+    let nightly: MobileMacCompatRemoteNightly?
+}
+
+struct MobileMacCompatRemoteRequirement: Decodable {
     let stableMinVersion: String
     let nightly: MobileMacCompatRemoteNightly?
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteEntry.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteEntry.swift
@@ -8,8 +8,3 @@ struct MobileMacCompatRemoteEntry: Decodable {
     let stableMinVersion: String?
     let nightly: MobileMacCompatRemoteNightly?
 }
-
-struct MobileMacCompatRemoteRequirement: Decodable {
-    let stableMinVersion: String
-    let nightly: MobileMacCompatRemoteNightly?
-}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteRequirement.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatRemoteRequirement.swift
@@ -1,0 +1,5 @@
+/// One wire-format Mac compatibility requirement for an iOS build kind.
+struct MobileMacCompatRemoteRequirement: Decodable {
+    let stableMinVersion: String
+    let nightly: MobileMacCompatRemoteNightly?
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
@@ -35,7 +35,8 @@ extension MobileShellComposite {
         guard let violation = macCompatPolicy.violation(
             iosVersion: versionGateIOSAppVersion,
             channel: channel,
-            macAppVersion: macAppVersion
+            macAppVersion: macAppVersion,
+            buildType: versionGateBuildType
         ) else {
             return .allowed
         }
@@ -58,7 +59,8 @@ extension MobileShellComposite {
               let violation = macCompatPolicy.violation(
                   iosVersion: versionGateIOSAppVersion,
                   channel: channel,
-                  macAppVersion: authenticatedMacAppVersion
+                  macAppVersion: authenticatedMacAppVersion,
+                  buildType: versionGateBuildType
               ) else {
             return
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11648,8 +11648,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func applyMacCompatibilityPolicy(_ policy: MobileMacCompatPolicy) {
         macCompatPolicy = policy
         let tier = policy.tier(forIOSVersion: versionGateIOSAppVersion)
-        let requiredStableMacVersion = tier?.stableMinVersion.description
-        let requiredNightlyMacVersion = tier?.nightly.map {
+        let buildType = versionGateBuildType
+        let requirement = tier?.buildKinds[buildType.token]
+        let requiredStableMacVersion = (requirement?.stableMinVersion ?? tier?.stableMinVersion)?.description
+        let requiredNightlyMacVersion = (requirement?.nightly ?? tier?.nightly).map {
             "\($0.minBaseVersion)-nightly.\($0.minBuild)"
         }
         MobileMacListAuthState.shared.applyPolicyMinimumSupportedMacVersions(
@@ -11676,6 +11678,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// the empty stamp), which parses to no tier and therefore no gate.
     var versionGateIOSAppVersion: String {
         feedbackStampProvider().appVersion
+    }
+
+    var versionGateBuildType: MobileBuildType {
+        feedbackStampProvider().buildType
     }
 
     /// Replaces a generic classification with the exact version-gate

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11649,10 +11649,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         macCompatPolicy = policy
         let tier = policy.tier(forIOSVersion: versionGateIOSAppVersion)
         let buildType = versionGateBuildType
-        let requirement = tier?.buildKinds[buildType.token]
-        let requiredStableMacVersion = (requirement?.stableMinVersion ?? tier?.stableMinVersion)?.description
-        let nightlyRequirement = tier == nil ? nil : (requirement != nil ? requirement?.nightly : tier?.nightly)
-        let requiredNightlyMacVersion = nightlyRequirement.map {
+        let requirement: MobileMacCompatPolicy.Requirement? = {
+            guard let tier else { return nil }
+            return tier.buildKinds[buildType.token]
+                ?? MobileMacCompatPolicy.Requirement(
+                    stableMinVersion: tier.stableMinVersion,
+                    nightly: tier.nightly
+                )
+        }()
+        let requiredStableMacVersion = requirement?.stableMinVersion.description
+        let requiredNightlyMacVersion = requirement?.nightly.map {
             "\($0.minBaseVersion)-nightly.\($0.minBuild)"
         }
         MobileMacListAuthState.shared.applyPolicyMinimumSupportedMacVersions(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11651,7 +11651,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let buildType = versionGateBuildType
         let requirement = tier?.buildKinds[buildType.token]
         let requiredStableMacVersion = (requirement?.stableMinVersion ?? tier?.stableMinVersion)?.description
-        let requiredNightlyMacVersion = (requirement?.nightly ?? tier?.nightly).map {
+        let nightlyRequirement = tier == nil ? nil : (requirement != nil ? requirement?.nightly : tier?.nightly)
+        let requiredNightlyMacVersion = nightlyRequirement.map {
             "\($0.minBaseVersion)-nightly.\($0.minBuild)"
         }
         MobileMacListAuthState.shared.applyPolicyMinimumSupportedMacVersions(

--- a/web/app/api/mobile-mac-compat/route.ts
+++ b/web/app/api/mobile-mac-compat/route.ts
@@ -82,7 +82,11 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
     if (prod === undefined) {
       throw new Error(`${path}.buildKinds must include a prod requirement`);
     }
+    const supportedKinds = new Set(["dev", "beta", "internal", "demo", "prod"]);
     for (const [kind, requirement] of Object.entries(entry.buildKinds)) {
+      if (!supportedKinds.has(kind)) {
+        throw new Error(`${path}.buildKinds.${kind} is not a supported build kind`);
+      }
       const requirementPath = `${path}.buildKinds.${kind}`;
       version(requirement.stableMinVersion, `${requirementPath}.stableMinVersion`);
       if (requirement.nightly !== undefined) {

--- a/web/app/api/mobile-mac-compat/route.ts
+++ b/web/app/api/mobile-mac-compat/route.ts
@@ -109,6 +109,9 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
     }
   } else {
     // Accept the pre-build-kind shape during a rolling deployment.
+    if (entry.stableMinVersion === undefined) {
+      throw new Error(`${path}.stableMinVersion is required for legacy entries`);
+    }
     version(entry.stableMinVersion, `${path}.stableMinVersion`);
     if (entry.nightly !== undefined) {
       version(entry.nightly.minBaseVersion, `${path}.nightly.minBaseVersion`);

--- a/web/app/api/mobile-mac-compat/route.ts
+++ b/web/app/api/mobile-mac-compat/route.ts
@@ -78,6 +78,9 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
     }
   }
   if (entry.buildKinds !== undefined) {
+    if (entry.buildKinds.prod === undefined && entry.stableMinVersion === undefined) {
+      throw new Error(`${path}.buildKinds must include a prod requirement`);
+    }
     for (const [kind, requirement] of Object.entries(entry.buildKinds)) {
       const requirementPath = `${path}.buildKinds.${kind}`;
       version(requirement.stableMinVersion, `${requirementPath}.stableMinVersion`);

--- a/web/app/api/mobile-mac-compat/route.ts
+++ b/web/app/api/mobile-mac-compat/route.ts
@@ -78,7 +78,8 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
     }
   }
   if (entry.buildKinds !== undefined) {
-    if (entry.buildKinds.prod === undefined && entry.stableMinVersion === undefined) {
+    const prod = entry.buildKinds.prod;
+    if (prod === undefined) {
       throw new Error(`${path}.buildKinds must include a prod requirement`);
     }
     for (const [kind, requirement] of Object.entries(entry.buildKinds)) {
@@ -87,6 +88,19 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
       if (requirement.nightly !== undefined) {
         version(requirement.nightly.minBaseVersion, `${requirementPath}.nightly.minBaseVersion`);
         build(requirement.nightly.minBuild, `${requirementPath}.nightly.minBuild`);
+      }
+    }
+    if (entry.stableMinVersion !== undefined) {
+      version(entry.stableMinVersion, `${path}.stableMinVersion`);
+      if (compareDottedVersions(entry.stableMinVersion, prod.stableMinVersion) !== 0) {
+        throw new Error(`${path}.stableMinVersion must match ${path}.buildKinds.prod.stableMinVersion`);
+      }
+    }
+    if (entry.nightly !== undefined) {
+      version(entry.nightly.minBaseVersion, `${path}.nightly.minBaseVersion`);
+      build(entry.nightly.minBuild, `${path}.nightly.minBuild`);
+      if (prod.nightly === undefined || compareDottedVersions(entry.nightly.minBaseVersion, prod.nightly.minBaseVersion) !== 0 || entry.nightly.minBuild !== prod.nightly.minBuild) {
+        throw new Error(`${path}.nightly must match ${path}.buildKinds.prod.nightly`);
       }
     }
   } else {

--- a/web/app/api/mobile-mac-compat/route.ts
+++ b/web/app/api/mobile-mac-compat/route.ts
@@ -77,10 +77,22 @@ function validateEntry(entry: MobileMacCompatEntry, path: string): void {
       );
     }
   }
-  version(entry.stableMinVersion, `${path}.stableMinVersion`);
-  if (entry.nightly !== undefined) {
-    version(entry.nightly.minBaseVersion, `${path}.nightly.minBaseVersion`);
-    build(entry.nightly.minBuild, `${path}.nightly.minBuild`);
+  if (entry.buildKinds !== undefined) {
+    for (const [kind, requirement] of Object.entries(entry.buildKinds)) {
+      const requirementPath = `${path}.buildKinds.${kind}`;
+      version(requirement.stableMinVersion, `${requirementPath}.stableMinVersion`);
+      if (requirement.nightly !== undefined) {
+        version(requirement.nightly.minBaseVersion, `${requirementPath}.nightly.minBaseVersion`);
+        build(requirement.nightly.minBuild, `${requirementPath}.nightly.minBuild`);
+      }
+    }
+  } else {
+    // Accept the pre-build-kind shape during a rolling deployment.
+    version(entry.stableMinVersion, `${path}.stableMinVersion`);
+    if (entry.nightly !== undefined) {
+      version(entry.nightly.minBaseVersion, `${path}.nightly.minBaseVersion`);
+      build(entry.nightly.minBuild, `${path}.nightly.minBuild`);
+    }
   }
 }
 

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -80,6 +80,9 @@ export const mobileMacCompatList: MobileMacCompatList = {
   entries: [
     {
       minIOSVersion: "1.0.0",
+      // Keep these mirrored to prod while older iOS clients are still deployed.
+      stableMinVersion: "0.64.23",
+      nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
         beta: { stableMinVersion: "0.64.22" },

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -34,6 +34,12 @@ export interface MobileMacCompatNightlyRequirement {
   minBuild: string;
 }
 
+export interface MobileMacCompatRequirement {
+  /** Minimums for one iOS distribution build kind. */
+  stableMinVersion: string;
+  nightly?: MobileMacCompatNightlyRequirement;
+}
+
 export interface MobileMacCompatEntry {
   /** Inclusive minimum iOS marketing version this tier applies to. The tier with the greatest minIOSVersion <= the app's version wins; an app below every tier is unconstrained (fail-open). */
   minIOSVersion: string;
@@ -46,9 +52,10 @@ export interface MobileMacCompatEntry {
    * (fail-open), same as an app below every tier.
    */
   maxIOSVersion?: string;
-  /** Inclusive minimum stable-channel Mac marketing version, dotted numeric. */
-  stableMinVersion: string;
-  /** Minimum nightly-channel Mac build. Omitted = nightly channel unconstrained for this tier. */
+  /** Requirements keyed by iOS build kind (`dev`, `beta`, `internal`, `demo`, `prod`). */
+  buildKinds?: Record<string, MobileMacCompatRequirement>;
+  /** @deprecated legacy single-policy fields, accepted during rollout. */
+  stableMinVersion?: string;
   nightly?: MobileMacCompatNightlyRequirement;
 }
 
@@ -73,8 +80,16 @@ export const mobileMacCompatList: MobileMacCompatList = {
   entries: [
     {
       minIOSVersion: "1.0.0",
-      stableMinVersion: "0.64.23",
-      nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+      buildKinds: {
+        dev: { stableMinVersion: "0.64.0" },
+        beta: { stableMinVersion: "0.64.22" },
+        internal: { stableMinVersion: "0.64.22" },
+        demo: { stableMinVersion: "0.64.22" },
+        prod: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
+      },
     },
   ],
 };

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -29,8 +29,7 @@ describe("mobile-mac-compat route", () => {
     entries: [
       {
         minIOSVersion: "1.0.4",
-        stableMinVersion: "0.64.23",
-        nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        buildKinds: { prod: { stableMinVersion: "0.64.23", nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" } } },
       },
     ],
   };
@@ -90,15 +89,21 @@ describe("mobile-mac-compat route", () => {
     expect(validateList(mobileMacCompatList)).toEqual(mobileMacCompatList);
   });
 
+  test("keeps minimums scoped to each build kind", () => {
+    const entry = mobileMacCompatList.entries[0];
+    expect(entry.buildKinds?.prod.stableMinVersion).toBe("0.64.23");
+    expect(entry.buildKinds?.internal.stableMinVersion).toBe("0.64.22");
+    expect(entry.buildKinds?.beta.stableMinVersion).toBe("0.64.22");
+  });
+
   test("accepts a tier without a nightly requirement and multiple ascending tiers", () => {
     const list: MobileMacCompatList = {
       ...base,
       entries: [
-        { minIOSVersion: "1.0.4", stableMinVersion: "0.64.23" },
+        { minIOSVersion: "1.0.4", buildKinds: { prod: { stableMinVersion: "0.64.23" } } },
         {
           minIOSVersion: "1.1",
-          stableMinVersion: "0.65.0",
-          nightly: { minBaseVersion: "0.65.0", minBuild: "3345650013300" },
+          buildKinds: { prod: { stableMinVersion: "0.65.0", nightly: { minBaseVersion: "0.65.0", minBuild: "3345650013300" } } },
         },
       ],
     };
@@ -240,7 +245,7 @@ describe("mobile-mac-compat route", () => {
       ...base,
       entries: [
         { minIOSVersion: "1.1", stableMinVersion: "0.65.0" },
-        { minIOSVersion: "1.0.4", stableMinVersion: "0.64.23" },
+        { minIOSVersion: "1.0.4", buildKinds: { prod: { stableMinVersion: "0.64.23" } } },
       ],
     };
     expect(() => validateList(list)).toThrow(
@@ -252,7 +257,7 @@ describe("mobile-mac-compat route", () => {
     const list: MobileMacCompatList = {
       ...base,
       entries: [
-        { minIOSVersion: "1.0.4", stableMinVersion: "0.64.23" },
+        { minIOSVersion: "1.0.4", buildKinds: { prod: { stableMinVersion: "0.64.23" } } },
         { minIOSVersion: "1.0.4", stableMinVersion: "0.64.24" },
       ],
     };

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -101,6 +101,11 @@ describe("mobile-mac-compat route", () => {
     expect(() => validateList({ ...mobileMacCompatList, entries: [{ ...entry, stableMinVersion: "0.64.22" }] })).toThrow("must match");
   });
 
+  test("rejects unknown build kinds", () => {
+    const entry = mobileMacCompatList.entries[0];
+    expect(() => validateList({ ...mobileMacCompatList, entries: [{ ...entry, buildKinds: { ...entry.buildKinds, typo: { stableMinVersion: "0.64.0" } } }] })).toThrow("not a supported build kind");
+  });
+
   test("accepts a tier without a nightly requirement and multiple ascending tiers", () => {
     const list: MobileMacCompatList = {
       ...base,

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -96,6 +96,11 @@ describe("mobile-mac-compat route", () => {
     expect(entry.buildKinds?.beta.stableMinVersion).toBe("0.64.22");
   });
 
+  test("rejects conflicting legacy and build-kind minimums", () => {
+    const entry = mobileMacCompatList.entries[0];
+    expect(() => validateList({ ...mobileMacCompatList, entries: [{ ...entry, stableMinVersion: "0.64.22" }] })).toThrow("must match");
+  });
+
   test("accepts a tier without a nightly requirement and multiple ascending tiers", () => {
     const list: MobileMacCompatList = {
       ...base,


### PR DESCRIPTION
The mobile Mac compatibility gate now stores stable and nightly minimums per iOS build kind (`dev`, `beta`, `internal`, `demo`, `prod`) and evaluates the running build kind. This prevents the App Store floor from blocking beta and internal builds while preserving legacy payload decoding during rollout. Focused Bun route tests and `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileMacCompatPolicyTests` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791584048&installation_model_id=21920&pr_number=12233&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12233&signature=a2d584b4d6639ec67788377c9baf3708d124bbc84a7e033ab4e47fa38d73ef53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission policy for iOS–Mac pairing (who gets blocked vs allowed); incorrect mapping could wrongly refuse or admit connections, though legacy decoding and prod fallbacks limit rollout risk.
> 
> **Overview**
> Mac compatibility minimums are now **per iOS distribution build kind** (`dev`, `beta`, `internal`, `demo`, `prod`) instead of a single tier-wide floor. **`MobileMacCompatPolicy.violation`** takes the running **`MobileBuildType`** (from the feedback stamp), picks **`tier.buildKinds[buildType.token]`**, and falls back to the tier’s legacy **`stableMinVersion` / `nightly`** when a kind is missing.
> 
> The **`GET /api/mobile-mac-compat`** payload and **`mobileMacCompatList`** add optional **`buildKinds`** (prod required when present); legacy top-level **`stableMinVersion` / `nightly`** stay valid for rollout and must match prod when both shapes appear. Server validation rejects unknown kinds and conflicting legacy vs prod minimums. **Baked policy**, policy refresh UI minimums, and live/revalidate gates all use the same build-kind resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d7194d83b44de958cf1ac888543717b46dbec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes mobile Mac compatibility minimums to each iOS build kind so the App Store floor no longer blocks beta and internal builds. The gate now evaluates the running build kind against per-kind stable and nightly minimums (`dev`, `beta`, `internal`, `demo`, `prod`) and falls back to the tier's legacy floor when a kind is absent. Legacy single-policy payloads stay valid during rollout; when `buildKinds` is present, prod is required, unknown kinds are rejected, and legacy fields must match prod.

<sup>Written for commit e7d7194d83b44de958cf1ac888543717b46dbec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build-type-specific macOS compatibility requirements for Dev, Beta, Internal, Demo, and Production builds.
  - Compatibility checks now apply the appropriate minimum macOS version and nightly-build requirements for each iOS build type.
  - Updated compatibility policy data to support tailored requirements while maintaining support for existing policy formats.

- **Bug Fixes**
  - Improved validation of compatibility policies, including detection of conflicting requirements and unknown build types.

- **Tests**
  - Added coverage for build-type-specific minimums and continued support for existing policy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->