### PR TITLE
fix: isolate Ghostty numeric locale from CoreUI symbol crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,6 +1196,25 @@ jobs:
             -only-testing:cmuxTests/GhosttyTerminalViewVisibilityPolicyTests \
             test
 
+      - name: Run Ghostty numeric locale tests
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          # LC_NUMERIC is process-global. Keep these tests in their own app-host
+          # invocation and disable Xcode's parallel test execution for it.
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          scripts/ci/run-in-console-session.sh \
+            scripts/ci/run-app-host-xcodebuild.sh \
+            -project cmux.xcodeproj -scheme cmux-numeric-locale -configuration Debug \
+            -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            -only-testing:cmuxTests/GhosttyNumericLocaleTests \
+            -parallel-testing-enabled NO \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            test
+
       - name: Run unit tests
         run: |
           set -euo pipefail

--- a/Sources/GhosttyNumericLocaleController.swift
+++ b/Sources/GhosttyNumericLocaleController.swift
@@ -1,0 +1,15 @@
+import Darwin
+
+/// Keeps AppKit and CoreUI's in-process numeric parsing independent of
+/// Ghostty's user-locale initialization.
+struct GhosttyNumericLocaleController {
+    /// Pins only `LC_NUMERIC` to the POSIX locale for the host process.
+    ///
+    /// Ghostty still receives the user's locale through `LANG` and the other
+    /// C locale categories remain unchanged. Terminal child processes inherit
+    /// the environment rather than this in-process category override.
+    @discardableResult
+    func pinProcessNumericLocale() -> Bool {
+        setlocale(LC_NUMERIC, "C") != nil
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -871,6 +871,13 @@ class GhosttyApp {
             unsetenv("NO_COLOR")
         }
 
+        let numericLocaleController = GhosttyNumericLocaleController()
+        defer {
+            // Ghostty may apply the user's locale during initialization. Restore
+            // the CoreUI-safe numeric locale on every exit, including failures.
+            numericLocaleController.pinProcessNumericLocale()
+        }
+
         // Initialize Ghostty library first
         let result = ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv)
         if result != GHOSTTY_SUCCESS {
@@ -883,7 +890,7 @@ class GhosttyApp {
             )
             return
         }
-        GhosttyNumericLocaleController().pinProcessNumericLocale()
+        numericLocaleController.pinProcessNumericLocale()
 
         resolvedUserShell = TerminalShellResolver.resolveCurrentUserShell()
         if let resolvedUserShell {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -883,13 +883,13 @@ class GhosttyApp {
             )
             return
         }
+        GhosttyNumericLocaleController().pinProcessNumericLocale()
 
         resolvedUserShell = TerminalShellResolver.resolveCurrentUserShell()
         if let resolvedUserShell {
             setenv("SHELL", resolvedUserShell, 1)
         }
 
-        // Load config
         guard let primaryConfig = ghostty_config_new() else {
             #if DEBUG
             cmuxDebugLog("ghostty.initialize.config.failed")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1548,6 +1548,7 @@
 		C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */; };
 		EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */; };
 		C54860070000000000000001 /* GhosttyNSViewSurfaceLinkCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860070000000000000002 /* GhosttyNSViewSurfaceLinkCopy.swift */; };
+		C0DE12220000000000000003 /* GhosttyNumericLocaleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12220000000000000004 /* GhosttyNumericLocaleController.swift */; };
 		C0DE12220000000000000001 /* GhosttyNumericLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12220000000000000002 /* GhosttyNumericLocaleTests.swift */; };
 		BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */; };
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
@@ -4944,6 +4945,7 @@
 		C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+SelectionTranslation.swift"; sourceTree = "<group>"; };
 		EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+TerminalCustomUpload.swift"; sourceTree = "<group>"; };
 		C54860070000000000000002 /* GhosttyNSViewSurfaceLinkCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNSViewSurfaceLinkCopy.swift; sourceTree = "<group>"; };
+		C0DE12220000000000000004 /* GhosttyNumericLocaleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNumericLocaleController.swift; sourceTree = "<group>"; };
 		C0DE12220000000000000002 /* GhosttyNumericLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNumericLocaleTests.swift; sourceTree = "<group>"; };
 		4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyOptionAsAltModsTests.swift; sourceTree = "<group>"; };
 		3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPasteboardFidelityTests.swift; sourceTree = "<group>"; };
@@ -8047,6 +8049,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F0A1100C0000000000000001 /* GhosttyMouseSessionLedgerSession.swift */,
 				F0A110080000000000000001 /* GhosttyMouseSessionLedgerSurfaceIdentity.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
+				C0DE12220000000000000004 /* GhosttyNumericLocaleController.swift */,
 				9612B0010000000000000001 /* TerminalPortalReconciliation.swift */,
 				E89950040000000000000002 /* KeyboardCopyModeGridMetrics.swift */,
 				E89950030000000000000002 /* KeyboardCopyModeResolvedCell.swift */,
@@ -11781,6 +11784,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */,
 				EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */,
 				C54860070000000000000001 /* GhosttyNSViewSurfaceLinkCopy.swift in Sources */,
+				C0DE12220000000000000003 /* GhosttyNumericLocaleController.swift in Sources */,
 				816400000000000000000001 /* GhosttyScrollView.swift in Sources */,
 				B8835700000000000000000F /* GhosttySurfaceCallbackContext+ClipboardInputSequencing.swift in Sources */,
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1548,6 +1548,7 @@
 		C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */; };
 		EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */; };
 		C54860070000000000000001 /* GhosttyNSViewSurfaceLinkCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860070000000000000002 /* GhosttyNSViewSurfaceLinkCopy.swift */; };
+		C0DE12220000000000000001 /* GhosttyNumericLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12220000000000000002 /* GhosttyNumericLocaleTests.swift */; };
 		BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */; };
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
 		7269A0017269A0017269A001 /* GhosttyPhysicalInputFocusReassertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7269A0027269A0027269A002 /* GhosttyPhysicalInputFocusReassertionTests.swift */; };
@@ -4943,6 +4944,7 @@
 		C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+SelectionTranslation.swift"; sourceTree = "<group>"; };
 		EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+TerminalCustomUpload.swift"; sourceTree = "<group>"; };
 		C54860070000000000000002 /* GhosttyNSViewSurfaceLinkCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNSViewSurfaceLinkCopy.swift; sourceTree = "<group>"; };
+		C0DE12220000000000000002 /* GhosttyNumericLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNumericLocaleTests.swift; sourceTree = "<group>"; };
 		4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyOptionAsAltModsTests.swift; sourceTree = "<group>"; };
 		3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPasteboardFidelityTests.swift; sourceTree = "<group>"; };
 		7269A0027269A0027269A002 /* GhosttyPhysicalInputFocusReassertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPhysicalInputFocusReassertionTests.swift; sourceTree = "<group>"; };
@@ -9526,6 +9528,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
+				C0DE12220000000000000002 /* GhosttyNumericLocaleTests.swift */,
 				A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */,
 				A11C00050000000000000002 /* StackAccountAvatarViewTests.swift */,
 				A11C00030000000000000002 /* StackAccountAvatarImageLoaderTests.swift */,
@@ -13730,6 +13733,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
 				F0A110030000000000000001 /* GhosttyMouseSessionLedgerTests.swift in Sources */,
 				A11EAF000000000000000000 /* GhosttyNotificationDispatcherTests.swift in Sources */,
+				C0DE12220000000000000001 /* GhosttyNumericLocaleTests.swift in Sources */,
 				BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */,
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
 				7269A0017269A0017269A001 /* GhosttyPhysicalInputFocusReassertionTests.swift in Sources */,

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-numeric-locale.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-numeric-locale.xcscheme
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="1500" version="1.7">
+  <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+    <BuildActionEntries>
+      <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting="YES" buildForRunning="NO" buildForProfiling="NO" buildForArchiving="NO" buildForAnalyzing="NO">
+        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="F1000004A1B2C3D4E5F60718" BuildableName="cmuxTests.xctest" BlueprintName="cmuxTests" ReferencedContainer="container:cmux.xcodeproj"/>
+      </BuildActionEntry>
+    </BuildActionEntries>
+  </BuildAction>
+  <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+    <Testables>
+      <TestableReference skipped="NO" parallelizable="NO">
+        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="F1000004A1B2C3D4E5F60718" BuildableName="cmuxTests.xctest" BlueprintName="cmuxTests" ReferencedContainer="container:cmux.xcodeproj"/>
+      </TestableReference>
+    </Testables>
+    <MacroExpansion>
+      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
+    </MacroExpansion>
+    <EnvironmentVariables>
+      <EnvironmentVariable key="SWIFT_BACKTRACE" value="interactive=no,timeout=0s,symbolicate=off,color=no" isEnabled="YES"/>
+    </EnvironmentVariables>
+  </TestAction>
+  <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">
+    <BuildableProductRunnable runnableDebuggingMode="0">
+      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
+    </BuildableProductRunnable>
+  </LaunchAction>
+  <ProfileAction buildConfiguration="Debug" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
+    <BuildableProductRunnable runnableDebuggingMode="0">
+      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="cmux" ReferencedContainer="container:cmux.xcodeproj"/>
+    </BuildableProductRunnable>
+  </ProfileAction>
+  <AnalyzeAction buildConfiguration="Debug"/>
+  <ArchiveAction buildConfiguration="Debug" revealArchiveInOrganizer="YES"/>
+</Scheme>

--- a/cmuxTests/GhosttyNumericLocaleTests.swift
+++ b/cmuxTests/GhosttyNumericLocaleTests.swift
@@ -1,0 +1,58 @@
+import AppKit
+import Darwin
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// The embedded Ghostty runtime must not leave AppKit's numeric locale on a
+/// comma-decimal setting, which makes CoreUI's symbol rasterizer unstable on
+/// macOS 27.
+@Suite("Ghostty numeric locale", .serialized)
+struct GhosttyNumericLocaleTests {
+    @Test
+    func pinsNumericLocaleForAppKit() {
+        let previous = setlocale(LC_NUMERIC, nil).map { String(cString: $0) }
+        defer {
+            if let previous {
+                _ = setlocale(LC_NUMERIC, previous)
+            }
+        }
+
+        guard setlocale(LC_NUMERIC, "de_DE.UTF-8") != nil else {
+            Issue.record("de_DE.UTF-8 is unavailable on this macOS runner")
+            return
+        }
+        let didPin = GhosttyNumericLocaleController().pinProcessNumericLocale()
+
+        #expect(didPin)
+        guard let current = setlocale(LC_NUMERIC, nil) else {
+            Issue.record("LC_NUMERIC could not be queried after pinning")
+            return
+        }
+        #expect(String(cString: current) == "C")
+    }
+
+    @Test @MainActor
+    func pinnedLocaleMaterializesSystemSymbol() throws {
+        let previous = setlocale(LC_NUMERIC, nil).map { String(cString: $0) }
+        defer {
+            if let previous {
+                _ = setlocale(LC_NUMERIC, previous)
+            }
+        }
+
+        guard setlocale(LC_NUMERIC, "de_DE.UTF-8") != nil else {
+            Issue.record("de_DE.UTF-8 is unavailable on this macOS runner")
+            return
+        }
+        GhosttyNumericLocaleController().pinProcessNumericLocale()
+
+        let image = try #require(NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil))
+        var rect = NSRect(x: 0, y: 0, width: 16, height: 16)
+        #expect(image.cgImage(forProposedRect: &rect, context: nil, hints: nil) != nil)
+    }
+}

--- a/cmuxTests/GhosttyNumericLocaleTests.swift
+++ b/cmuxTests/GhosttyNumericLocaleTests.swift
@@ -14,6 +14,7 @@ import Testing
 @Suite("Ghostty numeric locale", .serialized)
 struct GhosttyNumericLocaleTests {
     @Test
+    /// Pins the process numeric locale without changing the user's other locale settings.
     func pinsNumericLocaleForAppKit() {
         let previous = setlocale(LC_NUMERIC, nil).map { String(cString: $0) }
         defer {
@@ -37,6 +38,7 @@ struct GhosttyNumericLocaleTests {
     }
 
     @Test @MainActor
+    /// Confirms AppKit can rasterize a system symbol after numeric locale pinning.
     func pinnedLocaleMaterializesSystemSymbol() throws {
         let previous = setlocale(LC_NUMERIC, nil).map { String(cString: $0) }
         defer {

--- a/scripts/ci/cmux_unit_test_shard.py
+++ b/scripts/ci/cmux_unit_test_shard.py
@@ -40,6 +40,7 @@ FOCUSED_GATE_SELECTORS = {
     "cmuxTests/CLISSHSessionAttachAnchorTests",
     "cmuxTests/GhosttyTerminalViewVisibilityPolicyTests",
     "cmuxTests/GhosttyOptionAsAltModsTests",
+    "cmuxTests/GhosttyNumericLocaleTests",
     "cmuxTests/KeyboardShortcutSettingsFileStoreNoOpPersistenceTests",
     "cmuxTests/RemoteTmuxMirrorLayoutIdentityTests",
     "cmuxTests/SidebarWorkspaceSwitchLayoutFaultTests",


### PR DESCRIPTION
## Problem

On macOS 27 beta, opening Preferences can crash CoreUI's SF Symbol rasterizer when embedded Ghostty applies a comma-decimal `LC_NUMERIC` to the host process. The locale mutation is process-wide, so every AppKit/CoreUI symbol surface can be affected.

## Fix

`GhosttyNumericLocaleController` pins only the host process's `LC_NUMERIC` category to the POSIX `C` locale while preserving `LANG` and the other locale categories for terminal child processes. `initializeGhostty()` pins immediately after successful `ghostty_init` and uses a `defer` to re-pin on every exit, including initialization failures.

## Tests and CI

- `GhosttyNumericLocaleTests` verifies locale pinning and AppKit SF Symbol materialization.
- The locale-mutating suite runs through the dedicated `cmux-numeric-locale` scheme with `parallelizable="NO"` and `-parallel-testing-enabled NO`.
- The suite is excluded from the normal unit-test shard selector and runs in its own app-host CI invocation, preserving parallel execution for unrelated tests.
- Local validation: `python3 scripts/ci/cmux_unit_test_shard.py --validate`, `python3 tests/test_ci_cmux_unit_test_shard.py`, scheme XML parse, `git diff --check`, tagged Debug build via `./scripts/reload.sh --tag issue-12222-preferences-coreui-crash`.
- The focused local XCTest wrapper could not start a logged-in GUI console session on this runner; the tagged app build completed successfully. Hosted checks for the prior revision passed, and checks for this revision are running.

## Commits

1. `test: cover Ghostty numeric locale isolation`
2. `fix: isolate Ghostty numeric locale from CoreUI`
3. `test: isolate numeric locale suite from parallel runs`

Closes #12222. Also covers the embedded-Ghostty locale root cause documented in #7880.
