### PR TITLE
Fix DOMRect crashes in browser.eval on macOS 15

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService+EvaluationScript.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService+EvaluationScript.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+extension BrowserControlService {
+    /// Builds the async function body used by browser automation and user evals.
+    ///
+    /// DOM rectangles must become plain geometry objects in the web process:
+    /// WebKit on macOS 15 can crash the host while deserializing a native DOMRect,
+    /// before Swift-side normalization gets a chance to run.
+    ///
+    /// - Parameters:
+    ///   - script: JavaScript to execute.
+    ///   - useEval: Whether to evaluate a script string or insert a trusted expression.
+    ///   - frameSelector: Optional same-origin frame supplying `document`.
+    /// - Returns: A function body that awaits and wraps a bridge-safe result.
+    public func evaluationScript(
+        script: String,
+        useEval: Bool,
+        frameSelector: String?
+    ) -> String {
+        let framePrelude: String
+        if let frameSelector {
+            framePrelude = """
+            let __cmuxDoc = document;
+            try {
+              const __cmuxFrame = document.querySelector(\(jsonLiteral(frameSelector)));
+              if (__cmuxFrame && __cmuxFrame.contentDocument) {
+                __cmuxDoc = __cmuxFrame.contentDocument;
+              }
+            } catch (_) {}
+            """
+        } else {
+            framePrelude = "const __cmuxDoc = document;"
+        }
+
+        let executionBlock = useEval
+            ? "const __r = eval(\(jsonLiteral(script)));"
+            : "const __r = \(script);"
+        let circularReferenceMessage = jsonLiteral(String(
+            localized: "cli.browser.error.circularEvaluationResult",
+            defaultValue: "Browser evaluation result contains a circular reference"
+        ))
+
+        return """
+        \(framePrelude)
+
+        const __cmuxMaybeAwait = async (__r) => {
+          if (__r !== null && (typeof __r === 'object' || typeof __r === 'function') && typeof __r.then === 'function') {
+            return await __r;
+          }
+          return __r;
+        };
+
+        const __cmuxAncestors = new WeakSet();
+        const __cmuxCopies = new WeakMap();
+        const __cmuxBridgeSafeValue = (__value) => {
+          if (__value === null || typeof __value !== 'object') {
+            return __value;
+          }
+          if (__cmuxAncestors.has(__value)) {
+            throw new Error(\(circularReferenceMessage));
+          }
+          if (__cmuxCopies.has(__value)) {
+            return __cmuxCopies.get(__value);
+          }
+
+          // Brand checks also recognize rectangles and containers from iframes.
+          const __tag = Object.prototype.toString.call(__value);
+          const __isRect =
+            (typeof DOMRectReadOnly !== 'undefined' && __value instanceof DOMRectReadOnly) ||
+            __tag === '[object DOMRect]' || __tag === '[object DOMRectReadOnly]';
+          const __isArray = Array.isArray(__value);
+          if (!__isRect && !__isArray && __tag !== '[object Object]') {
+            return __value;
+          }
+
+          __cmuxAncestors.add(__value);
+          try {
+            const __copy = __isArray ? [] : {};
+            __cmuxCopies.set(__value, __copy);
+            const __keys = __isRect
+              ? ['x', 'y', 'width', 'height', 'top', 'right', 'bottom', 'left']
+              : Object.keys(__value);
+            if (__isArray) {
+              __copy.length = __value.length;
+            }
+            for (const __key of __keys) {
+              // Define own properties so a literal "__proto__" key stays data.
+              Object.defineProperty(__copy, __key, {
+                value: __cmuxBridgeSafeValue(__value[__key]),
+                enumerable: true,
+                configurable: true,
+                writable: true
+              });
+            }
+            return __copy;
+          } finally {
+            __cmuxAncestors.delete(__value);
+          }
+        };
+
+        const __cmuxEvalInFrame = async function() {
+          const document = __cmuxDoc;
+          \(executionBlock)
+          const __value = await __cmuxMaybeAwait(__r);
+          return {
+            [\(jsonLiteral(evalEnvelope.typeKey))]: (typeof __value === 'undefined')
+              ? \(jsonLiteral(evalEnvelope.typeUndefined)) : \(jsonLiteral(evalEnvelope.typeValue)),
+            [\(jsonLiteral(evalEnvelope.valueKey))]: __cmuxBridgeSafeValue(__value)
+          };
+        };
+
+        return await __cmuxEvalInFrame();
+        """
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService.swift
@@ -7,15 +7,15 @@ import Foundation
 /// lifecycle nor any AppKit/WebKit object. Specifically it builds the JavaScript
 /// strings for the semantic element locators (`find.role`, `find.text`, and the
 /// other `find.*` actions), canonical keyboard events, the not-found diagnostics
-/// probe, and the `find.first`/`find.last`/`find.nth` selector scripts; it
-/// normalizes raw JavaScript results into JSON-serializable values; it classifies
-/// JavaScript failures; and it composes the human-readable element-not-found
-/// message.
+/// probe, the browser-eval bridge wrapper, and the `find.first`/`find.last`/`find.nth`
+/// selector scripts; it normalizes raw JavaScript results into JSON-serializable
+/// values; it classifies JavaScript failures; and it composes the human-readable
+/// element-not-found message.
 ///
 /// The owning `@MainActor` controller keeps the per-surface mutable state
 /// (element-ref table, dialog queue, init scripts) and the WebKit evaluation seam;
-/// it forwards into this service for the stateless work, so the RPC wire output is
-/// byte-for-byte identical to the previous inlined implementation.
+/// it forwards into this service for the stateless work and retains the RPC
+/// envelope format.
 public struct BrowserControlService: Sendable {
     /// Envelope constants for the `browser eval` undefined/value distinction.
     public let evalEnvelope: BrowserEvalEnvelope

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserEvaluationScriptTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserEvaluationScriptTests.swift
@@ -57,7 +57,7 @@ final class BrowserEvaluationScriptTests: NSObject, WKNavigationDelegate {
         return {__cmux_t: typeof value === 'undefined' ? 'undefined' : 'value', __cmux_v: value};
         """
         let expected = try #require(try await webView.callAsyncJavaScript(
-            baseline, arguments: [:], in: nil, in: .page
+            baseline, arguments: [:], in: nil, contentWorld: .page
         ) as? NSDictionary)
         let result = try await evaluate(script)
         #expect(NSDictionary(dictionary: result) == expected)
@@ -73,7 +73,7 @@ final class BrowserEvaluationScriptTests: NSObject, WKNavigationDelegate {
     func errorsReturnNormallyAndNextEvaluationSucceeds(script: String) async throws {
         try await loadPage()
         await #expect(throws: (any Error).self) {
-            try await self.evaluate(script)
+            _ = try await self.evaluate(script)
         }
         let next = try await evaluate("6 * 7")
         #expect(next["__cmux_v"] as? Int == 42)
@@ -97,7 +97,7 @@ final class BrowserEvaluationScriptTests: NSObject, WKNavigationDelegate {
         frameSelector: String? = nil
     ) async throws -> [String: Any] {
         let body = service.evaluationScript(script: script, useEval: useEval, frameSelector: frameSelector)
-        let result = try await webView.callAsyncJavaScript(body, arguments: [:], in: nil, in: .page)
+        let result = try await webView.callAsyncJavaScript(body, arguments: [:], in: nil, contentWorld: .page)
         return try #require(result as? [String: Any])
     }
 

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserEvaluationScriptTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserEvaluationScriptTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+import WebKit
+@testable import CmuxBrowser
+
+@MainActor
+@Suite(.serialized, .timeLimit(.minutes(1)))
+final class BrowserEvaluationScriptTests: NSObject, WKNavigationDelegate {
+    private let webView = WKWebView()
+    private let service = BrowserControlService()
+    private var navigation: AsyncThrowingStream<Void, any Error>.Continuation?
+
+    @Test(arguments: [
+        "new DOMRect(1, 2, 3, 4)",
+        "new DOMRectReadOnly(1, 2, 3, 4)",
+        "Promise.resolve(new DOMRect(1, 2, 3, 4))",
+        "({rect: new DOMRect(1, 2, 3, 4)}).rect",
+        "(() => { const frame = document.querySelector('iframe'); return new frame.contentWindow.DOMRect(1, 2, 3, 4); })()",
+        "document.querySelector('#geometry').getBoundingClientRect()"
+    ])
+    func rectanglesCrossWebKitAsGeometry(script: String) async throws {
+        try await loadPage()
+        let result = try await evaluate(script)
+        let rect = try #require(result["__cmux_v"] as? [String: Double])
+        #expect(rect == ["x": 1, "y": 2, "width": 3, "height": 4, "top": 2, "right": 4, "bottom": 6, "left": 1])
+    }
+
+    @Test(arguments: [
+        "({rect: new DOMRect(1, 2, 3, 4), items: [new DOMRectReadOnly(1, 2, 3, 4)]})",
+        "document.querySelector('iframe').contentWindow.eval('({rect: new DOMRect(1, 2, 3, 4), items: [new DOMRectReadOnly(1, 2, 3, 4)]})')",
+        "(() => { const rect = new DOMRect(1, 2, 3, 4); return {rect, items: [rect]}; })()",
+        "(() => { class Result { constructor() { this.rect = new DOMRect(1, 2, 3, 4); this.items = [this.rect]; } } return new Result(); })()"
+    ])
+    func nestedRectanglesAndRepeatedReferences(script: String) async throws {
+        try await loadPage()
+        let result = try await evaluate(script)
+        let value = try #require(result["__cmux_v"] as? [String: Any])
+        let rect = try #require(value["rect"] as? [String: Double])
+        let items = try #require(value["items"] as? [[String: Double]])
+        #expect(rect == ["x": 1, "y": 2, "width": 3, "height": 4, "top": 2, "right": 4, "bottom": 6, "left": 1])
+        #expect(items == [rect])
+    }
+
+    @Test(arguments: [
+        "({zero: 0, text: 'ordinary', flag: false, empty: null, nested: [1, 'two', {}]})",
+        "[null, undefined, , 3]",
+        "JSON.parse('{\"__proto__\": {\"value\": 42}}')",
+        "(() => { const value = {a: 1}; return [value, value]; })()",
+        "new Date('2026-01-01T00:00:00Z')",
+        "null",
+        "undefined"
+    ])
+    func ordinaryValuesMatchExistingBridge(script: String) async throws {
+        try await loadPage()
+        let baseline = """
+        const value = eval(\(service.jsonLiteral(script)));
+        return {__cmux_t: typeof value === 'undefined' ? 'undefined' : 'value', __cmux_v: value};
+        """
+        let expected = try #require(try await webView.callAsyncJavaScript(
+            baseline, arguments: [:], in: nil, in: .page
+        ) as? NSDictionary)
+        let result = try await evaluate(script)
+        #expect(NSDictionary(dictionary: result) == expected)
+    }
+
+    @Test(arguments: [
+        "throw new Error('eval failed')",
+        "Promise.reject(new Error('promise failed'))",
+        "(() => { const value = {}; value.self = value; return value; })()",
+        "(() => { const value = []; value.push(value); return value; })()",
+        "({get rect() { throw new Error('getter failed'); }})"
+    ])
+    func errorsReturnNormallyAndNextEvaluationSucceeds(script: String) async throws {
+        try await loadPage()
+        await #expect(throws: (any Error).self) {
+            try await self.evaluate(script)
+        }
+        let next = try await evaluate("6 * 7")
+        #expect(next["__cmux_v"] as? Int == 42)
+    }
+
+    @Test func trustedExpressionAndSelectedDocumentUseTheSameWrapper() async throws {
+        try await loadPage()
+        let result = try await evaluate(
+            "document.querySelector('#geometry').getBoundingClientRect()",
+            useEval: false,
+            frameSelector: "iframe"
+        )
+        let rect = try #require(result["__cmux_v"] as? [String: Double])
+        #expect(rect["x"] == 11)
+        #expect(rect["y"] == 12)
+    }
+
+    private func evaluate(
+        _ script: String,
+        useEval: Bool = true,
+        frameSelector: String? = nil
+    ) async throws -> [String: Any] {
+        let body = service.evaluationScript(script: script, useEval: useEval, frameSelector: frameSelector)
+        let result = try await webView.callAsyncJavaScript(body, arguments: [:], in: nil, in: .page)
+        return try #require(result as? [String: Any])
+    }
+
+    private func loadPage() async throws {
+        let (events, continuation) = AsyncThrowingStream<Void, any Error>.makeStream()
+        navigation = continuation
+        webView.navigationDelegate = self
+        webView.loadHTMLString("""
+            <div id="geometry" style="position:fixed;left:1px;top:2px;width:3px;height:4px"></div>
+            <iframe srcdoc="<div id='geometry' style='position:fixed;left:11px;top:12px;width:3px;height:4px'></div>"></iframe>
+            """, baseURL: nil)
+        for try await _ in events {}
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+        self.navigation?.finish()
+        self.navigation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: any Error) {
+        self.navigation?.finish(throwing: error)
+        self.navigation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation?, withError error: any Error) {
+        self.navigation?.finish(throwing: error)
+        self.navigation = nil
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -41055,6 +41055,17 @@
         }
       }
     },
+    "cli.browser.error.circularEvaluationResult": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser evaluation result contains a circular reference"
+          }
+        }
+      }
+    },
     "cli.browser.error.diffViewerAllowlistInvalid": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7138,52 +7138,11 @@ class TerminalController {
                 channel: .javaScript
             ))
         }
-        let scriptLiteral = v2JSONLiteral(script)
-        let framePrelude: String
-        if let frameSelector = v2BrowserCurrentFrameSelector(surfaceId: surfaceId) {
-            let selectorLiteral = v2JSONLiteral(frameSelector)
-            framePrelude = """
-            let __cmuxDoc = document;
-            try {
-              const __cmuxFrame = document.querySelector(\(selectorLiteral));
-              if (__cmuxFrame && __cmuxFrame.contentDocument) {
-                __cmuxDoc = __cmuxFrame.contentDocument;
-              }
-            } catch (_) {}
-            """
-        } else {
-            framePrelude = "const __cmuxDoc = document;"
-        }
-
-        let executionBlock: String
-        if useEval {
-            executionBlock = "const __r = eval(\(scriptLiteral));"
-        } else {
-            executionBlock = "const __r = \(script);"
-        }
-
-        let asyncFunctionBody = """
-        \(framePrelude)
-
-        const __cmuxMaybeAwait = async (__r) => {
-          if (__r !== null && (typeof __r === 'object' || typeof __r === 'function') && typeof __r.then === 'function') {
-            return await __r;
-          }
-          return __r;
-        };
-
-        const __cmuxEvalInFrame = async function() {
-          const document = __cmuxDoc;
-          \(executionBlock)
-          const __value = await __cmuxMaybeAwait(__r);
-          return {
-            __cmux_t: (typeof __value === 'undefined') ? 'undefined' : 'value',
-            __cmux_v: __value
-          };
-        };
-
-        return await __cmuxEvalInFrame();
-        """
+        let asyncFunctionBody = v2BrowserControl.evaluationScript(
+            script: script,
+            useEval: useEval,
+            frameSelector: v2BrowserCurrentFrameSelector(surfaceId: surfaceId)
+        )
 
         var rawResult: BrowserJavaScriptEvaluationResult
         if #available(macOS 11.0, *) {

--- a/tests_v2/test_browser_eval_domrect.py
+++ b/tests_v2/test_browser_eval_domrect.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Regression: browser.eval returns bridge-safe DOM geometry and normal errors."""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+
+def _must(condition: bool, message: str) -> None:
+    if not condition:
+        raise cmuxError(message)
+
+
+def _value(payload: dict):
+    return (payload or {}).get("value")
+
+
+def _assert_rect(value, label: str) -> None:
+    _must(isinstance(value, dict), f"Expected {label} to be a dictionary: {value!r}")
+    expected = {
+        "x": 1,
+        "y": 2,
+        "width": 3,
+        "height": 4,
+        "top": 2,
+        "right": 4,
+        "bottom": 6,
+        "left": 1,
+    }
+    for key, expected_value in expected.items():
+        _must(
+            float(value.get(key)) == expected_value,
+            f"Expected {label}.{key}={expected_value}, got {value!r}",
+        )
+
+
+def _expect_eval_error(client: cmux, surface_id: str, script: str) -> None:
+    try:
+        client._call(
+            "browser.eval",
+            {
+                "surface_id": surface_id,
+                "script": script,
+            },
+        )
+    except cmuxError as exc:
+        _must("js_error" in str(exc), f"Expected a normal JavaScript error: {exc}")
+        return
+    raise cmuxError("Expected browser.eval to return a normal evaluation error")
+
+
+def main() -> int:
+    surface_id = ""
+    with cmux(SOCKET_PATH) as client:
+        try:
+            opened = client._call("browser.open_split", {"url": "about:blank"}) or {}
+            surface_id = str(opened.get("surface_id") or "")
+            _must(bool(surface_id), f"browser.open_split returned no surface_id: {opened}")
+
+            direct_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "new DOMRect(1, 2, 3, 4)",
+                },
+            ) or {}
+            _assert_rect(_value(direct_result), "direct DOMRect")
+
+            nested_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "({bounds: new DOMRect(1, 2, 3, 4), items: [new DOMRect(1, 2, 3, 4)]})",
+                },
+            ) or {}
+            nested_value = _value(nested_result) or {}
+            _assert_rect(nested_value.get("bounds"), "nested DOMRect")
+            nested_items = nested_value.get("items") or []
+            _must(len(nested_items) == 1, f"Expected one nested DOMRect: {nested_result}")
+            _assert_rect(nested_items[0], "array DOMRect")
+
+            readonly_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "({available: typeof DOMRectReadOnly !== 'undefined', rect: typeof DOMRectReadOnly === 'undefined' ? null : new DOMRectReadOnly(1, 2, 3, 4)})",
+                },
+            ) or {}
+            readonly_value = _value(readonly_result) or {}
+            if readonly_value.get("available"):
+                _assert_rect(readonly_value.get("rect"), "DOMRectReadOnly")
+            else:
+                _must(readonly_value.get("rect") is None, f"Unavailable DOMRectReadOnly should be null: {readonly_result}")
+
+            promised_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "Promise.resolve(new DOMRect(1, 2, 3, 4))",
+                },
+            ) or {}
+            _assert_rect(_value(promised_result), "promised DOMRect")
+
+            cross_realm_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "(() => { const frame = document.createElement('iframe'); document.body.appendChild(frame); const rect = new frame.contentWindow.DOMRect(1, 2, 3, 4); const isCrossRealm = !(rect instanceof DOMRectReadOnly); frame.remove(); return {isCrossRealm, rect}; })()",
+                },
+            ) or {}
+            cross_realm_value = _value(cross_realm_result) or {}
+            _must(
+                cross_realm_value.get("isCrossRealm") is True,
+                f"Expected iframe DOMRect to come from another JavaScript realm: {cross_realm_result}",
+            )
+            _assert_rect(cross_realm_value.get("rect"), "cross-realm DOMRect")
+
+            ordinary_result = client._call(
+                "browser.eval",
+                {
+                    "surface_id": surface_id,
+                    "script": "({zero: 0, text: 'ordinary', flag: false, empty: null})",
+                },
+            ) or {}
+            _must(
+                _value(ordinary_result) == {"zero": 0, "text": "ordinary", "flag": False, "empty": None},
+                f"Ordinary eval value changed: {ordinary_result}",
+            )
+
+            # Containers created in the other realm also need recursive traversal.
+            cross_container = client._call(
+                "browser.eval",
+                {"surface_id": surface_id, "script": "(() => { const frame = document.createElement('iframe'); document.body.appendChild(frame); const value = frame.contentWindow.eval('({rect: new DOMRect(1, 2, 3, 4)})'); frame.remove(); return value; })()"},
+            ) or {}
+            _assert_rect(_value(cross_container)["rect"], "cross-realm container DOMRect")
+
+            layout = client._call(
+                "browser.eval",
+                {"surface_id": surface_id, "script": "(() => { const element = document.createElement('div'); element.style.cssText = 'position:fixed;left:1px;top:2px;width:3px;height:4px'; document.body.appendChild(element); const rect = element.getBoundingClientRect(); element.remove(); return rect; })()"},
+            ) or {}
+            _assert_rect(_value(layout), "layout DOMRect")
+
+            aliases = client._call(
+                "browser.eval",
+                {"surface_id": surface_id, "script": "(() => { const shared = {rect: new DOMRect(1, 2, 3, 4)}; return [shared, shared]; })()"},
+            ) or {}
+            _must(len(_value(aliases)) == 2, f"Missing repeated reference: {aliases}")
+            for alias in _value(aliases):
+                _assert_rect(alias["rect"], "aliased DOMRect")
+
+            undefined = client._call(
+                "browser.eval", {"surface_id": surface_id, "script": "undefined"},
+            ) or {}
+            _must(_value(undefined) == {"__cmux_t": "undefined", "__cmux_v": None}, f"Undefined changed: {undefined}")
+            null = client._call(
+                "browser.eval", {"surface_id": surface_id, "script": "null"},
+            ) or {}
+            _must(_value(null) is None, f"Null changed: {null}")
+
+            for script in (
+                "throw new Error('browser-eval-regression-error')",
+                "Promise.reject(new Error('browser-eval-regression-error'))",
+                "(() => { const value = {}; value.self = value; return value; })()",
+                "({get rect() { throw new Error('getter failed'); }})",
+            ):
+                _expect_eval_error(client, surface_id, script)
+            survived_error = client._call(
+                "browser.eval",
+                {"surface_id": surface_id, "script": "6 * 7"},
+            ) or {}
+            _must(_value(survived_error) == 42, f"Evaluation did not recover after an error: {survived_error}")
+        finally:
+            if surface_id:
+                try:
+                    client._call("surface.close", {"surface_id": surface_id})
+                except (cmuxError, OSError):
+                    pass
+
+    print("PASS: browser.eval bridges DOMRect values and preserves normal values/errors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`browser.eval` could terminate the cmux host on macOS 15.5 when WebKit deserialized a DOMRect, including one nested in a result. Convert DOMRect and DOMRectReadOnly values to their eight geometry fields inside the web process before returning the existing eval envelope.

The shared evaluation wrapper handles nested objects/arrays, promises, iframe realms, and repeated references. Circular containers and throwing getters return normal JavaScript errors. Existing frame selection, CSP fallback, ordinary values, and undefined/null handling remain intact.

Closes #12221.

Validation:
- Pushed HEAD `44401402909e52e3c17986dea926baef4a7fff60` built successfully on the fleet as [issue12221](http://127.0.0.1:17320/issue12221).
- Focused CmuxBrowser suites: 22 tests passed, including 23 real WKWebView cases.
- In an isolated harness, all six geometry cases failed with result conversion bypassed and passed with conversion restored.
- `tests_v2/test_browser_eval_domrect.py` passed through the built app's socket on a leased Mac: direct/nested/read-only/promised/cross-frame rectangles, real layout geometry, repeated references, undefined/null, errors, and subsequent evaluation.
- Test wiring and Package.resolved policy checks passed.
- Localization audit: the new circular-reference error has an English catalog entry; no web messages or UI labels changed.

Package tests ran on macOS 26.5.1; the full-app socket regression ran on macOS 26.5. The reported macOS 15.5 environment was unavailable in the reachable fleet, so reproduction of its native crash remains unverified. The development backend was disabled for this browser-only dogfood build because the shared backend hostname was unavailable.

The socket regression and implementation are separate commits. The PR remains unmerged pending dogfood approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the browser automation eval result path and serialization semantics for geometry and nested structures; mitigated by broad regression tests but still touches a core WebKit bridge.
> 
> **Overview**
> **`browser.eval` now converts `DOMRect` / `DOMRectReadOnly` (and nested geometry) into plain `{x,y,width,height,...}` objects in the web process** before WebKit hands results back to Swift, avoiding host crashes on macOS 15 when native rectangles are deserialized.
> 
> The eval wrapper is **extracted from `TerminalController` into `BrowserControlService.evaluationScript`**, which still handles iframe `document` selection, eval vs trusted expressions, promise awaiting, and the existing `__cmux_t` / `__cmux_v` envelope. New in-page logic recursively copies objects/arrays, preserves repeated references, rejects circular structures with a localized error, and leaves other value types on the prior bridge behavior.
> 
> **Coverage:** WKWebView unit tests in CmuxBrowser and a socket-level `tests_v2/test_browser_eval_domrect.py` regression exercise rectangles, cross-realm/iframes, ordinary values, errors, and recovery after failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44401402909e52e3c17986dea926baef4a7fff60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser evaluation now supports DOM geometry results, including nested and cross-frame values.
  * Promises, ordinary values, and `undefined` are returned with consistent browser-bridge handling.
  * Circular references and unsupported result structures now produce clear evaluation errors.

* **Bug Fixes**
  * Evaluation errors and rejected promises are surfaced normally, while subsequent evaluations continue to work.
  * Frame-targeted evaluations use the same reliable result handling as main-document evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->