### PR TITLE
web: tag broker and relay route queries with their route template

### DIFF
--- a/web/app/api/devices/iroh/challenge/route.ts
+++ b/web/app/api/devices/iroh/challenge/route.ts
@@ -1,6 +1,6 @@
-import { handleIrohRoute } from "../../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../../services/iroh/routeHandler";
 
 
 export async function POST(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "challenge");
+  return handleTaggedIrohRoute(request, "challenge");
 }

--- a/web/app/api/devices/iroh/endpoint-attestations/route.ts
+++ b/web/app/api/devices/iroh/endpoint-attestations/route.ts
@@ -1,6 +1,6 @@
-import { handleIrohRoute } from "../../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../../services/iroh/routeHandler";
 
 
 export async function POST(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "endpoint_attestation");
+  return handleTaggedIrohRoute(request, "endpoint_attestation");
 }

--- a/web/app/api/devices/iroh/pair-grants/route.ts
+++ b/web/app/api/devices/iroh/pair-grants/route.ts
@@ -1,6 +1,6 @@
-import { handleIrohRoute } from "../../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../../services/iroh/routeHandler";
 
 
 export async function POST(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "pair_grant");
+  return handleTaggedIrohRoute(request, "pair_grant");
 }

--- a/web/app/api/devices/iroh/register/route.ts
+++ b/web/app/api/devices/iroh/register/route.ts
@@ -1,6 +1,6 @@
-import { handleIrohRoute } from "../../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../../services/iroh/routeHandler";
 
 
 export async function POST(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "register");
+  return handleTaggedIrohRoute(request, "register");
 }

--- a/web/app/api/devices/iroh/relay-token/route.ts
+++ b/web/app/api/devices/iroh/relay-token/route.ts
@@ -1,6 +1,6 @@
-import { handleIrohRoute } from "../../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../../services/iroh/routeHandler";
 
 
 export async function POST(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "relay_token");
+  return handleTaggedIrohRoute(request, "relay_token");
 }

--- a/web/app/api/devices/iroh/route.ts
+++ b/web/app/api/devices/iroh/route.ts
@@ -1,10 +1,10 @@
-import { handleIrohRoute } from "../../../../services/iroh/routeHandler";
+import { handleTaggedIrohRoute } from "../../../../services/iroh/routeHandler";
 
 
 export async function GET(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "discover");
+  return handleTaggedIrohRoute(request, "discover");
 }
 
 export async function DELETE(request: Request): Promise<Response> {
-  return handleIrohRoute(request, "revoke");
+  return handleTaggedIrohRoute(request, "revoke");
 }

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -12,6 +12,7 @@
 // means 503: admissions of NEW endpoints fail closed, the relay side carries
 // availability through its allow cache.
 
+import { runWithCloudDbQueryTags } from "../../../../db/queryTags";
 import { env } from "../../../env";
 import { jsonResponse } from "../../../../services/relay/http";
 import {
@@ -228,5 +229,8 @@ async function readBoundedBody(
 }
 
 export function POST(request: Request): Promise<Response> {
-  return handleRelayAllowRequest(request, productionDeps);
+  return runWithCloudDbQueryTags(
+    { source: "app", route: "/api/relay/allow" },
+    async () => await handleRelayAllowRequest(request, productionDeps),
+  );
 }

--- a/web/app/api/relay/preferences/route.ts
+++ b/web/app/api/relay/preferences/route.ts
@@ -1,6 +1,7 @@
 // Read and update account-scoped Iroh relay selection metadata.
 // Custom relay secrets stay in the native client's Keychain and are rejected here.
 
+import { runWithCloudDbQueryTags } from "../../../../db/queryTags";
 import { checkRateLimit } from "@vercel/firewall";
 
 import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
@@ -133,9 +134,15 @@ export async function handlePutRelayPreference(
 }
 
 export function GET(request: Request): Promise<Response> {
-  return handleGetRelayPreference(request, productionDeps);
+  return runWithCloudDbQueryTags(
+    { source: "app", route: "/api/relay/preferences" },
+    async () => await handleGetRelayPreference(request, productionDeps),
+  );
 }
 
 export function PUT(request: Request): Promise<Response> {
-  return handlePutRelayPreference(request, productionDeps);
+  return runWithCloudDbQueryTags(
+    { source: "app", route: "/api/relay/preferences" },
+    async () => await handlePutRelayPreference(request, productionDeps),
+  );
 }

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -1,6 +1,7 @@
 // Mint endpoint-bound access credentials and a signed, server-driven Iroh relay policy.
 // Auth is native-only because both credentials leave the browser boundary.
 
+import { runWithCloudDbQueryTags } from "../../../../db/queryTags";
 import { randomUUID, type KeyObject } from "node:crypto";
 
 import { checkRateLimit } from "@vercel/firewall";
@@ -341,5 +342,8 @@ async function parseRelayTokenRequest(
 }
 
 export function POST(request: Request): Promise<Response> {
-  return handleRelayTokenRequest(request, productionDeps);
+  return runWithCloudDbQueryTags(
+    { source: "app", route: "/api/relay/token" },
+    async () => await handleRelayTokenRequest(request, productionDeps),
+  );
 }

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -1,3 +1,4 @@
+import { runWithCloudDbQueryTags } from "../../db/queryTags";
 import { createHash } from "node:crypto";
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
@@ -42,6 +43,37 @@ type RouteDependencies = {
     operation: () => Promise<void>,
   ) => void;
 };
+
+/**
+ * Route template for one broker operation, used as the bounded SQLCommenter
+ * `route` tag so PlanetScale Insights can attribute load per operation. Two
+ * operations share the collection route because they differ only by verb.
+ */
+export function irohRouteTemplate(operation: IrohRouteOperation): string {
+  switch (operation) {
+    case "challenge": return "/api/devices/iroh/challenge";
+    case "register": return "/api/devices/iroh/register";
+    case "endpoint_attestation": return "/api/devices/iroh/endpoint-attestations";
+    case "pair_grant": return "/api/devices/iroh/pair-grants";
+    case "relay_token": return "/api/devices/iroh/relay-token";
+    case "discover":
+    case "revoke":
+      return "/api/devices/iroh";
+  }
+}
+
+export function handleTaggedIrohRoute(
+  request: Request,
+  operation: IrohRouteOperation,
+  dependencies: RouteDependencies = {},
+): Promise<Response> {
+  // The broker routes bypass withApiRouteSpan (they verify tokens locally to
+  // stay off Stack's budget), so they set their own Cloud DB query tags here.
+  return runWithCloudDbQueryTags(
+    { source: "app", route: irohRouteTemplate(operation) },
+    async () => await handleIrohRoute(request, operation, dependencies),
+  );
+}
 
 export async function handleIrohRoute(
   request: Request,

--- a/web/tests/db-query-tags.test.ts
+++ b/web/tests/db-query-tags.test.ts
@@ -54,3 +54,33 @@ describe("cloud db query tags", () => {
     expect(formatCloudDbQueryComment(undefined, undefined)).toBe("/*application='cmux-web',source='app'*/");
   });
 });
+
+describe("iroh route query tags", () => {
+  test("every broker operation maps to its route template", async () => {
+    const { irohRouteTemplate } = await import("../services/iroh/routeHandler");
+    expect(irohRouteTemplate("challenge")).toBe("/api/devices/iroh/challenge");
+    expect(irohRouteTemplate("register")).toBe("/api/devices/iroh/register");
+    expect(irohRouteTemplate("discover")).toBe("/api/devices/iroh");
+    expect(irohRouteTemplate("revoke")).toBe("/api/devices/iroh");
+    expect(irohRouteTemplate("endpoint_attestation")).toBe("/api/devices/iroh/endpoint-attestations");
+    expect(irohRouteTemplate("pair_grant")).toBe("/api/devices/iroh/pair-grants");
+    expect(irohRouteTemplate("relay_token")).toBe("/api/devices/iroh/relay-token");
+  });
+
+  test("handleIrohRoute runs its work inside the route's tag context", async () => {
+    const { handleIrohRoute } = await import("../services/iroh/routeHandler");
+    let seen: ReturnType<typeof currentCloudDbQueryTags>;
+    const response = await handleIrohRoute(
+      new Request("https://cmux.test/api/devices/iroh/register", { method: "POST" }),
+      "register",
+      {
+        verify: async () => {
+          seen = currentCloudDbQueryTags();
+          return null;
+        },
+      },
+    );
+    expect(response.status).toBe(401);
+    expect(seen).toEqual({ source: "app", route: "/api/devices/iroh/register" });
+  });
+});

--- a/web/tests/db-query-tags.test.ts
+++ b/web/tests/db-query-tags.test.ts
@@ -68,9 +68,9 @@ describe("iroh route query tags", () => {
   });
 
   test("handleIrohRoute runs its work inside the route's tag context", async () => {
-    const { handleIrohRoute } = await import("../services/iroh/routeHandler");
+    const { handleTaggedIrohRoute } = await import("../services/iroh/routeHandler");
     let seen: ReturnType<typeof currentCloudDbQueryTags>;
-    const response = await handleIrohRoute(
+    const response = await handleTaggedIrohRoute(
       new Request("https://cmux.test/api/devices/iroh/register", { method: "POST" }),
       "register",
       {


### PR DESCRIPTION
After https://github.com/manaflow-ai/cmux/pull/12215 deployed, Insights shows `application=cmux-web`, `release`, and `source=app` on 2.9M statements per 3 h, but `route` only on the ten routes that use `withApiRouteSpan` (4.6k statements). The iroh broker routes and the relay token, allow, and preferences routes verify tokens locally and skip that wrapper, so the hottest statements carry no route.

`handleTaggedIrohRoute` wraps `handleIrohRoute` in `runWithCloudDbQueryTags` with a bounded template per operation (`discover` and `revoke` share `/api/devices/iroh`); the seven broker route files call the tagged entry. The three relay entrypoints wrap their handlers the same way. `handleIrohRoute` keeps its name so the complexity baseline stays matched.

Commit 1 adds two tests (template map, and that the injected verify dependency observes the route tag); commit 2 makes them pass. Broker and relay suites green, complexity gate flat.

https://claude.ai/code/session_01GDMKMnvdKKL4LHgACBmeNC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791596065&installation_model_id=21920&pr_number=12238&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12238&signature=3b99a96b155079bbb05e278d1e8db745f9f399ea75f739948933f4deab6dbdf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wrapping around existing handlers; no auth, business logic, or SQL behavior changes.
> 
> **Overview**
> Adds **Cloud DB SQLCommenter `route` tags** on high-traffic handlers that skip `withApiRouteSpan`, so PlanetScale Insights can attribute database load per API path instead of only `application`/`source`.
> 
> **Iroh broker:** New `handleTaggedIrohRoute` wraps `handleIrohRoute` in `runWithCloudDbQueryTags` using `irohRouteTemplate(operation)` (e.g. `discover`/`revoke` both map to `/api/devices/iroh`). All seven broker route entrypoints now call the tagged wrapper.
> 
> **Relay:** `POST /api/relay/allow`, `GET`/`PUT /api/relay/preferences`, and `POST /api/relay/token` wrap their existing handlers the same way with fixed route strings.
> 
> Tests lock the operation→template map and assert the tag context is active during broker handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9e7bfa0ba4389115b278973c620a2832b2a1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags broker and relay route queries with their route template so PlanetScale Insights can attribute the hottest statements to specific endpoints. Previously these routes verified tokens locally and skipped `withApiRouteSpan`, leaving most Cloud DB load without a route tag; now all broker operations and the three relay entrypoints run inside `runWithCloudDbQueryTags` with a bounded route per operation (discover and revoke share `/api/devices/iroh`).

<sup>Written for commit dc9e7bfa0ba4389115b278973c620a2832b2a1cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added route-specific tracking metadata to Iroh device and relay API requests.
  * Standardized tracking across device discovery, registration, pairing, challenges, endpoint attestations, revocation, relay access, preferences, and token operations.
  * Existing request behavior and responses remain unchanged.

* **Tests**
  * Added coverage to verify that route metadata is correctly assigned and preserved during request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->