### PR TITLE
web: set the health probe statement_timeout inside a transaction

### DIFF
--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -278,9 +278,17 @@ export async function pingCloudDb(
       prepare: false,
       connect_timeout: Math.max(1, Math.ceil(timeoutMs / 1_000)),
       idle_timeout: 1,
-      connection: { statement_timeout: Math.max(1, Math.floor(timeoutMs)) },
     });
-    const query = sql.unsafe("select 1");
+    // The deadline is set with `set local` inside an explicit transaction
+    // rather than as a startup parameter: PgBouncer in transaction pooling
+    // mode (the production pooled URL) rejects `statement_timeout` in the
+    // startup options with "unsupported startup parameter", and a plain
+    // session-level `set` would leak onto the shared server connection.
+    // One simple-protocol query keeps `query.cancel()` available for aborts.
+    const statementTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+    const query = sql.unsafe(
+      `begin; set local statement_timeout = ${statementTimeoutMs}; select 1; commit`,
+    );
     const cancel = () => {
       try {
         query.cancel();


### PR DESCRIPTION
`/api/coderouter/health` reports postgres `probe_failed` in production. The probe opened a fresh postgres.js connection with `connection: { statement_timeout }`, which PgBouncer in transaction pooling mode (the production pooled `DATABASE_URL` on PlanetScale) rejects at startup with `FATAL: unsupported startup parameter in options: statement_timeout`. Application queries never set it, so only the health endpoint and the coderouter alerts that read it were affected.

The probe now sends `begin; set local statement_timeout = N; select 1; commit` as one simple-protocol query. `set local` scopes the deadline to the transaction, so nothing leaks onto the pooled server connection, and `query.cancel()` still handles aborts.

Verified live from the worktree with `pingCloudDb` against both the pooled (port 6432) and direct (port 5432) PlanetScale URLs: both return in ~280 ms, where the pooled URL failed before. No unit test covers this because reproducing the failure needs a real PgBouncer.

https://claude.ai/code/session_0125iVvyn59KbAh8qjS861Qa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791598171&installation_model_id=21920&pr_number=12241&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12241&signature=8e318751d5d9ff56e975b85adcf5c536e5fe93482bd78368890ffbbb0e431ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the dedicated health probe connection path; application query clients are unchanged.
> 
> **Overview**
> Fixes production **`probe_failed`** on the coderouter health check when using a **PgBouncer transaction-pooled** `DATABASE_URL`.
> 
> The **`pingCloudDb`** URL-driver path no longer passes **`statement_timeout`** as a postgres.js startup option (PgBouncer rejects it with *unsupported startup parameter*). Instead, the probe runs a single simple-protocol statement: **`begin; set local statement_timeout = N; select 1; commit`**, so the deadline applies only inside that transaction and does not leak on the shared pooled backend connection. Abort handling via **`query.cancel()`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d92fd112621695f7472c4dec57ff69c7db41da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coderouter health probe reporting `probe_failed` against the production pooled `DATABASE_URL`. The probe previously passed `statement_timeout` as a postgres.js startup parameter, which PgBouncer in transaction pooling mode rejects at connection time.

The probe now sends `begin; set local statement_timeout = N; select 1; commit` as one simple-protocol query. `set local` keeps the deadline scoped to the transaction so it never leaks onto the shared pooled server connection, and `query.cancel()` still handles aborts.

<sup>Written for commit 57d92fd112621695f7472c4dec57ff69c7db41da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud database health checks when using transaction pooling.
  - Health probes now apply query timeouts in a way that remains compatible with supported connection poolers.
  - Existing query cancellation behavior is preserved for interrupted health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->