### PR TITLE
web: delete expired VM leases after a 7-day retention window

### DIFF
--- a/web/app/api/internal/vm/leases/revoke-expired/route.ts
+++ b/web/app/api/internal/vm/leases/revoke-expired/route.ts
@@ -1,5 +1,5 @@
 import { jsonResponse } from "@/services/vms/routeHelpers";
-import { revokeExpiredIdentityLeases, runVmWorkflow } from "@/services/vms/workflows";
+import { pruneExpiredLeases, revokeExpiredIdentityLeases, runVmWorkflow } from "@/services/vms/workflows";
 import { authorizeCronRequest } from "@/services/cronAuth";
 
 
@@ -22,5 +22,6 @@ async function handle(request: Request): Promise<Response> {
   }
 
   const revoked = await runVmWorkflow(revokeExpiredIdentityLeases());
-  return jsonResponse({ ok: true, revoked });
+  const deleted = await runVmWorkflow(pruneExpiredLeases());
+  return jsonResponse({ ok: true, revoked, deleted });
 }

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -482,6 +482,16 @@ export type VmRepositoryShape = {
     readonly userId: string;
     readonly limit: number;
   }) => Effect.Effect<CloudVmIdentityLeaseRow[], VmDatabaseError>;
+  /**
+   * Delete leases that expired before `before` and no longer need provider
+   * cleanup: either they never carried a provider identity, or that identity
+   * was already revoked. Leases with an unrevoked identity stay so the
+   * revoke cron keeps retrying them. Returns the number of rows deleted.
+   */
+  readonly deleteExpiredLeases?: (input: {
+    readonly before: Date;
+    readonly limit: number;
+  }) => Effect.Effect<number, VmDatabaseError>;
   readonly markLeaseRevocationRetry?: (input: {
     readonly id: string;
     readonly retryAfter: Date;
@@ -2969,6 +2979,27 @@ export const vmRepositoryLiveShape: VmRepositoryShape = {
           isNotNull(cloudVms.providerVmId),
         ))
         .orderBy(asc(cloudVmLeases.createdAt), asc(cloudVmLeases.id)) as CloudVmAccessLeaseRow[];
+    }),
+
+  deleteExpiredLeases: (input) =>
+    dbEffect("deleteExpiredLeases", async () => {
+      const db = cloudDb();
+      const candidates = db
+        .select({ id: cloudVmLeases.id })
+        .from(cloudVmLeases)
+        .where(
+          and(
+            lt(cloudVmLeases.expiresAt, input.before),
+            or(isNull(cloudVmLeases.providerIdentityHandle), isNotNull(cloudVmLeases.revokedAt)),
+          ),
+        )
+        .orderBy(asc(cloudVmLeases.expiresAt), asc(cloudVmLeases.id))
+        .limit(input.limit);
+      const deleted = await db
+        .delete(cloudVmLeases)
+        .where(inArray(cloudVmLeases.id, candidates))
+        .returning({ id: cloudVmLeases.id });
+      return deleted.length;
     }),
 
   markLeasesRevoked: (ids) =>

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -185,6 +185,10 @@ export const VmWorkflowLive = Layer.mergeAll(VmRepositoryWithAnalyticsLive, VmPr
 
 const EXPIRED_IDENTITY_REVOKE_BATCH = 5;
 const EXPIRED_IDENTITY_REVOKE_RETRY_BACKOFF_MS = 10 * 60 * 1000;
+/** Expired leases are kept this long for support and audit, then deleted. */
+export const EXPIRED_LEASE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+/** Delete batch per cron run; the cron runs every 10 minutes. */
+const EXPIRED_LEASE_DELETE_BATCH = 5_000;
 const IDENTITY_REVOKE_PROVIDER_TIMEOUT = "5 seconds";
 const ACTIVE_IDENTITY_REVOKE_HOT_PATH_LIMIT = 8;
 const ACCOUNT_DELETION_IDENTITY_REVOKE_BATCH = 8;
@@ -2432,6 +2436,28 @@ export function destroyVm(input: {
         ...(homeVolume ? { homeVolume, homeVolumeDeleted } : {}),
       },
     }).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
+
+/**
+ * Delete leases that expired more than `EXPIRED_LEASE_RETENTION_MS` ago and
+ * need no provider cleanup. Every attach and exec mints a lease, so without
+ * this the table grows by every session ever opened (11k rows, all expired,
+ * on the Aurora ledger before the PlanetScale move).
+ */
+export function pruneExpiredLeases(input: {
+  readonly now?: Date;
+  readonly limit?: number;
+} = {}) {
+  return Effect.gen(function* () {
+    const repo = yield* VmRepository;
+    const deleteExpiredLeases = repo.deleteExpiredLeases;
+    if (!deleteExpiredLeases) return 0;
+    const now = input.now ?? new Date();
+    return yield* deleteExpiredLeases({
+      before: new Date(now.getTime() - EXPIRED_LEASE_RETENTION_MS),
+      limit: input.limit ?? EXPIRED_LEASE_DELETE_BATCH,
+    });
   });
 }
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -58,6 +58,8 @@ import {
   openVmCmuxRemote,
   openVmSession,
   revokeExpiredIdentityLeases,
+  pruneExpiredLeases,
+  EXPIRED_LEASE_RETENTION_MS,
   revokeUserIdentityLeasesForAccountDeletion,
   resetBaseVm,
   restoreVm,
@@ -1428,6 +1430,53 @@ describe("VM Effect workflows", () => {
 
     expect(revokedIdentities).toEqual(["identity-account-delete-success"]);
     expect(String(thrown)).toContain(VmAccountDeletionIdentityRevocationError.name);
+  });
+
+  test("pruneExpiredLeases deletes leases expired past the retention window in one bounded batch", async () => {
+    const now = new Date("2026-09-10T00:00:00.000Z");
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000132",
+      userId: "user-workflow-prune-leases",
+      providerVmId: "provider-vm-prune-leases",
+      status: "running",
+    });
+    const calls: { before: Date; limit: number }[] = [];
+    const repo = testWorkflowRepo({
+      vm,
+      deleteExpiredLeases: (input) =>
+        Effect.sync(() => {
+          calls.push(input);
+          return 42;
+        }),
+    });
+
+    const deleted = await Effect.runPromise(
+      pruneExpiredLeases({ now }).pipe(
+        Effect.provide(workflowLayer(repo, unusedProviderGateway())),
+      ),
+    );
+
+    expect(deleted).toBe(42);
+    expect(calls).toEqual([
+      { before: new Date(now.getTime() - EXPIRED_LEASE_RETENTION_MS), limit: 5000 },
+    ]);
+    expect(EXPIRED_LEASE_RETENTION_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  test("pruneExpiredLeases is a no-op for repositories without the delete capability", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000133",
+      userId: "user-workflow-prune-leases-noop",
+      providerVmId: "provider-vm-prune-leases-noop",
+      status: "running",
+    });
+    const repo = testWorkflowRepo({ vm });
+
+    const deleted = await Effect.runPromise(
+      pruneExpiredLeases().pipe(Effect.provide(workflowLayer(repo, unusedProviderGateway()))),
+    );
+
+    expect(deleted).toBe(0);
   });
 
   test("revokeExpiredIdentityLeases uses a small default cron batch", async () => {
@@ -6222,6 +6271,7 @@ function testWorkflowRepo(input: {
   readonly leases?: RecordedLease[];
   readonly activeIdentityLeases?: CloudVmLeaseRow[];
   readonly expiredIdentityLeases?: VmRepositoryShape["expiredIdentityLeases"];
+  readonly deleteExpiredLeases?: VmRepositoryShape["deleteExpiredLeases"];
   readonly accountDeletionIdentityLeases?: VmRepositoryShape["accountDeletionIdentityLeases"];
   readonly markLeasesRevoked?: VmRepositoryShape["markLeasesRevoked"];
   readonly revokedLeaseIds?: string[];
@@ -6277,6 +6327,7 @@ function testWorkflowRepo(input: {
         input.leases?.push(lease);
       }),
     expiredIdentityLeases: input.expiredIdentityLeases,
+    deleteExpiredLeases: input.deleteExpiredLeases,
     accountDeletionIdentityLeases: input.accountDeletionIdentityLeases ?? (() => Effect.succeed([])),
     markLeaseRevocationRetry: (retry) =>
       Effect.sync(() => {


### PR DESCRIPTION
Every attach and exec mints a `cloud_vm_leases` row, and `/api/internal/vm/leases/revoke-expired` only stamped `revoked_at`. The Aurora ledger held 11,110 leases before the PlanetScale move, all expired, 10,673 of them from the last seven days.

The cron now also runs `pruneExpiredLeases`: delete leases that expired more than 7 days ago and need no provider cleanup (no provider identity handle, or identity already revoked), 5,000 rows per run through an `inArray` subselect ordered by expiry. Leases with an unrevoked identity are kept so the revoke path keeps retrying them. The route response gains a `deleted` count.

Tests: two workflow tests pin the cutoff (`now - 7d`), the batch size, and the no-op path for repositories without the delete capability. `bun test tests/vm-workflows.test.ts` 55 pass, `tests/vm-lease-cron-route.test.ts` 2 pass, complexity gate clean. `bun run typecheck` fails on `tests/billing-purchase.test.ts:3312` on main already; untouched here.

Part of the DB retention work after the Aurora suspension. The follow-up PR adds a retention registry so every table declares its bound or drain.

https://claude.ai/code/session_0125iVvyn59KbAh8qjS861Qa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791600506&installation_model_id=21920&pr_number=12246&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12246&signature=979707c7bd9b511896d84e0e5b1f57c79266e99ade638be3932942216dbd98bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes production lease rows on a schedule; incorrect eligibility rules could remove rows still needed for provider identity cleanup or audit.
> 
> **Overview**
> Adds **bounded deletion** of stale `cloud_vm_leases` rows so the table does not grow forever from attach/exec minting; the existing revoke cron only marked identities revoked.
> 
> The internal **`/api/internal/vm/leases/revoke-expired`** handler still runs `revokeExpiredIdentityLeases`, then runs new **`pruneExpiredLeases`**, which deletes leases expired more than **7 days** ago that are safe to remove (no provider identity handle, or identity already revoked). Leases with an **unrevoked** provider identity are left for the revoke path. The JSON response now includes a **`deleted`** count alongside **`revoked`**.
> 
> **`deleteExpiredLeases`** on the VM repository implements the delete with a capped batch (default **5,000** per run, ordered by expiry). Workflow tests cover the retention cutoff, batch size, and no-op when the repo lacks the optional method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091e12cea124ff9eb9d8d1d0a12ce242df466ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `cloud_vm_leases` table from growing without bound by deleting leases that expired more than 7 days ago, in addition to the existing revoke step in the revoke-expired cron.

**Behavior**
- Deletes up to 5,000 leases per cron run, keeping leases with an unrevoked provider identity so the revoke path keeps retrying them.
- The `/api/internal/vm/leases/revoke-expired` response now includes a `deleted` count.

<sup>Written for commit 78f0e2b9d6986eee6cfc114e137fd76a8c997e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expired VM access leases are now automatically pruned after a seven-day retention period.
  * Lease cleanup runs in bounded batches and preserves leases that may still require provider cleanup.
  * Cleanup results now include the number of deleted leases alongside revoked leases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->