### PR TITLE
web: retention registry, generic drain cron, and telemetry off the ledger

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,12 @@ reviews:
   profile: assertive
   request_changes_workflow: false
   path_instructions:
+    - path: "web/db/**"
+      instructions: |
+        Apply `.github/review-bot-rules/db-table-retention.md` during review. Every table in `web/db/schema.ts` must have a correct entry in `web/db/retention.ts`: rows created per request, command, heartbeat, session, attempt, or issuance are drains with a timestamp cutoff, not `bounded`; rows with `expires_at`/`revoked_at`/`consumed_at`/`closed_at` need a drain that deletes them; per-command telemetry goes to PostHog, not Postgres. The PR must state expected rows per day and the retention window.
+    - path: "web/services/**"
+      instructions: |
+        Apply `.github/review-bot-rules/db-table-retention.md` to new insert paths. Flag any insert that writes one Postgres row per request, command, heartbeat, or attempt into a table registered as `bounded` in `web/db/retention.ts`, and any new event-style insert with no drain or non-Postgres sink.
     - path: "**/*"
       instructions: |
         Apply `.github/review-bot-rules/source-control-artifacts.md` during review. Flag local tool output, generated logs, screenshots, recordings, temp folders, dependency checkouts, caches, build output, and broad scratch directories that enter source control without a deliberate product, docs, fixture, build, or release reason.

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -11,6 +11,7 @@ Current rules:
 - `algorithmic-complexity.md`
 - `browser-automation-webkit-waits-off-main.md`
 - `cache-substitution-correctness.md`
+- `db-table-retention.md`
 - `full-internationalization.md`
 - `hot-path-allocating-formatting.md`
 - `no-ambient-global-state.md`

--- a/.github/review-bot-rules/db-table-retention.md
+++ b/.github/review-bot-rules/db-table-retention.md
@@ -1,0 +1,24 @@
+# Every Table Has a Bound or a Drain
+
+Apply this rule to changes under `web/db/schema.ts`, `web/db/migrations/`, and any `web/` code that inserts rows. The registry `web/db/retention.ts` is the source of truth: every table declares `bounded` (one row per named entity, deleted with it), `permanent`, or `drain` (a cutoff column the generic cron deletes past, or a table-specific cron route). `web/tests/db-retention-registry.test.ts` fails when a table is missing, so this rule catches what the test cannot: entries that are technically valid but wrong.
+
+The lessons are from the Aurora ledger before the PlanetScale move: `iroh_registration_challenges` grew to 4.7 GB in 35 hours with eight indexes, `cloud_vm_usage_events` reached 35,000 rows of which 96% were per-command telemetry nobody read back, and `cloud_vm_leases` held 11,000 rows that were all expired because the cron only marked them.
+
+## Fail
+
+- A new table whose registry entry says `bounded` but whose rows are created per request, per command, per heartbeat, per session, or per attempt (event, log, issuance, lease, challenge, delivery, attempt, audit). Those are drains.
+- A new insert path that writes one row per request or per command into Postgres when the row is only read by analytics. Per-command telemetry goes to PostHog, Axiom, or ClickHouse.
+- A row with an `expires_at`, `revoked_at`, `consumed_at`, or `closed_at` column whose only lifecycle is being marked, with no drain that deletes it after a stated window.
+- A drain entry whose cutoff column is not the column the code expires on, or a `route` entry pointing at a cron that does not delete from that table.
+- A PR that adds a table or insert path without stating the expected rows per day and the retention window in its description.
+
+## Pass
+
+- A `bounded` table keyed by user, device, team, VM, or another entity that the account deletion path removes.
+- A `drain` entry with a timestamp cutoff column and a window justified in the PR (idempotency windows, support lookback, billing audit).
+- A `permanent` entry with a stated reason (deletion tombstones).
+- A high-volume event forwarded to PostHog through an existing capture path with no Postgres row.
+
+## Report
+
+When this rule fails, name the table and the insert site, say which lifecycle produces unbounded rows, and propose the registry entry (`drain` column and days, or the non-Postgres sink) the change should ship with.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -35,3 +35,14 @@ the checker, trusted workflow, complexity rule, and Oxlint lock entries
 unchanged in normal pull requests. Policy changes need a separate reviewed
 update. The contributor-side `Web complexity candidate` check is only an early
 local diagnostic.
+
+## Every table has a bound or a drain
+
+`db/retention.ts` maps every table in `db/schema.ts` to `bounded` (one row
+per user, device, team, or VM, deleted with it), `permanent`, or `drain` (a
+timestamp column the hourly `/api/cron/db-retention` deletes past, or a
+table-specific cron route). `tests/db-retention-registry.test.ts` fails on
+a table without an entry, a stale entry, or a drain column that is not a
+timestamp. Rows created per request, command, heartbeat, session, attempt,
+or issuance are drains, and per-command telemetry goes to PostHog, not
+Postgres. State the expected rows per day and the window in the PR.

--- a/web/app/api/cron/db-retention/route.ts
+++ b/web/app/api/cron/db-retention/route.ts
@@ -1,0 +1,40 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
+import { drainTableRetention } from "../../../../services/retention/drain";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+
+// The drain's own time budget is 20 s; this only guards a hung connection.
+export const maxDuration = 60;
+
+export async function GET(request: Request): Promise<Response> {
+  return handle(request);
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return handle(request);
+}
+
+async function handle(request: Request): Promise<Response> {
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok && auth.reason === "cron_secret_missing") {
+    return jsonResponse({ error: "service_unavailable" }, 503);
+  }
+  if (!auth.ok) {
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
+
+  try {
+    const startedAt = Date.now();
+    const retention = await drainTableRetention({ now: new Date() });
+    console.info("db retention drain completed", {
+      rows_deleted: retention.rowsDeleted,
+      batches: retention.batches,
+      budget_exhausted: retention.budgetExhausted,
+      by_table: retention.byTable,
+      duration_ms: Date.now() - startedAt,
+    });
+    return jsonResponse({ ok: true, retention });
+  } catch {
+    console.error("db retention drain failed", { failure: "database" });
+    return jsonResponse({ error: "db_retention_failed" }, 500);
+  }
+}

--- a/web/db/retention.ts
+++ b/web/db/retention.ts
@@ -1,0 +1,103 @@
+// Retention registry: every table in db/schema.ts declares how its size stays
+// bounded. tests/db-retention-registry.test.ts fails the build when a table is
+// missing here, when an entry names a table or column that does not exist, or
+// when a drain column is not a timestamp. The registry is the contract; the
+// generic drain in services/retention/drain.ts executes the `column` entries,
+// and the `route` entries point at the table-specific drains.
+//
+// Background: with no retention, cloud_vm_usage_events reached 35k rows in four
+// months (96% per-command telemetry), cloud_vm_leases held 11k rows that were
+// all expired, and iroh_registration_challenges grew to 4.7 GB in 35 hours.
+
+export type RetentionPolicy =
+  /** One row per named entity, deleted with it. Grows only with real users. */
+  | { readonly kind: "bounded"; readonly by: string }
+  /** Rows must never be deleted by any job. */
+  | { readonly kind: "permanent"; readonly reason: string }
+  /** The generic cron deletes rows whose `column` is older than `days`. */
+  | { readonly kind: "drain"; readonly column: string; readonly days: number }
+  /** A table-specific job at `route` deletes rows on its own schedule. */
+  | { readonly kind: "drain"; readonly route: string };
+
+const IROH_RETENTION = "/api/internal/iroh/retention";
+const LEASE_RETENTION = "/api/internal/vm/leases/revoke-expired";
+
+/** Keyed by SQL table name. Keep alphabetical. */
+export const TABLE_RETENTION: Readonly<Record<string, RetentionPolicy>> = {
+  account_analytics_forward_leases: { kind: "drain", column: "expires_at", days: 7 },
+  account_deletion_tombstones: { kind: "permanent", reason: "deleted accounts must stay deleted" },
+  account_mutation_leases: { kind: "bounded", by: "user" },
+  admin_plan_grants: { kind: "bounded", by: "grant" },
+  billing_email_claims: { kind: "bounded", by: "user" },
+  billing_email_verification_deliveries: { kind: "drain", column: "created_at", days: 365 },
+  cloud_organizations: { kind: "bounded", by: "organization" },
+  cloud_vm_access_grant_sessions: { kind: "bounded", by: "access grant" },
+  cloud_vm_access_grants: { kind: "bounded", by: "user device" },
+  cloud_vm_base_events: { kind: "drain", column: "created_at", days: 365 },
+  cloud_vm_base_generations: { kind: "bounded", by: "base" },
+  cloud_vm_bases: { kind: "bounded", by: "user" },
+  cloud_vm_billing_grants: { kind: "bounded", by: "customer item" },
+  cloud_vm_domains: { kind: "bounded", by: "owner hostname" },
+  cloud_vm_leases: { kind: "drain", route: LEASE_RETENTION },
+  cloud_vm_networks: { kind: "bounded", by: "user provider" },
+  cloud_vm_notification_deliveries: { kind: "bounded", by: "notification event (cascade)" },
+  cloud_vm_notification_events: { kind: "drain", column: "expires_at", days: 30 },
+  cloud_vm_publication_auth_codes: { kind: "drain", column: "expires_at", days: 7 },
+  cloud_vm_publication_auth_transactions: { kind: "drain", column: "expires_at", days: 7 },
+  cloud_vm_publication_email_grants: { kind: "bounded", by: "publication" },
+  cloud_vm_publication_provider_configs: { kind: "bounded", by: "provider" },
+  cloud_vm_publication_sessions: { kind: "drain", column: "expires_at", days: 30 },
+  cloud_vm_publication_vm_guards: { kind: "bounded", by: "vm" },
+  cloud_vm_publications: { kind: "bounded", by: "vm hostname" },
+  cloud_vm_sessions: { kind: "drain", column: "closed_at", days: 90 },
+  cloud_vm_tunnel_enrollment_locks: { kind: "drain", column: "expires_at", days: 7 },
+  cloud_vm_tunnels: { kind: "bounded", by: "user device purpose" },
+  cloud_vm_usage_events: { kind: "drain", column: "created_at", days: 365 },
+  cloud_vms: { kind: "bounded", by: "user (destroyed rows kept as the billing trail)" },
+  coderouter_accounts: { kind: "bounded", by: "team provider" },
+  coderouter_claude_accounts: { kind: "bounded", by: "team" },
+  coderouter_credentials: { kind: "bounded", by: "account" },
+  coderouter_route_tokens: { kind: "drain", column: "expires_at", days: 30 },
+  coderouter_session_accounts: { kind: "bounded", by: "team session" },
+  coderouter_vault_leases: { kind: "drain", column: "expires_at", days: 7 },
+  device_app_instances: { kind: "bounded", by: "device tag" },
+  device_tokens: { kind: "bounded", by: "device bundle" },
+  devices: { kind: "bounded", by: "user device" },
+  iroh_account_security_states: { kind: "bounded", by: "user" },
+  iroh_endpoint_bindings: { kind: "drain", route: IROH_RETENTION },
+  iroh_pair_grant_issuances: { kind: "drain", route: IROH_RETENTION },
+  iroh_registration_challenges: { kind: "drain", route: IROH_RETENTION },
+  iroh_relay_catalog_state: { kind: "bounded", by: "singleton" },
+  iroh_relay_preferences: { kind: "bounded", by: "account" },
+  iroh_relay_token_issuances: { kind: "drain", route: IROH_RETENTION },
+  notification_send_events: { kind: "drain", column: "expires_at", days: 30 },
+  pro_welcome_fulfillments: { kind: "bounded", by: "checkout session" },
+  rate_limit_alert_reports: { kind: "bounded", by: "alert key" },
+  stack_identity_snapshots: { kind: "bounded", by: "user" },
+  stripe_customers: { kind: "bounded", by: "customer" },
+  stripe_subscriptions: { kind: "bounded", by: "subscription" },
+  stripe_webhook_events: { kind: "drain", column: "created_at", days: 180 },
+  subrouter_tenants: { kind: "bounded", by: "team" },
+  vault_cli_auth_requests: { kind: "drain", column: "expires_at", days: 7 },
+  vault_sessions: { kind: "bounded", by: "user agent session" },
+  vault_snapshots: { kind: "bounded", by: "session" },
+  vault_upload_grants: { kind: "drain", column: "expires_at", days: 30 },
+  vault_upload_tombstones: { kind: "drain", column: "expires_at", days: 30 },
+};
+
+export type ColumnDrain = {
+  readonly table: string;
+  readonly column: string;
+  readonly days: number;
+};
+
+/** The entries the generic cron executes, in registry order. */
+export function columnDrains(registry: Readonly<Record<string, RetentionPolicy>> = TABLE_RETENTION): readonly ColumnDrain[] {
+  const drains: ColumnDrain[] = [];
+  for (const [table, policy] of Object.entries(registry)) {
+    if (policy.kind === "drain" && "column" in policy) {
+      drains.push({ table, column: policy.column, days: policy.days });
+    }
+  }
+  return drains;
+}

--- a/web/services/retention/drain.ts
+++ b/web/services/retention/drain.ts
@@ -1,0 +1,106 @@
+// Generic retention drain for the `column` entries of db/retention.ts.
+//
+// Each batch is one statement that deletes at most `batchSize` rows older than
+// the table's cutoff, addressed by ctid so tables with composite or natural
+// keys need no special case. Batches stay small and the run is bounded by a
+// row and time budget, so a large backlog is worked off across cron runs
+// without holding long locks. Identifiers come only from the registry, which
+// the schema test checks against real tables and timestamp columns.
+import { sql } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { columnDrains, type ColumnDrain } from "../../db/retention";
+
+export const RETENTION_BATCH_SIZE = 500;
+export const RETENTION_MAX_ROWS = 50_000;
+export const RETENTION_MAX_DURATION_MS = 20_000;
+
+export type RetentionDrainResult = {
+  readonly rowsDeleted: number;
+  readonly batches: number;
+  readonly byTable: Readonly<Record<string, number>>;
+  readonly budgetExhausted: "rows" | "time" | null;
+};
+
+export type RetentionDrainDependencies = {
+  readonly deleteBatch: (drain: ColumnDrain, cutoff: Date, limit: number) => Promise<number>;
+  readonly now: () => number;
+};
+
+export function cutoffFor(drain: ColumnDrain, now: Date): Date {
+  return new Date(now.getTime() - drain.days * 24 * 60 * 60 * 1_000);
+}
+
+/** The exact statement one batch runs. Exported so the test can pin its shape. */
+export function deleteBatchStatement(drain: ColumnDrain, cutoff: Date, limit: number) {
+  const table = sql.identifier(drain.table);
+  const column = sql.identifier(drain.column);
+  return sql`
+    with candidates as materialized (
+      select ctid
+      from ${table}
+      where ${column} < ${cutoff.toISOString()}::timestamptz
+      order by ${column}
+      limit ${limit}
+    ), deleted as (
+      delete from ${table}
+      where ctid in (select ctid from candidates)
+      returning 1
+    )
+    select count(*)::int as affected from deleted
+  `;
+}
+
+async function deleteBatchInDatabase(drain: ColumnDrain, cutoff: Date, limit: number): Promise<number> {
+  const result = await cloudDb().execute(deleteBatchStatement(drain, cutoff, limit));
+  const rows = Array.isArray(result)
+    ? result as readonly Record<string, unknown>[]
+    : ((result as { readonly rows?: unknown } | null)?.rows as readonly Record<string, unknown>[] | undefined) ?? [];
+  const affected = Number(rows[0]?.affected ?? 0);
+  if (!Number.isSafeInteger(affected) || affected < 0 || affected > limit) {
+    throw new Error(`invalid retention batch result for ${drain.table}`);
+  }
+  return affected;
+}
+
+export const defaultRetentionDrainDependencies: RetentionDrainDependencies = {
+  deleteBatch: deleteBatchInDatabase,
+  now: () => Date.now(),
+};
+
+export async function drainTableRetention(
+  input: {
+    readonly now: Date;
+    readonly drains?: readonly ColumnDrain[];
+    readonly maxRows?: number;
+    readonly maxDurationMs?: number;
+    readonly batchSize?: number;
+  },
+  dependencies: RetentionDrainDependencies = defaultRetentionDrainDependencies,
+): Promise<RetentionDrainResult> {
+  const drains = input.drains ?? columnDrains();
+  const maxRows = input.maxRows ?? RETENTION_MAX_ROWS;
+  const maxDurationMs = input.maxDurationMs ?? RETENTION_MAX_DURATION_MS;
+  const batchSize = input.batchSize ?? RETENTION_BATCH_SIZE;
+  const startedAt = dependencies.now();
+  const byTable: Record<string, number> = {};
+  let rowsDeleted = 0;
+  let batches = 0;
+  let budgetExhausted: RetentionDrainResult["budgetExhausted"] = null;
+
+  outer: for (const drain of drains) {
+    const cutoff = cutoffFor(drain, input.now);
+    byTable[drain.table] = 0;
+    for (;;) {
+      if (rowsDeleted >= maxRows) { budgetExhausted = "rows"; break outer; }
+      if (dependencies.now() - startedAt >= maxDurationMs) { budgetExhausted = "time"; break outer; }
+      const limit = Math.min(batchSize, maxRows - rowsDeleted);
+      const affected = await dependencies.deleteBatch(drain, cutoff, limit);
+      batches += 1;
+      rowsDeleted += affected;
+      byTable[drain.table] += affected;
+      if (affected < limit) break;
+    }
+  }
+  return { rowsDeleted, batches, byTable, budgetExhausted };
+}

--- a/web/services/vms/productAnalytics.ts
+++ b/web/services/vms/productAnalytics.ts
@@ -41,6 +41,14 @@ export const VM_LEDGER_TO_POSTHOG_EVENT = {
 } as const satisfies Record<string, string>;
 
 export type VmLedgerEventType = keyof typeof VM_LEDGER_TO_POSTHOG_EVENT;
+
+/**
+ * Per-command telemetry that reaches PostHog only. These were 96% of the
+ * `cloud_vm_usage_events` ledger (33,700 of 35,000 rows in four months) and
+ * nothing reads them back from Postgres: billing, the reaper, alerts, and the
+ * snapshot checks all key on lifecycle and credit rows.
+ */
+export const TELEMETRY_ONLY_LEDGER_TYPES: ReadonlySet<string> = new Set(["vm.exec", "vm.attach"]);
 export type VmProductEventName = (typeof VM_LEDGER_TO_POSTHOG_EVENT)[VmLedgerEventType];
 
 export const VM_PRODUCT_EVENT_NAMES: readonly VmProductEventName[] = Object.values(VM_LEDGER_TO_POSTHOG_EVENT);
@@ -200,15 +208,20 @@ export function withVmProductAnalytics(
   return {
     ...repository,
     recordUsageEvent: (input) =>
-      repository.recordUsageEvent(input).pipe(
-        Effect.tap(() => Effect.sync(() => safeCapture(input))),
-      ),
-    recordUsageEvents: (inputs) =>
-      repository.recordUsageEvents(inputs).pipe(
+      TELEMETRY_ONLY_LEDGER_TYPES.has(input.eventType)
+        ? Effect.sync(() => safeCapture(input))
+        : repository.recordUsageEvent(input).pipe(
+          Effect.tap(() => Effect.sync(() => safeCapture(input))),
+        ),
+    recordUsageEvents: (inputs) => {
+      const persisted = inputs.filter((input) => !TELEMETRY_ONLY_LEDGER_TYPES.has(input.eventType));
+      const write = persisted.length === 0 ? Effect.void : repository.recordUsageEvents(persisted);
+      return write.pipe(
         Effect.tap(() => Effect.sync(() => {
           for (const input of inputs) safeCapture(input);
         })),
-      ),
+      );
+    },
   };
 }
 

--- a/web/tests/db-retention-cron-route.test.ts
+++ b/web/tests/db-retention-cron-route.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const originalCronSecret = process.env.CRON_SECRET;
+
+const route = await import("../app/api/cron/db-retention/route");
+
+afterEach(() => {
+  if (typeof originalCronSecret === "undefined") {
+    delete process.env.CRON_SECRET;
+  } else {
+    process.env.CRON_SECRET = originalCronSecret;
+  }
+});
+
+describe("db retention cron route", () => {
+  test("reports service unavailable without naming the secret when the cron secret is missing", async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await route.POST(new Request("https://cmux.test/api/cron/db-retention", { method: "POST" }));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "service_unavailable" });
+  });
+
+  test("requires the configured cron secret before draining", async () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    const response = await route.POST(
+      new Request("https://cmux.test/api/cron/db-retention", {
+        method: "POST",
+        headers: { authorization: "Bearer wrong" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "unauthorized" });
+  });
+});

--- a/web/tests/db-retention-registry.test.ts
+++ b/web/tests/db-retention-registry.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { getTableColumns, getTableName, is } from "drizzle-orm";
+import { CasingCache } from "drizzle-orm/casing";
+import { PgTable, PgTimestamp } from "drizzle-orm/pg-core";
+
+import * as schema from "../db/schema";
+import { columnDrains, TABLE_RETENTION } from "../db/retention";
+import {
+  cutoffFor,
+  deleteBatchStatement,
+  drainTableRetention,
+  type RetentionDrainDependencies,
+} from "../services/retention/drain";
+
+const schemaTables = (Object.values(schema) as unknown[]).filter((value): value is PgTable => is(value, PgTable));
+const schemaByName = new Map(schemaTables.map((table) => [getTableName(table), table]));
+
+describe("table retention registry", () => {
+  test("every schema table declares a retention policy", () => {
+    expect(schemaTables.length).toBeGreaterThan(0);
+    const missing = [...schemaByName.keys()].filter((name) => !(name in TABLE_RETENTION)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  test("every registry entry names a real table", () => {
+    const stale = Object.keys(TABLE_RETENTION).filter((name) => !schemaByName.has(name)).sort();
+    expect(stale).toEqual([]);
+  });
+
+  test("every column drain points at a timestamp column and a positive cutoff", () => {
+    const problems: string[] = [];
+    for (const drain of columnDrains()) {
+      const table = schemaByName.get(drain.table);
+      if (!table) { problems.push(`${drain.table}: unknown table`); continue; }
+      const column = Object.values(getTableColumns(table)).find((candidate) => candidate.name === drain.column);
+      if (!column) problems.push(`${drain.table}.${drain.column}: unknown column`);
+      else if (!is(column, PgTimestamp)) problems.push(`${drain.table}.${drain.column}: not a timestamp`);
+      if (!Number.isInteger(drain.days) || drain.days <= 0) problems.push(`${drain.table}: days must be a positive integer`);
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test("every route drain names a cron route that is scheduled", async () => {
+    const vercel = (await import("../vercel.json")) as { crons: { path: string }[] };
+    const scheduled = new Set(vercel.crons.map((cron) => cron.path));
+    const unscheduled = Object.entries(TABLE_RETENTION)
+      .filter(([, policy]) => policy.kind === "drain" && "route" in policy && !scheduled.has(policy.route))
+      .map(([table]) => table);
+    expect(unscheduled).toEqual([]);
+    expect(scheduled.has("/api/cron/db-retention")).toBe(true);
+  });
+});
+
+describe("generic retention drain", () => {
+  const drain = { table: "cloud_vm_usage_events", column: "created_at", days: 365 } as const;
+
+  test("the batch statement deletes by ctid below the cutoff with a limit", () => {
+    const cutoff = new Date("2025-09-10T00:00:00.000Z");
+    const query = deleteBatchStatement(drain, cutoff, 500).toQuery({
+      escapeName: (name) => `"${name}"`,
+      escapeParam: (index) => `$${index + 1}`,
+      escapeString: (value) => `'${value}'`,
+      casing: new CasingCache(),
+    });
+    const text = query.sql.replace(/\s+/g, " ");
+    expect(text).toContain('from "cloud_vm_usage_events" where "created_at" < $1::timestamptz order by "created_at" limit $2');
+    expect(text).toContain('delete from "cloud_vm_usage_events" where ctid in (select ctid from candidates)');
+    expect(query.params).toEqual([cutoff.toISOString(), 500]);
+  });
+
+  test("the cutoff is the retention window before now", () => {
+    const now = new Date("2026-09-10T00:00:00.000Z");
+    expect(cutoffFor(drain, now).toISOString()).toBe("2025-09-10T00:00:00.000Z");
+  });
+
+  test("drains each table in batches until a short batch, within the row budget", async () => {
+    const calls: { table: string; limit: number }[] = [];
+    const backlog: Record<string, number> = { a: 1_200, b: 0, c: 300 };
+    const dependencies: RetentionDrainDependencies = {
+      now: () => 0,
+      deleteBatch: async (target, _cutoff, limit) => {
+        calls.push({ table: target.table, limit });
+        const affected = Math.min(limit, backlog[target.table] ?? 0);
+        backlog[target.table] = (backlog[target.table] ?? 0) - affected;
+        return affected;
+      },
+    };
+    const drains = ["a", "b", "c"].map((table) => ({ table, column: "created_at", days: 1 }));
+
+    const result = await drainTableRetention({ now: new Date(), drains, batchSize: 500 }, dependencies);
+
+    expect(result.byTable).toEqual({ a: 1_200, b: 0, c: 300 });
+    expect(result.rowsDeleted).toBe(1_500);
+    expect(result.batches).toBe(5);
+    expect(result.budgetExhausted).toBeNull();
+    expect(calls.map((call) => call.limit)).toEqual([500, 500, 500, 500, 500]);
+  });
+
+  test("stops at the row budget and reports it", async () => {
+    const dependencies: RetentionDrainDependencies = {
+      now: () => 0,
+      deleteBatch: async (_target, _cutoff, limit) => limit,
+    };
+    const drains = [{ table: "a", column: "created_at", days: 1 }];
+
+    const result = await drainTableRetention({ now: new Date(), drains, batchSize: 500, maxRows: 1_200 }, dependencies);
+
+    expect(result.rowsDeleted).toBe(1_200);
+    expect(result.batches).toBe(3);
+    expect(result.budgetExhausted).toBe("rows");
+  });
+
+  test("stops at the time budget between batches", async () => {
+    let clock = 0;
+    const dependencies: RetentionDrainDependencies = {
+      now: () => clock,
+      deleteBatch: async (_target, _cutoff, limit) => {
+        clock += 6_000;
+        return limit;
+      },
+    };
+    const drains = [{ table: "a", column: "created_at", days: 1 }];
+
+    const result = await drainTableRetention({ now: new Date(), drains, maxDurationMs: 10_000 }, dependencies);
+
+    expect(result.batches).toBe(2);
+    expect(result.budgetExhausted).toBe("time");
+  });
+});

--- a/web/tests/vm-product-analytics.test.ts
+++ b/web/tests/vm-product-analytics.test.ts
@@ -191,7 +191,20 @@ describe("repository analytics sink", () => {
       ledgerRow({ eventType: "vm.create.failed" }),
     ]));
     expect(captured.map((input) => input.eventType)).toEqual(["vm.created", "vm.attach", "vm.create.failed"]);
-    expect(written.map((input) => input.eventType)).toEqual(["vm.created", "vm.attach", "vm.create.failed"]);
+    expect(written.map((input) => input.eventType)).toEqual(["vm.created", "vm.create.failed"]);
+  });
+
+  test("exec and attach reach PostHog without a ledger row", async () => {
+    const { repo, written } = fakeRepository();
+    const captured: VmUsageEventInput[] = [];
+    const decorated = withVmProductAnalytics(repo, (input) => {
+      captured.push(input);
+    });
+    await Effect.runPromise(decorated.recordUsageEvent(ledgerRow({ eventType: "vm.exec" })));
+    await Effect.runPromise(decorated.recordUsageEvent(ledgerRow({ eventType: "vm.attach" })));
+    await Effect.runPromise(decorated.recordUsageEvents([ledgerRow({ eventType: "vm.exec" })]));
+    expect(captured.map((input) => input.eventType)).toEqual(["vm.exec", "vm.attach", "vm.exec"]);
+    expect(written).toHaveLength(0);
   });
 
   test("a throwing capture never fails the ledger write", async () => {

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -38,6 +38,10 @@
     {
       "path": "/api/cron/vm-reaper",
       "schedule": "49 * * * *"
+    },
+    {
+      "path": "/api/cron/db-retention",
+      "schedule": "41 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/12246. Background: before the PlanetScale move the Aurora ledger had `iroh_registration_challenges` at 4.7 GB after 35 hours, `cloud_vm_usage_events` at 35k rows (96% per-command telemetry), and `cloud_vm_leases` at 11k rows, all expired.

**Registry.** `web/db/retention.ts` maps every table in `db/schema.ts` to `bounded`, `permanent`, or `drain` (a timestamp column the generic cron deletes past, or a table-specific cron route). `tests/db-retention-registry.test.ts` imports the schema at runtime and fails on a table without an entry, a stale entry, a non-timestamp drain column, or a route drain missing from `vercel.json`. Adding a table without deciding its retention no longer compiles green.

**Generic drain.** `/api/cron/db-retention` runs hourly. Each batch deletes at most 500 rows older than the cutoff, addressed by ctid so composite and natural keys need no special case, under a 50,000-row and 20-second budget. Identifiers come only from the registry, which the test checks against real tables and columns. Column drains (17 tables): expired publication auth codes and transactions, tunnel enrollment locks, vault CLI auth requests, coderouter vault leases, analytics forward leases after 7 days; notification events, publication sessions, coderouter route tokens, vault upload grants and tombstones, notification send events after 30 days; closed VM sessions after 90 days; Stripe webhook idempotency rows after 180 days; usage events, base events, billing email deliveries after 365 days. Every statement was executed against the pooled PlanetScale URL with a no-match cutoff, about 56 ms each, 0 rows affected.

**Telemetry off the ledger.** `vm.exec` and `vm.attach` reach PostHog through the existing capture decorator without a ledger row. Readers of the ledger (billing credits, reaper, alerts, snapshot checks, per-user count in the data export) key on other types.

**Enforcement for future agents.** `.github/review-bot-rules/db-table-retention.md` plus CodeRabbit path instructions for `web/db/**` and `web/services/**`, and a section in `web/AGENTS.md`. The test is the hard gate; the rule and doc catch entries that are valid but wrong.

Expected volume after this PR: usage events about 5 rows/day, leases deleted by 12246, everything else bounded or drained. Tests: 82 pass across the registry, cron route, analytics, and workflow files. `bun run typecheck` still fails only on the pre-existing `tests/billing-purchase.test.ts` errors on main.

https://claude.ai/code/session_0125iVvyn59KbAh8qjS861Qa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791600898&installation_model_id=21920&pr_number=12247&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12247&signature=15f6efd233db202fc5f6b030768fc50ba4c022be26ac182477fb827212b3e74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a retention registry covering every table in the schema, a generic hourly cron that deletes expired rows, and moves `vm.exec` and `vm.attach` telemetry out of the Postgres ledger into PostHog.

**What changed**
- New `web/db/retention.ts` maps each table to `bounded`, `permanent`, or `drain`; a schema test fails on missing or invalid entries, now covering the tables merged in from main.
- New `/api/cron/db-retention` drains 17 tables in 500-row batches under a 50,000-row and 20-second budget.
- `vm.exec` and `vm.attach` no longer write ledger rows; they still reach PostHog through the existing capture path.
- Added a review-bot rule and `AGENTS.md` section so future changes must state retention windows.
- The drain cron is scheduled in `vercel.json`; route-based drains for iroh and lease tables are unchanged.

<sup>Written for commit c379a561e31db175c003a580325b67120e4a2090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a production cron that deletes rows across many tables from registry config; misclassified policies or drain columns could remove needed data or leave tables unbounded. Skipping ledger writes for `vm.exec`/`vm.attach` changes persisted analytics history but is scoped to types documented as telemetry-only.
> 
> **Overview**
> Introduces a **table retention contract** so Postgres growth stays bounded: `web/db/retention.ts` classifies every schema table as `bounded`, `permanent`, or `drain` (timestamp column or dedicated cron route), with `tests/db-retention-registry.test.ts` enforcing coverage, valid drain columns, and scheduled routes in `vercel.json`.
> 
> Adds an **hourly generic drain** at `/api/cron/db-retention` (scheduled `41 * * * *`) that batch-deletes stale rows for registry `column` drains via `services/retention/drain.ts`, with row/time budgets and ctid-based deletes.
> 
> **Stops persisting high-volume VM telemetry** in `cloud_vm_usage_events`: `vm.exec` and `vm.attach` still go to PostHog through `withVmProductAnalytics` but skip ledger inserts.
> 
> **Future PR enforcement** via `db-table-retention.md`, CodeRabbit path rules for `web/db/**` and `web/services/**`, and an `web/AGENTS.md` section requiring expected rows/day and retention windows in PR descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253b9c705d4eff35aba4e9203da2c4cf26949efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated database retention policies and scheduled cleanup for eligible records.
  - Added an authorized retention-maintenance endpoint with processing limits and failure handling.
  - Added safeguards ensuring database tables have defined retention behavior.

- **Changes**
  - VM execution and attachment analytics are now sent to PostHog without being stored in the database ledger.
  - Database retention cleanup now runs automatically on an hourly schedule.

- **Tests**
  - Added coverage for retention configuration, cleanup behavior, endpoint authorization, and analytics storage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->