### PR TITLE
web: send the mailbox verification link when Stack refuses a purchase sign-in link

### DIFF
--- a/web/services/billing/purchase.ts
+++ b/web/services/billing/purchase.ts
@@ -128,6 +128,17 @@ export type StackBillingUser = ProBillingClaimUser & {
     primaryEmailVerified?: boolean;
     clientReadOnlyMetadata?: unknown;
   }): Promise<unknown>;
+  listContactChannels?(): Promise<readonly StackBillingContactChannel[]>;
+};
+
+/** The slice of a Stack contact channel the purchase email path uses. */
+export type StackBillingContactChannel = {
+  readonly id: string;
+  readonly type: string;
+  readonly value: string;
+  readonly isPrimary: boolean;
+  readonly isVerified: boolean;
+  sendVerificationEmail(options?: { callbackUrl?: string }): Promise<unknown>;
 };
 
 type StackBillingUserLookup = {
@@ -3062,23 +3073,66 @@ async function requestPurchaseMagicLink(
       },
       async () => {
         await mutationLease.refresh();
-        const result = await input.stackApp!.sendMagicLinkEmail!(input.email, {
-          callbackUrl: PURCHASE_MAGIC_LINK_CALLBACK,
+        await deliverPurchaseSignInEmail(input.stackApp!, {
+          email: input.email,
+          stackUserId: input.stackUserId,
         });
-        if (isFailedStackResult(result)) {
-          throw new PurchaseMagicLinkProviderRejectedError(
-            "Stack sign-in link request failed",
-          );
-        }
       },
     );
-  } catch {
+  } catch (error) {
     // The billing rows are already durable. A failed message can be retried by
     // the recovery endpoint, so email delivery must not roll back a purchase.
     console.warn("billing.purchase.magic_link_failed", {
-      failure: "provider_unavailable",
+      failure: error instanceof PurchaseMagicLinkProviderRejectedError
+        ? "provider_rejected"
+        : "provider_unavailable",
+      message: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+const PURCHASE_VERIFICATION_CALLBACK = "https://cmux.com/handler/email-verification";
+
+/**
+ * Send the purchaser the one email that lets them reach their entitlement.
+ *
+ * Stack refuses a sign-in (magic) link for an address that belongs to an
+ * existing unverified user, and the checkout shell is created exactly that
+ * way, so the sign-in link alone never reached a new purchaser. When Stack
+ * refuses it, send the mailbox verification link for that contact channel
+ * instead: verifying the address is what lets the purchaser sign in, and the
+ * after-sign-in handler then transfers the parked claim.
+ */
+export async function deliverPurchaseSignInEmail(
+  stackApp: Pick<StackBillingApp, "sendMagicLinkEmail" | "getUser">,
+  input: { readonly email: string; readonly stackUserId: string },
+): Promise<"magic_link" | "verification"> {
+  if (!stackApp.sendMagicLinkEmail) {
+    throw new PurchaseMagicLinkProviderRejectedError("Stack cannot send sign-in links");
+  }
+  const result = await stackApp.sendMagicLinkEmail(input.email, {
+    callbackUrl: PURCHASE_MAGIC_LINK_CALLBACK,
+  });
+  if (!isFailedStackResult(result)) return "magic_link";
+  const matching = canonicalizeEmailForMatching(input.email);
+  const user = await stackApp.getUser(input.stackUserId);
+  const channels = (await user?.listContactChannels?.()) ?? [];
+  const channel = channels.find(
+    (candidate) =>
+      candidate.type === "email" &&
+      !candidate.isVerified &&
+      canonicalizeEmailForMatching(candidate.value) === matching,
+  );
+  if (!channel) {
+    throw new PurchaseMagicLinkProviderRejectedError("Stack sign-in link request failed");
+  }
+  const verification = await channel.sendVerificationEmail({
+    callbackUrl: PURCHASE_VERIFICATION_CALLBACK,
+  });
+  if (isFailedStackResult(verification)) {
+    throw new PurchaseMagicLinkProviderRejectedError("Stack verification email request failed");
+  }
+  return "verification";
 }
 
 async function stackUserIdForStripeCustomer(

--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -3312,3 +3312,52 @@ describe("billing user lookup without a user-list scan", () => {
     expect(listUsers.mock.calls.length).toBeLessThanOrEqual(400);
   });
 });
+
+describe("purchase sign-in email delivery", () => {
+  test("sends the magic link when Stack accepts it", async () => {
+    const { deliverPurchaseSignInEmail } = await import("../services/billing/purchase");
+    const sendMagicLinkEmail = mock(async () => undefined);
+    const kind = await deliverPurchaseSignInEmail(
+      { sendMagicLinkEmail, getUser: mock(async () => null) } as never,
+      { email: "buyer@example.com", stackUserId: "u1" },
+    );
+    expect(kind).toBe("magic_link");
+    expect(sendMagicLinkEmail).toHaveBeenCalledWith("buyer@example.com", {
+      callbackUrl: "https://cmux.com/handler/after-sign-in",
+    });
+  });
+
+  test("falls back to the mailbox verification link when Stack refuses a sign-in link for an unverified shell", async () => {
+    const { deliverPurchaseSignInEmail } = await import("../services/billing/purchase");
+    const sendVerificationEmail = mock(async () => undefined);
+    const channel = {
+      id: "ch1",
+      type: "email",
+      value: "Buyer@Example.com",
+      isPrimary: true,
+      isVerified: false,
+      usedForAuth: true,
+      sendVerificationEmail,
+    };
+    const stackApp = {
+      sendMagicLinkEmail: mock(async () => ({ status: "error", error: { code: "USER_EMAIL_ALREADY_EXISTS" } })),
+      getUser: mock(async () => ({ id: "u1", primaryEmail: "buyer@example.com", listContactChannels: async () => [channel] })),
+    };
+    const kind = await deliverPurchaseSignInEmail(stackApp as never, { email: "buyer@example.com", stackUserId: "u1" });
+    expect(kind).toBe("verification");
+    expect(sendVerificationEmail).toHaveBeenCalledWith({
+      callbackUrl: "https://cmux.com/handler/email-verification",
+    });
+  });
+
+  test("a refused sign-in link with no unverified channel is a provider rejection", async () => {
+    const { deliverPurchaseSignInEmail, PurchaseMagicLinkProviderRejectedError } = await import("../services/billing/purchase");
+    const stackApp = {
+      sendMagicLinkEmail: mock(async () => ({ status: "error" })),
+      getUser: mock(async () => ({ id: "u1", primaryEmail: "buyer@example.com", listContactChannels: async () => [] })),
+    };
+    await expect(
+      deliverPurchaseSignInEmail(stackApp as never, { email: "buyer@example.com", stackUserId: "u1" }),
+    ).rejects.toBeInstanceOf(PurchaseMagicLinkProviderRejectedError);
+  });
+});

--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -3351,7 +3351,8 @@ describe("purchase sign-in email delivery", () => {
   });
 
   test("a refused sign-in link with no unverified channel is a provider rejection", async () => {
-    const { deliverPurchaseSignInEmail, PurchaseMagicLinkProviderRejectedError } = await import("../services/billing/purchase");
+    const { deliverPurchaseSignInEmail } = await import("../services/billing/purchase");
+    const { PurchaseMagicLinkProviderRejectedError } = await import("../services/billing/emailVerificationDelivery");
     const stackApp = {
       sendMagicLinkEmail: mock(async () => ({ status: "error" })),
       getUser: mock(async () => ({ id: "u1", primaryEmail: "buyer@example.com", listContactChannels: async () => [] })),


### PR DESCRIPTION
**Bug.** After a paid checkout the purchaser's shell account is created unverified (by design: a Stripe email does not prove mailbox control), and the code then asks Stack for a sign-in magic link to that address. Stack refuses that with `USER_EMAIL_ALREADY_EXISTS` / `would_work_if_email_was_verified` for any existing unverified user, so the link was never sent and the failure was logged as `provider_unavailable`. In the 2026-09-10 backfill run 161 of 161 sign-in emails failed this way. Reproduced by calling Stack's send-sign-in-code endpoint for one such account (409), and by sending that same account a contact-channel verification email (200).

**Fix.** `deliverPurchaseSignInEmail` sends the sign-in link and, when Stack refuses it, sends the verification link for the matching unverified email contact channel (callback `/handler/email-verification`). Verifying the mailbox is exactly what lets the purchaser sign in, and `/handler/after-sign-in` then transfers the parked claim through `claimPendingProBilling`. The warning now carries the failure kind and message. A rejected attempt still releases the delivery row, so re-running the by-email backfill retries only the unsent emails. Principled: the verification link is the channel Stack provides for this state; no verification flag is forced from payment data.

**Tests.** Commit 1 adds three failing tests (accepted link, refused link falls back to the verification link, refused link with no unverified channel is a provider rejection); commit 2 makes them pass. Purchase and email-verification suites green, complexity gate flat.

**Repair after merge.** `bun run stripe:backfill-subscriptions --by-email --apply` resends the 161 refused emails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791602884&installation_model_id=21920&pr_number=12249&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12249&signature=ab11ca22eebafe572d5a0f7ee5ce21133c2cc4289143fc738f578a14e46afbee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-purchase auth email behavior for unverified Stack accounts; wrong channel matching could send the wrong link, but billing commits are unchanged and delivery remains idempotent/retryable.
> 
> **Overview**
> Fixes **post-checkout email delivery** when Stack rejects a sign-in magic link for an **unverified purchaser shell** (the usual checkout path).
> 
> Purchase magic-link sending now goes through **`deliverPurchaseSignInEmail`**: it still requests the after-sign-in magic link first; if Stack returns an error, it loads the user’s contact channels and sends a **mailbox verification** email on the matching unverified email channel (`/handler/email-verification`) instead of treating the attempt as a generic provider failure. **`StackBillingUser`** gains optional **`listContactChannels`** and a **`StackBillingContactChannel`** type for that fallback. **`requestPurchaseMagicLink`** warnings distinguish **`provider_rejected`** from **`provider_unavailable`** and include the error message.
> 
> Three unit tests cover the happy path, verification fallback, and rejection when no unverified channel exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f89d42f290962882d691972d17630c13e1b4003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes purchase sign-in emails being dropped when Stack refuses a magic link for a purchaser whose shell account is unverified.

- `deliverPurchaseSignInEmail` now falls back to sending the mailbox verification link for the matching unverified email contact channel when Stack refuses the sign-in link.
- Verifying the mailbox lets the purchaser sign in; the after-sign-in handler then transfers the parked claim.
- The log warning now carries the failure kind and message; a rejected attempt still releases the delivery row, so re-running the by-email backfill retries only the unsent emails.
- Adds tests for accepted links, refused links falling back to verification, and refused links with no unverified channel treated as provider rejections.

After merge, run `bun run stripe:backfill-subscriptions --by-email --apply` to resend the 161 refused emails.

<sup>Written for commit 9f89d42f290962882d691972d17630c13e1b4003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase sign-in emails now support fallback delivery through an eligible unverified email channel when magic-link delivery is rejected.
  * Delivery failures preserve billing state and provide clearer provider availability or rejection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->