### PR TITLE
web: treat a thrown Stack refusal of the sign-in link as the verification-link case

### DIFF
--- a/web/services/billing/purchase.ts
+++ b/web/services/billing/purchase.ts
@@ -3103,6 +3103,15 @@ const PURCHASE_VERIFICATION_CALLBACK = "https://cmux.com/handler/email-verificat
  * instead: verifying the address is what lets the purchaser sign in, and the
  * after-sign-in handler then transfers the parked claim.
  */
+/** Stack refused a sign-in link because the address belongs to an unverified user. */
+function isUnverifiedMailboxRefusal(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === "USER_EMAIL_ALREADY_EXISTS") return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && /already exists/i.test(message);
+}
+
 export async function deliverPurchaseSignInEmail(
   stackApp: Pick<StackBillingApp, "sendMagicLinkEmail" | "getUser">,
   input: { readonly email: string; readonly stackUserId: string },
@@ -3110,10 +3119,17 @@ export async function deliverPurchaseSignInEmail(
   if (!stackApp.sendMagicLinkEmail) {
     throw new PurchaseMagicLinkProviderRejectedError("Stack cannot send sign-in links");
   }
-  const result = await stackApp.sendMagicLinkEmail(input.email, {
-    callbackUrl: PURCHASE_MAGIC_LINK_CALLBACK,
-  });
-  if (!isFailedStackResult(result)) return "magic_link";
+  try {
+    const result = await stackApp.sendMagicLinkEmail(input.email, {
+      callbackUrl: PURCHASE_MAGIC_LINK_CALLBACK,
+    });
+    if (!isFailedStackResult(result)) return "magic_link";
+  } catch (error) {
+    // The SDK throws the refusal as a KnownError rather than returning a
+    // failed result. Anything else (transport, timeout) may have sent the
+    // message, so it stays ambiguous and keeps its delivery marker.
+    if (!isUnverifiedMailboxRefusal(error)) throw error;
+  }
   const matching = canonicalizeEmailForMatching(input.email);
   const user = await stackApp.getUser(input.stackUserId);
   const channels = (await user?.listContactChannels?.()) ?? [];

--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -3362,3 +3362,44 @@ describe("purchase sign-in email delivery", () => {
     ).rejects.toBeInstanceOf(PurchaseMagicLinkProviderRejectedError);
   });
 });
+
+describe("purchase sign-in email delivery when Stack throws", () => {
+  const channel = {
+    id: "ch1",
+    type: "email",
+    value: "buyer@example.com",
+    isPrimary: true,
+    isVerified: false,
+    usedForAuth: true,
+    sendVerificationEmail: mock(async () => undefined),
+  };
+  const user = { id: "u1", primaryEmail: "buyer@example.com", listContactChannels: async () => [channel] };
+
+  test("a thrown unverified-mailbox refusal falls back to the verification link", async () => {
+    const { deliverPurchaseSignInEmail } = await import("../services/billing/purchase");
+    const stackApp = {
+      sendMagicLinkEmail: mock(async () => {
+        throw new Error('A user with email "buyer@example.com" already exists but the email is not verified.');
+      }),
+      getUser: mock(async () => user),
+    };
+    channel.sendVerificationEmail.mockClear();
+    const kind = await deliverPurchaseSignInEmail(stackApp as never, { email: "buyer@example.com", stackUserId: "u1" });
+    expect(kind).toBe("verification");
+    expect(channel.sendVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  test("any other thrown error is surfaced unchanged so the delivery marker stays", async () => {
+    const { deliverPurchaseSignInEmail } = await import("../services/billing/purchase");
+    const boom = new Error("socket hang up");
+    const stackApp = {
+      sendMagicLinkEmail: mock(async () => { throw boom; }),
+      getUser: mock(async () => user),
+    };
+    channel.sendVerificationEmail.mockClear();
+    await expect(
+      deliverPurchaseSignInEmail(stackApp as never, { email: "buyer@example.com", stackUserId: "u1" }),
+    ).rejects.toBe(boom);
+    expect(channel.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/12249. The Stack SDK throws `USER_EMAIL_ALREADY_EXISTS` as a KnownError instead of returning a failed result, so the verification-link fallback never ran: the first resend attempt after 12249 logged 64 of 64 refusals with the message `A user with email "…" already exists but the email is not verified`.

`deliverPurchaseSignInEmail` now catches that refusal (by error code or message) and sends the contact-channel verification link; any other thrown error (transport, timeout) is surfaced unchanged so an ambiguous delivery keeps its marker. Commit 1 adds the two failing tests, commit 2 makes them pass. Purchase and email-verification suites green (101), complexity gate flat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791603890&installation_model_id=21920&pr_number=12251&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12251&signature=b162b3099e23bf0bf3c44b61c30e5acf2e8e91a22fdf53aa15a1d34116f3abe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-checkout email delivery for billing; behavior change is narrow (refusal detection) but affects purchaser onboarding when Stack throws rather than returning errors.
> 
> **Overview**
> **Fixes purchase sign-in email delivery when Stack throws instead of returning an error result** for unverified checkout shells.
> 
> `deliverPurchaseSignInEmail` already fell back to a mailbox verification link when `sendMagicLinkEmail` returned a failed result; the Stack SDK can also **throw** `USER_EMAIL_ALREADY_EXISTS` (or an “already exists” message) in that case, which bypassed the fallback and blocked purchasers from getting the right email.
> 
> The PR adds `isUnverifiedMailboxRefusal` and wraps the magic-link call in **try/catch**: recognized refusals follow the existing verification-channel path; **any other throw** (e.g. transport/timeout) is re-thrown so ambiguous sends keep their delivery marker. Tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3700cd7073e7c4b1030fe3cb5319b53034b4d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles a thrown Stack refusal in the purchase sign-in email flow so the verification-link fallback runs when the address already exists but is unverified.

- Catches the `USER_EMAIL_ALREADY_EXISTS` error (or any error message containing "already exists") and sends the mailbox verification link instead of throwing.
- Re-throws any other thrown error (e.g., transport, timeout) unchanged so an ambiguous delivery keeps its marker.
- Adds tests for both the thrown-refusal fallback and the re-thrown error case.

<sup>Written for commit e3700cd7073e7c4b1030fe3cb5319b53034b4d7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved purchase sign-in email delivery when a mailbox is already registered but has not been verified.
  - The system now sends a verification email instead of failing when this specific condition occurs.
  - Other email delivery errors continue to be reported normally.

- **Tests**
  - Added coverage for verification-email fallback behavior and preservation of unrelated delivery errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->