### PR TITLE
admin: audit log and invited admin roster

### DIFF
--- a/web/app/api/admin/audit/route.ts
+++ b/web/app/api/admin/audit/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+
+import { listAdminAudit, parseAuditListQuery } from "../../../../services/admin/auditLog";
+import { adminJsonResponse, requireAdmin } from "../../../../services/admin/routeAuth";
+
+/** GET /api/admin/audit?cursor=&limit= — newest first, keyset paged (limit ≤ 200). */
+export async function GET(request: NextRequest) {
+  const gate = await requireAdmin(request);
+  if (!gate.ok) return gate.response;
+
+  const query = parseAuditListQuery({
+    cursor: request.nextUrl.searchParams.get("cursor"),
+    limit: request.nextUrl.searchParams.get("limit"),
+  });
+  if (!query) return adminJsonResponse({ error: "invalid_query" }, 400);
+  const page = await listAdminAudit(query);
+  return adminJsonResponse(page);
+}

--- a/web/app/api/admin/email-grants/route.ts
+++ b/web/app/api/admin/email-grants/route.ts
@@ -19,6 +19,8 @@ import {
 import { canonicalizeEmailForMatching } from "../../../../services/billing/emailMatching";
 import { enforceBrowserMutationProtection } from "../../../../services/vms/routeHelpers";
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * POST /api/admin/email-grants { email, plan: "pro" | "founders" }
  *
@@ -32,27 +34,30 @@ export async function POST(request: NextRequest) {
   const gate = await requireAdmin(request);
   if (!gate.ok) return gate.response;
 
-  const body = await readJsonBody(request);
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-  const { email, plan } = body as { email?: unknown; plan?: unknown };
-  if (typeof email !== "string" || !email.trim() || !isAdminGrantablePlanId(plan)) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-
+  const parsed = parseEmailGrantBody(await readJsonBody(request));
+  // Audited from here on: a malformed body from an admin is still recorded.
   return withAdminAudit(
     {
       actor: gate.admin,
       action: "email_grant_create",
       targetKind: "email",
-      targetId: canonicalizeEmailForMatching(email),
-      targetLabel: email.trim(),
-      details: { plan },
+      targetId: parsed ? canonicalizeEmailForMatching(parsed.email) : null,
+      targetLabel: parsed?.email ?? null,
+      details: parsed ? { plan: parsed.plan } : null,
       requestId: auditRequestId(request),
     },
-    () => createEmailGrant(email, plan, gate.admin),
+    async () =>
+      parsed
+        ? createEmailGrant(parsed.email, parsed.plan, gate.admin)
+        : adminJsonResponse({ error: "invalid_body" }, 400),
   );
+}
+
+function parseEmailGrantBody(body: unknown): { email: string; plan: AdminGrantablePlanId } | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const { email, plan } = body as { email?: unknown; plan?: unknown };
+  if (typeof email !== "string" || !email.trim() || !isAdminGrantablePlanId(plan)) return null;
+  return { email: email.trim(), plan };
 }
 
 async function createEmailGrant(
@@ -106,20 +111,20 @@ export async function DELETE(request: NextRequest) {
   const grantId = body && typeof body === "object" && !Array.isArray(body)
     ? (body as { grantId?: unknown }).grantId
     : undefined;
-  if (typeof grantId !== "string" || !/^[0-9a-f-]{36}$/i.test(grantId)) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
+  const validGrantId = typeof grantId === "string" && UUID_PATTERN.test(grantId) ? grantId : null;
+  // Audited from here on: a malformed body from an admin is still recorded.
   return withAdminAudit(
     {
       actor: gate.admin,
       action: "email_grant_revoke",
       targetKind: "email_grant",
-      targetId: grantId,
+      targetId: validGrantId,
       requestId: auditRequestId(request),
     },
     async () => {
+      if (!validGrantId) return adminJsonResponse({ error: "invalid_body" }, 400);
       try {
-        const result = await revokePendingEmailGrant({ grantId, admin: gate.admin });
+        const result = await revokePendingEmailGrant({ grantId: validGrantId, admin: gate.admin });
         return adminJsonResponse({ ok: true, ...result });
       } catch (error) {
         if (isMissingGrantsTableError(error)) {

--- a/web/app/api/admin/email-grants/route.ts
+++ b/web/app/api/admin/email-grants/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 
 import {
+  type AdminGrantablePlanId,
   AdminInvalidEmailError,
   createPendingEmailGrant,
   isAdminGrantablePlanId,
@@ -9,6 +10,7 @@ import {
   searchAdminUsers,
   setManualPlanGrant,
 } from "../../../../services/admin/proGrants";
+import { auditRequestId, withAdminAudit } from "../../../../services/admin/auditLog";
 import {
   adminJsonResponse,
   readJsonBody,
@@ -39,6 +41,25 @@ export async function POST(request: NextRequest) {
     return adminJsonResponse({ error: "invalid_body" }, 400);
   }
 
+  return withAdminAudit(
+    {
+      actor: gate.admin,
+      action: "email_grant_create",
+      targetKind: "email",
+      targetId: canonicalizeEmailForMatching(email),
+      targetLabel: email.trim(),
+      details: { plan },
+      requestId: auditRequestId(request),
+    },
+    () => createEmailGrant(email, plan, gate.admin),
+  );
+}
+
+async function createEmailGrant(
+  email: string,
+  plan: AdminGrantablePlanId,
+  admin: { id: string; primaryEmail: string | null },
+): Promise<Response> {
   // Only a VERIFIED owner of the address is granted directly. An unverified
   // account can be registered by anyone with someone else's email, so those
   // wait in the pending table until a verified sign-in claims the grant.
@@ -50,11 +71,7 @@ export async function POST(request: NextRequest) {
       canonicalizeEmailForMatching(user.email) === canonical,
   );
   if (matches.length === 1) {
-    const user = await setManualPlanGrant({
-      targetUserId: matches[0]!.id,
-      plan,
-      admin: gate.admin,
-    });
+    const user = await setManualPlanGrant({ targetUserId: matches[0]!.id, plan, admin });
     return adminJsonResponse({ user });
   }
   if (matches.length > 1) {
@@ -62,11 +79,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { unclearedUserIds, ...pendingGrant } = await createPendingEmailGrant({
-      email,
-      plan,
-      admin: gate.admin,
-    });
+    const { unclearedUserIds, ...pendingGrant } = await createPendingEmailGrant({ email, plan, admin });
     // Recorded, but a superseded grant is still active on these accounts
     // until their next sign-in or a manual "Remove grant". Say so.
     return adminJsonResponse({ pendingGrant, unclearedUserIds });
@@ -96,14 +109,25 @@ export async function DELETE(request: NextRequest) {
   if (typeof grantId !== "string" || !/^[0-9a-f-]{36}$/i.test(grantId)) {
     return adminJsonResponse({ error: "invalid_body" }, 400);
   }
-  try {
-    const result = await revokePendingEmailGrant({ grantId, admin: gate.admin });
-    return adminJsonResponse({ ok: true, ...result });
-  } catch (error) {
-    if (isMissingGrantsTableError(error)) {
-      console.error("admin.pending_grants.table_missing", { hint: "run the admin_plan_grants migration" });
-      return adminJsonResponse({ error: "grants_unavailable" }, 503);
-    }
-    throw error;
-  }
+  return withAdminAudit(
+    {
+      actor: gate.admin,
+      action: "email_grant_revoke",
+      targetKind: "email_grant",
+      targetId: grantId,
+      requestId: auditRequestId(request),
+    },
+    async () => {
+      try {
+        const result = await revokePendingEmailGrant({ grantId, admin: gate.admin });
+        return adminJsonResponse({ ok: true, ...result });
+      } catch (error) {
+        if (isMissingGrantsTableError(error)) {
+          console.error("admin.pending_grants.table_missing", { hint: "run the admin_plan_grants migration" });
+          return adminJsonResponse({ error: "grants_unavailable" }, 503);
+        }
+        throw error;
+      }
+    },
+  );
 }

--- a/web/app/api/admin/members/handlers.ts
+++ b/web/app/api/admin/members/handlers.ts
@@ -31,7 +31,7 @@ export type AdminMembersRouteDependencies = {
   readonly now?: () => Date;
 };
 
-const UUID_PATTERN = /^[0-9a-f-]{36}$/i;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) {
   /** GET /api/admin/members — every member row, newest invite first. */
@@ -49,19 +49,19 @@ export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) 
     const gate = await requireAdmin(request);
     if (!gate.ok) return gate.response;
 
+    // Audited from here on: a malformed body from an authenticated admin is
+    // still an admin action, recorded with no target.
     const email = readEmail(await readJsonBody(request));
-    if (!email) return adminJsonResponse({ error: "invalid_body" }, 400);
-
     return withAdminAudit(
       {
         actor: gate.admin,
         action: "member_invite",
         targetKind: "admin_member",
-        targetLabel: email.toLowerCase(),
+        targetLabel: email?.toLowerCase() ?? null,
         requestId: auditRequestId(request),
         db: deps.auditDb,
       },
-      () => invite(email, gate.admin),
+      () => (email ? invite(email, gate.admin) : invalidBody()),
     );
   }
 
@@ -90,8 +90,6 @@ export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) 
     if (!gate.ok) return gate.response;
 
     const memberId = readMemberId(await readJsonBody(request));
-    if (!memberId) return adminJsonResponse({ error: "invalid_body" }, 400);
-
     return withAdminAudit(
       {
         actor: gate.admin,
@@ -101,7 +99,7 @@ export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) 
         requestId: auditRequestId(request),
         db: deps.auditDb,
       },
-      () => revoke(memberId, gate.admin),
+      () => (memberId ? revoke(memberId, gate.admin) : invalidBody()),
     );
   }
 
@@ -126,6 +124,10 @@ export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) 
 export const defaultAdminMembersDependencies: AdminMembersRouteDependencies = {
   sendInvite: sendAdminMemberInviteEmail,
 };
+
+async function invalidBody(): Promise<Response> {
+  return adminJsonResponse({ error: "invalid_body" }, 400);
+}
 
 function readEmail(body: unknown): string | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) return null;

--- a/web/app/api/admin/members/handlers.ts
+++ b/web/app/api/admin/members/handlers.ts
@@ -1,0 +1,140 @@
+// Handlers for /api/admin/members, built by a factory so tests can inject the
+// member store and the invitation sender. route.ts exports the default wiring.
+
+import type { NextRequest } from "next/server";
+
+import { auditRequestId, withAdminAudit, type AdminAuditDb } from "../../../../services/admin/auditLog";
+import { sendAdminMemberInviteEmail, type AdminInviteSender } from "../../../../services/admin/memberInviteEmail";
+import {
+  AdminMemberAlreadyActiveError,
+  AdminMemberInvalidEmailError,
+  AdminMemberNotFoundError,
+  AdminMemberSelfRevokeError,
+  adminMemberRow,
+  inviteAdminMember,
+  listAdminMembers,
+  revokeAdminMember,
+  type AdminMembersStore,
+} from "../../../../services/admin/members";
+import {
+  adminJsonResponse,
+  readJsonBody,
+  requireAdmin,
+  type AdminPrincipal,
+} from "../../../../services/admin/routeAuth";
+import { enforceBrowserMutationProtection } from "../../../../services/vms/routeHelpers";
+
+export type AdminMembersRouteDependencies = {
+  readonly store?: AdminMembersStore;
+  readonly auditDb?: AdminAuditDb;
+  readonly sendInvite: AdminInviteSender;
+  readonly now?: () => Date;
+};
+
+const UUID_PATTERN = /^[0-9a-f-]{36}$/i;
+
+export function createAdminMembersHandlers(deps: AdminMembersRouteDependencies) {
+  /** GET /api/admin/members — every member row, newest invite first. */
+  async function GET(request: NextRequest) {
+    const gate = await requireAdmin(request);
+    if (!gate.ok) return gate.response;
+    const members = await listAdminMembers({ store: deps.store });
+    return adminJsonResponse({ members });
+  }
+
+  /** POST /api/admin/members { email } — invite (or re-invite) an admin. */
+  async function POST(request: NextRequest) {
+    const protection = enforceBrowserMutationProtection(request);
+    if (protection) return protection;
+    const gate = await requireAdmin(request);
+    if (!gate.ok) return gate.response;
+
+    const email = readEmail(await readJsonBody(request));
+    if (!email) return adminJsonResponse({ error: "invalid_body" }, 400);
+
+    return withAdminAudit(
+      {
+        actor: gate.admin,
+        action: "member_invite",
+        targetKind: "admin_member",
+        targetLabel: email.toLowerCase(),
+        requestId: auditRequestId(request),
+        db: deps.auditDb,
+      },
+      () => invite(email, gate.admin),
+    );
+  }
+
+  async function invite(email: string, admin: AdminPrincipal): Promise<Response> {
+    let member;
+    try {
+      ({ member } = await inviteAdminMember({ email, admin, store: deps.store, now: deps.now }));
+    } catch (error) {
+      if (error instanceof AdminMemberInvalidEmailError) {
+        return adminJsonResponse({ error: "invalid_email" }, 400);
+      }
+      if (error instanceof AdminMemberAlreadyActiveError) {
+        return adminJsonResponse({ error: "already_member" }, 409);
+      }
+      throw error;
+    }
+    const { sent } = await deps.sendInvite({ to: member.email, inviterEmail: admin.primaryEmail });
+    return adminJsonResponse({ member: adminMemberRow(member), emailSent: sent });
+  }
+
+  /** DELETE /api/admin/members { memberId } — revoke; the caller cannot revoke themselves. */
+  async function DELETE(request: NextRequest) {
+    const protection = enforceBrowserMutationProtection(request);
+    if (protection) return protection;
+    const gate = await requireAdmin(request);
+    if (!gate.ok) return gate.response;
+
+    const memberId = readMemberId(await readJsonBody(request));
+    if (!memberId) return adminJsonResponse({ error: "invalid_body" }, 400);
+
+    return withAdminAudit(
+      {
+        actor: gate.admin,
+        action: "member_revoke",
+        targetKind: "admin_member",
+        targetId: memberId,
+        requestId: auditRequestId(request),
+        db: deps.auditDb,
+      },
+      () => revoke(memberId, gate.admin),
+    );
+  }
+
+  async function revoke(memberId: string, admin: AdminPrincipal): Promise<Response> {
+    try {
+      await revokeAdminMember({ memberId, admin, store: deps.store, now: deps.now });
+      return adminJsonResponse({ ok: true });
+    } catch (error) {
+      if (error instanceof AdminMemberSelfRevokeError) {
+        return adminJsonResponse({ error: "self_revoke" }, 400);
+      }
+      if (error instanceof AdminMemberNotFoundError) {
+        return adminJsonResponse({ error: "member_not_found" }, 404);
+      }
+      throw error;
+    }
+  }
+
+  return { GET, POST, DELETE };
+}
+
+export const defaultAdminMembersDependencies: AdminMembersRouteDependencies = {
+  sendInvite: sendAdminMemberInviteEmail,
+};
+
+function readEmail(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const { email } = body as { email?: unknown };
+  return typeof email === "string" && email.trim() ? email.trim() : null;
+}
+
+function readMemberId(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const { memberId } = body as { memberId?: unknown };
+  return typeof memberId === "string" && UUID_PATTERN.test(memberId) ? memberId : null;
+}

--- a/web/app/api/admin/members/me/route.ts
+++ b/web/app/api/admin/members/me/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+
+import { touchAdminMember } from "../../../../../services/admin/members";
+import { adminJsonResponse, requireAdmin } from "../../../../../services/admin/routeAuth";
+
+/**
+ * GET /api/admin/members/me — who the caller is and which rule admitted them.
+ * For invited members this also stamps accepted_at (first call) and
+ * last_seen_at (every call).
+ */
+export async function GET(request: NextRequest) {
+  const gate = await requireAdmin(request);
+  if (!gate.ok) return gate.response;
+  if (gate.source === "member" && gate.admin.primaryEmail) {
+    await touchAdminMember(gate.admin.primaryEmail);
+  }
+  return adminJsonResponse({
+    admin: { id: gate.admin.id, email: gate.admin.primaryEmail },
+    source: gate.source,
+  });
+}

--- a/web/app/api/admin/members/route.ts
+++ b/web/app/api/admin/members/route.ts
@@ -1,0 +1,3 @@
+import { createAdminMembersHandlers, defaultAdminMembersDependencies } from "./handlers";
+
+export const { GET, POST, DELETE } = createAdminMembersHandlers(defaultAdminMembersDependencies);

--- a/web/app/api/admin/subscriptions/route.ts
+++ b/web/app/api/admin/subscriptions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 
+import { auditRequestId, withAdminAudit } from "../../../../services/admin/auditLog";
 import {
   adminJsonResponse,
   readJsonBody,
@@ -43,17 +44,29 @@ export async function POST(request: NextRequest) {
     return adminJsonResponse({ error: "billing_unavailable" }, 503);
   }
 
-  try {
-    const applied = await applySubscriptionAction({ scope, ownerId: ownerId.trim(), action });
-    if (!applied) return adminJsonResponse({ error: "no_subscription" }, 404);
-    return adminJsonResponse({ ok: true, action });
-  } catch (error) {
-    captureBillingError(error, {
-      route: "/api/admin/subscriptions",
-      stackUserId: gate.admin.id,
-      action,
-      scope,
-    });
-    return adminJsonResponse({ error: "billing_error" }, 502);
-  }
+  return withAdminAudit(
+    {
+      actor: gate.admin,
+      action: action === "cancel" ? "subscription_cancel" : "subscription_resume",
+      targetKind: scope,
+      targetId: ownerId.trim(),
+      details: { action, scope },
+      requestId: auditRequestId(request),
+    },
+    async () => {
+      try {
+        const applied = await applySubscriptionAction({ scope, ownerId: ownerId.trim(), action });
+        if (!applied) return adminJsonResponse({ error: "no_subscription" }, 404);
+        return adminJsonResponse({ ok: true, action });
+      } catch (error) {
+        captureBillingError(error, {
+          route: "/api/admin/subscriptions",
+          stackUserId: gate.admin.id,
+          action,
+          scope,
+        });
+        return adminJsonResponse({ error: "billing_error" }, 502);
+      }
+    },
+  );
 }

--- a/web/app/api/admin/subscriptions/route.ts
+++ b/web/app/api/admin/subscriptions/route.ts
@@ -24,49 +24,58 @@ export async function POST(request: NextRequest) {
   const gate = await requireAdmin(request);
   if (!gate.ok) return gate.response;
 
-  const body = await readJsonBody(request);
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-  const { scope, ownerId, action } = body as {
-    scope?: unknown;
-    ownerId?: unknown;
-    action?: unknown;
-  };
-  if (
-    (scope !== "user" && scope !== "team") ||
-    typeof ownerId !== "string" || !ownerId.trim() ||
-    (action !== "cancel" && action !== "resume")
-  ) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-  if (!isStripeBillingConfigured()) {
-    return adminJsonResponse({ error: "billing_unavailable" }, 503);
-  }
-
+  const parsed = parseSubscriptionBody(await readJsonBody(request));
+  // Audited from here on, including a malformed body and Stripe being
+  // unconfigured: both are authenticated admin actions.
   return withAdminAudit(
     {
       actor: gate.admin,
-      action: action === "cancel" ? "subscription_cancel" : "subscription_resume",
-      targetKind: scope,
-      targetId: ownerId.trim(),
-      details: { action, scope },
+      action: parsed?.action === "resume" ? "subscription_resume" : "subscription_cancel",
+      targetKind: parsed?.scope ?? "subscription",
+      targetId: parsed?.ownerId ?? null,
+      details: parsed ? { action: parsed.action, scope: parsed.scope } : null,
       requestId: auditRequestId(request),
     },
     async () => {
-      try {
-        const applied = await applySubscriptionAction({ scope, ownerId: ownerId.trim(), action });
-        if (!applied) return adminJsonResponse({ error: "no_subscription" }, 404);
-        return adminJsonResponse({ ok: true, action });
-      } catch (error) {
-        captureBillingError(error, {
-          route: "/api/admin/subscriptions",
-          stackUserId: gate.admin.id,
-          action,
-          scope,
-        });
-        return adminJsonResponse({ error: "billing_error" }, 502);
+      if (!parsed) return adminJsonResponse({ error: "invalid_body" }, 400);
+      if (!isStripeBillingConfigured()) {
+        return adminJsonResponse({ error: "billing_unavailable" }, 503);
       }
+      return applySubscription(parsed, gate.admin.id);
     },
   );
+}
+
+type SubscriptionBody = {
+  scope: "user" | "team";
+  ownerId: string;
+  action: "cancel" | "resume";
+};
+
+function parseSubscriptionBody(body: unknown): SubscriptionBody | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const { scope, ownerId, action } = body as { scope?: unknown; ownerId?: unknown; action?: unknown };
+  if (scope !== "user" && scope !== "team") return null;
+  if (typeof ownerId !== "string" || !ownerId.trim()) return null;
+  if (action !== "cancel" && action !== "resume") return null;
+  return { scope, ownerId: ownerId.trim(), action };
+}
+
+async function applySubscription(
+  { scope, ownerId, action }: SubscriptionBody,
+  adminUserId: string,
+): Promise<Response> {
+  try {
+    const applied = await applySubscriptionAction({ scope, ownerId, action });
+    if (!applied) return adminJsonResponse({ error: "no_subscription" }, 404);
+    return adminJsonResponse({ ok: true, action });
+  } catch (error) {
+    captureBillingError(error, {
+      route: "/api/admin/subscriptions",
+      stackUserId: adminUserId,
+      action,
+      scope,
+    });
+    return adminJsonResponse({ error: "billing_error" }, 502);
+  }
 }

--- a/web/app/api/admin/teams/route.ts
+++ b/web/app/api/admin/teams/route.ts
@@ -5,6 +5,7 @@ import {
   AdminTeamNotFoundError,
   setTeamManualPlanGrant,
 } from "../../../../services/admin/proGrants";
+import { auditRequestId, withAdminAudit } from "../../../../services/admin/auditLog";
 import {
   adminJsonResponse,
   readJsonBody,
@@ -32,12 +33,27 @@ export async function POST(request: NextRequest) {
     return adminJsonResponse({ error: "invalid_body" }, 400);
   }
 
+  const resolvedPlan = plan === null ? null : TEAM_PLAN_ID;
+  return withAdminAudit(
+    {
+      actor: gate.admin,
+      action: "team_grant_set",
+      targetKind: "team",
+      targetId: teamId.trim(),
+      details: { plan: resolvedPlan },
+      requestId: auditRequestId(request),
+    },
+    () => applyTeamGrant(teamId.trim(), resolvedPlan, gate.admin),
+  );
+}
+
+async function applyTeamGrant(
+  teamId: string,
+  plan: typeof TEAM_PLAN_ID | null,
+  admin: { id: string; primaryEmail: string | null },
+): Promise<Response> {
   try {
-    const team = await setTeamManualPlanGrant({
-      teamId: teamId.trim(),
-      plan: plan === null ? null : TEAM_PLAN_ID,
-      admin: gate.admin,
-    });
+    const team = await setTeamManualPlanGrant({ teamId, plan, admin });
     return adminJsonResponse({ team });
   } catch (error) {
     if (error instanceof AdminTeamNotFoundError) {

--- a/web/app/api/admin/teams/route.ts
+++ b/web/app/api/admin/teams/route.ts
@@ -21,30 +21,30 @@ export async function POST(request: NextRequest) {
   const gate = await requireAdmin(request);
   if (!gate.ok) return gate.response;
 
-  const body = await readJsonBody(request);
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-  const { teamId, plan } = body as { teamId?: unknown; plan?: unknown };
-  if (typeof teamId !== "string" || !teamId.trim()) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-  if (plan !== null && plan !== TEAM_PLAN_ID) {
-    return adminJsonResponse({ error: "invalid_body" }, 400);
-  }
-
-  const resolvedPlan = plan === null ? null : TEAM_PLAN_ID;
+  const parsed = parseTeamGrantBody(await readJsonBody(request));
+  // Audited from here on: a malformed body from an admin is still recorded.
   return withAdminAudit(
     {
       actor: gate.admin,
       action: "team_grant_set",
       targetKind: "team",
-      targetId: teamId.trim(),
-      details: { plan: resolvedPlan },
+      targetId: parsed?.teamId ?? null,
+      details: parsed ? { plan: parsed.plan } : null,
       requestId: auditRequestId(request),
     },
-    () => applyTeamGrant(teamId.trim(), resolvedPlan, gate.admin),
+    async () =>
+      parsed
+        ? applyTeamGrant(parsed.teamId, parsed.plan, gate.admin)
+        : adminJsonResponse({ error: "invalid_body" }, 400),
   );
+}
+
+function parseTeamGrantBody(body: unknown): { teamId: string; plan: typeof TEAM_PLAN_ID | null } | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const { teamId, plan } = body as { teamId?: unknown; plan?: unknown };
+  if (typeof teamId !== "string" || !teamId.trim()) return null;
+  if (plan !== null && plan !== TEAM_PLAN_ID) return null;
+  return { teamId: teamId.trim(), plan: plan === null ? null : TEAM_PLAN_ID };
 }
 
 async function applyTeamGrant(

--- a/web/app/api/admin/users/route.ts
+++ b/web/app/api/admin/users/route.ts
@@ -46,18 +46,17 @@ export async function POST(request: NextRequest) {
   if (!gate.ok) return gate.response;
 
   const parsed = parseGrantBody(await readJsonBody(request));
-  if (!parsed) return adminJsonResponse({ error: "invalid_body" }, 400);
-
+  // Audited from here on: a malformed body from an admin is still recorded.
   return withAdminAudit(
     {
       actor: gate.admin,
       action: "user_grant_set",
       targetKind: "user",
-      targetId: parsed.userId,
-      details: { plan: parsed.plan },
+      targetId: parsed?.userId ?? null,
+      details: parsed ? { plan: parsed.plan } : null,
       requestId: auditRequestId(request),
     },
-    () => applyUserGrant(parsed, gate.admin),
+    async () => (parsed ? applyUserGrant(parsed, gate.admin) : adminJsonResponse({ error: "invalid_body" }, 400)),
   );
 }
 

--- a/web/app/api/admin/users/route.ts
+++ b/web/app/api/admin/users/route.ts
@@ -11,6 +11,7 @@ import {
   searchAdminUsers,
   setManualPlanGrant,
 } from "../../../../services/admin/proGrants";
+import { auditRequestId, withAdminAudit } from "../../../../services/admin/auditLog";
 import {
   adminJsonResponse,
   readJsonBody,
@@ -47,11 +48,28 @@ export async function POST(request: NextRequest) {
   const parsed = parseGrantBody(await readJsonBody(request));
   if (!parsed) return adminJsonResponse({ error: "invalid_body" }, 400);
 
+  return withAdminAudit(
+    {
+      actor: gate.admin,
+      action: "user_grant_set",
+      targetKind: "user",
+      targetId: parsed.userId,
+      details: { plan: parsed.plan },
+      requestId: auditRequestId(request),
+    },
+    () => applyUserGrant(parsed, gate.admin),
+  );
+}
+
+async function applyUserGrant(
+  parsed: { userId: string; plan: "pro" | "founders" | null },
+  admin: { id: string; primaryEmail: string | null },
+): Promise<Response> {
   try {
     const user = await setManualPlanGrant({
       targetUserId: parsed.userId,
       plan: parsed.plan,
-      admin: gate.admin,
+      admin,
     });
     return adminJsonResponse({ user });
   } catch (error) {

--- a/web/db/migrations/20260909100000_admin_audit_log/migration.sql
+++ b/web/db/migrations/20260909100000_admin_audit_log/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "admin_audit_log" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "actor_user_id" text NOT NULL,
+  "actor_email" text,
+  "action" text NOT NULL,
+  "target_kind" text NOT NULL,
+  "target_id" text,
+  "target_label" text,
+  "details" jsonb,
+  "outcome" text NOT NULL,
+  "error" text,
+  "request_id" text,
+  CONSTRAINT "admin_audit_log_outcome_check" CHECK ("outcome" in ('ok', 'error'))
+);
+--> statement-breakpoint
+CREATE INDEX "admin_audit_log_created_at_idx" ON "admin_audit_log" ("created_at" DESC);
+--> statement-breakpoint
+CREATE INDEX "admin_audit_log_actor_created_at_idx" ON "admin_audit_log" ("actor_user_id", "created_at" DESC);

--- a/web/db/migrations/20260909100100_admin_members/migration.sql
+++ b/web/db/migrations/20260909100100_admin_members/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "admin_members" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "email" text NOT NULL,
+  "invited_by_user_id" text NOT NULL,
+  "invited_by_email" text,
+  "invited_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "accepted_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone,
+  "last_seen_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "admin_members_email_unique" ON "admin_members" ("email");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1370,6 +1370,33 @@ export const adminPlanGrants = pgTable(
   ],
 );
 
+// Operator actions taken through the admin API. One row per mutation, written
+// after the route has produced its response so the outcome (and the error code
+// on failure) is recorded. Reads page by (created_at, id) keyset.
+export const adminAuditLog = pgTable(
+  "admin_audit_log",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    actorUserId: text("actor_user_id").notNull(),
+    actorEmail: text("actor_email"),
+    /** Stable snake_case action name, e.g. user_grant_set. */
+    action: text("action").notNull(),
+    targetKind: text("target_kind").notNull(),
+    targetId: text("target_id"),
+    targetLabel: text("target_label"),
+    details: jsonb("details"),
+    outcome: text("outcome").notNull(),
+    error: text("error"),
+    requestId: text("request_id"),
+  },
+  (table) => [
+    index("admin_audit_log_created_at_idx").on(table.createdAt.desc()),
+    index("admin_audit_log_actor_created_at_idx").on(table.actorUserId, table.createdAt.desc()),
+    check("admin_audit_log_outcome_check", sql`${table.outcome} in ('ok', 'error')`),
+  ],
+);
+
 export const billingEmailClaims = pgTable(
   "billing_email_claims",
   {

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1397,6 +1397,24 @@ export const adminAuditLog = pgTable(
   ],
 );
 
+// Invited admins. A verified Stack email that matches an unrevoked row opens
+// the admin surface in addition to the company-domain rule (services/admin/access).
+export const adminMembers = pgTable(
+  "admin_members",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    /** Lower-cased, trimmed email. */
+    email: text("email").notNull(),
+    invitedByUserId: text("invited_by_user_id").notNull(),
+    invitedByEmail: text("invited_by_email"),
+    invitedAt: timestamp("invited_at", { withTimezone: true }).notNull().defaultNow(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+  },
+  (table) => [uniqueIndex("admin_members_email_unique").on(table.email)],
+);
+
 export const billingEmailClaims = pgTable(
   "billing_email_claims",
   {

--- a/web/services/admin/auditLog.ts
+++ b/web/services/admin/auditLog.ts
@@ -1,0 +1,237 @@
+// Admin audit log.
+//
+// Every admin mutation route records one row: who acted, what they targeted,
+// the request details, and the outcome. A failed audit write is reported with
+// a stable console event and never changes the route's response.
+
+import { and, desc, eq, lt, or, sql } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { adminAuditLog } from "../../db/schema";
+
+export type AdminAuditOutcome = "ok" | "error";
+
+export type AdminAuditDb = Pick<ReturnType<typeof cloudDb>, "select" | "insert">;
+
+export type AdminAuditActor = {
+  readonly id: string;
+  readonly primaryEmail?: string | null;
+};
+
+export type AdminAuditEntry = {
+  readonly actor: AdminAuditActor;
+  /** Stable snake_case name, e.g. user_grant_set. */
+  readonly action: string;
+  readonly targetKind: string;
+  readonly targetId?: string | null;
+  readonly targetLabel?: string | null;
+  readonly details?: Record<string, unknown> | null;
+  readonly requestId?: string | null;
+};
+
+export type RecordAdminAuditInput = AdminAuditEntry & {
+  readonly outcome: AdminAuditOutcome;
+  readonly error?: string | null;
+  readonly db?: AdminAuditDb;
+};
+
+export type AdminAuditRow = {
+  readonly id: string;
+  /** ISO timestamp. */
+  readonly at: string;
+  readonly actorUserId: string;
+  readonly actorEmail: string | null;
+  readonly action: string;
+  readonly targetKind: string;
+  readonly targetId: string | null;
+  readonly targetLabel: string | null;
+  readonly details: unknown;
+  readonly outcome: AdminAuditOutcome;
+  readonly error: string | null;
+};
+
+export type AdminAuditPage = {
+  readonly rows: AdminAuditRow[];
+  readonly nextCursor: string | null;
+};
+
+export const ADMIN_AUDIT_DEFAULT_LIMIT = 50;
+export const ADMIN_AUDIT_MAX_LIMIT = 200;
+
+const AUDIT_WRITE_FAILED_EVENT = "admin.audit.write_failed";
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Writes one audit row. Never throws: a lost audit row is logged, not surfaced. */
+export async function recordAdminAudit(input: RecordAdminAuditInput): Promise<void> {
+  try {
+    const db = input.db ?? cloudDb();
+    await db.insert(adminAuditLog).values({
+      actorUserId: input.actor.id,
+      actorEmail: input.actor.primaryEmail ?? null,
+      action: input.action,
+      targetKind: input.targetKind,
+      targetId: input.targetId ?? null,
+      targetLabel: input.targetLabel ?? null,
+      details: input.details ?? null,
+      outcome: input.outcome,
+      error: input.error ?? null,
+      requestId: input.requestId ?? null,
+    });
+  } catch (error) {
+    console.error(AUDIT_WRITE_FAILED_EVENT, {
+      action: input.action,
+      targetKind: input.targetKind,
+      targetId: input.targetId ?? null,
+      actorUserId: input.actor.id,
+      outcome: input.outcome,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Runs an admin mutation and records its outcome from the response: 2xx is
+ * `ok`, anything else is `error` with the JSON `error` code. A thrown defect is
+ * recorded as `error` with the error name and then rethrown.
+ */
+export async function withAdminAudit(
+  entry: AdminAuditEntry & { readonly db?: AdminAuditDb },
+  run: () => Promise<Response>,
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await run();
+  } catch (error) {
+    await recordAdminAudit({ ...entry, outcome: "error", error: errorCodeForThrown(error) });
+    throw error;
+  }
+  const error = response.ok ? null : await responseErrorCode(response);
+  await recordAdminAudit({ ...entry, outcome: response.ok ? "ok" : "error", error });
+  return response;
+}
+
+/** Vercel stamps every request with x-vercel-id; other hosts may set x-request-id. */
+export function auditRequestId(request: Request): string | null {
+  return request.headers.get("x-vercel-id") ?? request.headers.get("x-request-id");
+}
+
+function errorCodeForThrown(error: unknown): string {
+  if (error instanceof Error) return error.name || "Error";
+  return "unknown";
+}
+
+async function responseErrorCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.clone().json()) as { error?: unknown };
+    if (body && typeof body === "object" && typeof body.error === "string") return body.error;
+  } catch {
+    // Non-JSON error body: the status is the only code we have.
+  }
+  return `http_${response.status}`;
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+
+type AuditCursor = { readonly at: string; readonly id: string };
+
+/**
+ * Cursor = base64url of `<created_at as Postgres text>|<id>`. The Postgres
+ * text form keeps microseconds, so the keyset compare never skips rows that
+ * share a millisecond with the cursor.
+ */
+export function encodeAuditCursor(cursor: AuditCursor): string {
+  return Buffer.from(`${cursor.at}|${cursor.id}`, "utf8").toString("base64url");
+}
+
+export function decodeAuditCursor(value: string): AuditCursor | null {
+  if (!/^[A-Za-z0-9_-]{1,200}$/.test(value)) return null;
+  const decoded = Buffer.from(value, "base64url").toString("utf8");
+  const separator = decoded.lastIndexOf("|");
+  if (separator <= 0) return null;
+  const at = decoded.slice(0, separator);
+  const id = decoded.slice(separator + 1);
+  if (!UUID_PATTERN.test(id)) return null;
+  if (!/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,6})?[+-]\d{2}(:\d{2})?$/.test(at)) return null;
+  return { at, id };
+}
+
+/** Parses `?cursor=&limit=` for the list route; null means the query is invalid. */
+export function parseAuditListQuery(params: {
+  readonly cursor: string | null;
+  readonly limit: string | null;
+}): { cursor: string | null; limit: number } | null {
+  const cursor = params.cursor === null || params.cursor === "" ? null : params.cursor;
+  if (cursor !== null && decodeAuditCursor(cursor) === null) return null;
+  if (params.limit === null || params.limit === "") {
+    return { cursor, limit: ADMIN_AUDIT_DEFAULT_LIMIT };
+  }
+  if (!/^\d{1,4}$/.test(params.limit)) return null;
+  const limit = Number(params.limit);
+  if (limit < 1) return null;
+  return { cursor, limit: Math.min(limit, ADMIN_AUDIT_MAX_LIMIT) };
+}
+
+export async function listAdminAudit(input: {
+  readonly cursor?: string | null;
+  readonly limit?: number;
+  readonly db?: AdminAuditDb;
+}): Promise<AdminAuditPage> {
+  const limit = Math.min(Math.max(input.limit ?? ADMIN_AUDIT_DEFAULT_LIMIT, 1), ADMIN_AUDIT_MAX_LIMIT);
+  const cursor = input.cursor ? decodeAuditCursor(input.cursor) : null;
+  if (input.cursor && !cursor) throw new AdminAuditInvalidCursorError();
+  const db = input.db ?? cloudDb();
+  const createdAtText = sql<string>`${adminAuditLog.createdAt}::text`;
+  const rows = await db
+    .select({
+      id: adminAuditLog.id,
+      createdAt: adminAuditLog.createdAt,
+      createdAtText,
+      actorUserId: adminAuditLog.actorUserId,
+      actorEmail: adminAuditLog.actorEmail,
+      action: adminAuditLog.action,
+      targetKind: adminAuditLog.targetKind,
+      targetId: adminAuditLog.targetId,
+      targetLabel: adminAuditLog.targetLabel,
+      details: adminAuditLog.details,
+      outcome: adminAuditLog.outcome,
+      error: adminAuditLog.error,
+    })
+    .from(adminAuditLog)
+    .where(cursor ? keysetBefore(cursor) : undefined)
+    .orderBy(desc(adminAuditLog.createdAt), desc(adminAuditLog.id))
+    .limit(limit + 1);
+  const page = rows.slice(0, limit);
+  const last = rows.length > limit ? page[page.length - 1] : undefined;
+  return {
+    rows: page.map((row) => ({
+      id: row.id,
+      at: row.createdAt.toISOString(),
+      actorUserId: row.actorUserId,
+      actorEmail: row.actorEmail ?? null,
+      action: row.action,
+      targetKind: row.targetKind,
+      targetId: row.targetId ?? null,
+      targetLabel: row.targetLabel ?? null,
+      details: row.details ?? null,
+      outcome: row.outcome === "error" ? "error" : "ok",
+      error: row.error ?? null,
+    })),
+    nextCursor: last ? encodeAuditCursor({ at: last.createdAtText, id: last.id }) : null,
+  };
+}
+
+function keysetBefore(cursor: AuditCursor) {
+  const at = sql`${cursor.at}::timestamptz`;
+  return or(
+    lt(adminAuditLog.createdAt, at),
+    and(eq(adminAuditLog.createdAt, at), lt(adminAuditLog.id, cursor.id)),
+  );
+}
+
+export class AdminAuditInvalidCursorError extends Error {
+  constructor() {
+    super("Invalid audit cursor");
+    this.name = "AdminAuditInvalidCursorError";
+  }
+}

--- a/web/services/admin/auditLog.ts
+++ b/web/services/admin/auditLog.ts
@@ -78,13 +78,13 @@ export async function recordAdminAudit(input: RecordAdminAuditInput): Promise<vo
       requestId: input.requestId ?? null,
     });
   } catch (error) {
+    // No identifiers or raw database text in the log line: the row that was
+    // lost is described by its shape only.
     console.error(AUDIT_WRITE_FAILED_EVENT, {
       action: input.action,
       targetKind: input.targetKind,
-      targetId: input.targetId ?? null,
-      actorUserId: input.actor.id,
       outcome: input.outcome,
-      message: error instanceof Error ? error.message : String(error),
+      cause: errorCodeForThrown(error),
     });
   }
 }

--- a/web/services/admin/memberInviteEmail.ts
+++ b/web/services/admin/memberInviteEmail.ts
@@ -64,10 +64,20 @@ export const sendAdminMemberInviteEmail: AdminInviteSender = async (input) => {
     to: input.to,
     inviterEmail: input.inviterEmail,
   });
-  const { error } = await resend.emails.send(payload);
-  if (error) {
-    console.error("admin.members.invite_email_failed", { to: input.to, error });
+  // The member row is already written when this runs, so a transport failure
+  // is reported as "not sent", never as a failed invite.
+  try {
+    const { error } = await resend.emails.send(payload);
+    if (error) {
+      console.error("admin.members.invite_email_failed", { to: input.to, error });
+      return { sent: false };
+    }
+    return { sent: true };
+  } catch (error) {
+    console.error("admin.members.invite_email_failed", {
+      to: input.to,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return { sent: false };
   }
-  return { sent: true };
 };

--- a/web/services/admin/memberInviteEmail.ts
+++ b/web/services/admin/memberInviteEmail.ts
@@ -1,0 +1,73 @@
+// Admin invitation email. Plain text, sent through Resend with the same key
+// and sender configuration as the other transactional mail.
+
+import { Resend } from "resend";
+
+import { env } from "../../app/env";
+import { DEFAULT_FROM_EMAIL } from "../../app/api/stripe/founders-welcome/welcome-email";
+
+export const ADMIN_APP_URL = "https://cmux-admin.vercel.app";
+export const ADMIN_INVITE_SUBJECT = "You have been invited to cmux admin";
+
+export type AdminMemberInviteEmail = {
+  readonly from: string;
+  readonly to: string[];
+  readonly subject: string;
+  readonly text: string;
+};
+
+export type AdminInviteEmailConfig = {
+  readonly resendApiKey: string;
+  readonly fromEmail: string;
+};
+
+export type AdminInviteSender = (input: {
+  readonly to: string;
+  readonly inviterEmail: string | null;
+}) => Promise<{ sent: boolean }>;
+
+export function buildAdminMemberInviteEmail(params: {
+  readonly from: string;
+  readonly to: string;
+  readonly inviterEmail: string | null;
+}): AdminMemberInviteEmail {
+  const inviter = params.inviterEmail ?? "a cmux admin";
+  return {
+    from: params.from,
+    to: [params.to],
+    subject: ADMIN_INVITE_SUBJECT,
+    text: [
+      `${inviter} invited you to cmux admin.`,
+      "",
+      `Open ${ADMIN_APP_URL} and sign in with this email address (${params.to}).`,
+      "Access is tied to the invited address, so another account will not work.",
+    ].join("\n"),
+  };
+}
+
+/** Null until RESEND_API_KEY is set; the invite is still recorded without mail. */
+export function resolveAdminInviteEmailConfig(): AdminInviteEmailConfig | null {
+  const resendApiKey = env.RESEND_API_KEY;
+  if (!resendApiKey) return null;
+  return {
+    resendApiKey,
+    fromEmail: env.CMUX_FEEDBACK_FROM_EMAIL || DEFAULT_FROM_EMAIL,
+  };
+}
+
+export const sendAdminMemberInviteEmail: AdminInviteSender = async (input) => {
+  const config = resolveAdminInviteEmailConfig();
+  if (!config) return { sent: false };
+  const resend = new Resend(config.resendApiKey);
+  const payload = buildAdminMemberInviteEmail({
+    from: `cmux <${config.fromEmail}>`,
+    to: input.to,
+    inviterEmail: input.inviterEmail,
+  });
+  const { error } = await resend.emails.send(payload);
+  if (error) {
+    console.error("admin.members.invite_email_failed", { to: input.to, error });
+    return { sent: false };
+  }
+  return { sent: true };
+};

--- a/web/services/admin/members.ts
+++ b/web/services/admin/members.ts
@@ -1,0 +1,243 @@
+// Invited admin roster.
+//
+// A member row is an email that may open the admin surface once its owner
+// signs in with that email verified (services/admin/routeAuth). Rows are
+// never deleted: revoking sets revoked_at, and a later invite clears it so the
+// row keeps its id and history.
+
+import { desc, eq } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { adminMembers } from "../../db/schema";
+import { isPlausibleEmail } from "./proGrants";
+
+export type AdminMemberRecord = {
+  readonly id: string;
+  readonly email: string;
+  readonly invitedByUserId: string;
+  readonly invitedByEmail: string | null;
+  readonly invitedAt: Date;
+  readonly acceptedAt: Date | null;
+  readonly revokedAt: Date | null;
+  readonly lastSeenAt: Date | null;
+};
+
+export type AdminMemberRow = {
+  readonly id: string;
+  readonly email: string;
+  readonly invitedByEmail: string | null;
+  readonly invitedAt: string;
+  readonly acceptedAt: string | null;
+  readonly revokedAt: string | null;
+  readonly lastSeenAt: string | null;
+};
+
+export type AdminMemberPatch = Partial<
+  Pick<
+    AdminMemberRecord,
+    "invitedByUserId" | "invitedByEmail" | "invitedAt" | "acceptedAt" | "revokedAt" | "lastSeenAt"
+  >
+>;
+
+/** Storage boundary for member rows; the drizzle implementation is below. */
+export type AdminMembersStore = {
+  list(): Promise<AdminMemberRecord[]>;
+  findByEmail(email: string): Promise<AdminMemberRecord | null>;
+  findById(id: string): Promise<AdminMemberRecord | null>;
+  insert(values: {
+    readonly email: string;
+    readonly invitedByUserId: string;
+    readonly invitedByEmail: string | null;
+  }): Promise<AdminMemberRecord>;
+  update(id: string, patch: AdminMemberPatch): Promise<AdminMemberRecord | null>;
+};
+
+export class AdminMemberInvalidEmailError extends Error {
+  constructor(readonly email: string) {
+    super("Not a plausible email address");
+    this.name = "AdminMemberInvalidEmailError";
+  }
+}
+
+export class AdminMemberAlreadyActiveError extends Error {
+  constructor(readonly member: AdminMemberRecord) {
+    super("Email is already an active admin member");
+    this.name = "AdminMemberAlreadyActiveError";
+  }
+}
+
+export class AdminMemberNotFoundError extends Error {
+  constructor(readonly memberId: string) {
+    super("Admin member not found");
+    this.name = "AdminMemberNotFoundError";
+  }
+}
+
+export class AdminMemberSelfRevokeError extends Error {
+  constructor(readonly memberId: string) {
+    super("An admin cannot revoke their own membership");
+    this.name = "AdminMemberSelfRevokeError";
+  }
+}
+
+export function normalizeAdminMemberEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isAdminMemberActive(member: AdminMemberRecord | null | undefined): member is AdminMemberRecord {
+  return Boolean(member && member.revokedAt === null);
+}
+
+export function adminMemberRow(member: AdminMemberRecord): AdminMemberRow {
+  return {
+    id: member.id,
+    email: member.email,
+    invitedByEmail: member.invitedByEmail,
+    invitedAt: member.invitedAt.toISOString(),
+    acceptedAt: member.acceptedAt?.toISOString() ?? null,
+    revokedAt: member.revokedAt?.toISOString() ?? null,
+    lastSeenAt: member.lastSeenAt?.toISOString() ?? null,
+  };
+}
+
+export async function listAdminMembers(
+  options: { readonly store?: AdminMembersStore } = {},
+): Promise<AdminMemberRow[]> {
+  const store = options.store ?? defaultAdminMembersStore();
+  return (await store.list()).map(adminMemberRow);
+}
+
+/**
+ * Creates the member, or reopens a revoked row for the same email. An active
+ * row is a conflict. The returned `created` flag says whether a new row was
+ * inserted.
+ */
+export async function inviteAdminMember(input: {
+  readonly email: string;
+  readonly admin: { readonly id: string; readonly primaryEmail?: string | null };
+  readonly store?: AdminMembersStore;
+  readonly now?: () => Date;
+}): Promise<{ member: AdminMemberRecord; created: boolean }> {
+  if (!isPlausibleEmail(input.email)) throw new AdminMemberInvalidEmailError(input.email);
+  const store = input.store ?? defaultAdminMembersStore();
+  const email = normalizeAdminMemberEmail(input.email);
+  const inviter = { invitedByUserId: input.admin.id, invitedByEmail: input.admin.primaryEmail ?? null };
+  const existing = await store.findByEmail(email);
+  if (!existing) {
+    return { member: await insertMember(store, email, inviter), created: true };
+  }
+  if (existing.revokedAt === null) throw new AdminMemberAlreadyActiveError(existing);
+  const reopened = await store.update(existing.id, {
+    ...inviter,
+    invitedAt: (input.now ?? (() => new Date()))(),
+    acceptedAt: null,
+    revokedAt: null,
+  });
+  if (!reopened) throw new AdminMemberNotFoundError(existing.id);
+  return { member: reopened, created: false };
+}
+
+async function insertMember(
+  store: AdminMembersStore,
+  email: string,
+  inviter: { readonly invitedByUserId: string; readonly invitedByEmail: string | null },
+): Promise<AdminMemberRecord> {
+  try {
+    return await store.insert({ email, ...inviter });
+  } catch (error) {
+    // Two admins inviting the same email at once: the unique index rejects the
+    // second insert, which is the "already a member" case for that caller.
+    if (isUniqueViolation(error)) {
+      const raced = await store.findByEmail(email);
+      if (raced) throw new AdminMemberAlreadyActiveError(raced);
+    }
+    throw error;
+  }
+}
+
+export async function revokeAdminMember(input: {
+  readonly memberId: string;
+  readonly admin: { readonly id: string; readonly primaryEmail?: string | null };
+  readonly store?: AdminMembersStore;
+  readonly now?: () => Date;
+}): Promise<AdminMemberRecord> {
+  const store = input.store ?? defaultAdminMembersStore();
+  const member = await store.findById(input.memberId);
+  if (!member) throw new AdminMemberNotFoundError(input.memberId);
+  const adminEmail = input.admin.primaryEmail ? normalizeAdminMemberEmail(input.admin.primaryEmail) : null;
+  if (adminEmail !== null && adminEmail === member.email) {
+    throw new AdminMemberSelfRevokeError(member.id);
+  }
+  if (!isAdminMemberActive(member)) return member;
+  const revoked = await store.update(member.id, { revokedAt: (input.now ?? (() => new Date()))() });
+  return revoked ?? member;
+}
+
+/** The unrevoked member row for a verified email, or null. */
+export async function findActiveAdminMember(
+  email: string,
+  options: { readonly store?: AdminMembersStore } = {},
+): Promise<AdminMemberRecord | null> {
+  const store = options.store ?? defaultAdminMembersStore();
+  const member = await store.findByEmail(normalizeAdminMemberEmail(email));
+  return isAdminMemberActive(member) ? member : null;
+}
+
+/** Stamps accepted_at on the first visit and last_seen_at on every visit. */
+export async function touchAdminMember(
+  email: string,
+  options: { readonly store?: AdminMembersStore; readonly now?: () => Date } = {},
+): Promise<AdminMemberRecord | null> {
+  const store = options.store ?? defaultAdminMembersStore();
+  const member = await findActiveAdminMember(email, { store });
+  if (!member) return null;
+  const now = (options.now ?? (() => new Date()))();
+  return await store.update(member.id, {
+    lastSeenAt: now,
+    ...(member.acceptedAt === null ? { acceptedAt: now } : {}),
+  });
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    if ((current as { code?: unknown }).code === "23505") return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Drizzle-backed store
+
+export type AdminMembersDb = Pick<ReturnType<typeof cloudDb>, "select" | "insert" | "update">;
+
+export function drizzleAdminMembersStore(db: AdminMembersDb): AdminMembersStore {
+  return {
+    async list() {
+      return await db.select().from(adminMembers).orderBy(desc(adminMembers.invitedAt));
+    },
+    async findByEmail(email) {
+      const rows = await db.select().from(adminMembers).where(eq(adminMembers.email, email)).limit(1);
+      return rows[0] ?? null;
+    },
+    async findById(id) {
+      const rows = await db.select().from(adminMembers).where(eq(adminMembers.id, id)).limit(1);
+      return rows[0] ?? null;
+    },
+    async insert(values) {
+      const rows = await db.insert(adminMembers).values(values).returning();
+      return rows[0]!;
+    },
+    async update(id, patch) {
+      const rows = await db.update(adminMembers).set(patch).where(eq(adminMembers.id, id)).returning();
+      return rows[0] ?? null;
+    },
+  };
+}
+
+function defaultAdminMembersStore(): AdminMembersStore {
+  return drizzleAdminMembersStore(cloudDb());
+}

--- a/web/services/admin/members.ts
+++ b/web/services/admin/members.ts
@@ -5,7 +5,7 @@
 // never deleted: revoking sets revoked_at, and a later invite clears it so the
 // row keeps its id and history.
 
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { adminMembers } from "../../db/schema";
@@ -50,6 +50,8 @@ export type AdminMembersStore = {
     readonly invitedByEmail: string | null;
   }): Promise<AdminMemberRecord>;
   update(id: string, patch: AdminMemberPatch): Promise<AdminMemberRecord | null>;
+  /** Applies the patch only while the row is still revoked; null when it is active (or gone). */
+  reopen(id: string, patch: AdminMemberPatch): Promise<AdminMemberRecord | null>;
 };
 
 export class AdminMemberInvalidEmailError extends Error {
@@ -127,14 +129,19 @@ export async function inviteAdminMember(input: {
     return { member: await insertMember(store, email, inviter), created: true };
   }
   if (existing.revokedAt === null) throw new AdminMemberAlreadyActiveError(existing);
-  const reopened = await store.update(existing.id, {
+  // The reopen is conditional on revoked_at so two concurrent re-invites
+  // cannot both succeed: the loser sees no row and reports the conflict.
+  const reopened = await store.reopen(existing.id, {
     ...inviter,
     invitedAt: (input.now ?? (() => new Date()))(),
     acceptedAt: null,
     revokedAt: null,
+    lastSeenAt: null,
   });
-  if (!reopened) throw new AdminMemberNotFoundError(existing.id);
-  return { member: reopened, created: false };
+  if (reopened) return { member: reopened, created: false };
+  const raced = await store.findById(existing.id);
+  if (raced && raced.revokedAt === null) throw new AdminMemberAlreadyActiveError(raced);
+  throw new AdminMemberNotFoundError(existing.id);
 }
 
 async function insertMember(
@@ -233,6 +240,14 @@ export function drizzleAdminMembersStore(db: AdminMembersDb): AdminMembersStore 
     },
     async update(id, patch) {
       const rows = await db.update(adminMembers).set(patch).where(eq(adminMembers.id, id)).returning();
+      return rows[0] ?? null;
+    },
+    async reopen(id, patch) {
+      const rows = await db
+        .update(adminMembers)
+        .set(patch)
+        .where(and(eq(adminMembers.id, id), isNotNull(adminMembers.revokedAt)))
+        .returning();
       return rows[0] ?? null;
     },
   };

--- a/web/services/admin/routeAuth.ts
+++ b/web/services/admin/routeAuth.ts
@@ -4,6 +4,7 @@ import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
 import { authProviderErrorResponse } from "../vms/authErrors";
 import { jsonResponse, parseBearer } from "../vms/routeHelpers";
 import { isAdminUser } from "./access";
+import { findActiveAdminMember } from "./members";
 import { withStackAuthSpan } from "../auth/stackTelemetry";
 
 const ANONYMOUS_IF_EXISTS = "anonymous-if-exists[deprecated]" as const;
@@ -13,8 +14,11 @@ export type AdminPrincipal = {
   readonly primaryEmail: string | null;
 };
 
+/** How the caller qualified: a verified company-domain email, or an invited member row. */
+export type AdminSource = "company_domain" | "member";
+
 export type AdminGate =
-  | { readonly ok: true; readonly admin: AdminPrincipal }
+  | { readonly ok: true; readonly admin: AdminPrincipal; readonly source: AdminSource }
   | { readonly ok: false; readonly response: Response };
 
 /** Admin user data must never land in a shared or browser cache. */
@@ -26,8 +30,8 @@ export function adminJsonResponse(data: unknown, status = 200): Response {
 
 /**
  * Resolves the caller (cookie session or native bearer pair) and requires a
- * verified company email. 401 for signed-out or anonymous callers, 403 for
- * everyone who is not an admin.
+ * verified company email, or a verified email with an active admin_members
+ * row. 401 for signed-out or anonymous callers, 403 for everyone else.
  */
 export async function requireAdmin(request: NextRequest): Promise<AdminGate> {
   if (!isStackConfigured()) {
@@ -57,10 +61,32 @@ export async function requireAdmin(request: NextRequest): Promise<AdminGate> {
   if (!user || user.isAnonymous) {
     return { ok: false, response: adminJsonResponse({ error: "unauthorized" }, 401) };
   }
-  if (!isAdminUser(user)) {
+  const source = await resolveAdminSource(user);
+  if (!source) {
     return { ok: false, response: adminJsonResponse({ error: "forbidden" }, 403) };
   }
-  return { ok: true, admin: { id: user.id, primaryEmail: user.primaryEmail ?? null } };
+  return { ok: true, admin: { id: user.id, primaryEmail: user.primaryEmail ?? null }, source };
+}
+
+async function resolveAdminSource(user: {
+  readonly primaryEmail: string | null;
+  readonly primaryEmailVerified: boolean;
+  readonly isAnonymous: boolean;
+}): Promise<AdminSource | null> {
+  if (isAdminUser(user)) return "company_domain";
+  // The member rule needs the same verified, non-anonymous mailbox as the
+  // domain rule: an unverified sign-up can claim any invited address.
+  if (user.isAnonymous || user.primaryEmailVerified !== true || !user.primaryEmail) return null;
+  try {
+    return (await findActiveAdminMember(user.primaryEmail)) ? "member" : null;
+  } catch (error) {
+    // A missing table or unreachable database fails closed for invited
+    // members; company-domain admins never reach this lookup.
+    console.error("admin.members.lookup_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 export async function readJsonBody(request: NextRequest): Promise<unknown | undefined> {

--- a/web/tests/admin-audit-log.test.ts
+++ b/web/tests/admin-audit-log.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
 import { adminAuditLog } from "../db/schema";
 import {
   ADMIN_AUDIT_MAX_LIMIT,
@@ -117,7 +120,7 @@ describe("admin audit log", () => {
     expect(inserted).toEqual([]);
     expect(logged).toHaveLength(1);
     expect(logged[0]?.[0]).toBe("admin.audit.write_failed");
-    expect(logged[0]?.[1]).toMatchObject({ action: "member_invite", message: "connection refused" });
+    expect(logged[0]?.[1]).toEqual({ action: "member_invite", targetKind: "admin_member", outcome: "ok", cause: "Error" });
   });
 
   test("withAdminAudit records ok for 2xx and the error code otherwise", async () => {
@@ -195,7 +198,13 @@ describe("admin audit log", () => {
 
     stored = [stored[1]!];
     const second = await listAdminAudit({ cursor: first.nextCursor, limit: 1, db: fakeDb() });
-    expect(lastWhere).toBeDefined();
+    // The keyset predicate is strictly "before the cursor" on (created_at, id),
+    // with the cursor's own timestamp and id as the bound parameters.
+    const rendered = new PgDialect().sqlToQuery(lastWhere as SQL);
+    expect(rendered.sql).toBe(
+      '(("admin_audit_log"."created_at" < $1::timestamptz) or ((("admin_audit_log"."created_at" = $2::timestamptz) and ("admin_audit_log"."id" < $3))))',
+    );
+    expect(rendered.params).toEqual(["2026-09-09 10:00:01.000+00", "2026-09-09 10:00:01.000+00", ID_B]);
     expect(second.rows.map((row) => [row.id, row.outcome, row.error])).toEqual([[ID_A, "error", "user_not_found"]]);
     expect(second.nextCursor).toBeNull();
   });

--- a/web/tests/admin-audit-log.test.ts
+++ b/web/tests/admin-audit-log.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { adminAuditLog } from "../db/schema";
+import {
+  ADMIN_AUDIT_MAX_LIMIT,
+  decodeAuditCursor,
+  encodeAuditCursor,
+  listAdminAudit,
+  parseAuditListQuery,
+  recordAdminAudit,
+  withAdminAudit,
+  type AdminAuditDb,
+} from "../services/admin/auditLog";
+
+type StoredRow = Record<string, unknown> & { id: string; createdAt: Date; createdAtText: string };
+
+let inserted: Array<Record<string, unknown>> = [];
+let stored: StoredRow[] = [];
+let insertFails = false;
+let lastLimit: number | null = null;
+let lastWhere: unknown = "unset";
+
+function fakeDb(): AdminAuditDb {
+  return {
+    insert: (table: unknown) => ({
+      values: async (values: Record<string, unknown>) => {
+        if (table !== adminAuditLog) throw new Error("unexpected table");
+        if (insertFails) throw new Error("connection refused");
+        inserted.push(values);
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: (clause: unknown) => {
+          lastWhere = clause;
+          return {
+            orderBy: () => ({
+              limit: async (limit: number) => {
+                lastLimit = limit;
+                return stored.slice(0, limit);
+              },
+            }),
+          };
+        },
+      }),
+    }),
+  } as unknown as AdminAuditDb;
+}
+
+const actor = { id: "admin-1", primaryEmail: "lawrence@manaflow.ai" };
+const ID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function storedRow(id: string, at: string, overrides: Partial<StoredRow> = {}): StoredRow {
+  return {
+    id,
+    createdAt: new Date(at),
+    createdAtText: at.replace("T", " ").replace("Z", "+00"),
+    actorUserId: "admin-1",
+    actorEmail: "lawrence@manaflow.ai",
+    action: "user_grant_set",
+    targetKind: "user",
+    targetId: "u1",
+    targetLabel: null,
+    details: { plan: "pro" },
+    outcome: "ok",
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("admin audit log", () => {
+  const consoleError = console.error;
+  beforeEach(() => {
+    inserted = [];
+    stored = [];
+    insertFails = false;
+    lastLimit = null;
+    lastWhere = "unset";
+  });
+  afterEach(() => {
+    console.error = consoleError;
+  });
+
+  test("recordAdminAudit writes the actor, target, details, and outcome", async () => {
+    await recordAdminAudit({
+      actor,
+      action: "team_grant_set",
+      targetKind: "team",
+      targetId: "t1",
+      details: { plan: "team" },
+      outcome: "ok",
+      requestId: "req-1",
+      db: fakeDb(),
+    });
+    expect(inserted).toEqual([{
+      actorUserId: "admin-1",
+      actorEmail: "lawrence@manaflow.ai",
+      action: "team_grant_set",
+      targetKind: "team",
+      targetId: "t1",
+      targetLabel: null,
+      details: { plan: "team" },
+      outcome: "ok",
+      error: null,
+      requestId: "req-1",
+    }]);
+  });
+
+  test("a failed audit write is logged with a stable event and never throws", async () => {
+    insertFails = true;
+    const logged: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      logged.push(args);
+    };
+    await recordAdminAudit({ actor, action: "member_invite", targetKind: "admin_member", outcome: "ok", db: fakeDb() });
+    expect(inserted).toEqual([]);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.[0]).toBe("admin.audit.write_failed");
+    expect(logged[0]?.[1]).toMatchObject({ action: "member_invite", message: "connection refused" });
+  });
+
+  test("withAdminAudit records ok for 2xx and the error code otherwise", async () => {
+    const db = fakeDb();
+    const entry = { actor, action: "user_grant_set", targetKind: "user", targetId: "u1", db };
+    const ok = await withAdminAudit(entry, async () => Response.json({ user: {} }));
+    expect(ok.status).toBe(200);
+    const notFound = await withAdminAudit(entry, async () =>
+      Response.json({ error: "user_not_found" }, { status: 404 }));
+    expect(await notFound.json()).toEqual({ error: "user_not_found" });
+    await expect(withAdminAudit(entry, async () => {
+      throw new TypeError("boom");
+    })).rejects.toThrow("boom");
+    expect(inserted.map((row) => [row.outcome, row.error])).toEqual([
+      ["ok", null],
+      ["error", "user_not_found"],
+      ["error", "TypeError"],
+    ]);
+    // The response body is still readable after auditing.
+    expect(await ok.json()).toEqual({ user: {} });
+  });
+
+  test("a failed audit write does not change the route response", async () => {
+    insertFails = true;
+    console.error = () => {};
+    const response = await withAdminAudit(
+      { actor, action: "user_grant_set", targetKind: "user", db: fakeDb() },
+      async () => Response.json({ ok: true }),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  test("cursors round-trip and reject garbage", () => {
+    const cursor = encodeAuditCursor({ at: "2026-09-09 10:00:00.123456+00", id: ID_A });
+    expect(decodeAuditCursor(cursor)).toEqual({ at: "2026-09-09 10:00:00.123456+00", id: ID_A });
+    expect(decodeAuditCursor("")).toBeNull();
+    expect(decodeAuditCursor("not base64!")).toBeNull();
+    expect(decodeAuditCursor(Buffer.from("junk|not-a-uuid").toString("base64url"))).toBeNull();
+    expect(decodeAuditCursor(Buffer.from(`1; drop table|${ID_A}`).toString("base64url"))).toBeNull();
+  });
+
+  test("parseAuditListQuery defaults, clamps, and rejects bad input", () => {
+    expect(parseAuditListQuery({ cursor: null, limit: null })).toEqual({ cursor: null, limit: 50 });
+    expect(parseAuditListQuery({ cursor: "", limit: "" })).toEqual({ cursor: null, limit: 50 });
+    expect(parseAuditListQuery({ cursor: null, limit: "5000" })).toEqual({ cursor: null, limit: ADMIN_AUDIT_MAX_LIMIT });
+    expect(parseAuditListQuery({ cursor: null, limit: "0" })).toBeNull();
+    expect(parseAuditListQuery({ cursor: null, limit: "ten" })).toBeNull();
+    expect(parseAuditListQuery({ cursor: "nope!", limit: null })).toBeNull();
+    const cursor = encodeAuditCursor({ at: "2026-09-09 10:00:00+00", id: ID_A });
+    expect(parseAuditListQuery({ cursor, limit: "10" })).toEqual({ cursor, limit: 10 });
+  });
+
+  test("listAdminAudit maps rows and hands back a keyset cursor only when more remain", async () => {
+    stored = [
+      storedRow(ID_B, "2026-09-09T10:00:01.000Z"),
+      storedRow(ID_A, "2026-09-09T10:00:00.000Z", { outcome: "error", error: "user_not_found" }),
+    ];
+    const first = await listAdminAudit({ limit: 1, db: fakeDb() });
+    expect(lastLimit).toBe(2);
+    expect(lastWhere).toBeUndefined();
+    expect(first.rows).toEqual([{
+      id: ID_B,
+      at: "2026-09-09T10:00:01.000Z",
+      actorUserId: "admin-1",
+      actorEmail: "lawrence@manaflow.ai",
+      action: "user_grant_set",
+      targetKind: "user",
+      targetId: "u1",
+      targetLabel: null,
+      details: { plan: "pro" },
+      outcome: "ok",
+      error: null,
+    }]);
+    expect(first.nextCursor).toBe(encodeAuditCursor({ at: "2026-09-09 10:00:01.000+00", id: ID_B }));
+
+    stored = [stored[1]!];
+    const second = await listAdminAudit({ cursor: first.nextCursor, limit: 1, db: fakeDb() });
+    expect(lastWhere).toBeDefined();
+    expect(second.rows.map((row) => [row.id, row.outcome, row.error])).toEqual([[ID_A, "error", "user_not_found"]]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  test("listAdminAudit clamps the limit and rejects a bad cursor", async () => {
+    await listAdminAudit({ limit: 10_000, db: fakeDb() });
+    expect(lastLimit).toBe(ADMIN_AUDIT_MAX_LIMIT + 1);
+    await expect(listAdminAudit({ cursor: "garbage!", db: fakeDb() })).rejects.toThrow("Invalid audit cursor");
+    expect(mock).toBeDefined();
+  });
+});

--- a/web/tests/admin-members-route.test.ts
+++ b/web/tests/admin-members-route.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { adminAuditLog } from "../db/schema";
+import type { AdminAuditDb } from "../services/admin/auditLog";
+import type { AdminMemberRecord, AdminMembersStore } from "../services/admin/members";
+
+type StackUser = {
+  id: string;
+  primaryEmail: string | null;
+  primaryEmailVerified: boolean;
+  isAnonymous: boolean;
+};
+
+let currentUser: StackUser | null = null;
+const getUser = mock(async () => currentUser);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  promoteStackUserFromAnonymousViaApi: async () => undefined,
+  stackServerApp: { getUser },
+}));
+
+const { createAdminMembersHandlers } = await import("../app/api/admin/members/handlers");
+
+// In-memory member store: the same contract the drizzle store implements.
+let members: AdminMemberRecord[] = [];
+let nextId = 1;
+const NOW = new Date("2026-09-09T12:00:00.000Z");
+
+const store: AdminMembersStore = {
+  async list() {
+    return [...members];
+  },
+  async findByEmail(email) {
+    return members.find((member) => member.email === email) ?? null;
+  },
+  async findById(id) {
+    return members.find((member) => member.id === id) ?? null;
+  },
+  async insert(values) {
+    const member: AdminMemberRecord = {
+      id: `00000000-0000-4000-8000-00000000000${nextId++}`,
+      ...values,
+      invitedAt: NOW,
+      acceptedAt: null,
+      revokedAt: null,
+      lastSeenAt: null,
+    };
+    members.push(member);
+    return member;
+  },
+  async update(id, patch) {
+    const index = members.findIndex((member) => member.id === id);
+    if (index < 0) return null;
+    members[index] = { ...members[index]!, ...patch };
+    return members[index]!;
+  },
+};
+
+let auditRows: Array<Record<string, unknown>> = [];
+const auditDb = {
+  insert: (table: unknown) => ({
+    values: async (values: Record<string, unknown>) => {
+      if (table === adminAuditLog) auditRows.push(values);
+    },
+  }),
+} as unknown as AdminAuditDb;
+
+const sendInvite = mock(async (): Promise<{ sent: boolean }> => ({ sent: true }));
+
+const { GET, POST, DELETE } = createAdminMembersHandlers({ store, auditDb, sendInvite, now: () => NOW });
+
+const admin = (): StackUser => ({
+  id: "admin-1",
+  primaryEmail: "lawrence@manaflow.ai",
+  primaryEmailVerified: true,
+  isAnonymous: false,
+});
+
+function mutation(body: unknown, method: "POST" | "DELETE" = "POST", headers: Record<string, string> = {}) {
+  return new NextRequest("https://cmux.com/api/admin/members", {
+    method,
+    headers: {
+      "content-type": "application/json",
+      origin: "https://cmux.com",
+      "sec-fetch-site": "same-origin",
+      "x-vercel-id": "iad1::req-1",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("admin members routes", () => {
+  beforeEach(() => {
+    currentUser = admin();
+    members = [];
+    nextId = 1;
+    auditRows = [];
+    sendInvite.mockClear();
+  });
+
+  test("GET lists members and is admin-only", async () => {
+    await POST(mutation({ email: "Pat@Example.com" }));
+    const response = await GET(new NextRequest("https://cmux.com/api/admin/members"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      members: [{
+        id: "00000000-0000-4000-8000-000000000001",
+        email: "pat@example.com",
+        invitedByEmail: "lawrence@manaflow.ai",
+        invitedAt: NOW.toISOString(),
+        acceptedAt: null,
+        revokedAt: null,
+        lastSeenAt: null,
+      }],
+    });
+    currentUser = { id: "user", primaryEmail: "pat@example.com", primaryEmailVerified: true, isAnonymous: false };
+    expect((await GET(new NextRequest("https://cmux.com/api/admin/members"))).status).toBe(403);
+  });
+
+  test("POST creates the member, sends the invite, and audits it", async () => {
+    const response = await POST(mutation({ email: "Pat@Example.com" }));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { member: Record<string, unknown>; emailSent: boolean };
+    expect(body.member).toMatchObject({ email: "pat@example.com", invitedByEmail: "lawrence@manaflow.ai" });
+    expect(body.emailSent).toBe(true);
+    expect(members[0]).toMatchObject({ email: "pat@example.com", invitedByUserId: "admin-1", revokedAt: null });
+    expect(sendInvite).toHaveBeenCalledWith({ to: "pat@example.com", inviterEmail: "lawrence@manaflow.ai" });
+    expect(auditRows).toEqual([expect.objectContaining({
+      actorUserId: "admin-1",
+      actorEmail: "lawrence@manaflow.ai",
+      action: "member_invite",
+      targetKind: "admin_member",
+      targetLabel: "pat@example.com",
+      outcome: "ok",
+      error: null,
+      requestId: "iad1::req-1",
+    })]);
+  });
+
+  test("POST reports emailSent false when the sender is not configured", async () => {
+    sendInvite.mockImplementationOnce(async () => ({ sent: false }));
+    const response = await POST(mutation({ email: "pat@example.com" }));
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as { emailSent: boolean }).emailSent).toBe(false);
+    expect(members).toHaveLength(1);
+  });
+
+  test("POST returns 409 for an active member and re-invites a revoked one", async () => {
+    await POST(mutation({ email: "pat@example.com" }));
+    const conflict = await POST(mutation({ email: "PAT@example.com " }));
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toEqual({ error: "already_member" });
+    expect(sendInvite).toHaveBeenCalledTimes(1);
+    expect(auditRows.at(-1)).toMatchObject({ action: "member_invite", outcome: "error", error: "already_member" });
+
+    await DELETE(mutation({ memberId: members[0]!.id }, "DELETE"));
+    expect(members[0]?.revokedAt).toEqual(NOW);
+    const reinvited = await POST(mutation({ email: "pat@example.com" }));
+    expect(reinvited.status).toBe(200);
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({ revokedAt: null, acceptedAt: null });
+    expect(sendInvite).toHaveBeenCalledTimes(2);
+  });
+
+  test("POST validates the body and the email, and rejects cross-site browser calls", async () => {
+    expect((await POST(mutation({}))).status).toBe(400);
+    expect((await POST(mutation({ email: "   " }))).status).toBe(400);
+    const junk = await POST(mutation({ email: "not-an-email" }));
+    expect(junk.status).toBe(400);
+    expect(await junk.json()).toEqual({ error: "invalid_email" });
+    expect((await POST(mutation({ email: "x@example.com" }, "POST", {
+      "sec-fetch-site": "cross-site",
+      origin: "https://evil.example",
+    }))).status).toBe(403);
+    expect(members).toEqual([]);
+    expect(sendInvite).not.toHaveBeenCalled();
+  });
+
+  test("DELETE revokes a member and audits it", async () => {
+    await POST(mutation({ email: "pat@example.com" }));
+    const response = await DELETE(mutation({ memberId: members[0]!.id }, "DELETE"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(members[0]?.revokedAt).toEqual(NOW);
+    expect(auditRows.at(-1)).toMatchObject({
+      action: "member_revoke",
+      targetKind: "admin_member",
+      targetId: members[0]!.id,
+      outcome: "ok",
+    });
+    expect((await DELETE(mutation({ memberId: "00000000-0000-4000-8000-000000000009" }, "DELETE"))).status).toBe(404);
+    expect((await DELETE(mutation({ memberId: "1; drop" }, "DELETE"))).status).toBe(400);
+  });
+
+  test("DELETE refuses a self-revoke", async () => {
+    await POST(mutation({ email: "Lawrence@manaflow.ai" }));
+    const response = await DELETE(mutation({ memberId: members[0]!.id }, "DELETE"));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "self_revoke" });
+    expect(members[0]?.revokedAt).toBeNull();
+    expect(auditRows.at(-1)).toMatchObject({ action: "member_revoke", outcome: "error", error: "self_revoke" });
+  });
+});

--- a/web/tests/admin-members-route.test.ts
+++ b/web/tests/admin-members-route.test.ts
@@ -57,6 +57,11 @@ const store: AdminMembersStore = {
     members[index] = { ...members[index]!, ...patch };
     return members[index]!;
   },
+  async reopen(id, patch) {
+    const current = members.find((member) => member.id === id);
+    if (!current || current.revokedAt === null) return null;
+    return await store.update(id, patch);
+  },
 };
 
 let auditRows: Array<Record<string, unknown>> = [];
@@ -68,7 +73,8 @@ const auditDb = {
   }),
 } as unknown as AdminAuditDb;
 
-const sendInvite = mock(async (): Promise<{ sent: boolean }> => ({ sent: true }));
+let sendResult = { sent: true };
+const sendInvite = mock(async (): Promise<{ sent: boolean }> => sendResult);
 
 const { GET, POST, DELETE } = createAdminMembersHandlers({ store, auditDb, sendInvite, now: () => NOW });
 
@@ -99,6 +105,7 @@ describe("admin members routes", () => {
     members = [];
     nextId = 1;
     auditRows = [];
+    sendResult = { sent: true };
     sendInvite.mockClear();
   });
 
@@ -118,7 +125,8 @@ describe("admin members routes", () => {
         lastSeenAt: null,
       }],
     });
-    currentUser = { id: "user", primaryEmail: "pat@example.com", primaryEmailVerified: true, isAnonymous: false };
+    // An address with no member row and no company domain.
+    currentUser = { id: "user", primaryEmail: "stranger@example.com", primaryEmailVerified: true, isAnonymous: false };
     expect((await GET(new NextRequest("https://cmux.com/api/admin/members"))).status).toBe(403);
   });
 
@@ -143,7 +151,7 @@ describe("admin members routes", () => {
   });
 
   test("POST reports emailSent false when the sender is not configured", async () => {
-    sendInvite.mockImplementationOnce(async () => ({ sent: false }));
+    sendResult = { sent: false };
     const response = await POST(mutation({ email: "pat@example.com" }));
     expect(response.status).toBe(200);
     expect(((await response.json()) as { emailSent: boolean }).emailSent).toBe(false);
@@ -158,17 +166,41 @@ describe("admin members routes", () => {
     expect(sendInvite).toHaveBeenCalledTimes(1);
     expect(auditRows.at(-1)).toMatchObject({ action: "member_invite", outcome: "error", error: "already_member" });
 
+    await store.update(members[0]!.id, { acceptedAt: NOW, lastSeenAt: NOW });
     await DELETE(mutation({ memberId: members[0]!.id }, "DELETE"));
     expect(members[0]?.revokedAt).toEqual(NOW);
     const reinvited = await POST(mutation({ email: "pat@example.com" }));
     expect(reinvited.status).toBe(200);
     expect(members).toHaveLength(1);
-    expect(members[0]).toMatchObject({ revokedAt: null, acceptedAt: null });
+    // A re-invite starts a new tenure: nothing from the old one is shown.
+    expect(members[0]).toMatchObject({ revokedAt: null, acceptedAt: null, lastSeenAt: null });
     expect(sendInvite).toHaveBeenCalledTimes(2);
   });
 
+  test("POST returns 409 when a concurrent invite reopened the row first", async () => {
+    await POST(mutation({ email: "pat@example.com" }));
+    await DELETE(mutation({ memberId: members[0]!.id }, "DELETE"));
+    // Simulate the race: the other request wins between findByEmail and reopen.
+    const original = store.reopen;
+    store.reopen = async (id, patch) => {
+      await store.update(id, { revokedAt: null });
+      return await original(id, patch);
+    };
+    try {
+      const response = await POST(mutation({ email: "pat@example.com" }));
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ error: "already_member" });
+    } finally {
+      store.reopen = original;
+    }
+    expect(sendInvite).toHaveBeenCalledTimes(1);
+  });
+
   test("POST validates the body and the email, and rejects cross-site browser calls", async () => {
-    expect((await POST(mutation({}))).status).toBe(400);
+    const malformed = await POST(mutation({}));
+    expect(malformed.status).toBe(400);
+    // An authenticated admin's malformed request is still an audited action.
+    expect(auditRows.at(-1)).toMatchObject({ action: "member_invite", targetLabel: null, outcome: "error", error: "invalid_body" });
     expect((await POST(mutation({ email: "   " }))).status).toBe(400);
     const junk = await POST(mutation({ email: "not-an-email" }));
     expect(junk.status).toBe(400);
@@ -195,6 +227,8 @@ describe("admin members routes", () => {
     });
     expect((await DELETE(mutation({ memberId: "00000000-0000-4000-8000-000000000009" }, "DELETE"))).status).toBe(404);
     expect((await DELETE(mutation({ memberId: "1; drop" }, "DELETE"))).status).toBe(400);
+    expect((await DELETE(mutation({ memberId: "------------------------------------" }, "DELETE"))).status).toBe(400);
+    expect(auditRows.at(-1)).toMatchObject({ action: "member_revoke", targetId: null, outcome: "error", error: "invalid_body" });
   });
 
   test("DELETE refuses a self-revoke", async () => {

--- a/web/tests/admin-route-auth-members.test.ts
+++ b/web/tests/admin-route-auth-members.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { adminMembers } from "../db/schema";
+
+const dbClientModule = await import("../db/client");
+const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
+const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
+
+type StackUser = {
+  id: string;
+  primaryEmail: string | null;
+  primaryEmailVerified: boolean;
+  isAnonymous: boolean;
+};
+
+let stackConfigured = true;
+let currentUser: StackUser | null = null;
+const getUser = mock(async () => currentUser);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => stackConfigured,
+  promoteStackUserFromAnonymousViaApi: async () => undefined,
+  stackServerApp: { getUser },
+}));
+
+let memberRows: Array<Record<string, unknown>> = [];
+let membersLookupFails = false;
+let memberLookups = 0;
+
+mock.module("../db/client", () => ({
+  createAwsRdsIamPool: realCreateAwsRdsIamPool,
+  closeCloudDbForTests: realCloseCloudDbForTests,
+  cloudDb: () => ({
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table !== adminMembers) return [];
+            memberLookups += 1;
+            if (membersLookupFails) {
+              throw Object.assign(new Error("relation \"admin_members\" does not exist"), { code: "42P01" });
+            }
+            return memberRows;
+          },
+        }),
+      }),
+    }),
+  }),
+}));
+
+const { requireAdmin } = await import("../services/admin/routeAuth");
+
+function request() {
+  return new NextRequest("https://cmux.com/api/admin/members/me");
+}
+
+function memberRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "11111111-2222-4333-8444-555555555555",
+    email: "pat@example.com",
+    invitedByUserId: "admin-1",
+    invitedByEmail: "lawrence@manaflow.ai",
+    invitedAt: new Date("2026-09-09T00:00:00.000Z"),
+    acceptedAt: null,
+    revokedAt: null,
+    lastSeenAt: null,
+    ...overrides,
+  };
+}
+
+describe("requireAdmin member rule", () => {
+  beforeEach(() => {
+    stackConfigured = true;
+    memberRows = [];
+    membersLookupFails = false;
+    memberLookups = 0;
+  });
+
+  test("company-domain admins are admitted without a member lookup", async () => {
+    currentUser = { id: "admin-1", primaryEmail: "lawrence@manaflow.ai", primaryEmailVerified: true, isAnonymous: false };
+    const gate = await requireAdmin(request());
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.source).toBe("company_domain");
+      expect(gate.admin).toEqual({ id: "admin-1", primaryEmail: "lawrence@manaflow.ai" });
+    }
+    expect(memberLookups).toBe(0);
+  });
+
+  test("a verified email with an active member row is admitted as a member", async () => {
+    memberRows = [memberRow()];
+    currentUser = { id: "u1", primaryEmail: "Pat@Example.com", primaryEmailVerified: true, isAnonymous: false };
+    const gate = await requireAdmin(request());
+    expect(gate.ok).toBe(true);
+    if (gate.ok) expect(gate.source).toBe("member");
+    expect(memberLookups).toBe(1);
+  });
+
+  test("revoked, missing, and unverified members are forbidden", async () => {
+    memberRows = [memberRow({ revokedAt: new Date("2026-09-09T01:00:00.000Z") })];
+    currentUser = { id: "u1", primaryEmail: "pat@example.com", primaryEmailVerified: true, isAnonymous: false };
+    let gate = await requireAdmin(request());
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.response.status).toBe(403);
+
+    memberRows = [];
+    gate = await requireAdmin(request());
+    expect(gate.ok).toBe(false);
+
+    memberRows = [memberRow()];
+    currentUser = { id: "u1", primaryEmail: "pat@example.com", primaryEmailVerified: false, isAnonymous: false };
+    const lookupsBefore = memberLookups;
+    gate = await requireAdmin(request());
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.response.status).toBe(403);
+    expect(memberLookups).toBe(lookupsBefore);
+  });
+
+  test("anonymous and signed-out callers stay 401", async () => {
+    memberRows = [memberRow()];
+    currentUser = { id: "anon", primaryEmail: "pat@example.com", primaryEmailVerified: true, isAnonymous: true };
+    let gate = await requireAdmin(request());
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.response.status).toBe(401);
+    currentUser = null;
+    gate = await requireAdmin(request());
+    if (!gate.ok) expect(gate.response.status).toBe(401);
+    expect(memberLookups).toBe(0);
+  });
+
+  test("a failed member lookup fails closed with 403 and a logged event", async () => {
+    membersLookupFails = true;
+    const logged: unknown[][] = [];
+    const consoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      logged.push(args);
+    };
+    try {
+      currentUser = { id: "u1", primaryEmail: "pat@example.com", primaryEmailVerified: true, isAnonymous: false };
+      const gate = await requireAdmin(request());
+      expect(gate.ok).toBe(false);
+      if (!gate.ok) expect(gate.response.status).toBe(403);
+    } finally {
+      console.error = consoleError;
+    }
+    expect(logged[0]?.[0]).toBe("admin.members.lookup_failed");
+  });
+});

--- a/web/tests/admin-route-auth-members.test.ts
+++ b/web/tests/admin-route-auth-members.test.ts
@@ -126,6 +126,7 @@ describe("requireAdmin member rule", () => {
     if (!gate.ok) expect(gate.response.status).toBe(401);
     currentUser = null;
     gate = await requireAdmin(request());
+    expect(gate.ok).toBe(false);
     if (!gate.ok) expect(gate.response.status).toBe(401);
     expect(memberLookups).toBe(0);
   });


### PR DESCRIPTION
Adds an admin audit log and an invited-admin roster for the cmux-admin app.

Every admin mutation route (users, teams, email-grants POST and DELETE, subscriptions, and the new member routes) now writes one `admin_audit_log` row with the acting admin, target, details, and outcome; failures are recorded with the error code, and a failed audit write is logged as `admin.audit.write_failed` without changing the response. `requireAdmin` also admits a verified email with an unrevoked `admin_members` row; the company-domain rule is unchanged.

New routes:
- `GET /api/admin/audit?cursor=&limit=` (keyset paged, limit ≤ 200)
- `GET /api/admin/members`
- `POST /api/admin/members` `{ email }` (creates or re-invites, sends the Resend invitation, 409 `already_member`)
- `DELETE /api/admin/members` `{ memberId }` (400 `self_revoke` for the caller's own row)
- `GET /api/admin/members/me` (stamps `accepted_at` and `last_seen_at` for member rows)

Migrations: `web/db/migrations/20260909100000_admin_audit_log` and `web/db/migrations/20260909100100_admin_members`. The operator runs both on production before merge.

The invitation email uses `RESEND_API_KEY` and sends from `CMUX_FEEDBACK_FROM_EMAIL` (falls back to the founders sender). Without `RESEND_API_KEY` the invite is still recorded and the response carries `emailSent: false`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606151&installation_model_id=21920&pr_number=12253&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12253&signature=fa4a3abd67d8282ad7aeca5add6fdcabf9346a07d8faa50c25fc134809bc5c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Expands who can access admin (invited members) and touches billing/subscription and plan-grant paths; auth and audit behavior need correct migration order and verified-email checks.
> 
> **Overview**
> Introduces **persistent audit logging** for admin mutations and an **invited-admin roster** so non–company-domain operators can access the admin app.
> 
> Every wrapped mutation (user/team/email grants, subscription cancel/resume, member invite/revoke) runs through `withAdminAudit`, which writes one `admin_audit_log` row with actor, target, details, request id, and **ok/error** (including malformed bodies). Failed audit inserts log `admin.audit.write_failed` and do not alter the HTTP response. **`GET /api/admin/audit`** exposes keyset-paged history (limit ≤ 200).
> 
> **`requireAdmin`** still admits company-domain users unchanged; it also admits callers with a **verified** primary email matching an active `admin_members` row. Member lookup errors fail closed (403). New APIs list/invite/revoke members (Resend invite optional via `RESEND_API_KEY`), plus **`GET /api/admin/members/me`** to stamp acceptance and last-seen for invited admins.
> 
> Requires two new DB migrations (`admin_audit_log`, `admin_members`) before deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240ce924bf626f839ae807113f75be558a59565d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin audit log and an invited-admin roster to the cmux-admin app. Every authenticated admin mutation now writes one `admin_audit_log` row with the acting admin, target, details, and outcome, including malformed bodies and unavailable billing; failed writes are logged as `admin.audit.write_failed` and never change the response. `requireAdmin` now also admits a verified email with an unrevoked `admin_members` row, in addition to the company-domain rule. The new roster routes list, invite, revoke, and track members; invites are sent via Resend, falling back to `emailSent: false` when the key is unset or the send fails. Re-invites clear the prior tenure and use a conditional reopen so concurrent invites cannot both succeed.

**Migration**
- Run `web/db/migrations/20260909100000_admin_audit_log` and `20260909100100_admin_members` before merging.

<sup>Written for commit 240ce924bf626f839ae807113f75be558a59565d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for inviting, listing, and revoking administrator members.
  - Invited administrators receive access instructions by email.
  - Invited administrators can access admin features alongside company-domain administrators.
  - Added an admin profile endpoint with account and access details.
  - Added a paginated audit log for reviewing administrative activity.

- **Improvements**
  - Administrative grants, subscription changes, team changes, and member actions are now recorded.
  - Added validation and safeguards for invitations, revocations, and audit-log requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->