### PR TITLE
test(ui): assert the New Machine kind through the picker's segment values

### DIFF
--- a/cmuxUITests/NewMachineSheetKindUITests.swift
+++ b/cmuxUITests/NewMachineSheetKindUITests.swift
@@ -48,45 +48,42 @@ final class NewMachineSheetKindUITests: XCTestCase {
         // A segment's selection shows as its accessibility value (1 = on);
         // the summary under the picker is the user-visible witness of the
         // selection, so it is what the assertions rest on.
-        let desktop = app.radioButtons["Desktop"]
-        let base = app.radioButtons["Base"]
+        // Scope every query to the sheet: the main window behind it holds a
+        // terminal whose accessibility tree is large, and whole-app text
+        // predicates against it time out.
+        let sheet = app.sheets.firstMatch
+        let scope: XCUIElement = sheet.waitForExistence(timeout: 8.0) ? sheet : app
+        let desktop = scope.radioButtons["Desktop"]
+        let base = scope.radioButtons["Base"]
         if !desktop.waitForExistence(timeout: 8.0) {
             print("NewMachineSheetKindUITests hierarchy:\n\(app.debugDescription.prefix(6000))")
         }
         XCTAssertTrue(desktop.exists, "Expected the Desktop segment of the Kind picker in the New Machine sheet")
         XCTAssertTrue(base.exists, "Expected the Base segment of the Kind picker")
         attachScreenshot(of: app, named: "new-machine-sheet-opened")
-        print("NewMachineSheetKindUITests segments: desktop=\(String(describing: desktop.value)) selected=\(desktop.isSelected) base=\(String(describing: base.value)) selected=\(base.isSelected)")
-        let desktopSummary = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS[c] %@", "screen you can watch")
-        ).firstMatch
-        let baseSummary = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS[c] %@", "terminal only")
-        ).firstMatch
-        XCTAssertTrue(
-            desktopSummary.waitForExistence(timeout: 3.0),
-            "A plain Create must make a machine with a screen: the sheet opens on Desktop"
+        // The segment values are the witness of the selection (1 = on). The
+        // summary text under the picker is SwiftUI text whose accessibility
+        // label is not reliably queryable, so it is logged, not asserted.
+        let summary = scope.descendants(matching: .any)["NewMachineSheet.kindSummary"].firstMatch
+        print("NewMachineSheetKindUITests segments: desktop=\(String(describing: desktop.value)) base=\(String(describing: base.value)) summary=\(summary.exists ? "\(summary.label) / \(String(describing: summary.value))" : "<not exposed>")")
+        XCTAssertEqual(
+            Self.segmentIsOn(desktop), true,
+            "A plain Create must make a machine with a screen: the sheet opens on Desktop (value \(String(describing: desktop.value)))"
         )
-        XCTAssertFalse(baseSummary.exists, "Base must not be the preselected kind")
-        if let desktopOn = Self.segmentIsOn(desktop), let baseOn = Self.segmentIsOn(base) {
-            XCTAssertTrue(desktopOn && !baseOn, "Desktop segment should be the selected one")
-        }
+        XCTAssertEqual(Self.segmentIsOn(base), false, "Base must not be the preselected kind")
         attachScreenshot(of: app, named: "new-machine-sheet-desktop-preselected")
 
         // Base is one click away, never the default.
         base.click()
         XCTAssertTrue(
-            pollUntil(timeout: 4.0) { baseSummary.exists && !desktopSummary.exists },
-            "Expected the picker to select Base and the summary to say terminal only"
+            pollUntil(timeout: 4.0) { Self.segmentIsOn(base) == true && Self.segmentIsOn(desktop) == false },
+            "Expected the picker to select Base after the click (desktop \(String(describing: desktop.value)), base \(String(describing: base.value)))"
         )
-        if let desktopOn = Self.segmentIsOn(desktop), let baseOn = Self.segmentIsOn(base) {
-            XCTAssertTrue(baseOn && !desktopOn, "Base segment should be the selected one after the click")
-        }
         attachScreenshot(of: app, named: "new-machine-sheet-base-explicit")
 
-        let cancel = app.buttons["NewMachineSheet.cancel"].exists
-            ? app.buttons["NewMachineSheet.cancel"]
-            : app.buttons["Cancel"]
+        let cancel = scope.buttons["NewMachineSheet.cancel"].exists
+            ? scope.buttons["NewMachineSheet.cancel"]
+            : scope.buttons["Cancel"]
         XCTAssertTrue(cancel.waitForExistence(timeout: 3.0), "Expected the sheet's Cancel button")
         cancel.click()
         XCTAssertTrue(pollUntil(timeout: 5.0) { !desktop.exists }, "Cancel should close the sheet")

--- a/cmuxUITests/NewMachineSheetKindUITests.swift
+++ b/cmuxUITests/NewMachineSheetKindUITests.swift
@@ -48,11 +48,13 @@ final class NewMachineSheetKindUITests: XCTestCase {
         // A segment's selection shows as its accessibility value (1 = on);
         // the summary under the picker is the user-visible witness of the
         // selection, so it is what the assertions rest on.
-        // Scope every query to the sheet: the main window behind it holds a
-        // terminal whose accessibility tree is large, and whole-app text
-        // predicates against it time out.
-        let sheet = app.sheets.firstMatch
-        let scope: XCUIElement = sheet.waitForExistence(timeout: 8.0) ? sheet : app
+        // The sheet is attached to the main window (`NSWindow.beginSheet`), and
+        // every query is scoped to it: the window behind it holds a terminal
+        // whose accessibility tree is large, and whole-app text predicates
+        // against it time out. No fallback to the whole app: a picker found
+        // anywhere else would not be this sheet.
+        let scope = app.sheets.firstMatch
+        XCTAssertTrue(scope.waitForExistence(timeout: 8.0), "Expected the New Machine sheet on the main window")
         let desktop = scope.radioButtons["Desktop"]
         let base = scope.radioButtons["Base"]
         if !desktop.waitForExistence(timeout: 8.0) {


### PR DESCRIPTION
Follow-up to #12243 (issue #12239).

The `NewMachineSheetKindUITests` XCUITest merged with #12243 opens the sheet correctly (the hosted lane's recording shows **Kind: Desktop | Base** with Desktop preselected), but it failed on the hosted lane for two locator reasons: a whole-app static-text predicate walked the terminal's accessibility tree and timed out, and once scoped, the summary `Text` under the picker is not exposed with a queryable label at all. The segments, by contrast, are radio buttons whose accessibility value is `1` when selected (`desktop=Optional(1) base=Optional(0)` in the run logs).

This change scopes every query to the sheet and asserts the selection through the segment values: Desktop on and Base off when the sheet opens, the reverse after clicking Base, then Cancel closes the sheet. The summary text is logged for the record, not asserted.

Tests: hosted `test-e2e.yml` run of `cmuxUITests/NewMachineSheetKindUITests` with `record_video=true`, linked in a comment when green. `python3 scripts/swift_file_length_budget.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606432&installation_model_id=21920&pr_number=12254&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12254&signature=e1de4be289ee41793cdf14211c26b69149ea124813a6d1d39d062953856950c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to XCUITest locators and assertions; no production or runtime behavior is modified.
> 
> **Overview**
> **New Machine kind picker UI test** is updated so hosted CI stops timing out and still verifies Desktop/Base behavior.
> 
> All element lookups run against **`app.sheets.firstMatch`** (picker segments, cancel, summary) instead of the full app, avoiding walks through the terminal’s large accessibility tree.
> 
> **Assertions** now use the Desktop/Base radio segments’ accessibility values via `segmentIsOn` (Desktop on / Base off at open; reversed after clicking Base). Whole-app static-text predicates on the kind summary are removed; summary is only **logged** through `NewMachineSheet.kindSummary` when exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ec697ed1cddb9b2f6cfad81a2b74504c519443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage for the New Machine workflow.
  - Updated machine-type selection and cancellation checks to use more reliable sheet-scoped interactions.
  - Added accessibility-value validation for machine-type segments, reducing failures caused by timeouts and complex terminal interface elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the New Machine sheet kind picker test to the sheet and asserts Desktop/Base via segment accessibility values, so CI no longer times out walking the terminal's accessibility tree.

- Whole-app static-text predicates timed out, and the summary text under the picker was not queryable.
- Requires the sheet to exist on the main window; a picker found elsewhere would not be this sheet.
- Asserts Desktop/Base selection through the segment values (1 = on) and logs the summary text without asserting it.
- Follows up issue #12239.

<sup>Written for commit 50a7a4e6f324d4fedd9db0dde91f7278e5acdab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

