### PR TITLE
web: page on Stripe webhook errors, unsent purchase emails, and cron 5xx; keep operational traces

### DIFF
--- a/web/app/api/cron/vm-alerts/route.ts
+++ b/web/app/api/cron/vm-alerts/route.ts
@@ -1,4 +1,6 @@
 import { authorizeCronRequest } from "../../../../services/cronAuth";
+import { runBillingAlertChecks } from "../../../../services/observability/billingAlerts";
+import { runCronAlertChecks } from "../../../../services/observability/cronAlerts";
 import { runVmAlertChecks } from "../../../../services/observability/vmAlerts";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 
@@ -13,7 +15,9 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const checks = await runVmAlertChecks();
+  const billing = await runBillingAlertChecks();
+  const cron = await runCronAlertChecks();
   // Top-level `configured` makes a sink-less production deployment visible to
   // anything scraping the cron response, not only readers of the summary.
-  return jsonResponse({ configured: checks.alertSink.configured, checks });
+  return jsonResponse({ configured: checks.alertSink.configured, checks, billing, cron });
 }

--- a/web/services/observability/billingAlerts.ts
+++ b/web/services/observability/billingAlerts.ts
@@ -1,4 +1,5 @@
-import { and, count, gte, isNotNull, isNull, lt, desc } from "drizzle-orm";
+import { and, countDistinct, desc, eq, gte, isNotNull, isNull, lt, notExists, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { cloudDb } from "../../db/client";
 import { billingEmailVerificationDeliveries, stripeWebhookEvents } from "../../db/schema";
 import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from "./alerts";
@@ -104,13 +105,24 @@ async function countUnsentPurchaseEmailsInDb(
   since: Date,
   olderThan: Date,
 ): Promise<number> {
+  // One purchaser can own several delivery rows (one per checkout session);
+  // a row only matters when no session ever reached that account's inbox.
   const [row] = await db
-    .select({ count: count() })
+    .select({ count: countDistinct(billingEmailVerificationDeliveries.stackUserId) })
     .from(billingEmailVerificationDeliveries)
     .where(and(
       isNull(billingEmailVerificationDeliveries.sentAt),
       gte(billingEmailVerificationDeliveries.createdAt, since),
       lt(billingEmailVerificationDeliveries.createdAt, olderThan),
+      notExists(
+        db
+          .select({ one: sql`1` })
+          .from(alias(billingEmailVerificationDeliveries, "sent"))
+          .where(and(
+            eq(sql`"sent"."stack_user_id"`, billingEmailVerificationDeliveries.stackUserId),
+            isNotNull(sql`"sent"."sent_at"`),
+          )),
+      ),
     ));
   return Number(row?.count ?? 0);
 }

--- a/web/services/observability/billingAlerts.ts
+++ b/web/services/observability/billingAlerts.ts
@@ -1,0 +1,116 @@
+import { and, count, gte, isNotNull, isNull, lt, desc } from "drizzle-orm";
+import { cloudDb } from "../../db/client";
+import { billingEmailVerificationDeliveries, stripeWebhookEvents } from "../../db/schema";
+import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from "./alerts";
+
+/**
+ * Billing checks that ride the five-minute alerts cron.
+ *
+ * Two silent failures on 2026-09-10 motivate these: a paid checkout whose
+ * webhook processing threw (`stripe_webhook_events.error`) and 161 purchase
+ * sign-in emails Stack refused, both invisible until someone read a table.
+ */
+export type BillingAlertCheckSummary = {
+  readonly triggered: boolean;
+  readonly count: number;
+};
+
+export type BillingAlertSummary = {
+  readonly webhookErrors: BillingAlertCheckSummary;
+  readonly unsentPurchaseEmails: BillingAlertCheckSummary;
+};
+
+export type WebhookErrorSample = {
+  readonly count: number;
+  readonly types: readonly string[];
+  readonly latest: string | null;
+};
+
+const WEBHOOK_ERROR_WINDOW_MS = 60 * 60 * 1_000;
+const UNSENT_EMAIL_WINDOW_MS = 24 * 60 * 60 * 1_000;
+/** A delivery normally completes within seconds; allow the retry lease to lapse first. */
+const UNSENT_EMAIL_GRACE_MS = 15 * 60 * 1_000;
+
+export async function runBillingAlertChecks(options: {
+  readonly db?: ReturnType<typeof cloudDb>;
+  readonly env?: Record<string, string | undefined>;
+  readonly now?: Date;
+  readonly fetch?: AlertFetch;
+  readonly sendAlert?: (input: AlertInput) => Promise<AlertResult>;
+  readonly countWebhookErrors?: (since: Date) => Promise<WebhookErrorSample>;
+  readonly countUnsentPurchaseEmails?: (since: Date, olderThan: Date) => Promise<number>;
+} = {}): Promise<BillingAlertSummary> {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const send = options.sendAlert ?? ((input) => sendAlert(input, { fetch: options.fetch, env }));
+  const db = () => options.db ?? cloudDb();
+  const countErrors = options.countWebhookErrors ?? ((since) => countWebhookErrorsInDb(db(), since));
+  const countUnsent =
+    options.countUnsentPurchaseEmails ?? ((since, olderThan) => countUnsentPurchaseEmailsInDb(db(), since, olderThan));
+
+  const errors = await countErrors(new Date(now.getTime() - WEBHOOK_ERROR_WINDOW_MS));
+  if (errors.count > 0) {
+    await send({
+      key: "stripe-webhook-errors",
+      title: "Stripe webhook processing errors",
+      body: [
+        `${errors.count} webhook event(s) failed processing in the last hour.`,
+        `Types: ${errors.types.length ? errors.types.join(", ") : "unknown"}.`,
+        errors.latest ? `Latest error: ${errors.latest}` : "",
+        "A paid checkout in this set has no entitlement until it is replayed.",
+      ].filter(Boolean).join(" "),
+      severity: "critical",
+    });
+  }
+
+  const unsent = await countUnsent(
+    new Date(now.getTime() - UNSENT_EMAIL_WINDOW_MS),
+    new Date(now.getTime() - UNSENT_EMAIL_GRACE_MS),
+  );
+  if (unsent > 0) {
+    await send({
+      key: "purchase-emails-unsent",
+      title: "Purchase sign-in emails not delivered",
+      body: `${unsent} purchase email(s) created in the last 24 hours are still unsent after 15 minutes. Rerun the by-email backfill to retry them.`,
+      severity: "warning",
+    });
+  }
+
+  return {
+    webhookErrors: { triggered: errors.count > 0, count: errors.count },
+    unsentPurchaseEmails: { triggered: unsent > 0, count: unsent },
+  };
+}
+
+async function countWebhookErrorsInDb(
+  db: ReturnType<typeof cloudDb>,
+  since: Date,
+): Promise<WebhookErrorSample> {
+  const rows = await db
+    .select({ type: stripeWebhookEvents.type, error: stripeWebhookEvents.error })
+    .from(stripeWebhookEvents)
+    .where(and(isNotNull(stripeWebhookEvents.error), gte(stripeWebhookEvents.createdAt, since)))
+    .orderBy(desc(stripeWebhookEvents.createdAt))
+    .limit(50);
+  return {
+    count: rows.length,
+    types: [...new Set(rows.map((row) => row.type))].sort(),
+    latest: rows[0]?.error?.slice(0, 200) ?? null,
+  };
+}
+
+async function countUnsentPurchaseEmailsInDb(
+  db: ReturnType<typeof cloudDb>,
+  since: Date,
+  olderThan: Date,
+): Promise<number> {
+  const [row] = await db
+    .select({ count: count() })
+    .from(billingEmailVerificationDeliveries)
+    .where(and(
+      isNull(billingEmailVerificationDeliveries.sentAt),
+      gte(billingEmailVerificationDeliveries.createdAt, since),
+      lt(billingEmailVerificationDeliveries.createdAt, olderThan),
+    ));
+  return Number(row?.count ?? 0);
+}

--- a/web/services/observability/cronAlerts.ts
+++ b/web/services/observability/cronAlerts.ts
@@ -1,0 +1,91 @@
+import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from "./alerts";
+
+/**
+ * Cron and internal routes fail silently: Vercel retries nothing and the
+ * trace sampler used to keep 2 percent of them. This check reads the last
+ * hour of traces from Axiom and pages once per run with the failing routes.
+ *
+ * Needs `CMUX_AXIOM_READ_TOKEN` (an Axiom API token with query access) and
+ * optionally `CMUX_AXIOM_TRACES_DATASET`; without the token the check is
+ * reported as unconfigured rather than failing the cron.
+ */
+export type CronAlertSummary = {
+  readonly configured: boolean;
+  readonly queryFailed: boolean;
+  readonly failures: { readonly triggered: boolean; readonly count: number };
+};
+
+const DEFAULT_DATASET = "cmux-prod-otel-traces";
+const WINDOW_MINUTES = 65;
+
+export async function runCronAlertChecks(options: {
+  readonly env?: Record<string, string | undefined>;
+  readonly now?: Date;
+  readonly fetch?: AlertFetch;
+  readonly sendAlert?: (input: AlertInput) => Promise<AlertResult>;
+} = {}): Promise<CronAlertSummary> {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const token = env.CMUX_AXIOM_READ_TOKEN?.trim();
+  const send = options.sendAlert ?? ((input) => sendAlert(input, { fetch: options.fetch, env }));
+  if (!token) {
+    return { configured: false, queryFailed: false, failures: { triggered: false, count: 0 } };
+  }
+  const dataset = env.CMUX_AXIOM_TRACES_DATASET?.trim() || DEFAULT_DATASET;
+  const doFetch: AlertFetch = options.fetch ?? fetch;
+  const apl = [
+    `['${dataset}']`,
+    `| where _time > ago(${WINDOW_MINUTES}m)`,
+    "| where name startswith 'GET /api/cron/' or name startswith 'POST /api/cron/' or name startswith 'GET /api/internal/' or name startswith 'POST /api/internal/'",
+    "| extend code = tostring(['attributes.custom']['http.status_code'])",
+    "| summarize c=count() by name, code",
+  ].join(" ");
+  let failing: Array<{ route: string; count: number }>;
+  try {
+    const response = await doFetch("https://api.axiom.co/v1/datasets/_apl?format=legacy", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        apl,
+        startTime: new Date(now.getTime() - WINDOW_MINUTES * 60_000).toISOString(),
+        endTime: now.toISOString(),
+      }),
+    });
+    if (!response.ok) throw new Error(`axiom query ${response.status}`);
+    failing = parseFailingRoutes(await response.json());
+  } catch (error) {
+    console.warn("observability.cron_alerts.query_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { configured: true, queryFailed: true, failures: { triggered: false, count: 0 } };
+  }
+  const total = failing.reduce((sum, row) => sum + row.count, 0);
+  if (total > 0) {
+    await send({
+      key: "cron-route-failures",
+      title: "Cron or internal routes returned 5xx",
+      body: [
+        `${total} failed run(s) in the last ${WINDOW_MINUTES} minutes:`,
+        failing.map((row) => `${row.route}: ${row.count}`).join(", ") + ".",
+      ].join(" "),
+      severity: "warning",
+    });
+  }
+  return { configured: true, queryFailed: false, failures: { triggered: total > 0, count: total } };
+}
+
+function parseFailingRoutes(payload: unknown): Array<{ route: string; count: number }> {
+  const series = (payload as { buckets?: { series?: unknown[] } })?.buckets?.series ?? [];
+  const out = new Map<string, number>();
+  for (const s of series as Array<{ groups?: unknown[] }>) {
+    for (const g of s.groups ?? []) {
+      const group = (g as { group?: Record<string, unknown>; aggregations?: Array<{ value?: unknown }> });
+      const name = String(group.group?.name ?? "");
+      const code = String(group.group?.code ?? "");
+      const value = Number(group.aggregations?.[0]?.value ?? 0);
+      if (!name || !/^5\d\d$/.test(code) || !Number.isFinite(value) || value <= 0) continue;
+      out.set(name, (out.get(name) ?? 0) + value);
+    }
+  }
+  return [...out.entries()].map(([route, count]) => ({ route, count })).sort((a, b) => b.count - a.count);
+}

--- a/web/services/observability/sampler.ts
+++ b/web/services/observability/sampler.ts
@@ -26,6 +26,11 @@ export const PRIORITY_PATH_PREFIXES = [
   "/v1",
   "/api/coderouter",
   "/api/admin",
+  // Operational routes are low volume and every failure needs a full trace:
+  // scheduled crons, the retention drain, and Stripe webhook processing.
+  "/api/cron",
+  "/api/internal",
+  "/api/stripe/webhook",
 ] as const;
 const PRIORITY_SUBSYSTEMS: ReadonlySet<string> = new Set(["vm-cloud", "coderouter"]);
 

--- a/web/tests/billing-alerts.test.ts
+++ b/web/tests/billing-alerts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+import { runBillingAlertChecks } from "../services/observability/billingAlerts";
+import type { AlertInput } from "../services/observability/alerts";
+
+function recorder() {
+  const sent: AlertInput[] = [];
+  const sendAlert = mock(async (input: AlertInput) => {
+    sent.push(input);
+    return { sent: true, configured: true };
+  });
+  return { sent, sendAlert };
+}
+
+describe("billing alert checks", () => {
+  test("a webhook processing error in the window pages as critical with the event types", async () => {
+    const { sent, sendAlert } = recorder();
+    const summary = await runBillingAlertChecks({
+      now: new Date("2026-09-10T06:00:00.000Z"),
+      sendAlert,
+      countWebhookErrors: async () => ({ count: 2, types: ["checkout.session.completed"], latest: "Stack Auth user lookup exceeded its bounded page budget" }),
+      countUnsentPurchaseEmails: async () => 0,
+    });
+    expect(summary.webhookErrors).toEqual({ triggered: true, count: 2 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.key).toBe("stripe-webhook-errors");
+    expect(sent[0]?.severity).toBe("critical");
+    expect(sent[0]?.body).toContain("checkout.session.completed");
+    expect(sent[0]?.body).toContain("bounded page budget");
+  });
+
+  test("unsent purchase emails older than the grace period warn once per run", async () => {
+    const { sent, sendAlert } = recorder();
+    const summary = await runBillingAlertChecks({
+      now: new Date("2026-09-10T06:00:00.000Z"),
+      sendAlert,
+      countWebhookErrors: async () => ({ count: 0, types: [], latest: null }),
+      countUnsentPurchaseEmails: async () => 3,
+    });
+    expect(summary.unsentPurchaseEmails).toEqual({ triggered: true, count: 3 });
+    expect(sent.map((a) => a.key)).toEqual(["purchase-emails-unsent"]);
+    expect(sent[0]?.severity).toBe("warning");
+  });
+
+  test("a quiet hour sends nothing", async () => {
+    const { sent, sendAlert } = recorder();
+    const summary = await runBillingAlertChecks({
+      now: new Date("2026-09-10T06:00:00.000Z"),
+      sendAlert,
+      countWebhookErrors: async () => ({ count: 0, types: [], latest: null }),
+      countUnsentPurchaseEmails: async () => 0,
+    });
+    expect(sent).toHaveLength(0);
+    expect(summary.webhookErrors.triggered).toBe(false);
+    expect(summary.unsentPurchaseEmails.triggered).toBe(false);
+  });
+});

--- a/web/tests/cron-alerts.test.ts
+++ b/web/tests/cron-alerts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test";
+import { runCronAlertChecks } from "../services/observability/cronAlerts";
+import type { AlertInput } from "../services/observability/alerts";
+
+function axiomResponse(groups: Array<{ name: string; code: string; count: number }>) {
+  return new Response(
+    JSON.stringify({
+      buckets: {
+        series: [
+          {
+            groups: groups.map((g) => ({
+              group: { name: g.name, code: g.code },
+              aggregations: [{ value: g.count }],
+            })),
+          },
+        ],
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("cron alert checks", () => {
+  test("a 5xx on any cron or internal route in the last hour warns with the route list", async () => {
+    const sent: AlertInput[] = [];
+    const fetch = mock(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.apl).toContain("/api/cron/");
+      expect(body.apl).toContain("/api/internal/");
+      return axiomResponse([
+        { name: "GET /api/cron/vm-reconcile", code: "500", count: 2 },
+        { name: "GET /api/internal/iroh/retention", code: "200", count: 6 },
+      ]);
+    });
+    const summary = await runCronAlertChecks({
+      env: { CMUX_AXIOM_READ_TOKEN: "t", CMUX_AXIOM_TRACES_DATASET: "cmux-prod-otel-traces" },
+      fetch: fetch as never,
+      sendAlert: async (input) => { sent.push(input); return { sent: true, configured: true }; },
+    });
+    expect(summary.configured).toBe(true);
+    expect(summary.failures).toEqual({ triggered: true, count: 2 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.key).toBe("cron-route-failures");
+    expect(sent[0]?.body).toContain("GET /api/cron/vm-reconcile: 2");
+    expect(sent[0]?.body).not.toContain("retention");
+  });
+
+  test("without a read token the check reports unconfigured and sends nothing", async () => {
+    const sent: AlertInput[] = [];
+    const summary = await runCronAlertChecks({
+      env: {},
+      fetch: mock(async () => { throw new Error("must not be called"); }) as never,
+      sendAlert: async (input) => { sent.push(input); return { sent: true, configured: true }; },
+    });
+    expect(summary.configured).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("an Axiom outage does not itself page and does not throw", async () => {
+    const sent: AlertInput[] = [];
+    const summary = await runCronAlertChecks({
+      env: { CMUX_AXIOM_READ_TOKEN: "t" },
+      fetch: mock(async () => new Response("nope", { status: 503 })) as never,
+      sendAlert: async (input) => { sent.push(input); return { sent: true, configured: true }; },
+    });
+    expect(summary.configured).toBe(true);
+    expect(summary.queryFailed).toBe(true);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -282,3 +282,14 @@ describe("withApiRouteSpan re-rooting under head sampling", () => {
     expect(child?.links.length ?? 0).toBe(0);
   });
 });
+
+describe("always-kept operational routes", () => {
+  test("cron, internal, and Stripe webhook routes are priority paths", async () => {
+    const { isPriorityPath } = await import("../services/observability/sampler");
+    expect(isPriorityPath("/api/cron/vm-alerts")).toBe(true);
+    expect(isPriorityPath("/api/internal/iroh/retention")).toBe(true);
+    expect(isPriorityPath("/api/stripe/webhook")).toBe(true);
+    expect(isPriorityPath("/api/stripe/webhooks-other")).toBe(false);
+    expect(isPriorityPath("/api/devices/iroh/register")).toBe(false);
+  });
+});


### PR DESCRIPTION
Two silent failures on 2026-09-10 (a paid checkout whose webhook processing threw, and 161 purchase sign-in emails Stack refused) reached nobody, and cron 5xx responses were visible only in a 2 percent trace sample. This adds three checks to the existing five-minute `vm-alerts` cron, using the same Slack sink:

- **Stripe webhook errors** (critical): any `stripe_webhook_events` row with an error in the last hour, with event types and the latest message.
- **Unsent purchase emails** (warning): accounts whose purchase email is still unsent 15 minutes after creation in the last 24 hours, deduped per account (verified live: 2 on production, 163 rows were duplicates).
- **Cron and internal 5xx** (warning): failures on `/api/cron/*` and `/api/internal/*` in the last 65 minutes, read from Axiom with `CMUX_AXIOM_READ_TOKEN` (optional `CMUX_AXIOM_TRACES_DATASET`); without the token the check reports `configured: false`. An Axiom outage logs and does not page.

The trace sampler now keeps `/api/cron`, `/api/internal`, and `/api/stripe/webhook` at 100 percent so the cron check sees every run; those routes are low volume.

Commit 1 adds the failing tests (billing checks with injected counters, cron check with a fake Axiom response, sampler priority paths); commits 2 and 3 make them pass. 32 tests across the observability suites green, complexity gate flat. The billing counters were run live against the staging branch and production.

After merge: set `CMUX_AXIOM_READ_TOKEN` on the cmux production project.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791610816&installation_model_id=21920&pr_number=12257&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12257&signature=e2690b76027232f6af2f0cf69dd1f84ee81d4db5870f739859a27d9e31a30b26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds billing-adjacent DB monitoring and an optional Axiom dependency on a production cron route, but does not change webhook or entitlement processing logic.
> 
> **Overview**
> Extends the five-minute **`vm-alerts`** cron so it runs **billing** and **cron** checks alongside existing VM alerts, and returns **`billing`** and **`cron`** summaries in the JSON response (top-level **`configured`** still reflects the VM alert Slack sink).
> 
> **Billing alerts** query the DB on each run: **critical** pages when any `stripe_webhook_events` row has an error in the last hour (types + latest message); **warning** when distinct accounts still have purchase sign-in emails unsent 15+ minutes after creation in the last 24h (deduped per `stack_user_id`).
> 
> **Cron alerts** query Axiom traces for **5xx** on `/api/cron/*` and `/api/internal/*` over ~65 minutes when `CMUX_AXIOM_READ_TOKEN` is set; missing token yields `configured: false`, and Axiom failures set `queryFailed` without paging.
> 
> The trace sampler now **always keeps** spans for `/api/cron`, `/api/internal`, and `/api/stripe/webhook` so operational failures are fully visible in traces. Unit tests cover billing/cron alert behavior and the new priority paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870ba076735216921edc8b9f9fe5e4caa70fc807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three alert checks to the five-minute `vm-alerts` cron so silent billing and cron failures page to Slack. Stripe webhook errors and unsent purchase emails previously reached nobody, and cron 5xx responses were only visible in a 2% trace sample.

**New Features**
- Stripe webhook errors in the last hour page as critical with event types and the latest message.
- Purchase emails still unsent 15 minutes after creation warn, deduped per account (2 on production).
- Cron and internal 5xx responses in the last 65 minutes warn with the failing routes, read from Axiom; an Axiom outage logs without paging.
- The trace sampler keeps `/api/cron`, `/api/internal`, and `/api/stripe/webhook` at 100%.

**Migration**
- Set `CMUX_AXIOM_READ_TOKEN` on the production project; without it the cron check reports `configured: false`.

<sup>Written for commit 870ba076735216921edc8b9f9fe5e4caa70fc807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated billing monitoring for webhook processing errors and delayed purchase sign-in emails.
  - Added monitoring for failed cron and internal routes, with alerts for detected server errors.
  - Combined VM, billing, and cron monitoring results in the scheduled alert response.
  - Improved trace retention for cron, internal, and Stripe webhook routes to support troubleshooting.

- **Bug Fixes**
  - Alert checks now handle missing configuration and monitoring service outages without generating misleading alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->