### PR TITLE
Cloud: honor enrolled address families when selecting private routes

### DIFF
--- a/Sources/Cloud/CloudMachineLinkManager+PrivateRoute.swift
+++ b/Sources/Cloud/CloudMachineLinkManager+PrivateRoute.swift
@@ -19,6 +19,9 @@ extension CloudMachineLinkManager {
         let addresses = candidates.filter {
             CloudWireGuardHub.routesHost($0, enrolledRoutes: hub.routes)
         }
+        if addresses.count == 1, let address = addresses.first {
+            return Self.route(for: address)
+        }
         guard addresses.count > 1, let primary = addresses.first else { return primaryRoute }
         let connected: CloudHubConnector.Connected
         do {
@@ -33,6 +36,11 @@ extension CloudMachineLinkManager {
         }
         connected.connection.cancel()
         let host = connected.host.contains(":") ? "[\(connected.host)]" : connected.host
+        return "ws://\(host):1337/v1/link"
+    }
+
+    private static func route(for address: String) -> String {
+        let host = address.contains(":") ? "[\(address)]" : address
         return "ws://\(host):1337/v1/link"
     }
 }

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -182,11 +182,13 @@ actor CloudMachineLinkManager {
             }
             guard let hub else { throw ManagerError.wireGuardHubMissing }
             let claim = try await hub.acquire()
-            guard Self.usesWireGuardHub(
-                route: privateRoute,
-                clientCapabilities: capabilities,
-                enrolledRoutes: claim.ready.routes
-            ) else {
+            let candidates = privateAddresses(for: machineID)
+            let hasEligibleCandidate = candidates.contains {
+                CloudWireGuardHub.routesHost($0, enrolledRoutes: claim.ready.routes)
+            }
+            guard candidates.isEmpty
+                ? Self.usesWireGuardHub(route: privateRoute, clientCapabilities: capabilities, enrolledRoutes: claim.ready.routes)
+                : hasEligibleCandidate else {
                 await hub.release(claim.lease)
                 throw ManagerError.privateRouteRequired(privateRoute)
             }

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -501,16 +501,33 @@ extension TerminalController {
                 let hub = await MainActor.run { CmuxTuiSurfaceProviderRegistry.shared.wireGuardHub }
                 guard let hub else { throw CloudMachineLinkManager.ManagerError.wireGuardHubMissing }
                 let ready = try await hub.pinForExternalClient()
-                guard CloudMachineLinkManager.usesWireGuardHub(
-                    route: route,
-                    clientCapabilities: clientCapabilities,
-                    enrolledRoutes: ready.routes
-                ) else {
-                    throw CloudMachineLinkManager.ManagerError.privateRouteRequired(route)
-                }
                 payload["wireguard_hub_socket"] = ready.socketPath
                 let addresses = payload["network_addresses"] as? [String: Any] ?? [:]
-                payload["route"] = try await registry.resolvedPrivateRoute(machineID: vmId, through: ready, fallbackRoute: route, addresses: ["ipv4", "ipv6"].compactMap { addresses[$0] as? String })
+                var candidates = ["ipv4", "ipv6"].compactMap { addresses[$0] as? String }
+                if candidates.isEmpty {
+                    candidates = await registry.privateAddresses(machineID: vmId)
+                }
+                if candidates.isEmpty {
+                    guard CloudMachineLinkManager.usesWireGuardHub(
+                        route: route,
+                        clientCapabilities: clientCapabilities,
+                        enrolledRoutes: ready.routes
+                    ) else {
+                        throw CloudMachineLinkManager.ManagerError.privateRouteRequired(route)
+                    }
+                } else {
+                    guard candidates.contains(where: {
+                        CloudWireGuardHub.routesHost($0, enrolledRoutes: ready.routes)
+                    }) else {
+                        throw CloudMachineLinkManager.ManagerError.privateRouteRequired(route)
+                    }
+                }
+                payload["route"] = try await registry.resolvedPrivateRoute(
+                    machineID: vmId,
+                    through: ready,
+                    fallbackRoute: route,
+                    addresses: candidates
+                )
                 return payload
             }
         case "vm.sessions":

--- a/Sources/Surfaces/CmuxTuiSurfaceProviderRegistry.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviderRegistry.swift
@@ -235,6 +235,10 @@ final class CmuxTuiSurfaceProviderRegistry {
         await links.privateRoute(for: machineID)
     }
 
+    func privateAddresses(machineID: String) async -> [String] {
+        await links.privateAddresses(for: machineID)
+    }
+
     func resolvedPrivateRoute(machineID: String, through hub: CloudWireGuardHub.Ready, fallbackRoute: String, addresses: [String]) async throws -> String {
         try await links.resolvedPrivateRoute(machineID: machineID, through: hub, fallbackRoute: fallbackRoute, addresses: addresses)
     }

--- a/cmuxTests/CloudPrivateRouteSelectionTests.swift
+++ b/cmuxTests/CloudPrivateRouteSelectionTests.swift
@@ -37,6 +37,16 @@ struct CloudPrivateRouteSelectionTests {
         #expect(route == "ws://[fd00::2]:1337/v1/link")
     }
 
+    @Test func soleIPv4AddressInsideTheEnrolledRoutesWinsAfterFiltering() async throws {
+        let route = try await manager().resolvedPrivateRoute(
+            machineID: "vm-test",
+            through: CloudWireGuardHub.Ready(socketPath: "/unused", routes: ["10.16.0.0/24"]),
+            fallbackRoute: "ws://[fd00::2]:1337/v1/link",
+            addresses: ["fd00::2", "10.16.0.2"]
+        )
+        #expect(route == "ws://10.16.0.2:1337/v1/link")
+    }
+
     @Test func legacyCallerWithoutAddressCandidatesKeepsItsRoute() async throws {
         let route = try await manager().resolvedPrivateRoute(
             machineID: "vm-test",


### PR DESCRIPTION
Superseded by merged #12266. Its shared resolver covers the sole enrolled family, all-candidate eligibility, and stored-address fallback implemented here. Closing this stacked duplicate; #12268 owns the separate live provider-network reachability fix.

Cloud connections could keep an old IPv4 route even when the WireGuard hub enrolled only IPv6 (or vice versa). Select the sole enrolled address after filtering, and check all known candidates before rejecting a connection. Repeated `vm tui` connections also reuse the registry's saved address candidates when their endpoint payload omits `network_addresses`.

Stacked on #12267. This follow-up contains the route eligibility fix; the parent contains the dual-stack connection work and the failing regression tests.

Validation:
- The parent regression run reproduced both stale-IPv4 failures: https://github.com/manaflow-ai/cmux/actions/runs/34469774911
- The focused route-selection run on `d7cdb3d322ec39583fb4731d72dfe843bfed02d7` was cancelled after confirming that merged #12266 supersedes this implementation: https://github.com/manaflow-ai/cmux/actions/runs/34480011525
- Test wiring and workspace package grouping checks passed; `git diff --check` passed.
- Tagged fleet build passed on pushed HEAD `d7cdb3d322ec39583fb4731d72dfe843bfed02d7`; the downloaded bundle records `CMUXCommit=d7cdb3d32`. [Build](http://127.0.0.1:17320/cloud-snapshot-route-eligibility). The default development backend hostname does not resolve, so backend provisioning was disabled. Live Cloud connection dogfood remains pending.

Localization audit: no user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791637304&installation_model_id=21920&pr_number=12269&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12269&signature=c947ae5e198e32ffeea6d5a35b7255882eb676c1c9420798ee8088deb2e314a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d7cdb3d322ec39583fb4731d72dfe843bfed02d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud private route selection so connections no longer keep a route for an address family the WireGuard hub didn't enroll. Now selects the sole enrolled candidate after filtering, and rejects only when no candidate matches.

- Repeated `vm tui` connections reuse the registry's saved address candidates when the endpoint payload omits `network_addresses`.
- Route selection now checks all known candidates before rejecting a connection.

<sup>Written for commit d7cdb3d322ec39583fb4731d72dfe843bfed02d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Latest investigation (Nightly `02d75978e4`, September 10): the new VM daemon was running from creation, but the Nightly client dialed IPv4 only. Read-only probes through that same running WireGuard hub timed out after 8 seconds on IPv4 ports 1337 and 6901; IPv6 returned daemon HTTP 404 in 20 ms and desktop HTTP 200 in 48 ms. The UI subsequently reported the 60-second link timeout.

Upstream coordination: #12266 merged at 12:51 UTC and already includes a broader shared route resolver plus independent discovery. This stacked PR overlaps that merged work and should not be merged as a replacement. #12268 tracks the separate provider-network announcement fix and documents the interventions that restored the earlier VMs. The installed Nightly predates both changes.
