### PR TITLE
Fix CodeRouter mappings for Base and fork provisioning

### DIFF
--- a/web/app/api/vm/[id]/fork/route.ts
+++ b/web/app/api/vm/[id]/fork/route.ts
@@ -10,6 +10,7 @@ import { runVmRoute } from "../../../../../services/vms/routeWorkflow";
 import { setSpanAttributes } from "../../../../../services/telemetry";
 import { captureVmProvisionOutcome } from "../../../../../services/vms/observability";
 import { forkVm } from "../../../../../services/vms/workflows";
+import { vmModelPlaneGatewayFor } from "../../../../../services/vms/modelPlaneGateway";
 import { VmTimingRecorder } from "../../../../../services/vms/timings";
 import { authProviderErrorResponse } from "../../../../../services/vms/authErrors";
 import {
@@ -77,6 +78,10 @@ export async function POST(
         providerVmId: id,
         name,
         idempotencyKey,
+        modelPlane: vmModelPlaneGatewayFor({
+          teamId: entitlements.billingTeamId,
+          stackUserId: user.id,
+        }),
         timing,
       }), {
         request,

--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -26,6 +26,7 @@ import {
   type VmWorkflowErrorOverrides,
 } from "../../../../services/vms/routeHelpers";
 import { runVmRoute } from "../../../../services/vms/routeWorkflow";
+import { vmModelPlaneGatewayFor } from "../../../../services/vms/modelPlaneGateway";
 import type { VmTimingRecorder } from "../../../../services/vms/timings";
 import {
   openBaseVm,
@@ -102,6 +103,10 @@ export async function runBaseRoute(input: {
     image: imageSelection.image,
     imageVersion: imageSelection.imageVersion,
     baseName: parsed.body.name,
+    modelPlane: vmModelPlaneGatewayFor({
+      teamId: entitlements.billingTeamId,
+      stackUserId: input.user.id,
+    }),
     timing: input.timing,
   };
   const run = await runVmRoute(

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -731,6 +731,7 @@ export function openBaseVm(input: {
   readonly image: string;
   readonly imageVersion?: string | null;
   readonly baseName?: string;
+  readonly modelPlane?: VmModelPlaneProvisioner;
   readonly timing?: VmTimingSink;
 }): Effect.Effect<BaseVmEntry, VmWorkflowError, VmRepository | VmProviderGateway | VmBillingGateway> {
   return Effect.gen(function* () {
@@ -763,6 +764,7 @@ export function resetBaseVm(input: {
   readonly imageVersion?: string | null;
   readonly baseName?: string;
   readonly reason?: string | null;
+  readonly modelPlane?: VmModelPlaneProvisioner;
   readonly timing?: VmTimingSink;
 }): Effect.Effect<BaseVmEntry, VmWorkflowError, VmRepository | VmProviderGateway | VmBillingGateway> {
   return Effect.gen(function* () {
@@ -798,7 +800,8 @@ function finishBaseCreate(
     readonly image: string;
     readonly imageVersion?: string | null;
     readonly baseName?: string;
-      readonly timing?: VmTimingSink;
+    readonly modelPlane?: VmModelPlaneProvisioner;
+    readonly timing?: VmTimingSink;
   },
   create: BeginBaseCreateResult,
 ): Effect.Effect<BaseVmEntry, VmWorkflowError, never> {
@@ -858,6 +861,27 @@ function finishBaseCreate(
       ),
     );
 
+    const materials = yield* measureVmEffect(
+      input.timing,
+      "model_plane_provision",
+      provisionModelPlane(input.modelPlane, create.vm.id),
+    ).pipe(
+      Effect.tapError((err) =>
+        Effect.all([
+          refundCredit(billing, repo, create.vm, creditReservation),
+          repo.markBaseCreateFailed({
+            baseId: create.base.id,
+            generation: create.generation.generation,
+            vmId: create.vm.id,
+            userId: input.userId,
+            code: VM_MODEL_PLANE_FAILURE_CODES[err.kind],
+            message: errorMessage(err.cause),
+          }),
+          recordCreateFailureEvent(repo, input, create.vm, "model_plane_provision", errorMessage(err.cause)),
+        ], { discard: true }).pipe(Effect.catchAll(() => Effect.void)),
+      ),
+    );
+
     const handle = yield* measureVmEffect(
       input.timing,
       "provider_create",
@@ -865,12 +889,14 @@ function finishBaseCreate(
         image: input.image,
         displayName: create.vm.slug ?? undefined,
         providerMetadata: create.vm.providerMetadata,
+        edgeRules: materials?.edgeRules,
         network: { id: network.providerNetworkId },
       }),
     ).pipe(
       Effect.tapError((err) =>
         Effect.all([
           refundCredit(billing, repo, create.vm, creditReservation),
+          revokeModelPlane(input.modelPlane, create.vm.id),
           repo.markBaseCreateFailed({
             baseId: create.base.id,
             generation: create.generation.generation,
@@ -910,6 +936,7 @@ function finishBaseCreate(
       Effect.catchAll((err) =>
         Effect.gen(function* () {
           yield* rollbackProviderCreate(providers, input.provider, handle);
+          yield* revokeModelPlane(input.modelPlane, create.vm.id);
           yield* refundCredit(billing, repo, create.vm, creditReservation);
           yield* repo.markBaseCreateFailed({
             baseId: create.base.id,
@@ -1293,6 +1320,7 @@ export function forkVm(input: {
   readonly providerVmId: string;
   readonly name?: string;
   readonly idempotencyKey?: string;
+  readonly modelPlane?: VmModelPlaneProvisioner;
   readonly timing?: VmTimingSink;
 }) {
   return Effect.gen(function* () {
@@ -1320,7 +1348,10 @@ export function forkVm(input: {
       { forceProviderProbe: true, maxActiveVms: input.maxActiveVms },
     );
 
-    const nativeFork = source.provider === "freestyle" && providers.fork !== undefined;
+    // A native fork has no way to accept the new row's edge rules. Use the
+    // snapshot/create path for a model-plane machine so it receives its own
+    // VM-bound credential instead of inheriting an unrouteable alias.
+    const nativeFork = !input.modelPlane && source.provider === "freestyle" && providers.fork !== undefined;
     // The provider owns cloning the source. Record its initial shape and
     // reconcile the copied machine independently after the fork completes.
     const sourceHasReservation = hasVmResourceReservationMetadata(source.providerMetadata);
@@ -1520,6 +1551,7 @@ export function forkVm(input: {
       ...(sourceReservation ? { resourceReservation: sourceReservation } : {}),
       idempotencyKey: input.idempotencyKey,
       origin: "fork",
+      modelPlane: input.modelPlane,
       timing: input.timing,
     });
     yield* repo.recordUsageEvent({

--- a/web/tests/vm-model-plane-workflow.test.ts
+++ b/web/tests/vm-model-plane-workflow.test.ts
@@ -16,12 +16,15 @@ import {
   vmWorkflowErrorCause,
 } from "../services/vms/errors";
 import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
-import { VmRepository, type CloudVmRow, type VmRepositoryShape } from "../services/vms/repository";
+import { VmRepository, type BeginBaseCreateResult, type CloudVmRow, type VmRepositoryShape } from "../services/vms/repository";
 import { vmCreateLikeErrorResponse, vmWorkflowErrorResponse } from "../services/vms/routeHelpers";
 import {
   createVm,
   destroyVm,
+  forkVm,
+  openBaseVm,
   reconcileVmProviderStatuses,
+  resetBaseVm,
   restoreVm,
   type VmModelPlaneMaterials,
   type VmModelPlaneProvisioner,
@@ -34,7 +37,7 @@ import {
 
 const ROW_ID = "00000000-0000-4000-8000-00000000c0de";
 const MATERIALS: VmModelPlaneMaterials = {
-  edgeRules: [{ domain: "coderouter.dev", headers: { "x-coderouter-route-token": "crt_t", "x-cmux-vm-id": ROW_ID } }],
+  edgeRules: [{ domain: "coderouter.cmux.internal", destinationHost: "coderouter.dev", headers: { "x-coderouter-route-token": "crt_t", "x-cmux-vm-id": ROW_ID } }],
 };
 
 type UsageEvent = Parameters<VmRepositoryShape["recordUsageEvent"]>[0];
@@ -371,6 +374,111 @@ describe("restoreVm model plane", () => {
     );
     expect(provisioned).toEqual([ROW_ID]);
     expect(creates[0]?.image).toBe("snap-1");
+    expect(creates[0]?.edgeRules).toEqual(MATERIALS.edgeRules);
+  });
+});
+
+function baseRepo(failed: unknown[], overrides: Partial<VmRepositoryShape> = {}): VmRepositoryShape {
+  const vm = row();
+  const now = vm.createdAt;
+  const create: Extract<BeginBaseCreateResult, { kind: "create" }> = {
+    kind: "create",
+    vm,
+    base: {
+      id: "base-mp", scopeType: "team", scopeId: "team-mp", name: "base",
+      activeGeneration: 1, activeVmId: null, activeProvider: null, activeProviderVmId: null,
+      state: "provisioning", createdByUserId: vm.userId, lastOpenedByUserId: vm.userId,
+      createdAt: now, updatedAt: now,
+    },
+    generation: {
+      id: "generation-mp", baseId: "base-mp", generation: 1, vmId: vm.id,
+      provider: "freestyle", providerVmId: null, state: "provisioning",
+      createdByUserId: vm.userId, retainedAt: null, deletedAt: null, createdAt: now, updatedAt: now,
+    },
+    previousGeneration: null,
+    previousVm: null,
+  };
+  return {
+    ...fakeRepo({ usageEvents: [], failed: [] }),
+    beginBaseOpen: () => Effect.succeed(create),
+    beginBaseReset: () => Effect.succeed(create),
+    markBaseCreateRunning: (update) => Effect.succeed({ ...vm, status: "running", providerVmId: update.providerVmId }),
+    markBaseCreateFailed: (failure) => Effect.sync(() => { failed.push(failure); }),
+    ...overrides,
+  };
+}
+
+describe("Base model plane", () => {
+  for (const [name, operation] of [["open", openBaseVm], ["reset", resetBaseVm]] as const) {
+    test(`${name} installs a rule bound to the new row before handing out the Base`, async () => {
+      const creates: CreateOptions[] = [];
+      const provisioned: string[] = [];
+      const modelPlane = fakeModelPlane({ provisioned, revoked: [] });
+      // Keep this input assignable before the fix: the behavioral assertion,
+      // rather than a missing input property, must be the red regression.
+      const input = { ...createInput, modelPlane };
+      await Effect.runPromise(operation(input).pipe(Effect.provide(layer(
+        baseRepo([]),
+        { ...fakeProviders({ creates }), create: (provider, options) => {
+          expect(provisioned).toEqual([ROW_ID]);
+          return fakeProviders({ creates }).create(provider, options);
+        } },
+      ))));
+      expect(creates[0]?.edgeRules).toEqual(MATERIALS.edgeRules);
+    });
+
+    test(`${name} fails closed and refunds when provisioning cannot issue a route`, async () => {
+      const creates: CreateOptions[] = [];
+      const failed: unknown[] = [];
+      const refunds: unknown[] = [];
+      const input = { ...createInput, modelPlane: fakeModelPlane({
+        provisioned: [], revoked: [], fail: new VmModelPlaneError({ kind: "unavailable", cause: new Error("db down") }),
+      }) };
+      const result = await Effect.runPromise(operation(input).pipe(Effect.either, Effect.provide(layer(
+        baseRepo(failed), fakeProviders({ creates }), billingWithRefunds(refunds),
+      ))));
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") expect(result.left).toBeInstanceOf(VmModelPlaneError);
+      expect(creates).toEqual([]);
+      expect(failed).toEqual([expect.objectContaining({ vmId: ROW_ID, code: VM_MODEL_PLANE_FAILURE_CODES.unavailable })]);
+      expect(refunds).toHaveLength(1);
+    });
+
+    test(`${name} revokes its token on provider or finalization failure`, async () => {
+      for (const stage of ["provider", "database"] as const) {
+        const revoked: string[] = [];
+        const destroyed: string[] = [];
+        const input = { ...createInput, modelPlane: fakeModelPlane({ provisioned: [], revoked }) };
+        const repo = baseRepo([], stage === "database" ? {
+          markBaseCreateRunning: () => Effect.fail(new VmDatabaseError({ operation: "markBaseCreateRunning", cause: new Error("db") })),
+        } : {});
+        await Effect.runPromise(operation(input).pipe(Effect.either, Effect.provide(layer(
+          repo, fakeProviders({ creates: [], createFails: stage === "provider", destroyed }),
+        ))));
+        expect(revoked).toEqual([ROW_ID]);
+        expect(destroyed).toEqual(stage === "database" ? ["provider-vm-mp"] : []);
+      }
+    });
+  }
+});
+
+describe("fork model plane", () => {
+  test.each([false, true])("a fork gets its own inline rule even when a native fork is exposed: %s", async (native) => {
+    const creates: CreateOptions[] = [];
+    const provisioned: string[] = [];
+    const source = row({ id: "source-row", providerVmId: "source-vm", status: "running" });
+    const input = { ...createInput, teamIds: ["team-mp"], providerVmId: "source-vm", modelPlane: fakeModelPlane({ provisioned, revoked: [] }) };
+    const result = await Effect.runPromise(forkVm(input).pipe(Effect.provide(layer(
+      { ...fakeRepo({ usageEvents: [], failed: [] }), findUserVm: () => Effect.succeed(source) },
+      {
+        ...fakeProviders({ creates }),
+        snapshot: () => Effect.succeed({ id: "source-copy", createdAt: 0 }),
+        ...(native ? { fork: () => Effect.die(new Error("native fork cannot install the new VM's edge rule")) } : {}),
+      },
+    ))));
+    expect(result.fork.providerVmId).toBe("provider-vm-mp");
+    expect(provisioned).toEqual([ROW_ID]);
+    expect(creates[0]?.image).toBe("source-copy");
     expect(creates[0]?.edgeRules).toEqual(MATERIALS.edgeRules);
   });
 });

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -1097,6 +1097,11 @@ describe("VM REST auth", () => {
         expect(response.status).toBe(200);
         expect(runVmWorkflow).toHaveBeenCalledTimes(1);
         expect(route.constructor).toHaveBeenCalledTimes(1);
+        const provisionInput = (route.constructor.mock.calls as unknown[][])[0]?.[0] as {
+          modelPlane?: { provision?: unknown; revoke?: unknown };
+        };
+        expect(typeof provisionInput.modelPlane?.provision).toBe("function");
+        expect(typeof provisionInput.modelPlane?.revoke).toBe("function");
       }
     }
   });


### PR DESCRIPTION
## Summary

Base open/reset and fork could allocate a Cloud VM without its CodeRouter TLS rule. The image still points Codex at `https://coderouter.cmux.internal/v1/responses`, but the provider has no rule binding that source VM to the CodeRouter origin. A client retaining the alias address/CA then receives Freestyle's `404 no VM is mapped to coderouter.cmux.internal` on every reconnect.

Related to #12271. The original report does not identify its VM, so this fixes a reproduced provisioning defect without claiming that the reporter's particular machine has been repaired.

- Pass the existing team/user-scoped model-plane gateway through Base open/reset and fork.
- Base creation issues the new row's token before provider allocation, passes the inline rule, fails closed/refunds on provisioning failure, and revokes on provider or database-finalization rollback.
- Model-plane forks use the existing snapshot/create path, which provisions a rule bound to the copy's row. Trade-off: this takes a snapshot instead of using the native-fork interface, which cannot accept new edge rules. The current Freestyle driver does not implement native fork.
- Existing mappings, client retry policy, login origins, provider selection, and the guest's placeholder-only credential contract are unchanged. This does not automatically repair a previously allocated machine whose rule is missing.

## Regression attribution

The first incomplete model-plane wiring is `a9207e460e` (#11622): it added the provisioner to create and restore, omitting Base and fork. `0f19be0471` (#11813) then baked the internal alias into every image and added the alias destination host. The later `f838159173` (#11897) native-fork branch also bypasses model-plane setup.

Reviewed the requested suspects: #12144 (CLI bootstrap; #12139 is its issue), #12205 (browser login origin only; #12203 is its issue), #12111 (upstream provider selection), #12103 (dashboard accounts/team scope), and #11798 (CodeRouter telemetry/health). They do not create/delete the VM alias rule. The exact missing-mapping response is reproducible at the Freestyle edge before CodeRouter authentication. Removing the older startup probe (#11771/#11791) removed detection, but does not explain why a rule is absent.

## Validation

- `61dcd1ca54`: test-only commit. Hosted [web CI](https://github.com/manaflow-ai/cmux/actions/runs/34506013023/job/102968424899) passed typecheck and failed all 9 new regression cases. The remaining obsolete full-suite jobs were canceled after capturing this failure.
- `0ff462c504`: fix. 98 route/model-plane workflow tests pass; 136 additional provider, lifecycle, workflow adapter, and route-token authentication tests pass (57 database-only cases skipped locally). Typecheck and complexity pass. Scoped ESLint has no errors and one pre-existing unused-variable warning.
- Live Freestyle reproduction: on an isolated VM, retain the client's CA/address and delete its rule; three requests return the exact reported 404. Re-create the rule; the request reaches CodeRouter again.
- Live patched workflows: Base creation and snapshot/fork use real Freestyle allocation, inline TLS rules, and guest Codex 0.154.0. The controlled HTTPS origin uses the production route-token authenticator with an in-memory token store and a synthetic Responses stream. It deliberately truncates the first stream: Codex prints `Reconnecting... 1/5`, reconnects, and completes `pong`. Pause/resume retains the session; the fork resumes the same Codex conversation using a distinct VM-bound rule. A forged guest `x-cmux-vm-id` is overwritten by the edge and the correct binding is authenticated.
- Production read-only probes: 11 existing mapped machines reach CodeRouter over HTTP/1.1 and HTTP/2. A real model completion was blocked by the connected upstream account's usage limit; synthetic streaming isolates routing/reconnect from that quota.
- Fixed-head hosted [web CI](https://github.com/manaflow-ai/cmux/actions/runs/34506418769/job/102970475015): 2,767 pass, 242 skip, 0 fail; all 8 browser checks pass. Database-migration and workflow guards pass. Extra macOS jobs from the manual full-suite run are asynchronous.
- Tagged fleet build succeeded on `0ff462c504`: http://127.0.0.1:17320/issue-12271-coderouter-reconnect
- The post-merge CLA policy guard fails because its live-PR validation requires state `open` (scripts/ci/validate-cla-policy.rb:2472). CLA policy files are unchanged. This is not an all-required-checks-green result.
- No user-facing strings changed; localization audit found no new catalog entries required.

Preview: https://cmux-ol6rchg24-manaflow.vercel.app — READY on the pushed commit; Base open responds 401 without authentication. CLI config returns 503 because no branch-applicable preview Stack credentials are configured. Authenticated preview dogfood remains unavailable; the reconnect evidence above comes from the real-VM controlled-origin harness. The automatic clone-project previews had no API routes.

GitHub records an external merge by austinywang at 2026-09-10 17:13:13 UTC, commit 6c9fe2ab1894ff47b2e2f5908d828161e5832e0b. This task issued no merge command. Existing user sessions and route rules were preserved. All verification VMs, snapshots, and networks were deleted.
