### PR TITLE
Align mobile Mac floors with protocol history

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -25,29 +25,66 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
     /// The compiled-in fallback, mirroring the initial committed entries of
     /// `web/data/mobile-mac-compat.ts`. Keep the two in sync when editing:
     /// the remote list replaces this the first time a device fetches it.
-    /// The tier starts at 1.0.0 so it covers the App Store lane (which ships
-    /// as 1.0.0) as well as the 1.0.4 beta lane.
+    /// The fallback mirrors the protocol eras in
+    /// `web/data/mobile-mac-compat.ts`: 0.64.17 for the original release
+    /// transport, 0.64.20 for authenticated Iroh, and 0.64.23 for the rebuilt
+    /// Iroh transport. The App Store lane stays at 0.64.23 in every tier. The
+    /// BETA 1.0.4 build 20260817224846 is the last older-compatible build;
+    /// the later INTERNAL 1.0.4 cut uses the rebuilt transport.
     public static let baked: MobileMacCompatPolicy = {
         guard let minIOS = MobileMacAppVersion(parsing: "1.0.0"),
+              let maxIOS = MobileMacAppVersion(parsing: "1.0.3"),
+              let irohIOS = MobileMacAppVersion(parsing: "1.0.4"),
+              let nextIOS = MobileMacAppVersion(parsing: "1.0.5"),
+              let legacyStableMin = MobileMacAppVersion(parsing: "0.64.17"),
+              let irohStableMin = MobileMacAppVersion(parsing: "0.64.20"),
               let stableMin = MobileMacAppVersion(parsing: "0.64.23"),
               let nightlyBase = MobileMacAppVersion(parsing: "0.64.22")
         else {
             return MobileMacCompatPolicy(tiers: [])
         }
+        let nightly = NightlyRequirement(
+            minBaseVersion: nightlyBase,
+            minBuild: 3_345_650_013_202
+        )
+        let devMin = MobileMacAppVersion(parsing: "0.64.0")!
         return MobileMacCompatPolicy(tiers: [
             Tier(
                 minIOSVersion: minIOS,
+                maxIOSVersion: maxIOS,
                 stableMinVersion: stableMin,
-                nightly: NightlyRequirement(
-                    minBaseVersion: nightlyBase,
-                    minBuild: 3_345_650_013_202
-                ),
+                nightly: nightly,
                 buildKinds: [
-                    MobileBuildType.dev.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.0")!),
-                    MobileBuildType.beta.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
-                    MobileBuildType.internal.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
-                    MobileBuildType.demo.token: Requirement(stableMinVersion: MobileMacAppVersion(parsing: "0.64.22")!),
-                    MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: NightlyRequirement(minBaseVersion: nightlyBase, minBuild: 3_345_650_013_202)),
+                    MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: legacyStableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: legacyStableMin),
+                    MobileBuildType.demo.token: Requirement(stableMinVersion: legacyStableMin),
+                    MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
+                ]
+            ),
+            Tier(
+                minIOSVersion: irohIOS,
+                maxIOSVersion: irohIOS,
+                stableMinVersion: stableMin,
+                nightly: nightly,
+                buildKinds: [
+                    MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: irohStableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.demo.token: Requirement(stableMinVersion: irohStableMin),
+                    MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
+                ]
+            ),
+            Tier(
+                minIOSVersion: nextIOS,
+                stableMinVersion: stableMin,
+                nightly: nightly,
+                buildKinds: [
+                    MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.demo.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                 ]
             ),
         ])

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
@@ -288,15 +288,49 @@ import Testing
     // MARK: - Baked fallback
 
     @Test func bakedPolicyConstrainsEveryCurrentLaneToNextReleases() {
-        // The App Store lane ships as 1.0.0 and the beta lane as 1.0.4;
-        // both must fall inside the first tier.
-        for appVersion in ["1.0.0", "1.0.4"] {
-            let tier = MobileMacCompatPolicy.baked.tier(forIOSVersion: appVersion)
-            #expect(tier?.stableMinVersion == version("0.64.23"))
-            #expect(tier?.nightly?.minBuild == 3_345_650_013_202)
-        }
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.stableMinVersion == version("0.64.23"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.stableMinVersion == version("0.64.23"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.5")?.stableMinVersion == version("0.64.23"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.buildKinds["internal"]?.stableMinVersion == version("0.64.23"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.buildKinds["beta"]?.stableMinVersion == version("0.64.20"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.5")?.buildKinds["internal"]?.stableMinVersion == version("0.64.23"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.buildKinds["internal"]?.stableMinVersion == version("0.64.17"))
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.nightly?.minBuild == 3_345_650_013_202)
         // Versions below the first tier stay unconstrained.
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "0.9.9") == nil)
+    }
+
+    @Test func bakedPolicyUsesTheHistoricalInternalProtocolFloors() {
+        #expect(MobileMacCompatPolicy.baked.violation(
+            iosVersion: "1.0.3",
+            channel: .stable,
+            macAppVersion: "0.64.16",
+            buildType: .internal
+        ) != nil)
+        #expect(MobileMacCompatPolicy.baked.violation(
+            iosVersion: "1.0.3",
+            channel: .stable,
+            macAppVersion: "0.64.17",
+            buildType: .internal
+        ) == nil)
+        #expect(MobileMacCompatPolicy.baked.violation(
+            iosVersion: "1.0.4",
+            channel: .stable,
+            macAppVersion: "0.64.22",
+            buildType: .internal
+        ) != nil)
+        #expect(MobileMacCompatPolicy.baked.violation(
+            iosVersion: "1.0.4",
+            channel: .stable,
+            macAppVersion: "0.64.23",
+            buildType: .internal
+        ) == nil)
+        #expect(MobileMacCompatPolicy.baked.violation(
+            iosVersion: "1.0.4",
+            channel: .stable,
+            macAppVersion: "0.64.20",
+            buildType: .beta
+        ) == nil)
     }
 
     // MARK: - Fail-open when the server does not cover this app version

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -7,13 +7,17 @@
  * `minIOSVersion` <= the app's version wins, and an iOS version below every
  * tier is unconstrained (fail-open: an app whose version the server does not
  * cover gets NO Mac version limit rather than an accidental block-everything).
- * The initial tier starts at 1.0.0 so it covers every current lane — the
- * App Store app ships as 1.0.0 and the beta lane as 1.0.4 — and constrains
- * them to the next stable release (0.64.23; current stable is 0.64.22) and
- * the next nightly (the newest published nightly build at authoring time is
- * 3345650013201, so minBuild 3345650013202 means "any nightly published
- * after this was written"). Binaries built before the gate shipped ignore
- * this list entirely, so covering their versions is harmless.
+ * The first tier starts at 1.0.0 so it covers the App Store lane and older
+ * TestFlight builds. The tiers track the protocol milestones in git history:
+ * Tailscale pairing became usable with 0.64.17, authenticated Iroh with
+ * 0.64.20, and the rebuilt Iroh transport with 0.64.23. The App Store
+ * marketing version remains 1.0.0, so its build kind has to carry the
+ * stricter floor while older TestFlight versions retain the Mac releases they
+ * can actually use. In particular, BETA 1.0.4 build 20260817224846 is the
+ * last build that works with older Macs, while the later INTERNAL 1.0.4 cut
+ * uses the rebuilt transport and needs 0.64.23.
+ * Binaries built before the gate shipped ignore this list entirely, so
+ * covering their versions is harmless.
  *
  * Nightly builds are versioned `<base>-nightly.<run id><attempt>` by
  * .github/workflows/nightly.yml, so build counters are globally monotonic.
@@ -80,14 +84,46 @@ export const mobileMacCompatList: MobileMacCompatList = {
   entries: [
     {
       minIOSVersion: "1.0.0",
-      // Keep these mirrored to prod while older iOS clients are still deployed.
+      maxIOSVersion: "1.0.3",
+      // Legacy fields mirror prod while older iOS clients are still deployed.
       stableMinVersion: "0.64.23",
       nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
-        beta: { stableMinVersion: "0.64.22" },
-        internal: { stableMinVersion: "0.64.22" },
-        demo: { stableMinVersion: "0.64.22" },
+        beta: { stableMinVersion: "0.64.17" },
+        internal: { stableMinVersion: "0.64.17" },
+        demo: { stableMinVersion: "0.64.17" },
+        prod: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
+      },
+    },
+    {
+      minIOSVersion: "1.0.4",
+      maxIOSVersion: "1.0.4",
+      stableMinVersion: "0.64.23",
+      nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+      buildKinds: {
+        dev: { stableMinVersion: "0.64.0" },
+        beta: { stableMinVersion: "0.64.20" },
+        internal: { stableMinVersion: "0.64.23" },
+        demo: { stableMinVersion: "0.64.20" },
+        prod: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
+      },
+    },
+    {
+      minIOSVersion: "1.0.5",
+      stableMinVersion: "0.64.23",
+      nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+      buildKinds: {
+        dev: { stableMinVersion: "0.64.0" },
+        beta: { stableMinVersion: "0.64.23" },
+        internal: { stableMinVersion: "0.64.23" },
+        demo: { stableMinVersion: "0.64.23" },
         prod: {
           stableMinVersion: "0.64.23",
           nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -92,8 +92,10 @@ describe("mobile-mac-compat route", () => {
   test("keeps minimums scoped to each build kind", () => {
     const entry = mobileMacCompatList.entries[0];
     expect(entry.buildKinds?.prod.stableMinVersion).toBe("0.64.23");
-    expect(entry.buildKinds?.internal.stableMinVersion).toBe("0.64.22");
-    expect(entry.buildKinds?.beta.stableMinVersion).toBe("0.64.22");
+    expect(entry.buildKinds?.internal.stableMinVersion).toBe("0.64.17");
+    expect(entry.buildKinds?.beta.stableMinVersion).toBe("0.64.17");
+    expect(mobileMacCompatList.entries[1].buildKinds?.internal.stableMinVersion).toBe("0.64.23");
+    expect(mobileMacCompatList.entries[2].buildKinds?.internal.stableMinVersion).toBe("0.64.23");
   });
 
   test("rejects conflicting legacy and build-kind minimums", () => {


### PR DESCRIPTION
The mobile Mac compatibility payload now tracks the Mac versions each iOS lane can actually use as the backend protocol evolved.

- iOS 1.0.0 through 1.0.3 use 0.64.17 for TestFlight and demo lanes, matching the original Tailscale pairing contract.
- iOS 1.0.4 uses 0.64.20 for BETA and demo lanes, matching authenticated Iroh.
- The later INTERNAL 1.0.4 cut uses the rebuilt Iroh transport and requires 0.64.23. BETA build 20260817224846 remains the documented older-compatible 1.0.4 build.
- iOS 1.0.5 and newer use 0.64.23 for all non-dev lanes.
- The App Store lane remains at 0.64.23 in every tier.
- The compiled Swift fallback mirrors the server data.

Validation:
- `cd web && bun test tests/mobile-mac-compat-route.test.ts`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileMacCompatPolicyTests`
- `git diff --check`
- `bun run lint:complexity` could not run because the worktree is missing the `typescript` package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live pairing gates for iOS–Mac version checks across TestFlight and internal lanes; misaligned server vs baked fallback could wrongly block or admit Macs until clients refresh the list.
> 
> **Overview**
> Replaces the single “every iOS lane needs 0.64.23” compat tier with **three iOS-version bands** on `GET /api/mobile-mac-compat` and the matching `MobileMacCompatPolicy.baked` fallback, so Mac minimums follow real protocol milestones instead of blocking older TestFlight builds.
> 
> **iOS 1.0.0–1.0.3** (`maxIOSVersion` 1.0.3): beta, internal, and demo lanes require Mac **0.64.17**; **prod** (App Store) stays at **0.64.23**. **iOS 1.0.4** only: beta/demo at **0.64.20**, internal at **0.64.23** (later INTERNAL 1.0.4 cut vs last older-compatible BETA). **iOS 1.0.5+**: all build kinds at **0.64.23**.
> 
> Tests now assert per-tier `buildKinds` floors and historical internal/beta violation behavior; the web route test checks the new multi-entry list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb98c75a2ec965b4d7243a92b1df21cbd48b912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated Mobile Mac compatibility rules for iOS app versions 1.0.0 and later.
  * Added version-specific minimum protocol requirements for beta, internal, demo, development, and production builds.
  * Applied distinct compatibility thresholds to iOS versions 1.0.0–1.0.3, 1.0.4, and 1.0.5 and later.
  * Compatibility checks now consistently enforce requirements based on both iOS version and build type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->