### PR TITLE
Fix Nightly Freestyle machine creation

### DIFF
--- a/CLI/CMUXCLI+VMTransfer.swift
+++ b/CLI/CMUXCLI+VMTransfer.swift
@@ -1398,8 +1398,7 @@ extension CMUXCLI {
         var params: [String: Any] = [
             // Pool machines are shell boxes; the backend maps the kind to its image.
             "kind": VMMachineKind.base.rawValue,
-            "persistent_home": true,
-            "per_machine_home": true,
+            // Freestyle has no persistent-volume capability; keep pool creation usable.
             // Fresh key per run: a failed create is simply retried by the next
             // `vm run`, and the interactive `vm new` store stays untouched.
             "idempotency_key": UUID().uuidString,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4732,13 +4732,6 @@ struct CMUXCLI {
         try? saveVMCreateIdempotencyStore(store, to: url)
     }
 
-    private static func usesPersistentDefaultCloud(image: String?, providerOption: String?) -> Bool {
-        let normalizedImage = image?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard normalizedImage?.isEmpty != false else { return false }
-        let normalizedProvider = providerOption?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedProvider == nil || normalizedProvider == ""
-    }
-
     private static let browserDisabledDefaultsKey = "browserDisabledOverride"
     private static let defaultBrowserSettingsDomain = "com.cmuxterm.app"
     /// The shared MDM resolver, bound to the target `domain`'s suite with the
@@ -6010,26 +6003,8 @@ struct CMUXCLI {
                 // not expose sizing ignore this optional field; providers that do use it
                 // for runtime memory get it, and the backend applies the plan ceiling.
                 if let memoryMb { params["memory_mb"] = memoryMb }
-                // The persistent per-machine home is keyed off whether the *person*
-                // overrode the image/provider (`imageOptRaw`), not the CLI-injected
-                // default. Otherwise the desktop default would look like a custom
-                // image and silently drop `persistent_home`, making every new machine
-                // ephemeral. A bare `vm new` — desktop or `--base` — stays persistent.
-                let usesPersistentDefaultCloud = Self.usesPersistentDefaultCloud(
-                    image: imageOptRaw,
-                    providerOption: providerOpt
-                )
-                // The persistent-default create sends no provider override: the backend's
-                // CMUX_VM_DEFAULT_PROVIDER decides, with Freestyle as the default. An
-                // explicit provider remains available for deliberate rollback/experiments.
-                if usesPersistentDefaultCloud {
-                    // Every new machine is its own persistent computer: the backend mounts a
-                    // volume derived from the machine's generated name, so `vm new` mints a
-                    // fresh durable machine each time (up to the plan limit) instead of
-                    // reattaching the single shared slot. `vm base open` still owns the slot.
-                    params["persistent_home"] = true
-                    params["per_machine_home"] = true
-                }
+                // Freestyle is the default and only deployed provider. It does not support
+                // persistent home volumes, so leave both volume flags out of this request.
                 let targetWindow = try validatedWindowHandle(windowOpt ?? windowId, client: client)
                 // Store-based idempotency: retries of a failed create reuse the key; a
                 // successful create clears it, so the next `vm new` makes a new machine.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4699,14 +4699,7 @@ struct CMUXCLI {
         try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
-    private static func activeVMCreateIdempotency(image: String?, provider: String?, usesPersistentDefaultCloud: Bool) throws -> ActiveVMCreateIdempotency {
-        if usesPersistentDefaultCloud {
-            return ActiveVMCreateIdempotency(
-                signature: "persistent-cloud-vm-slot",
-                key: persistentCloudVMSlotID
-            )
-        }
-
+    private static func activeVMCreateIdempotency(image: String?, provider: String?) throws -> ActiveVMCreateIdempotency {
         let url = vmCreateIdempotencyStoreURL()
         let signature = vmCreateIdempotencySignature(image: image, provider: provider)
         let now = Date().timeIntervalSince1970
@@ -6010,8 +6003,7 @@ struct CMUXCLI {
                 // successful create clears it, so the next `vm new` makes a new machine.
                 let idempotency = try Self.activeVMCreateIdempotency(
                     image: imageOptRaw ?? "kind=\(machineKind.rawValue)",
-                    provider: normalizedProvider,
-                    usesPersistentDefaultCloud: false
+                    provider: normalizedProvider
                 )
                 params["idempotency_key"] = idempotency.key
                 let vmCreateStartedAt = Date()

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -299606,13 +299606,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A cloud computer with devtools and coding agents preinstalled. It keeps its home directory between sessions."
+            "value": "A cloud computer with devtools and coding agents preinstalled. Its home directory is reset when the machine is recreated."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "開発ツールとコーディングエージェントがプリインストールされたクラウドコンピュータ。ホームディレクトリはセッション間で保持されます。"
+            "value": "開発ツールとコーディングエージェントがプリインストールされたクラウドコンピュータ。マシンを再作成するとホームディレクトリはリセットされます。"
           }
         }
       }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -809,7 +809,7 @@ struct MachineRowActions {
         onCompletion: ((CloudVMActionLauncher.Completion) -> Void)? = nil,
         onCancellationReady: ((CloudVMActionLauncher.CancellationHandle) -> Void)? = nil
     ) -> Bool {
-        // `vm new` mints a fresh machine with its own persistent home and
+        // `vm new` mints a fresh machine with an ephemeral home and
         // attaches it; the base slot stays reachable via the ＋ menu's Open Base.
         let socketPath = TerminalController.shared.activeSocketPath(
             preferredPath: SocketControlSettings.socketPath()

--- a/Sources/Cloud/NewMachineModel.swift
+++ b/Sources/Cloud/NewMachineModel.swift
@@ -68,7 +68,7 @@ struct MachineSizeOption: Equatable, Sendable {
 final class NewMachineModel {
     /// Which create flow the sheet fronts.
     enum Mode: Equatable {
-        /// `cmux vm new`: a fresh machine with its own persistent home.
+        /// `cmux vm new`: a fresh Freestyle machine with an ephemeral home.
         case newMachine
         /// `cmux vm base open --workspace <id>`: the persistent Base slot's
         /// first provisioning. Base has no size choice (the backend sizes it)

--- a/Sources/Cloud/NewMachineSheet.swift
+++ b/Sources/Cloud/NewMachineSheet.swift
@@ -39,7 +39,7 @@ struct NewMachineSheet: View {
                 )
                 : String(
                     localized: "machines.new.subtitle",
-                    defaultValue: "A cloud computer with devtools and coding agents preinstalled. It keeps its home directory between sessions."
+                    defaultValue: "A cloud computer with devtools and coding agents preinstalled. Its home directory is reset when the machine is recreated."
                 ))
                 .cmuxFont(size: 12)
                 .foregroundStyle(.secondary)

--- a/cmuxTests/CLIVMTransferTests.swift
+++ b/cmuxTests/CLIVMTransferTests.swift
@@ -467,6 +467,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
             case "vm.list":
                 return self.v2Response(id: id, ok: true, result: ["vms": []])
             case "vm.create":
+                let params = request["params"] as? [String: Any] ?? [:]
+                XCTAssertNil(params["persistent_home"], "Freestyle does not support persistent home volumes")
+                XCTAssertNil(params["per_machine_home"], "Freestyle does not support per-machine home volumes")
                 return self.v2Response(id: id, ok: true, result: ["id": "fresh-1", "provider": "freestyle", "status": "creating", "image": "cmuxd-ws:tooling-20260509f"])
             case "vm.rename":
                 return self.v2Response(id: id, ok: true, result: ["id": "fresh-1", "displayName": "agent-pool"])

--- a/cmuxTests/VMDefaultCloudCommandTests.swift
+++ b/cmuxTests/VMDefaultCloudCommandTests.swift
@@ -105,6 +105,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 XCTAssertNotEqual(params["idempotency_key"] as? String, "cmux-default-freestyle-sshd-v1")
                 XCTAssertEqual(params["kind"] as? String, "desktop")
                 XCTAssertNil(params["image"])
+                XCTAssertNil(params["persistent_home"], "Freestyle does not support persistent home volumes")
+                XCTAssertNil(params["per_machine_home"], "Freestyle does not support per-machine home volumes")
                 return self.v2Response(
                     id: id,
                     ok: true,


### PR DESCRIPTION
Nightly New Machine creation failed because the CLI sent `persistent_home=true` and `per_machine_home=true` for every default `vm new`. The deployed provider is Freestyle, which advertises `persistentHome: false`, so the API correctly returned HTTP 400 with `This machine does not support persistent home volumes.`

This follow-up removes unsupported home-volume flags from both `vm new` and the `vm run` pool allocator. Freestyle machines now create with the provider image's ephemeral home until a volume-capable provider is deployed. The API capability guard remains in place for explicit unsupported requests.

Validation:
- Vercel production logs identified the exact 400 response and trace for Nightly build `0.64.22-nightly.3453613672401`.
- Regression tests assert `vm.create` payloads omit both flags for New Machine and VM run.
- Test commit `c9cabc39e4` precedes fix commit `8fe6c14214`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791672308&installation_model_id=21920&pr_number=12277&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12277&signature=c0cbea6bf145aaefdfcdbeed7a34527dbd030565ec959f092beffda97b280a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly New Machine creation failing because the CLI sent `persistent_home=true` and `per_machine_home=true` to the Freestyle provider, which rejects both with HTTP 400. The CLI now omits both flags from `vm new` and `vm run` pool creation, so Freestyle machines use the provider image's ephemeral home.

- Removes the persistent-default logic and its dedicated idempotency slot.
- Updates UI copy and docs to describe the ephemeral home behavior.
- Adds regression assertions that `vm.create` payloads omit both flags.
- Explicit unsupported requests still get rejected by the API's capability guard.

<sup>Written for commit fedb9d34d85b441283878a9e91ed8a190d7ba034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - New virtual machines and pool machines now use ephemeral home storage.
  - Home-volume mounts are no longer requested when creating machines.
  - Updated in-app descriptions and command documentation to clarify that home directories reset when machines are recreated.
  - Updated English and Japanese cloud computer descriptions to reflect the ephemeral home behavior.

- **Tests**
  - Added coverage confirming machine creation requests omit persistent and per-machine home-volume options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default VM provisioning semantics (no persistent per-machine home on Freestyle) and touches core `vm.create` CLI paths, though behavior now matches provider capabilities and avoids hard failures.
> 
> **Overview**
> Fixes **New Machine** and **`vm run` pool** creation failing against Freestyle with HTTP 400 by stopping the CLI from sending **`persistent_home`** and **`per_machine_home`** on `vm.create`.
> 
> **`vm new`** no longer runs the “persistent default cloud” branch that added those flags for bare desktop creates; idempotency is simplified to image/provider signature only. Pool allocation in **`createPoolVM`** drops the same flags. User-facing copy and comments now describe **ephemeral home** (reset when the machine is recreated); **Base** setup copy is unchanged and still uses the separate **`vm.base_open`** path.
> 
> Regression tests assert both volume flags are absent from `vm.create` in the default **`vm new`** and VM-run flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedb9d34d85b441283878a9e91ed8a190d7ba034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->