### PR TITLE
Fix signed Content-Type for R2 appcast uploads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1154,6 +1154,7 @@ jobs:
               --endpoint-url "$R2_ENDPOINT" \
               --bucket cmux-binaries \
               --key "nightly/$appcast" \
+              --content-type "application/xml" \
               --cache-control "no-cache, no-store, must-revalidate"
             echo "R2 appcast upload complete: https://files.cmux.com/nightly/$appcast"
           done

--- a/.github/workflows/r2-upload-tests.yml
+++ b/.github/workflows/r2-upload-tests.yml
@@ -1,0 +1,24 @@
+name: R2 upload tests
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/r2-upload-tests.yml
+      - .github/workflows/nightly.yml
+      - .github/workflows/release.yml
+      - .github/workflows/cmux-tui-artifacts.yml
+      - scripts/ci/upload-r2-object.py
+      - tests/test_ci_r2_upload_python.sh
+      - tests/test_r2_upload_requests.py
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  r2-upload-tests:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: bash tests/test_ci_r2_upload_python.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,6 +646,7 @@ jobs:
             --endpoint-url "$R2_ENDPOINT" \
             --bucket cmux-binaries \
             --key stable/appcast.xml \
+            --content-type "application/xml" \
             --cache-control "no-cache, no-store, must-revalidate"
 
           echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"

--- a/.github/workflows/repair-nightly-appcast-content-types.yml
+++ b/.github/workflows/repair-nightly-appcast-content-types.yml
@@ -1,0 +1,75 @@
+name: Repair nightly appcast Content-Type
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/repair-nightly-appcast-content-types.yml
+      - scripts/ci/repair-nightly-appcast-content-types.py
+      - scripts/ci/upload-r2-object.py
+      - tests/test_repair_nightly_appcast_content_types.py
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: Correct only the four existing nightly feeds with conditional writes
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: repair-nightly-appcast-content-types
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: python3 tests/test_repair_nightly_appcast_content_types.py
+
+  repair:
+    if: github.event_name == 'workflow_dispatch'
+    needs: test
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Refuse to race an active nightly workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          active=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/nightly.yml/runs?per_page=100" \
+            --jq '[.workflow_runs[] | select(.status != "completed")] | length')
+          if [ "$active" != 0 ]; then
+            echo "Nightly publication is active; retry this repair after it finishes."
+            exit 1
+          fi
+      - name: Repair current objects without changing their XML
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          EXECUTE: ${{ inputs.execute }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "$EXECUTE" = true ]; then args+=(--execute); fi
+          python3 scripts/ci/repair-nightly-appcast-content-types.py \
+            --endpoint-url "$R2_ENDPOINT" "${args[@]}"
+      - name: Verify all four public HEAD responses
+        if: inputs.execute
+        run: |
+          python3 - <<'PY'
+          import urllib.request
+          for feed in ("appcast-arm64.xml", "appcast-x86_64.xml", "appcast-universal.xml", "appcast.xml"):
+              request = urllib.request.Request(f"https://files.cmux.com/nightly/{feed}", method="HEAD")
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  content_type = response.headers.get("Content-Type")
+                  print(f"{feed}: HTTP {response.status} Content-Type: {content_type}")
+                  assert content_type == "application/xml", feed
+          PY

--- a/.github/workflows/repair-nightly-appcast-content-types.yml
+++ b/.github/workflows/repair-nightly-appcast-content-types.yml
@@ -65,11 +65,15 @@ jobs:
         if: inputs.execute
         run: |
           python3 - <<'PY'
-          import urllib.request
+          import subprocess
           for feed in ("appcast-arm64.xml", "appcast-x86_64.xml", "appcast-universal.xml", "appcast.xml"):
-              request = urllib.request.Request(f"https://files.cmux.com/nightly/{feed}", method="HEAD")
-              with urllib.request.urlopen(request, timeout=30) as response:
-                  content_type = response.headers.get("Content-Type")
-                  print(f"{feed}: HTTP {response.status} Content-Type: {content_type}")
-                  assert content_type == "application/xml", feed
+              output = subprocess.check_output(
+                  ["curl", "--fail", "--silent", "--show-error", "--head", "--max-time", "30",
+                   f"https://files.cmux.com/nightly/{feed}"], text=True,
+              )
+              headers = dict(line.split(":", 1) for line in output.splitlines() if ":" in line)
+              headers = {key.lower(): value.strip() for key, value in headers.items()}
+              content_type = headers.get("content-type")
+              print(f"{feed}: Content-Type: {content_type}")
+              assert content_type == "application/xml", feed
           PY

--- a/scripts/ci/repair-nightly-appcast-content-types.py
+++ b/scripts/ci/repair-nightly-appcast-content-types.py
@@ -7,8 +7,6 @@ import hashlib
 import importlib.util
 from pathlib import Path
 import sys
-import urllib.error
-import urllib.request
 import xml.etree.ElementTree as ET
 
 
@@ -23,7 +21,7 @@ METADATA = {"cache-control", "content-disposition", "content-encoding", "content
 def request(args, method, body=b"", headers=None):
     date = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     signed = uploader._build_signed_request(args, body, date, method=method, extra_headers=headers)
-    with urllib.request.urlopen(signed, timeout=30) as response:
+    with uploader._open_signed_request(signed, timeout=30) as response:
         return response.read(), {k.lower(): v for k, v in response.headers.items()}
 
 

--- a/scripts/ci/repair-nightly-appcast-content-types.py
+++ b/scripts/ci/repair-nightly-appcast-content-types.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Repair only the four existing nightly feeds, preserving their current bytes."""
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+
+
+spec = importlib.util.spec_from_file_location("r2_upload", Path(__file__).with_name("upload-r2-object.py"))
+uploader = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(uploader)
+
+APPCASTS = ("appcast-arm64.xml", "appcast-x86_64.xml", "appcast-universal.xml", "appcast.xml")
+METADATA = {"cache-control", "content-disposition", "content-encoding", "content-language", "expires", "x-amz-storage-class"}
+
+
+def request(args, method, body=b"", headers=None):
+    date = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    signed = uploader._build_signed_request(args, body, date, method=method, extra_headers=headers)
+    with urllib.request.urlopen(signed, timeout=30) as response:
+        return response.read(), {k.lower(): v for k, v in response.headers.items()}
+
+
+def repair(endpoint_url, execute=False):
+    for name in APPCASTS:
+        args = argparse.Namespace(endpoint_url=endpoint_url, bucket="cmux-binaries", key=f"nightly/{name}",
+                                  content_type="application/xml", cache_control="")
+        body, original = request(args, "GET")
+        if ET.fromstring(body).tag != "rss":
+            raise RuntimeError(f"{args.key}: refusing to modify a non-RSS object")
+        if not original.get("etag") or not original.get("cache-control"):
+            raise RuntimeError(f"{args.key}: missing ETag or Cache-Control; refusing to modify")
+        digest = hashlib.sha256(body).hexdigest()
+        metadata = {k: v for k, v in original.items() if k in METADATA or k.startswith("x-amz-meta-")}
+        if not execute:
+            print(f"Would repair {args.key}: type={original.get('content-type')} sha256={digest}")
+            continue
+        if original.get("content-type") != "application/xml":
+            args.cache_control = original["cache-control"]
+            # Sign the precondition as well as every preserved metadata field.
+            # A concurrent publication returns 412; never retry with stale bytes.
+            request(args, "PUT", body, {**metadata, "if-match": original["etag"]})
+        current, verified = request(args, "GET", headers={"if-match": original["etag"]})
+        if current != body or verified.get("content-type") != "application/xml":
+            raise RuntimeError(f"{args.key}: body or Content-Type verification failed")
+        if any(verified.get(k) != v for k, v in metadata.items()):
+            raise RuntimeError(f"{args.key}: metadata verification failed")
+        print(f"Verified {args.key}: application/xml sha256={digest} etag={verified['etag']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint-url", required=True)
+    parser.add_argument("--execute", action="store_true", help="Apply conditional metadata repairs (default: read only)")
+    args = parser.parse_args()
+    try:
+        repair(args.endpoint_url, args.execute)
+    except (OSError, RuntimeError, ET.ParseError) as error:
+        # Never print request headers or signed requests containing credentials.
+        sys.stderr.write(f"Nightly appcast repair stopped: {error}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -6,6 +6,7 @@ import datetime as dt
 import hashlib
 import hmac
 import json
+import mimetypes
 import os
 import sys
 import urllib.error
@@ -59,6 +60,7 @@ def _build_signed_request(
     }
     if method == "PUT":
         headers["cache-control"] = args.cache_control
+        headers["content-type"] = args.content_type
     if extra_headers:
         headers.update({name.lower(): value for name, value in extra_headers.items()})
     session_token = os.environ.get("AWS_SESSION_TOKEN")
@@ -141,12 +143,21 @@ def main() -> int:
     parser.add_argument("--key", required=True, help="Object key inside the bucket")
     parser.add_argument("--cache-control", required=True, help="Cache-Control metadata")
     parser.add_argument(
+        "--content-type",
+        help="Content-Type metadata (default: infer from file extension, otherwise application/octet-stream)",
+    )
+    parser.add_argument(
         "--write-once",
         action="store_true",
         help="Refuse to overwrite an immutable object; accept an identical existing object",
     )
     parser.add_argument("--dry-run-json", action="store_true", help="Print the signed request instead of uploading")
     args = parser.parse_args()
+    if not args.content_type:
+        content_type, encoding = mimetypes.guess_type(args.file)
+        # A compressed file is not the unencoded type returned by guess_type.
+        # Keep its bytes opaque unless the caller supplies the archive type.
+        args.content_type = content_type if content_type and not encoding else "application/octet-stream"
 
     with open(args.file, "rb") as file:
         body = file.read()

--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -14,6 +14,17 @@ import urllib.parse
 import urllib.request
 
 
+class _RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # A SigV4 signature is bound to its original host and path. Never
+        # forward it or a session token to a redirect destination.
+        return None
+
+
+def _open_signed_request(request: urllib.request.Request, *, timeout: int):
+    return urllib.request.build_opener(_RejectRedirects()).open(request, timeout=timeout)
+
+
 def _sign(key: bytes, message: str) -> bytes:
     return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()
 
@@ -45,8 +56,8 @@ def _build_signed_request(
         raise SystemExit("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required")
 
     parsed = urllib.parse.urlsplit(args.endpoint_url.rstrip("/"))
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise SystemExit(f"Invalid R2 endpoint URL: {args.endpoint_url}")
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise SystemExit("R2 endpoint URL must use HTTPS and include a host")
 
     date_stamp = amz_date[:8]
     canonical_uri = _canonical_path(args.bucket, args.key)
@@ -116,7 +127,7 @@ def _read_existing_object(
 
     head = _build_signed_request(args, b"", amz_date, method="HEAD")
     try:
-        with urllib.request.urlopen(head, timeout=30) as response:
+        with _open_signed_request(head, timeout=30) as response:
             response.read()
     except urllib.error.HTTPError as error:
         if error.code == 404:
@@ -124,7 +135,7 @@ def _read_existing_object(
         raise
 
     get = _build_signed_request(args, b"", amz_date, method="GET")
-    with urllib.request.urlopen(get, timeout=120) as response:
+    with _open_signed_request(get, timeout=120) as response:
         existing = response.read()
     actual_digest = hashlib.sha256(existing).hexdigest()
     if actual_digest != expected_digest:
@@ -203,7 +214,7 @@ def main() -> int:
             amz_date,
             extra_headers={"if-none-match": "*"} if args.write_once else None,
         )
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with _open_signed_request(request, timeout=30) as response:
             response.read()
             print(f"Uploaded {args.file} to s3://{args.bucket}/{args.key} ({response.status})")
             return 0

--- a/tests/test_ci_r2_upload_python.sh
+++ b/tests/test_ci_r2_upload_python.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 printf '<rss>ok</rss>' >"$TMP_DIR/appcast.xml"
 
 python3 -m py_compile "$ROOT_DIR/scripts/ci/upload-r2-object.py"
+python3 "$ROOT_DIR/tests/test_r2_upload_requests.py"
 
 AWS_ACCESS_KEY_ID=AKIDEXAMPLE \
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY \
@@ -34,9 +35,10 @@ authorization = headers.get("authorization", "")
 assert request["method"] == "PUT", request
 assert request["url"] == "https://example-account.r2.cloudflarestorage.com/cmux-binaries/nightly/appcast.xml", request
 assert headers["cache-control"] == "no-cache, no-store, must-revalidate", headers
+assert headers["content-type"] in {"application/xml", "text/xml"}, headers
 assert headers["x-amz-date"] == "20260102T030405Z", headers
 assert "Credential=AKIDEXAMPLE/20260102/auto/s3/aws4_request" in authorization, authorization
-assert "SignedHeaders=cache-control;host;x-amz-content-sha256;x-amz-date" in authorization, authorization
+assert "SignedHeaders=cache-control;content-type;host;x-amz-content-sha256;x-amz-date" in authorization, authorization
 assert len(headers["x-amz-content-sha256"]) == 64, headers
 PY
 

--- a/tests/test_r2_upload_requests.py
+++ b/tests/test_r2_upload_requests.py
@@ -155,6 +155,22 @@ class R2UploadRequestsTests(unittest.TestCase):
                         self.assertIn("authorization", headers)
                         self.assertEqual(headers["x-amz-security-token"], self.env["AWS_SESSION_TOKEN"])
 
+    def test_repair_reader_rejects_plaintext_and_redirects(self):
+        self.env["AWS_SESSION_TOKEN"] = "example-session-token"
+        collector, collected = self.start_endpoint(tls=False)
+        endpoint, requests = self.start_endpoint(redirects={"GET": (302, collector)})
+        for url, expected in ((collector, []), (endpoint, ["GET"])):
+            with self.subTest(endpoint=url):
+                result = subprocess.run(
+                    [sys.executable, str(UPLOADER.with_name("repair-nightly-appcast-content-types.py")),
+                     "--endpoint-url", url],
+                    env=self.env, capture_output=True, text=True, timeout=10,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(collected, [])
+                self.assertEqual([r[0] for r in requests], expected)
+                self.assertIn("HTTPS" if url == collector else "HTTP Error 302", result.stderr)
+
     def test_all_nightly_appcasts_explicit_xml_dry_run(self):
         for name in APPCASTS:
             with self.subTest(name=name):

--- a/tests/test_r2_upload_requests.py
+++ b/tests/test_r2_upload_requests.py
@@ -6,6 +6,7 @@ import http.server
 import json
 import os
 from pathlib import Path
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -20,6 +21,30 @@ CACHE_CONTROL = "no-cache, no-store, must-revalidate"
 
 
 class R2UploadRequestsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        tls = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(tls.cleanup)
+        root = Path(tls.name)
+        cls.cert = root / "localhost.pem"
+        key = root / "localhost.key"
+        config = root / "openssl.cnf"
+        config.write_text(
+            "[req]\nprompt = no\ndistinguished_name = dn\nx509_extensions = ext\n"
+            "[dn]\nCN = 127.0.0.1\n[ext]\nsubjectAltName = IP:127.0.0.1\n"
+            "basicConstraints = critical,CA:TRUE\n"
+            "keyUsage = critical,digitalSignature,keyEncipherment,keyCertSign\n"
+            "extendedKeyUsage = serverAuth\nsubjectKeyIdentifier = hash\n"
+            "authorityKeyIdentifier = keyid:always\n"
+        )
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-sha256", "-nodes",
+             "-days", "1", "-keyout", str(key), "-out", str(cls.cert), "-config", str(config)],
+            check=True, capture_output=True, timeout=30,
+        )
+        cls.tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        cls.tls_context.load_cert_chain(cls.cert, key)
+
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
@@ -32,6 +57,7 @@ class R2UploadRequestsTests(unittest.TestCase):
             CMUX_R2_UPLOAD_AMZ_DATE="20260102T030405Z",
             NO_PROXY="127.0.0.1",
             no_proxy="127.0.0.1",
+            SSL_CERT_FILE=str(self.cert),
         )
 
     def upload(self, name="appcast.xml", *flags, endpoint="https://example.invalid", body=BODY):
@@ -57,13 +83,20 @@ class R2UploadRequestsTests(unittest.TestCase):
         self.assertIn("content-type", signed)
         self.assertEqual(signed, sorted(signed))
 
-    def start_endpoint(self, existing=False):
+    def start_endpoint(self, existing=False, *, tls=True, redirects=None):
         requests = []
 
         class Handler(http.server.BaseHTTPRequestHandler):
             def record(self):
                 body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
                 requests.append((self.command, self.path, dict(self.headers.items()), body))
+                if redirects and self.command in redirects and self.path != "/redirect-target":
+                    code, target = redirects[self.command]
+                    self.send_response(code)
+                    self.send_header("Location", target)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
                 status = 404 if self.command == "HEAD" and not existing else 200
                 response = BODY if self.command == "GET" else b""
                 self.send_response(status)
@@ -77,7 +110,9 @@ class R2UploadRequestsTests(unittest.TestCase):
                 pass
 
         server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        if tls:
+            server.socket = self.tls_context.wrap_socket(server.socket, server_side=True)
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
         thread.start()
 
         def stop():
@@ -86,7 +121,39 @@ class R2UploadRequestsTests(unittest.TestCase):
             server.server_close()
 
         self.addCleanup(stop)
-        return f"http://127.0.0.1:{server.server_port}", requests
+        scheme = "https" if tls else "http"
+        return f"{scheme}://127.0.0.1:{server.server_port}", requests
+
+    def test_plaintext_endpoints_are_rejected_before_sending_credentials(self):
+        endpoint, requests = self.start_endpoint(tls=False)
+        self.env["AWS_SESSION_TOKEN"] = "example-session-token"
+        for flags in ((), ("--write-once",), ("--dry-run-json",)):
+            with self.subTest(flags=flags):
+                result = self.upload("appcast.xml", *flags, endpoint=endpoint)
+                self.assertEqual(requests, [], "No signed request may reach a plaintext endpoint")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("HTTPS", result.stderr)
+
+    def test_signed_requests_never_follow_redirects(self):
+        self.env["AWS_SESSION_TOKEN"] = "example-session-token"
+        for target_kind in ("https", "http", "same-origin"):
+            collector, collected = self.start_endpoint(existing=True, tls=target_kind != "http")
+            target = "/redirect-target" if target_kind == "same-origin" else collector + "/redirect-target"
+            for method in ("HEAD", "GET", "PUT"):
+                for code in (301, 302, 303, 307, 308):
+                    with self.subTest(target=target_kind, method=method, code=code):
+                        collected.clear()
+                        endpoint, requests = self.start_endpoint(existing=True, redirects={method: (code, target)})
+                        flags = () if method == "PUT" else ("--write-once",)
+                        result = self.upload("appcast.xml", *flags, endpoint=endpoint)
+                        expected = ["HEAD", "GET"] if method == "GET" else [method]
+                        self.assertEqual(collected, [], "Redirect must not forward signed headers to another origin")
+                        self.assertEqual([r[0] for r in requests], expected)
+                        self.assertNotEqual(result.returncode, 0)
+                        self.assertIn(f"HTTP {code}", result.stderr)
+                        headers = {k.lower(): v for k, v in requests[-1][2].items()}
+                        self.assertIn("authorization", headers)
+                        self.assertEqual(headers["x-amz-security-token"], self.env["AWS_SESSION_TOKEN"])
 
     def test_all_nightly_appcasts_explicit_xml_dry_run(self):
         for name in APPCASTS:

--- a/tests/test_r2_upload_requests.py
+++ b/tests/test_r2_upload_requests.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Exercise the uploader CLI and headers received after urllib processing."""
+
+import hashlib
+import http.server
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+
+
+UPLOADER = Path(__file__).resolve().parents[1] / "scripts/ci/upload-r2-object.py"
+APPCASTS = ("appcast-arm64.xml", "appcast-x86_64.xml", "appcast-universal.xml", "appcast.xml")
+BODY = b'<?xml version="1.0"?><rss><channel><title>Nightly</title></channel></rss>\n'
+CACHE_CONTROL = "no-cache, no-store, must-revalidate"
+
+
+class R2UploadRequestsTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
+        self.env.update(
+            AWS_ACCESS_KEY_ID="AKIDEXAMPLE",
+            AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            AWS_DEFAULT_REGION="auto",
+            CMUX_R2_UPLOAD_AMZ_DATE="20260102T030405Z",
+            NO_PROXY="127.0.0.1",
+            no_proxy="127.0.0.1",
+        )
+
+    def upload(self, name="appcast.xml", *flags, endpoint="https://example.invalid", body=BODY):
+        path = self.root / name
+        path.write_bytes(body)
+        return subprocess.run(
+            [sys.executable, str(UPLOADER), "--file", str(path),
+             "--endpoint-url", endpoint, "--bucket", "cmux-binaries",
+             "--key", f"nightly/{name}", "--cache-control", CACHE_CONTROL, *flags],
+            env=self.env, capture_output=True, text=True, timeout=10,
+        )
+
+    def dry_run(self, name, *flags):
+        result = self.upload(name, "--dry-run-json", *flags)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        request = json.loads(result.stdout)
+        return request, {k.lower(): v for k, v in request["headers"].items()}
+
+    def assert_upload_headers(self, headers, content_type):
+        self.assertEqual(headers.get("content-type"), content_type)
+        self.assertEqual(headers["cache-control"], CACHE_CONTROL)
+        signed = headers["authorization"].split("SignedHeaders=", 1)[1].split(",", 1)[0].split(";")
+        self.assertIn("content-type", signed)
+        self.assertEqual(signed, sorted(signed))
+
+    def start_endpoint(self, existing=False):
+        requests = []
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def record(self):
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                requests.append((self.command, self.path, dict(self.headers.items()), body))
+                status = 404 if self.command == "HEAD" and not existing else 200
+                response = BODY if self.command == "GET" else b""
+                self.send_response(status)
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+            do_PUT = do_GET = do_HEAD = record
+
+            def log_message(self, *_args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        def stop():
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+        self.addCleanup(stop)
+        return f"http://127.0.0.1:{server.server_port}", requests
+
+    def test_all_nightly_appcasts_explicit_xml_dry_run(self):
+        for name in APPCASTS:
+            with self.subTest(name=name):
+                request, headers = self.dry_run(name, "--content-type", "application/xml")
+                self.assert_upload_headers(headers, "application/xml")
+                self.assertEqual(request["url"], f"https://example.invalid/cmux-binaries/nightly/{name}")
+                self.assertEqual(request["body_sha256"], hashlib.sha256(BODY).hexdigest())
+                self.assertEqual(headers["x-amz-content-sha256"], request["body_sha256"])
+
+    def test_inferred_xml_is_sent_and_signed_on_the_wire(self):
+        endpoint, requests = self.start_endpoint()
+        result = self.upload(endpoint=endpoint)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(requests), 1)
+        method, path, headers, body = requests[0]
+        self.assertEqual((method, path, body), ("PUT", "/cmux-binaries/nightly/appcast.xml", BODY))
+        headers = {k.lower(): v for k, v in headers.items()}
+        self.assertIn(headers.get("content-type"), {"application/xml", "text/xml"})
+        self.assert_upload_headers(headers, headers["content-type"])
+
+    def test_explicit_type_overrides_extension_on_the_wire(self):
+        endpoint, requests = self.start_endpoint()
+        result = self.upload("appcast.xml", "--content-type", "application/rss+xml; charset=utf-8", endpoint=endpoint)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(requests), 1)
+        headers = {k.lower(): v for k, v in requests[0][2].items()}
+        self.assert_upload_headers(headers, "application/rss+xml; charset=utf-8")
+
+    def test_non_xml_defaults(self):
+        for name, expected in (("manifest.json", "application/json"),
+                               ("cmux-tui-darwin-arm64", "application/octet-stream"),
+                               ("appcast.xml.gz", "application/octet-stream")):
+            with self.subTest(name=name):
+                _, headers = self.dry_run(name)
+                self.assert_upload_headers(headers, expected)
+
+    def test_explicit_non_xml_type_and_signature(self):
+        _, binary = self.dry_run("artifact", "--content-type", "application/octet-stream")
+        _, archive = self.dry_run("artifact", "--content-type", "application/gzip")
+        self.assert_upload_headers(binary, "application/octet-stream")
+        self.assert_upload_headers(archive, "application/gzip")
+        self.assertNotEqual(binary["authorization"], archive["authorization"])
+
+    def test_write_once_put_keeps_condition_and_content_type_signed(self):
+        endpoint, requests = self.start_endpoint()
+        result = self.upload("manifest.json", "--write-once", endpoint=endpoint)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([r[0] for r in requests], ["HEAD", "PUT"])
+        headers = {k.lower(): v for k, v in requests[1][2].items()}
+        self.assert_upload_headers(headers, "application/json")
+        self.assertEqual(headers["if-none-match"], "*")
+        self.assertIn(";if-none-match;", headers["authorization"])
+
+    def test_write_once_existing_object_still_uses_bodyless_reads(self):
+        endpoint, requests = self.start_endpoint(existing=True)
+        result = self.upload("manifest.json", "--write-once", endpoint=endpoint)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([r[0] for r in requests], ["HEAD", "GET"])
+        for _, _, headers, body in requests:
+            headers = {k.lower(): v for k, v in headers.items()}
+            self.assertEqual(body, b"")
+            self.assertNotIn("content-type", headers)
+            self.assertNotIn("content-type", headers["authorization"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_repair_nightly_appcast_content_types.py
+++ b/tests/test_repair_nightly_appcast_content_types.py
@@ -30,7 +30,7 @@ class RepairTests(unittest.TestCase):
         response.read.return_value = b""
         response.headers = {}
         with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "example", "AWS_SECRET_ACCESS_KEY": "example"}, clear=True), \
-             patch.object(repair.urllib.request, "urlopen", return_value=response) as open_request:
+             patch.object(repair.uploader, "_open_signed_request", return_value=response) as open_request:
             repair.request(args, "PUT", BODY, {"if-match": ORIGINAL["etag"], "x-amz-meta-publisher": "nightly"})
         request = open_request.call_args.args[0]
         headers = {k.lower(): v for k, v in request.header_items()}

--- a/tests/test_repair_nightly_appcast_content_types.py
+++ b/tests/test_repair_nightly_appcast_content_types.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
+import urllib.error
+
+
+spec = importlib.util.spec_from_file_location(
+    "repair_appcasts", Path(__file__).resolve().parents[1] / "scripts/ci/repair-nightly-appcast-content-types.py"
+)
+repair = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(repair)
+BODY = b'<?xml version="1.0"?><rss><channel><title>Current nightly</title></channel></rss>\n'
+ORIGINAL = {"content-type": "application/x-www-form-urlencoded", "etag": '"original"',
+            "cache-control": "no-cache, no-store, must-revalidate", "content-language": "en",
+            "content-disposition": "inline", "expires": "Thu, 10 Sep 2026 22:25:53 GMT",
+            "x-amz-meta-publisher": "nightly", "x-amz-storage-class": "STANDARD"}
+
+
+class RepairTests(unittest.TestCase):
+    def test_repair_request_signs_content_type_condition_and_metadata(self):
+        args = argparse.Namespace(endpoint_url="https://example.invalid", bucket="cmux-binaries",
+                                  key="nightly/appcast.xml", content_type="application/xml",
+                                  cache_control=ORIGINAL["cache-control"])
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = b""
+        response.headers = {}
+        with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "example", "AWS_SECRET_ACCESS_KEY": "example"}, clear=True), \
+             patch.object(repair.urllib.request, "urlopen", return_value=response) as open_request:
+            repair.request(args, "PUT", BODY, {"if-match": ORIGINAL["etag"], "x-amz-meta-publisher": "nightly"})
+        request = open_request.call_args.args[0]
+        headers = {k.lower(): v for k, v in request.header_items()}
+        self.assertEqual(request.data, BODY)
+        self.assertEqual(headers["content-type"], "application/xml")
+        self.assertEqual(headers["if-match"], ORIGINAL["etag"])
+        signed = headers["authorization"].split("SignedHeaders=", 1)[1].split(",", 1)[0].split(";")
+        for name in ("content-type", "cache-control", "if-match", "x-amz-meta-publisher"):
+            self.assertIn(name, signed)
+
+    def run_repair(self, *, execute=True, original=None, conflict=False, corrupt=False):
+        self.calls = []
+        objects = {f"nightly/{name}": [BODY, dict(ORIGINAL if original is None else original)] for name in repair.APPCASTS}
+
+        def endpoint(args, method, body=b"", headers=None):
+            self.assertEqual(args.bucket, "cmux-binaries")
+            self.assertEqual(args.endpoint_url, "https://example.invalid")
+            self.calls.append((method, args.key, body, headers))
+            current, metadata = objects[args.key]
+            if method == "PUT":
+                if conflict:
+                    raise urllib.error.HTTPError("https://example.invalid", 412, "Precondition Failed", {}, None)
+                self.assertEqual(body, current)
+                self.assertEqual(headers["if-match"], metadata["etag"])
+                preserved = {k: v for k, v in metadata.items() if k in repair.METADATA or k.startswith("x-amz-meta-")}
+                self.assertEqual(headers, {**preserved, "if-match": metadata["etag"]})
+                self.assertEqual(args.content_type, "application/xml")
+                self.assertEqual(args.cache_control, metadata["cache-control"])
+                metadata["content-type"] = args.content_type
+                if corrupt:
+                    objects[args.key][0] = b"changed"
+                return b"", {}
+            self.assertEqual(method, "GET")
+            return current, dict(metadata)
+
+        with patch.object(repair, "request", side_effect=endpoint):
+            repair.repair("https://example.invalid", execute=execute)
+
+    def test_repairs_only_four_current_feeds_and_preserves_bytes_and_metadata(self):
+        self.run_repair()
+        self.assertEqual([key for method, key, _, _ in self.calls if method == "PUT"],
+                         [f"nightly/{name}" for name in repair.APPCASTS])
+        self.assertEqual([method for method, _, _, _ in self.calls], ["GET", "PUT", "GET"] * 4)
+        for method, _, _, headers in self.calls:
+            if method == "GET" and headers:
+                self.assertEqual(headers, {"if-match": ORIGINAL["etag"]})
+
+    def test_read_only_mode_never_writes(self):
+        self.run_repair(execute=False)
+        self.assertEqual([c[0] for c in self.calls], ["GET"] * 4)
+
+    def test_correct_metadata_is_not_rewritten(self):
+        self.run_repair(original={**ORIGINAL, "content-type": "application/xml"})
+        self.assertEqual([c[0] for c in self.calls], ["GET"] * 8)
+
+    def test_concurrent_publication_stops_without_retry(self):
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            self.run_repair(conflict=True)
+        self.assertEqual(caught.exception.code, 412)
+        self.assertEqual([c[0] for c in self.calls], ["GET", "PUT"])
+
+    def test_missing_precondition_or_metadata_stops_without_writing(self):
+        for key in ("etag", "cache-control"):
+            with self.subTest(key=key), self.assertRaises(RuntimeError):
+                self.run_repair(original={k: v for k, v in ORIGINAL.items() if k != key})
+            self.assertEqual([c[0] for c in self.calls], ["GET"])
+
+    def test_verification_detects_changed_body(self):
+        with self.assertRaisesRegex(RuntimeError, "verification failed"):
+            self.run_repair(corrupt=True)
+        self.assertEqual([c[0] for c in self.calls], ["GET", "PUT", "GET"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
R2 appcast uploads omitted Content-Type when signing, so urllib added `application/x-www-form-urlencoded` and R2 stored it. The uploader now signs and sends `--content-type`, or infers the type from the file with an opaque binary fallback for unknown/compressed files. All four nightly feeds and the stable appcast explicitly use `application/xml`; JSON manifests and binary artifacts retain appropriate types.

Signed PUT, HEAD, and GET requests now require HTTPS and share a transport that rejects all redirects, including same-origin redirects. The uploader and repair helper use the same path. Wire tests verify TLS with a temporary trusted certificate and assert that session tokens never reach redirect targets.

The manual repair workflow defaults to read-only and targets only the four existing nightly keys. It refuses active nightly publication, preserves current XML bytes and HTTP/custom metadata, and signs `If-Match` to reject concurrent updates without stale retries. It then verifies authenticated bytes/metadata and all four public HEAD responses using curl.

**Live repair completed:** all four nightly feeds now serve `application/xml`, with unchanged XML SHA-256, ETag, Content-Length, Cache-Control, and other observed metadata. R2 advanced Last-Modified as expected. [Final authenticated repair and public verification passed](https://github.com/manaflow-ai/cmux/actions/runs/34540910751) at HEAD `a832a47319`; no new release was published.

Validation:

- Test-only commit `c6117227c7`: [expected red CI](https://github.com/manaflow-ai/cmux/actions/runs/34540074011), including the actual incorrect HTTP header received after urllib processing.
- Fix commit `500affd6ca`: [green uploader CI](https://github.com/manaflow-ai/cmux/actions/runs/34540565304). The follow-up commit uses curl for the public verification probe.
- All 17 focused Python tests pass, covering XML keys, MIME overrides/inference, signed headers, immutable-object reads/writes, preserved metadata, and concurrent-update rejection. Existing dry-run guard, Python 3.9 syntax, YAML parsing, and diff whitespace checks pass.
- Review follow-up: regression-only commit `39575402e5` [fails as expected](https://github.com/manaflow-ai/cmux/actions/runs/34541893780); fix `be9252c42a` passes [HTTPS/redirect and uploader CI](https://github.com/manaflow-ai/cmux/actions/runs/34541987018) and [repair safety CI](https://github.com/manaflow-ai/cmux/actions/runs/34541987068). Coverage includes 45 combinations of redirect status, request method, and destination, plus plaintext rejection and the repair reader.
- Pipeline-only: no Mac runtime, Swift, or updater-driver changes; no app build/UI verification required. Localization audit found only internal CI help/workflow labels, with no product UI, user CLI, docs, or catalog changes.

Related to #12280. The separate Sparkle session race in #12279 is untouched. Until this PR is merged, another nightly using the old uploader can restore the incorrect metadata.
