### PR TITLE
Cloud VM create: drop unsupported home-volume flags instead of rejecting

### DIFF
--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -252,8 +252,7 @@ export async function POST(request: Request): Promise<Response> {
         imageVersion: imageSelection.imageVersion,
         provider,
         idempotencyKey,
-        persistentHome: candidate.persistentHome === true,
-        perMachineHome: candidate.perMachineHome === true,
+        ...homeVolumeOptionsFor(provider, candidate, span),
         memoryMb,
         imageSize: imageSelection.size ?? undefined,
         modelPlane,
@@ -281,17 +280,44 @@ export async function POST(request: Request): Promise<Response> {
   );
 }
 
+/**
+ * The home-volume flags the workflow receives. A provider that does not honor
+ * `CreateOptions.homeVolume` gets neither flag, so the row never claims a
+ * volume it does not have; the span records the drop for operators.
+ */
+function homeVolumeOptionsFor(
+  provider: ProviderId,
+  candidate: Record<string, unknown>,
+  span: Span,
+): { readonly persistentHome: boolean; readonly perMachineHome: boolean } {
+  const requested = {
+    persistentHome: candidate.persistentHome === true,
+    perMachineHome: candidate.perMachineHome === true,
+  };
+  const supported = vmCapabilitiesFor(provider).persistentHome;
+  const anyRequested = requested.persistentHome || requested.perMachineHome;
+  setSpanAttributes(span, {
+    "cmux.vm.home_volume_requested": anyRequested,
+    "cmux.vm.home_volume_dropped": anyRequested && !supported,
+  });
+  if (supported) return requested;
+  return { persistentHome: false, perMachineHome: false };
+}
+
 async function unsupportedCreateOptionResponse(
   provider: ProviderId,
   candidate: Record<string, unknown>,
   request: Request,
 ): Promise<Response | null> {
   const capabilities = vmCapabilitiesFor(provider);
+  // Only an explicit, user-chosen option is rejected here. `persistentHome` and
+  // `perMachineHome` are sent by every shipped `cmux vm new` (they are the
+  // client's default for a fresh machine, not a person's choice), so a provider
+  // that ignores home volumes must still create the machine; the route drops
+  // the flags and records that instead (see `homeVolumeOptionsFor`).
   const unsupported = candidate.memoryMb !== undefined && !capabilities.sizing
     ? { operation: "sizing" as const, field: "memoryMb" }
-    : (candidate.persistentHome === true || candidate.perMachineHome === true) && !capabilities.persistentHome
-      ? { operation: "persistentHome" as const, field: candidate.persistentHome === true ? "persistentHome" : "perMachineHome" }
-      : null;
+    : null;
   if (!unsupported) return null;
   const copy = await vmUnsupportedCopy(unsupported.operation, vmRequestLocale(request));
   return vmErrorResponse({

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -515,6 +515,35 @@ describe("VM REST auth", () => {
     expect(runVmWorkflow).toHaveBeenCalled();
   });
 
+  test("a default client create with home-volume flags succeeds on a provider that ignores them", async () => {
+    // Every shipped `cmux vm new` sends `persistentHome` + `perMachineHome`.
+    // Freestyle declares no `persistentHome` capability, so the route must
+    // drop the flags rather than fail the create with `vm_operation_unsupported`.
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-2",
+      provider: "freestyle",
+      image: "snapshot-test",
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { "idempotency-key": "idem-2", origin: "https://cmux.test" },
+        body: JSON.stringify({ persistentHome: true, perMachineHome: true }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id: "provider-vm-2", provider: "freestyle" });
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "freestyle",
+      persistentHome: false,
+      perMachineHome: false,
+    }));
+  });
+
   test("rejects an unknown `kind` on create and base open before touching workflows", async () => {
     getUser.mockResolvedValue(authedStackUser());
 


### PR DESCRIPTION
Since https://github.com/manaflow-ai/cmux/pull/11609 merged (2026-09-10 13:29 PT), every plain `cmux vm new` in production fails with `vm_operation_unsupported` ("This machine does not support persistent home volumes."). The CLI sends `persistentHome` + `perMachineHome` on every default create (`CLI/cmux.swift` around line 6030, all channels), and the Freestyle driver declares no `persistentHome` capability, so the new gate rejects the body. Only an explicit `--provider freestyle` bypasses it. Axiom shows the 400s on `cmux.api.POST /api/vm` with `cmux.vm.error_code = vm_operation_unsupported`.

The flags are a client default, not a user choice, so the route keeps the sizing gate only. The home-volume flags reach the workflow only when the provider honors them, so rows never claim a volume they do not have, and the span records `cmux.vm.home_volume_requested` / `cmux.vm.home_volume_dropped`.

Commit 1 adds the failing route test, commit 2 the fix. `bun run typecheck` and `bun test tests/vm-route-auth.test.ts tests/vm-unsupported-op.test.ts tests/vm-capabilities.test.ts` pass (96 tests).

Follow-up, not in this PR: the CLI should stop sending the flags for providers whose `capabilities.persistentHome` is false, and Freestyle should either honor `homeVolume` or the CLI comment promising a per-machine persistent home should go.

https://claude.ai/code/session_01EKhg9oquDiSgPHm4jeJF3G

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791673243&installation_model_id=21920&pr_number=12282&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12282&signature=007cba717f531c636dd25efda71a567b18bc2fb0293ec8626f4b8cbfec829956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VM create validation and provisioning inputs on a hot path; behavior is narrowed (fewer 400s) but incorrect capability checks could still mis-record home volume state.
> 
> **Overview**
> Fixes a production regression where default **`cmux vm new`** creates returned **`vm_operation_unsupported`** because the CLI always sends **`persistentHome`** / **`perMachineHome`** while Freestyle does not advertise **`persistentHome`**.
> 
> **POST `/api/vm`** now runs those flags through **`homeVolumeOptionsFor`**: they are passed to **`createVm`** only when the provider’s capabilities allow persistent home; otherwise both are cleared so the DB row does not claim a volume the driver cannot provision. OpenTelemetry spans record **`cmux.vm.home_volume_requested`** and **`cmux.vm.home_volume_dropped`**. The create “unsupported option” gate no longer treats home-volume fields as an explicit user choice—it only rejects unsupported **`memoryMb`** sizing.
> 
> A route auth test asserts a Freestyle create with the default home-volume body succeeds and **`createVm`** receives **`persistentHome: false`** and **`perMachineHome: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf0a94e9bb90f4d7b11d48303a04bea806d1af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VM creation now succeeds on providers that do not support persistent home volumes; unsupported home-volume options are safely ignored.
  * VM creation continues to reject unsupported memory-sizing options where applicable.
* **Tests**
  * Added coverage confirming default VM creation succeeds when persistent-home options are sent to providers without that capability.
  * Added verification that unsupported home-volume requests are passed as disabled rather than causing an unsupported-operation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->