### PR TITLE
Updater: finish delayed Sparkle callbacks on cancel

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -125,7 +125,7 @@ extension UpdateController {
             guard source == .user else { return }
             self?.cancelQueuedCheckByUser()
         }))
-        model.replaceActiveState(with: state)
+        driver.replaceActiveState(with: state)
     }
 
     private func waitForReadinessThenCheck() {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
@@ -65,7 +65,7 @@ extension UpdateController {
         // Sparkle may synchronously emit its identity-free dismissal while the reply/cancellation
         // runs; because the error is already visible and that callback is diagnostic-only, there
         // is no empty-pill window and no unresolved session left behind.
-        model.replaceActiveState(with: errorState)
+        driver.replaceActiveState(with: errorState)
     }
 
     func performAttemptAction(_ action: AttemptUpdateCoordinator.Action) {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -28,6 +28,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private let checkTimeoutDuration: TimeInterval = UpdateTiming.checkTimeoutDuration
     private var lastCheckStart: Date?
     private var pendingCheckTransitionTask: Task<Void, Never>?
+    /// The state captured by ``pendingCheckTransitionTask`` while its minimum-display delay is
+    /// pending. Keeping it separately lets cancellation causally finish callbacks (especially a
+    /// mandatory Sparkle update-choice reply) before the task drops its capture.
+    private var pendingCheckTransitionState: UpdateState?
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
 
@@ -216,10 +220,16 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
 
     // MARK: - State transition helpers
 
+    /// Replaces the visible state while first finishing any delayed callback-bearing transition.
+    /// Controller paths that supersede a check use this instead of mutating the model directly.
+    func replaceActiveState(with replacement: UpdateState) {
+        cancelPendingCheckTransition()
+        model.replaceActiveState(with: replacement)
+    }
+
     private func beginChecking(cancel: @escaping () -> Void) {
         model.setOverrideState(nil)
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
+        cancelPendingCheckTransition()
         checkTimeoutTask?.cancel()
         checkTimeoutTask = nil
         lastCheckStart = Date()
@@ -241,8 +251,7 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     }
 
     private func setStateAfterMinimumCheckDelay(_ newState: UpdateState) {
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
+        cancelPendingCheckTransition()
         checkTimeoutTask?.cancel()
         checkTimeoutTask = nil
 
@@ -260,23 +269,42 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         }
 
         let delay = minimumCheckDuration - elapsed
+        pendingCheckTransitionState = newState
         pendingCheckTransitionTask = Task { @MainActor [weak self] in
             // Bounded, cancellable minimum-display delay via the injected clock.
             try? await self?.clock.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self else { return }
-            guard case .checking = self.model.state else { return }
+            guard case .checking = self.model.state else {
+                guard let pendingState = self.pendingCheckTransitionState else { return }
+                self.pendingCheckTransitionState = nil
+                self.pendingCheckTransitionTask = nil
+                pendingState.finishAsSuperseded()
+                return
+            }
+            self.pendingCheckTransitionState = nil
+            self.pendingCheckTransitionTask = nil
             self.lastCheckStart = nil
             self.applyState(newState)
         }
     }
 
     private func setState(_ newState: UpdateState) {
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
+        cancelPendingCheckTransition()
         checkTimeoutTask?.cancel()
         checkTimeoutTask = nil
         lastCheckStart = nil
         applyState(newState)
+    }
+
+    /// Cancels the minimum-display task after causally completing the callback-bearing state it
+    /// captured. Without this handoff, cancelling while still visibly checking drops Sparkle's
+    /// mandatory update-choice reply and strands its session behind `sessionInProgress`.
+    private func cancelPendingCheckTransition() {
+        pendingCheckTransitionTask?.cancel()
+        pendingCheckTransitionTask = nil
+        guard let pendingState = pendingCheckTransitionState else { return }
+        pendingCheckTransitionState = nil
+        pendingState.finishAsSuperseded()
     }
 
     private func scheduleCheckTimeout() {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -492,7 +492,7 @@ import Testing
     /// the transition is discarded, so the finished cycle permits a retry.
     @Test func cancellingDelayedUpdateFoundDismissesPromptAndAllowsRetry() async {
         let harness = Harness()
-        let prompt = ChoiceBox()
+        let prompt = PromptReplyChoiceBox()
 
         harness.controller.checkForUpdates()
         harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {
@@ -514,7 +514,9 @@ import Testing
         harness.controller.driver.showUpdateFound(
             with: item,
             state: sparkleState,
-            reply: { choice in prompt.choice = choice }
+            reply: { choice in
+                MainActor.assumeIsolated { prompt.append(choice) }
+            }
         )
         guard case .checking(let checking) = harness.model.state else {
             Issue.record("found update should remain behind the minimum checking delay")
@@ -522,8 +524,8 @@ import Testing
         }
 
         checking.cancel()
-        #expect(prompt.choice == .dismiss)
-        #expect(prompt.choice == .dismiss, "the buffered Sparkle reply must be consumed once")
+        checking.cancel()
+        #expect(prompt.choices == [.dismiss], "the buffered Sparkle reply must be consumed once")
 
         harness.finishSparkleCycle()
         harness.controller.checkForUpdates()

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -486,4 +486,48 @@ import Testing
         }
         #expect(laterPrompt.choice == nil)
     }
+
+    /// A found-update callback can arrive while the minimum checking display delay is pending.
+    /// Cancelling that still-visible checking state must answer the buffered Sparkle prompt before
+    /// the transition is discarded, so the finished cycle permits a retry.
+    @Test func cancellingDelayedUpdateFoundDismissesPromptAndAllowsRetry() async {
+        let harness = Harness()
+        let prompt = ChoiceBox()
+
+        harness.controller.checkForUpdates()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {
+            harness.updater.sessionInProgress = false
+        })
+        let item = SUAppcastItem(dictionary: [
+            "title": "cmux 0.64.17",
+            "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+            "enclosure": [
+                "url": "https://example.com/cmux.zip",
+                "length": "1024",
+                "sparkle:version": "0.64.17",
+                "sparkle:shortVersionString": "0.64.17",
+            ],
+        ])!
+
+        // Sparkle owns this state, but UpdateDriver only needs the appcast item and reply here.
+        let sparkleState = unsafeBitCast(NSNull(), to: SPUUserUpdateState.self)
+        harness.controller.driver.showUpdateFound(
+            with: item,
+            state: sparkleState,
+            reply: { choice in prompt.choice = choice }
+        )
+        guard case .checking(let checking) = harness.model.state else {
+            Issue.record("found update should remain behind the minimum checking delay")
+            return
+        }
+
+        checking.cancel()
+        #expect(prompt.choice == .dismiss)
+        #expect(prompt.choice == .dismiss, "the buffered Sparkle reply must be consumed once")
+
+        harness.finishSparkleCycle()
+        harness.controller.checkForUpdates()
+        await waitUntil("replacement check to start") { harness.updater.checkForUpdatesCallCount == 2 }
+        #expect(harness.updater.sessionInProgress)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/12279

When Sparkle delivered `showUpdateFound` during cmux's minimum checking display delay, canceling the still-visible checking state canceled the transition task and dropped Sparkle's mandatory choice callback. The session then stayed active forever and blocked retries.

This change retains the delayed callback-bearing state and funnels cancellation/replacement through one cleanup path. Superseded delayed states are causally completed (`.dismiss` for an update prompt, acknowledgement/cancellation for other phases) before the task is discarded. Controller replacement paths use the same path.

The first commit adds a deterministic injected-clock regression that replays `showUserInitiatedUpdateCheck` → delayed `showUpdateFound` → cancel → exactly-once dismiss → cycle finish → retry. It fails on the first commit and passes with the fix.

Validation:
- `swift test --package-path Packages/macOS/CmuxUpdater --filter cancellingDelayedUpdateFoundDismissesPromptAndAllowsRetry`
- `swift test --package-path Packages/macOS/CmuxUpdater`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791673499&installation_model_id=21920&pr_number=12283&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12283&signature=19e8e35d156fc5555a38a926aeb4b75c8de3218c0868aa88d35e132fc5fef803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 206623babce13cb54105bce714e4c8812f336d2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stuck updater session where canceling a still-visible checking state dropped Sparkle's mandatory update-choice callback and blocked retries. Delayed callback-bearing states are now retained until cancelled, then causally completed (dismiss for update prompts, acknowledgement/cancellation for other phases) before the transition task is discarded.

**Bug Fixes**
- All cancellation and controller replacement paths now route through one cleanup path in `UpdateDriver`.
- Adds a regression test that replays a user-initiated check, delayed `showUpdateFound`, double cancel, and retry using an injected clock.

<sup>Written for commit 206623babce13cb54105bce714e4c8812f336d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update-checking transitions when a new update result arrives during the minimum display period.
  * Ensured pending update prompts are dismissed correctly and only once when superseded.
  * Fixed cases where the update process could fail to start a replacement check after a pending transition was cancelled.

* **Tests**
  * Added coverage for dismissing delayed update prompts and successfully retrying an update check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->