### PR TITLE
Fix CodeRouter browser completion on cmux.com

### DIFF
--- a/web/app/coderouter/auth/complete/page.module.css
+++ b/web/app/coderouter/auth/complete/page.module.css
@@ -1,0 +1,77 @@
+.page {
+  color-scheme: light dark;
+  --callback-background: #fafafa;
+  --callback-text: #171717;
+  --callback-muted: #737373;
+  --callback-border: #e5e5e5;
+  --callback-status: #15803d;
+  min-height: 100svh;
+  background: var(--callback-background);
+  color: var(--callback-text);
+}
+
+@media (prefers-color-scheme: dark) {
+  .page {
+    --callback-background: #0a0a0a;
+    --callback-text: #ededed;
+    --callback-muted: #a3a3a3;
+    --callback-border: #262626;
+    --callback-status: #4ade80;
+  }
+}
+
+.header { border-bottom: 1px solid var(--callback-border); }
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 1152px;
+  height: 48px;
+  margin: 0 auto;
+  padding: 0 24px;
+  font-size: 13px;
+}
+.brandName { font-size: 14px; font-weight: 600; letter-spacing: -0.025em; }
+.divider { margin: 0 4px; color: var(--callback-border); }
+.product { color: var(--callback-muted); }
+.main {
+  display: grid;
+  place-items: center;
+  min-height: calc(100svh - 49px);
+  padding: 48px 24px;
+}
+.confirmation { width: 100%; max-width: 480px; padding-bottom: 48px; text-align: center; }
+.title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 0;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.25;
+  text-wrap: balance;
+}
+.status {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--callback-status);
+  color: var(--callback-background);
+}
+.status svg { width: 14px; height: 14px; }
+.description {
+  max-width: 330px;
+  margin: 12px auto 0;
+  color: var(--callback-muted);
+  font-size: 15px;
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+@media (max-width: 480px) {
+  .title { font-size: 26px; }
+}

--- a/web/app/coderouter/auth/complete/page.tsx
+++ b/web/app/coderouter/auth/complete/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { getTranslations } from "next-intl/server";
+import styles from "./page.module.css";
+
+export const instant = false;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("coderouterAuth");
+  return {
+    title: `${t("title")} · coderouter`,
+    robots: { index: false, follow: false },
+    referrer: "no-referrer",
+  };
+}
+
+// This page acknowledges the local callback only. The CLI completes token
+// exchange and account upload; no credentials or query parameters are needed.
+export default async function CoderouterAuthCompletePage() {
+  const t = await getTranslations("coderouterAuth");
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.brand}>
+          <Image src="/logo.png" alt="" width={24} height={24} />
+          <span className={styles.brandName}>cmux</span>
+          <span className={styles.divider} aria-hidden="true">/</span>
+          <span className={styles.product}>coderouter</span>
+        </div>
+      </header>
+      <main className={styles.main}>
+        <section className={styles.confirmation} aria-labelledby="confirmation-title">
+          <h1 id="confirmation-title" className={styles.title}>
+            <span className={styles.status} aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m5 12 4 4 10-10" />
+              </svg>
+            </span>
+            <span>{t("title")}</span>
+          </h1>
+          <p className={styles.description}>{t("description")}</p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,4 +1,8 @@
 {
+  "coderouterAuth": {
+    "title": "Authorization received",
+    "description": "Return to your terminal to finish setup."
+  },
   "guestCLI": {
     "topologyHelp": "Arrange this machine without restarting its terminals:\n  cmux workspace new [--name <name>] [--json]\n  cmux workspace rename <workspace> <name> [--json]\n  cmux workspace move <workspace> --index <index> [--json]\n  cmux workspace focus|close <workspace> [--json]\n  cmux tab rename <tab> <name> [--json]\n  cmux terminal rename <terminal|current> <name> [--json]\n  cmux tab move <tab> --workspace <ws> --screen <screen> --pane <pane> --index <index> [--json]\n  cmux pane split <pane> <left|right|up|down> [--ratio <fraction>] [--json]\n  cmux pane swap <pane> --other-workspace <ws> --other-screen <screen> --other-pane <pane> [--json]\n  cmux pane resize <pane> --split <split> --ratio <fraction> [--json]\n  cmux pane|tab focus <id> [--json]\n  cmux workspace|pane|tab list [--json]\n\nUse IDs from cmux tree. Indices start at zero. A tab label belongs to one placement;\nterminal rename labels every current placement (no process is restarted).\nUse tab move for a terminal with several views so only the selected placement moves.\nFor a peer: cmux vm <workspace|pane|tab|terminal> <verb> <machine> ...\nSelector-first daemon syntax remains supported. Layout apply creates a new/empty\nworkspace; use move/swap/resize to rearrange an occupied one. These commands change\nthe daemon layout. On the Mac, open it with cmux vm workspace open <machine> <ws>.",
     "topologyUsage": "Invalid topology arguments. Run cmux workspace help for workspace, pane, tab, and terminal naming and layout commands.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1,4 +1,8 @@
 {
+  "coderouterAuth": {
+    "title": "認証を受け取りました",
+    "description": "ターミナルに戻ってセットアップを完了してください。"
+  },
   "guestCLI": {
     "topologyHelp": "ターミナルを再起動せずに、このマシンの配置を変更します:\n  cmux workspace new [--name <name>] [--json]\n  cmux workspace rename <workspace> <name> [--json]\n  cmux workspace move <workspace> --index <index> [--json]\n  cmux workspace focus|close <workspace> [--json]\n  cmux tab rename <tab> <name> [--json]\n  cmux terminal rename <terminal|current> <name> [--json]\n  cmux tab move <tab> --workspace <ws> --screen <screen> --pane <pane> --index <index> [--json]\n  cmux pane split <pane> <left|right|up|down> [--ratio <fraction>] [--json]\n  cmux pane swap <pane> --other-workspace <ws> --other-screen <screen> --other-pane <pane> [--json]\n  cmux pane resize <pane> --split <split> --ratio <fraction> [--json]\n  cmux pane|tab focus <id> [--json]\n  cmux workspace|pane|tab list [--json]\n\nID は cmux tree で確認できます。インデックスは 0 から始まります。\nタブ名は配置ごとに設定され、terminal rename はそのターミナルの現在の全配置を変更します。\n複数の表示があるターミナルは tab move で対象の配置だけを移動してください。\nピアでは cmux vm <workspace|pane|tab|terminal> <verb> <machine> ... を使います。\nセレクターを先に指定するデーモン構文も利用できます。layout apply は新規または空の\nワークスペース用です。使用中の配置は move/swap/resize で変更してください。\nこれらはデーモンのレイアウトを変更します。Mac で表示するには\ncmux vm workspace open <machine> <ws> を使います。",
     "topologyUsage": "配置コマンドの引数が無効です。名前変更と配置操作は cmux workspace help で確認してください。",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -128,6 +128,12 @@ function handleHostAndMachineRoutes(
     return NextResponse.next();
   }
 
+  if (pathname === "/coderouter/auth/complete" || pathname === "/coderouter/auth/complete/") {
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set("x-next-intl-locale", preferredAppRouteLocale(request));
+    return NextResponse.next({ request: { headers: requestHeaders } });
+  }
+
   // cmux consumes this marker before navigation. If an ordinary browser
   // reaches the server, canonicalize the URL while preserving every public
   // query parameter.

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -3,6 +3,19 @@ import { NextRequest } from "next/server";
 import middleware from "../proxy";
 
 describe("coderouter middleware", () => {
+  test.each(["en", "ja"])("serves the OAuth handoff in %s without a locale rewrite or sign-in", (locale) => {
+    const response = middleware(
+      new NextRequest("https://cmux.com/coderouter/auth/complete", {
+        headers: { host: "cmux.com", "accept-language": locale },
+      }),
+    );
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("x-middleware-request-x-next-intl-locale")).toBe(locale);
+  });
+
   test("serves the same dedicated landing page on cmux.com/coderouter", () => {
     const response = middleware(
       new NextRequest("https://cmux.com/coderouter", {


### PR DESCRIPTION
Completing `cmux cr add codex` currently leaves the browser on the CodeRouter CLI's localhost callback. Add `/coderouter/auth/complete` on cmux.com using the approved cmux confirmation design: logo, Geist typography, light/dark colors, and a clear terminal handoff.

The public page says “Authorization received — Return to your terminal to finish setup.” It acknowledges receipt only: the CLI still owns token exchange, account upload, and final success. The page needs no account session or OAuth parameters, is excluded from search indexing, and supports English/Japanese through the message catalogs with the normal English fallback for other locales. Middleware keeps the fixed URL outside the localized route tree while respecting the browser language.

Companion CLI PR: https://github.com/manaflow-ai/coderouter/pull/66. Deploy this web change before releasing CodeRouter 0.3.6. Existing installations need that CLI update; `cmux cr` delegates to the separately installed binary and does not update it automatically.

Validation:
- Test-only commit `7764911f1f`: both locale-routing regressions fail before the fix; all 8 focused middleware tests pass afterward.
- Typecheck, focused ESLint, complexity gate, and diff checks pass.
- Localization audit: both new strings are keyed in en/ja, catalogs parse, key sets match, and the new page has no bare user-facing English.
- The actual `cmux` Vercel preview built successfully on pushed HEAD. All 8 remote Chromium checks passed: English/Japanese × desktop/mobile × light/dark, HTTP 200, correct document language, Geist and logo loaded, no horizontal overflow, noindex and no-referrer metadata. Screenshots were visually inspected. The unrelated cmux41/cmux166 checks deploy static repository files and do not verify the web app.

Preview: https://cmux-j9zblmd2t-manaflow.vercel.app/coderouter/auth/complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a static, unauthenticated confirmation page and a narrow middleware bypass; no auth, token handling, or data changes.
> 
> **Overview**
> Adds a fixed public URL **`/coderouter/auth/complete`** on cmux.com so CodeRouter OAuth no longer ends on a localhost callback. The page is **acknowledgment-only** (success UI + “return to terminal” copy); it does not handle tokens, query params, or sign-in.
> 
> **UI:** New Next.js route with cmux/coderouter header branding, light/dark CSS, checkmark confirmation, **`noindex`** / **`no-referrer`** metadata, and **`coderouterAuth`** strings in **en** and **ja**.
> 
> **Routing:** Middleware treats this path like the existing coderouter landing exception—**no** `/<locale>/…` rewrite—while setting **`x-next-intl-locale`** from `Accept-Language` so copy localizes. Tests cover **en** and **ja** handoff without redirect or rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902f31354db414e234deb14a39559147cb69a756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a CodeRouter authentication completion page with cmux and CodeRouter branding.
  - Displays a success confirmation and instructs users to return to their terminal after authorization.
  - Added responsive styling for desktop and mobile screens.
  - Added English and Japanese localized content.
  - Authentication callback links now continue directly to the completion screen while respecting the app’s preferred language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->