### PR TITLE
web: accept and ignore home-volume flags on providers without home volumes (fixes cmux vm new 400 since PR 11609)

### DIFF
--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -14,6 +14,7 @@ import {
   type ProviderId,
   vmCapabilitiesFor,
 } from "../../../services/vms/drivers";
+import type { VmCapabilities } from "../../../services/vms/drivers/types";
 import { assertVmCreateEnabled } from "../../../services/vms/config";
 import { vmModelPlaneGatewayFor } from "../../../services/vms/modelPlaneGateway";
 import {
@@ -224,8 +225,11 @@ export async function POST(request: Request): Promise<Response> {
       const image = imageSelection.image;
       const unsupportedOption = await unsupportedCreateOptionResponse(provider, candidate, request);
       if (unsupportedOption) return unsupportedOption;
+      const optionPolicy = createOptionPolicy(vmCapabilitiesFor(provider), candidate);
+      const homeVolumeRequested = optionPolicy.kind === "accept" && optionPolicy.ignoredFields.length === 0;
       setSpanAttributes(span, {
         "cmux.vm.provider": provider,
+        "cmux.vm.ignored_create_fields": optionPolicy.kind === "accept" ? optionPolicy.ignoredFields.join(",") : "",
         "cmux.vm.image_set": image.length > 0,
         "cmux.vm.image_version": imageSelection.imageVersion,
         "cmux.vm.image_manifest": !!imageSelection.manifestEntry,
@@ -252,8 +256,8 @@ export async function POST(request: Request): Promise<Response> {
         imageVersion: imageSelection.imageVersion,
         provider,
         idempotencyKey,
-        persistentHome: candidate.persistentHome === true,
-        perMachineHome: candidate.perMachineHome === true,
+        persistentHome: homeVolumeRequested && candidate.persistentHome === true,
+        perMachineHome: homeVolumeRequested && candidate.perMachineHome === true,
         memoryMb,
         imageSize: imageSelection.size ?? undefined,
         modelPlane,
@@ -281,18 +285,42 @@ export async function POST(request: Request): Promise<Response> {
   );
 }
 
+/**
+ * How a create request's optional flags meet the resolved provider's capabilities.
+ *
+ * `memoryMb` on a provider without sizing is rejected: the caller paid for a size it
+ * would not get. `persistentHome`/`perMachineHome` on a provider without home volumes
+ * are ignored, not rejected: every shipped CLI sends them on the default create (the
+ * "each machine is its own persistent computer" contract, PR 10478), a Freestyle
+ * machine already is durable without a volume, and rejecting them took `cmux vm new`
+ * down for every installed client on 2026-09-10 (8 of 9 creates 400 after PR 11609).
+ * The ignored fields are reported so the span and the response can say so.
+ */
+export function createOptionPolicy(
+  capabilities: Pick<VmCapabilities, "sizing" | "persistentHome">,
+  candidate: Record<string, unknown>,
+):
+  | { readonly kind: "reject"; readonly operation: "sizing"; readonly field: "memoryMb" }
+  | { readonly kind: "accept"; readonly ignoredFields: readonly ("persistentHome" | "perMachineHome")[] } {
+  if (candidate.memoryMb !== undefined && !capabilities.sizing) {
+    return { kind: "reject", operation: "sizing", field: "memoryMb" };
+  }
+  const ignoredFields: ("persistentHome" | "perMachineHome")[] = [];
+  if (!capabilities.persistentHome) {
+    if (candidate.persistentHome === true) ignoredFields.push("persistentHome");
+    if (candidate.perMachineHome === true) ignoredFields.push("perMachineHome");
+  }
+  return { kind: "accept", ignoredFields };
+}
+
 async function unsupportedCreateOptionResponse(
   provider: ProviderId,
   candidate: Record<string, unknown>,
   request: Request,
 ): Promise<Response | null> {
-  const capabilities = vmCapabilitiesFor(provider);
-  const unsupported = candidate.memoryMb !== undefined && !capabilities.sizing
-    ? { operation: "sizing" as const, field: "memoryMb" }
-    : (candidate.persistentHome === true || candidate.perMachineHome === true) && !capabilities.persistentHome
-      ? { operation: "persistentHome" as const, field: candidate.persistentHome === true ? "persistentHome" : "perMachineHome" }
-      : null;
-  if (!unsupported) return null;
+  const policy = createOptionPolicy(vmCapabilitiesFor(provider), candidate);
+  if (policy.kind !== "reject") return null;
+  const unsupported = policy;
   const copy = await vmUnsupportedCopy(unsupported.operation, vmRequestLocale(request));
   return vmErrorResponse({
     error: "vm_operation_unsupported",

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -445,8 +445,10 @@ desktop, sizing, persistentHome, attachTransports}` — derived in
 `services/vms/drivers/index.ts` (`vmCapabilitiesOf`) from driver method presence, with the
 driver's declared `capabilities` overriding. Flags with no structural signal (`desktop`,
 `sizing`, `persistentHome`) default to false: a driver opts in to what it honors, and
-`POST /api/vm` rejects `memoryMb`/`persistentHome` requests the resolved provider would
-silently drop. Clients (the Mac app and CLI) gate verbs on this object and never on a
+`POST /api/vm` rejects a `memoryMb` request the resolved provider would silently drop, and
+ignores `persistentHome`/`perMachineHome` on a provider without home volumes (shipped CLIs
+send them on every default create; a Freestyle machine is durable without a volume), noting
+the dropped fields on the span. Clients (the Mac app and CLI) gate verbs on this object and never on a
 provider name, so a new provider registered in `drivers/index.ts` works end to end with no
 client update. `openAttach`/`openSSH`/`revokeSSHIdentity` are optional interface members;
 the gateway maps an absent method to `VmOperationUnsupportedError` (an honest 501).

--- a/web/tests/vm-create-option-policy.test.ts
+++ b/web/tests/vm-create-option-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { createOptionPolicy } from "../app/api/vm/route";
+
+describe("createOptionPolicy", () => {
+  test("home-volume flags on a provider without home volumes are ignored, not rejected", () => {
+    // What every shipped `cmux vm new` sends on the default create.
+    const policy = createOptionPolicy(
+      { sizing: true, persistentHome: false },
+      { persistentHome: true, perMachineHome: true, kind: "desktop" },
+    );
+    expect(policy).toEqual({ kind: "accept", ignoredFields: ["persistentHome", "perMachineHome"] });
+  });
+
+  test("home-volume flags on a provider with home volumes pass through untouched", () => {
+    expect(createOptionPolicy({ sizing: true, persistentHome: true }, { perMachineHome: true }))
+      .toEqual({ kind: "accept", ignoredFields: [] });
+  });
+
+  test("a size on a provider without sizing is still rejected", () => {
+    expect(createOptionPolicy({ sizing: false, persistentHome: false }, { memoryMb: 8192, persistentHome: true }))
+      .toEqual({ kind: "reject", operation: "sizing", field: "memoryMb" });
+  });
+
+  test("a bare create has nothing to ignore", () => {
+    expect(createOptionPolicy({ sizing: false, persistentHome: false }, {}))
+      .toEqual({ kind: "accept", ignoredFields: [] });
+  });
+});


### PR DESCRIPTION
Since https://github.com/manaflow-ai/cmux/pull/11609 merged (2026-09-10 20:29Z), `POST /api/vm` rejects `persistentHome`/`perMachineHome` when the provider declares no home-volume capability. The Freestyle driver declares `{stats, sizing, desktop}`, and every shipped CLI sends both flags on the default `cmux vm new` (and `vm run` pool creates). Axiom, `POST /api/vm`: 24 h before the merge 35 × 200, 0 × 400; since the merge 8 × 400, 1 × 200 (the GUI sheet, which sends no flags).

Fix: `createOptionPolicy` keeps the `memoryMb` rejection and ignores the two home flags on such providers, recording `cmux.vm.ignored_create_fields` on the span. Commit 1 is the test, commit 2 the fix. README updated.

Decision for the reviewer: this restores the pre-11609 contract (flags ignored where unsupported) instead of teaching the CLI to stop sending them; a CLI change would not repair installed clients.

https://claude.ai/code/session_01PTHiBBEfb9pBWWCfPsapL4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791677102&installation_model_id=21920&pr_number=12288&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12288&signature=1452448095d81695f762d5782b1b0f7d0a009213cccfd92c9a0a05161508c76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1713d18144cf27e3b235a9b4ac49bb7c7bf9373b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `POST /api/vm` returning 400 on `cmux vm new` when the provider lacks home-volume support, by ignoring `persistentHome`/`perMachineHome` flags instead of rejecting them. The `memoryMb` rejection for providers without sizing stays.

- Records ignored create fields on the span via `cmux.vm.ignored_create_fields`.
- Adds `createOptionPolicy` to centralize the capability check, with unit tests.
- Updates the VMs README to document the new behavior.

<sup>Written for commit 1713d18144cf27e3b235a9b4ac49bb7c7bf9373b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - VM creation now rejects unsupported memory-sizing requests with a clear validation error.
  - Home-volume options unsupported by a provider are safely ignored instead of causing creation to fail.
  - Supported providers continue receiving persistent and per-machine home-volume settings.
  - Ignored VM options are recorded for improved visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->