### PR TITLE
Fix Cloud workspace Desktop membership and terminal-only opens

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4367,13 +4367,6 @@ struct CMUXCLI {
         return VMMachineKind.defaultKind
     }
     private static let cloudVMDesktopPort = 6901
-    /// Whether a machine payload (`vm.create` / `vm.status` / `vm.base_open`
-    /// response) describes a machine with a screen: the backend's `kind` when it
-    /// sends one, otherwise the image name for older control planes.
-    static func cloudVMResponseHasDesktop(_ response: [String: Any]) -> Bool {
-        VMMachineKind.resolved(kind: response["kind"], image: response["image"]).hasDesktop
-    }
-
     /// `vm shell <id>` and `vm open <id>`: the shared cloud open path through the
     /// machine's cmux-tui remote daemon. Desktop panes are opened explicitly.
     func openVMWorkspaceShell(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4375,8 +4375,8 @@ struct CMUXCLI {
     }
 
     /// `vm shell <id>` and `vm open <id>`: the shared cloud open path through the
-    /// machine's cmux-tui remote daemon, then the screen beside the shell for desktop machines.
-    func openVMShellWithDesktop(
+    /// machine's cmux-tui remote daemon. Desktop panes are opened explicitly.
+    func openVMWorkspaceShell(
         vmId: String,
         windowRaw: String?,
         targetWorkspaceId: String?,
@@ -4384,7 +4384,7 @@ struct CMUXCLI {
         jsonOutput: Bool,
         idFormat: CLIIDFormat
     ) throws {
-        let shellWorkspace = try vmOpenShell(
+        try vmOpenShell(
             id: vmId,
             workspaceName: "vm:\(vmId)",
             windowRaw: windowRaw,
@@ -4395,22 +4395,10 @@ struct CMUXCLI {
             jsonOutput: jsonOutput,
             idFormat: idFormat
         )
-        if let status = try? client.sendV2(method: "vm.status", params: ["id": vmId], responseTimeout: 30),
-           Self.cloudVMResponseHasDesktop(status) {
-            // The screen belongs beside the shell it was opened with, not in whatever
-            // workspace holds focus once the attach settles.
-            let desktopWorkspace = shellWorkspace?.workspaceId ?? vmAttachedWorkspaceId(vmId: vmId, client: client)
-            _ = try? openVMDesktopSplit(
-                vmId: vmId,
-                client: client,
-                workspaceId: desktopWorkspace,
-                terminalSurfaceId: shellWorkspace?.terminalSurfaceId
-            )
-        }
     }
 
     /// Shows the VM's desktop (noVNC) as a browser pane. One path for every entrypoint —
-    /// `vm desktop`, `vm open <m>:desktop`, the split beside `vm shell`, and the sidebar
+    /// `vm desktop`, `vm open <m>:desktop`, and the sidebar
     /// tree — through the app's `vm.desktop_open`, which loads the machine's private URL
     /// after the browser Network Extension is ready and reports the surface.
     /// Returns false when the machine has no desktop.
@@ -5789,7 +5777,7 @@ struct CMUXCLI {
                 }
                 if case .machine(let vmId) = target {
                     // The bare machine is the shell: exactly `vm shell <machine>`.
-                    try openVMShellWithDesktop(
+                    try openVMWorkspaceShell(
                         vmId: vmId,
                         windowRaw: windowOpt ?? windowId,
                         targetWorkspaceId: workspaceOpt,
@@ -6086,7 +6074,7 @@ struct CMUXCLI {
                 // a failed attach must not make the next `vm new` replay this create and
                 // "create" the same machine again.
                 Self.clearVMCreateIdempotency(idempotency)
-                let createdWorkspace = try vmOpenShell(
+                try vmOpenShell(
                     id: id,
                     workspaceName: "vm:\(id)",
                     windowRaw: targetWindow,
@@ -6101,18 +6089,6 @@ struct CMUXCLI {
                     jsonOutput: jsonOutput,
                     idFormat: idFormat
                 )
-                // A machine with a screen shows it: stream the noVNC desktop into a browser
-                // split beside the shell so the workspace opens as terminal + desktop.
-                if Self.cloudVMResponseHasDesktop(response) {
-                    _ = try? openVMDesktopSplit(
-                        vmId: id,
-                        client: client,
-                        workspaceId: createdWorkspace?.workspaceId,
-                        // Re-focusing the shell would select its workspace; a background
-                        // open leaves the person where they are.
-                        terminalSurfaceId: focus ? createdWorkspace?.terminalSurfaceId : nil
-                    )
-                }
 
             case "desktop", "vnc":
                 // The machine's screen, on demand: the noVNC desktop opens as a browser
@@ -6129,7 +6105,7 @@ struct CMUXCLI {
                         """)
                 }
                 let desktopWorkspace = workspaceOpt ?? vmAttachedWorkspaceId(vmId: vmId, client: client)
-                // One desktop path for `vm desktop`, `vm open <m>:desktop`, `vm shell`'s split
+                // One desktop path for `vm desktop`, `vm open <m>:desktop`,
                 // and the sidebar tree: vm.desktop_open in the app.
                 guard try openVMDesktopSplit(vmId: vmId, client: client, workspaceId: desktopWorkspace, jsonOutput: jsonOutput) else {
                     throw CLIError(message: String(
@@ -6271,7 +6247,7 @@ struct CMUXCLI {
                           cmux vm ls
                         """)
                 }
-                try openVMShellWithDesktop(
+                try openVMWorkspaceShell(
                     vmId: vmId,
                     windowRaw: windowOpt ?? windowId,
                     targetWorkspaceId: nil,

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -907,7 +907,7 @@ enum CloudTreeNodeBuilder {
                 byWorkspace[placement.workspace.id] = rows
             }
         }
-        for member in localDisplayMembers(resources: resources, projections: snapshot.projections) {
+        for member in SurfaceProjection.localDisplayMembers(resources: resources, projections: snapshot.projections) {
             guard var rows = byWorkspace[member.workspaceID] else { continue }
             rows.displays.append(RemoteResourcePlacement(resource: member.resource, workspace: rows.workspace, view: nil))
             byWorkspace[member.workspaceID] = rows

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -892,7 +892,6 @@ enum CloudTreeNodeBuilder {
         snapshot: SurfaceCatalogSnapshot,
         projectionIndex: LocalProjectionIndex
     ) -> CloudTreeNode {
-        let displays = resources.filter { $0.kind == .display }
         var byWorkspace: [String: RemoteWorkspaceRows] = [:]
         for workspace in info.remoteWorkspaces ?? [] {
             byWorkspace[workspace.id] = RemoteWorkspaceRows(workspace: workspace)
@@ -907,6 +906,11 @@ enum CloudTreeNodeBuilder {
                 }
                 byWorkspace[placement.workspace.id] = rows
             }
+        }
+        for member in localDisplayMembers(resources: resources, projections: snapshot.projections) {
+            guard var rows = byWorkspace[member.workspaceID] else { continue }
+            rows.displays.append(RemoteResourcePlacement(resource: member.resource, workspace: rows.workspace, view: nil))
+            byWorkspace[member.workspaceID] = rows
         }
         let workspaces = byWorkspace.values.sorted { lhs, rhs in
             lhs.workspace.index != rhs.workspace.index ? lhs.workspace.index < rhs.workspace.index : lhs.workspace.id < rhs.workspace.id
@@ -923,15 +927,12 @@ enum CloudTreeNodeBuilder {
                     remoteWorkspaceID: workspace.id
                 )
             }
-            let shownDisplayPlacements: [RemoteResourcePlacement] = displayPlacements.isEmpty
-                ? displays.map { RemoteResourcePlacement(resource: $0, workspace: workspace, view: nil) }
-                : displayPlacements
             let openInLocal = projectionIndex.localWorkspaceShowing(
                 remoteWorkspaceID: workspace.id,
                 placements: realPlacements
             )
             let layout = layoutRows(
-                placements: terminalPlacements + browserPlacements + shownDisplayPlacements,
+                placements: terminalPlacements + browserPlacements + displayPlacements,
                 workspace: workspace,
                 machine: machine,
                 info: info,
@@ -939,16 +940,14 @@ enum CloudTreeNodeBuilder {
                 projectionIndex: projectionIndex,
                 openInLocal: openInLocal
             )
-            // The group keeps its members (a workspace's own placements; the implicit
-            // pool display stays out) but takes the rows' order.
-            let realPlacementSet = Set(realPlacements)
+            // Open and drag use the same actual placements in the rows' order.
             let orderedRealPlacements = layout.placements.map { placement in
                 SurfaceResourcePlacement(
                     resource: placement.resource.id,
                     remoteView: placement.view,
                     remoteWorkspaceID: workspace.id
                 )
-            }.filter { realPlacementSet.contains($0) }
+            }
             return CloudTreeNode(
                 id: nodeID(workspace: workspace.id, machine: machine),
                 kind: .workspace(

--- a/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
+++ b/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
@@ -61,7 +61,7 @@ extension CloudTreeNodeBuilder {
     /// socket's `vm.workspace_open` both read this, so a click and the CLI open
     /// the same set, and a tree rebuild stays O(resources × views) whatever the
     /// workspace count.
-    static func remoteWorkspaceMembersByWorkspace(resources: [SurfaceResource]) -> [String: CloudTreeRemoteWorkspaceMembers] {
+    static func remoteWorkspaceMembersByWorkspace(resources: [SurfaceResource], projections: [SurfaceProjection] = []) -> [String: CloudTreeRemoteWorkspaceMembers] {
         var byWorkspace: [String: CloudTreeRemoteWorkspaceMembers] = [:]
         for resource in resources {
             for workspace in resource.remoteWorkspaces {
@@ -74,12 +74,33 @@ extension CloudTreeNodeBuilder {
                 byWorkspace[workspace.id] = members
             }
         }
+        for member in localDisplayMembers(resources: resources, projections: projections) {
+            var members = byWorkspace[member.workspaceID] ?? .none
+            members.displays.append(member.resource)
+            byWorkspace[member.workspaceID] = members
+        }
         return byWorkspace
     }
 
+    /// Explicit VNC panes have no daemon tab. Their live catalog projections name
+    /// their bound workspace; availability in the machine display pool never does.
+    /// A daemon placement of the same display already supplies that workspace row.
+    static func localDisplayMembers(resources: [SurfaceResource], projections: [SurfaceProjection]) -> [(resource: SurfaceResource, workspaceID: String)] {
+        let displays = Dictionary(uniqueKeysWithValues: resources.filter { $0.kind == .display }.map { ($0.id, $0) })
+        var seen: [SurfaceResourceID: Set<String>] = [:]
+        return projections.compactMap { projection in
+            guard projection.remoteTabID == nil,
+                  let workspaceID = projection.remoteWorkspaceID,
+                  let resource = displays[projection.resource],
+                  !resource.remoteWorkspaces.contains(where: { $0.id == workspaceID }),
+                  seen[resource.id, default: []].insert(workspaceID).inserted else { return nil }
+            return (resource, workspaceID)
+        }
+    }
+
     /// The members of one workspace (an existing workspace nothing views has none).
-    static func remoteWorkspaceMembers(workspaceID: String, resources: [SurfaceResource]) -> CloudTreeRemoteWorkspaceMembers {
-        remoteWorkspaceMembersByWorkspace(resources: resources)[workspaceID] ?? .none
+    static func remoteWorkspaceMembers(workspaceID: String, resources: [SurfaceResource], projections: [SurfaceProjection] = []) -> CloudTreeRemoteWorkspaceMembers {
+        remoteWorkspaceMembersByWorkspace(resources: resources, projections: projections)[workspaceID] ?? .none
     }
 
     /// How many panes of each local workspace show each resource, built once per
@@ -112,14 +133,14 @@ extension CloudTreeNodeBuilder {
         let resources = snapshot.resources(on: machine)
         let workspaces = remoteWorkspaces(info: snapshot.machines.first { $0.id == machine }, resources: resources)
         if let byID = workspaces.first(where: { $0.id == trimmed }) {
-            return .found(byID, remoteWorkspaceMembers(workspaceID: byID.id, resources: resources))
+            return .found(byID, remoteWorkspaceMembers(workspaceID: byID.id, resources: resources, projections: snapshot.projections))
         }
         let byName = workspaces.filter { $0.name == trimmed }
         switch byName.count {
         case 0:
             return .notFound
         case 1:
-            return .found(byName[0], remoteWorkspaceMembers(workspaceID: byName[0].id, resources: resources))
+            return .found(byName[0], remoteWorkspaceMembers(workspaceID: byName[0].id, resources: resources, projections: snapshot.projections))
         default:
             return .ambiguous(byName)
         }

--- a/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
+++ b/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
@@ -74,28 +74,12 @@ extension CloudTreeNodeBuilder {
                 byWorkspace[workspace.id] = members
             }
         }
-        for member in localDisplayMembers(resources: resources, projections: projections) {
+        for member in SurfaceProjection.localDisplayMembers(resources: resources, projections: projections) {
             var members = byWorkspace[member.workspaceID] ?? .none
             members.displays.append(member.resource)
             byWorkspace[member.workspaceID] = members
         }
         return byWorkspace
-    }
-
-    /// Explicit VNC panes have no daemon tab. Their live catalog projections name
-    /// their bound workspace; availability in the machine display pool never does.
-    /// A daemon placement of the same display already supplies that workspace row.
-    static func localDisplayMembers(resources: [SurfaceResource], projections: [SurfaceProjection]) -> [(resource: SurfaceResource, workspaceID: String)] {
-        let displays = Dictionary(uniqueKeysWithValues: resources.filter { $0.kind == .display }.map { ($0.id, $0) })
-        var seen: [SurfaceResourceID: Set<String>] = [:]
-        return projections.compactMap { projection in
-            guard projection.remoteTabID == nil,
-                  let workspaceID = projection.remoteWorkspaceID,
-                  let resource = displays[projection.resource],
-                  !resource.remoteWorkspaces.contains(where: { $0.id == workspaceID }),
-                  seen[resource.id, default: []].insert(workspaceID).inserted else { return nil }
-            return (resource, workspaceID)
-        }
     }
 
     /// The members of one workspace (an existing workspace nothing views has none).

--- a/Sources/Surfaces/CloudPlacementCoordinator.swift
+++ b/Sources/Surfaces/CloudPlacementCoordinator.swift
@@ -55,6 +55,8 @@ final class CloudPlacementCoordinator {
     private func placement(of projection: SurfaceProjection, resource: SurfaceResource, catalog: SurfaceCatalog) -> SurfaceRemotePlacement? {
         let receipt = receipts[resource.id]?[projection.panelID]
         let live = catalog.projection(forPanel: projection.panelID).flatMap { $0.resource == resource.id ? $0 : nil }
+        // A local VNC pane must never borrow another viewer's daemon tab on close.
+        if resource.kind == .display, receipt == nil, (live ?? projection).remoteTabID == nil { return nil }
         guard let tabID = receipt?.tabID
             ?? catalog.cloudWorkspaceRenameService.remoteTabID(for: live ?? projection, resource: resource) else { return nil }
         guard let workspaceID = movedTabs[resource.machine]?[tabID]
@@ -66,6 +68,13 @@ final class CloudPlacementCoordinator {
     }
 
     func projectionDidMove(_ projection: SurfaceProjection, catalog: SurfaceCatalog) {
+        if projection.resource.kind == .display, projection.remoteTabID == nil {
+            // Local VNC membership follows the current binding, including removal
+            // when the pane moves into an unbound viewer workspace.
+            let target = boundRemoteWorkspaceID(forLocalWorkspace: projection.workspaceID, on: projection.resource.machine)
+            catalog.setRemotePlacement(for: projection, workspaceID: target, tabID: nil)
+            return
+        }
         guard let target = boundRemoteWorkspaceID(forLocalWorkspace: projection.workspaceID, on: projection.resource.machine),
               let provider = catalog.provider(for: projection.resource.machine) as? any SurfacePlacementSyncing else { return }
         enqueue(projection, catalog: catalog) {
@@ -78,9 +87,8 @@ final class CloudPlacementCoordinator {
             } else if resource.kind == .terminal, resource.remoteViews?.isEmpty == true,
                       projection.remoteTabID == nil {
                 result = try await provider.projectTerminal(resource.id, intoRemoteWorkspace: target)
-            } else if resource.kind == .display || (resource.kind == .browser && resource.remoteViews?.isEmpty != false) {
-                // Displays and port previews have no daemon tab; keep their local
-                // workspace association without inventing a remote placement.
+            } else if resource.kind == .browser && resource.remoteViews?.isEmpty != false {
+                // Port previews have no daemon tab; retain their local association.
                 catalog.setRemotePlacement(for: projection, workspaceID: target, tabID: nil)
                 return true
             } else {

--- a/Sources/Surfaces/CloudPlacementCoordinator.swift
+++ b/Sources/Surfaces/CloudPlacementCoordinator.swift
@@ -52,6 +52,16 @@ final class CloudPlacementCoordinator {
         }
     }
 
+    /// Resolve a local VNC pane before binding inference sees its old workspace.
+    func projectionInCurrentWorkspace(_ projection: SurfaceProjection) -> SurfaceProjection {
+        guard projection.resource.kind == .display, projection.remoteTabID == nil else { return projection }
+        var updated = projection
+        updated.remoteWorkspaceID = boundRemoteWorkspaceID(
+            forLocalWorkspace: projection.workspaceID, on: projection.resource.machine
+        )
+        return updated
+    }
+
     private func placement(of projection: SurfaceProjection, resource: SurfaceResource, catalog: SurfaceCatalog) -> SurfaceRemotePlacement? {
         let receipt = receipts[resource.id]?[projection.panelID]
         let live = catalog.projection(forPanel: projection.panelID).flatMap { $0.resource == resource.id ? $0 : nil }
@@ -71,8 +81,8 @@ final class CloudPlacementCoordinator {
         if projection.resource.kind == .display, projection.remoteTabID == nil {
             // Local VNC membership follows the current binding, including removal
             // when the pane moves into an unbound viewer workspace.
-            let target = boundRemoteWorkspaceID(forLocalWorkspace: projection.workspaceID, on: projection.resource.machine)
-            catalog.setRemotePlacement(for: projection, workspaceID: target, tabID: nil)
+            let current = projectionInCurrentWorkspace(projection)
+            catalog.setRemotePlacement(for: projection, workspaceID: current.remoteWorkspaceID, tabID: nil)
             return
         }
         guard let target = boundRemoteWorkspaceID(forLocalWorkspace: projection.workspaceID, on: projection.resource.machine),
@@ -119,8 +129,9 @@ final class CloudPlacementCoordinator {
                 confirmationCursors[state.machine]?[tabID] = nil
             }
             let trackedTab = state.lookupIndex.tab(id: tabID)
+            let contentKind = trackedTab?.contentKind == "screen" ? "display" : trackedTab?.contentKind
             if trackedTab?.contentID != projection.resource.key
-                || trackedTab?.contentKind != projection.resource.kind.rawValue {
+                || contentKind != projection.resource.kind.rawValue {
                 var updated = projection
                 updated.remoteWorkspaceID = nil
                 updated.remoteTabID = nil

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1657,7 +1657,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// several views has no safe implicit placement. Returning nil keeps the projection
     /// placement-neutral until a caller supplies an exact tab id.
     static func defaultRemoteView(for resource: SurfaceResource) -> SurfaceRemoteView? {
-        guard let views = resource.remoteViews, views.count == 1 else { return nil }
+        guard resource.kind != .display, let views = resource.remoteViews, views.count == 1 else { return nil }
         return views[0]
     }
 

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1656,7 +1656,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// Compatibility fallback for callers that only have a terminal identity. A terminal with
     /// several views has no safe implicit placement. Returning nil keeps the projection
     /// placement-neutral until a caller supplies an exact tab id.
-    private static func defaultRemoteView(for resource: SurfaceResource) -> SurfaceRemoteView? {
+    static func defaultRemoteView(for resource: SurfaceResource) -> SurfaceRemoteView? {
         guard let views = resource.remoteViews, views.count == 1 else { return nil }
         return views[0]
     }

--- a/Sources/Surfaces/SurfaceCatalog+Groups.swift
+++ b/Sources/Surfaces/SurfaceCatalog+Groups.swift
@@ -101,80 +101,6 @@ struct SurfaceResourceGroup: Hashable, Codable, Sendable {
 }
 
 extension SurfaceCatalog {
-    /// Builds the one canonical group for a daemon workspace. A resource is
-    /// repeated once for every tab placement, so opening a workspace cannot
-    /// collapse two tabs that point at the same terminal. Order matches the
-    /// Cloud sidebar: panes in layout order, the shown tab before that pane's
-    /// hidden tabs, then pane-less resources in kind order.
-    func remoteWorkspaceGroup(
-        machine: SurfaceMachineID,
-        workspaceID: String
-    ) throws -> SurfaceResourceGroup {
-        let machineSnapshot = snapshot
-        let machineInfo = machineSnapshot.machines.first { $0.id == machine }
-        var workspace = machineInfo?.remoteWorkspaces?.first { $0.id == workspaceID }
-        let resources = machineSnapshot.resources(on: machine)
-
-        struct Candidate {
-            let placement: SurfaceResourcePlacement
-            let layout: RemoteWorkspacePlacement
-        }
-        let orderedKinds: [SurfaceResourceKind] = [.terminal, .browser, .display]
-        var candidates: [Candidate] = []
-        for kind in orderedKinds {
-            let kindOrder = kind == .terminal ? 0 : (kind == .browser ? 1 : 2)
-            for resource in resources where resource.kind == kind {
-                if let views = resource.remoteViews, !views.isEmpty {
-                    for view in views where view.workspace.id == workspaceID {
-                        workspace = workspace ?? view.workspace
-                        candidates.append(Candidate(
-                            placement: SurfaceResourcePlacement(resource: resource.id, remoteView: view),
-                            layout: RemoteWorkspacePlacement(
-                                screenID: view.screenID,
-                                paneID: view.paneID,
-                                screenIndex: view.screenIndex,
-                                paneIndex: view.paneIndex,
-                                tabIndex: view.index,
-                                focused: view.focused == true,
-                                kindOrder: kindOrder
-                            )
-                        ))
-                    }
-                } else if let resourceWorkspace = resource.remoteWorkspace,
-                          resourceWorkspace.id == workspaceID {
-                    workspace = workspace ?? resourceWorkspace
-                    candidates.append(Candidate(
-                        placement: SurfaceResourcePlacement(
-                            resource: resource.id,
-                            remoteWorkspaceID: workspaceID
-                        ),
-                        layout: RemoteWorkspacePlacement(kindOrder: kindOrder)
-                    ))
-                }
-            }
-        }
-
-        guard let workspace else {
-            throw SurfaceCatalogError.destinationNotFound(
-                "workspace \(workspaceID) on \(machine.rawValue)"
-            )
-        }
-        guard !candidates.isEmpty else {
-            throw SurfaceCatalogError.destinationNotFound(
-                "workspace \(workspaceID) on \(machine.rawValue) has no projectable resources"
-            )
-        }
-        let layout = RemoteWorkspaceLayout(placements: candidates.map(\.layout))
-        let placements = layout.rows.flatMap { row in
-            [candidates[row.shownIndex].placement] + row.hiddenIndices.map { candidates[$0].placement }
-        }
-        return SurfaceResourceGroup(
-            title: workspace.name,
-            placements: placements,
-            remoteWorkspaceID: workspaceID
-        )
-    }
-
     /// Finds the pane hosting a panel, so the rest of a group can join it as tabs.
     typealias PaneLookup = @MainActor (_ panelID: UUID, _ workspaceID: UUID) -> String?
 
@@ -277,6 +203,11 @@ extension SurfaceCatalog {
         }
         let workspaceID = member.remoteWorkspaceID ?? fallbackWorkspaceID
         guard let workspaceID else { return nil }
+        if member.resource.kind == .display, projections.contains(where: {
+            $0.resource == member.resource && $0.remoteTabID == nil && $0.remoteWorkspaceID == workspaceID
+        }) {
+            return nil
+        }
         return try remoteView(for: member.resource, workspaceID: workspaceID)
     }
 

--- a/Sources/Surfaces/SurfaceCatalog+WorkspaceMembership.swift
+++ b/Sources/Surfaces/SurfaceCatalog+WorkspaceMembership.swift
@@ -1,0 +1,86 @@
+import CmuxCore
+import Foundation
+
+extension SurfaceCatalog {
+    /// Builds the one canonical group for a daemon workspace. A resource is
+    /// repeated once for every tab placement, so opening a workspace cannot
+    /// collapse two tabs that point at the same terminal. Order matches the
+    /// Cloud sidebar: panes in layout order, the shown tab before that pane's
+    /// hidden tabs, then pane-less resources in kind order.
+    func remoteWorkspaceGroup(
+        machine: SurfaceMachineID,
+        workspaceID: String
+    ) throws -> SurfaceResourceGroup {
+        let machineSnapshot = snapshot
+        let machineInfo = machineSnapshot.machines.first { $0.id == machine }
+        var workspace = machineInfo?.remoteWorkspaces?.first { $0.id == workspaceID }
+        let resources = machineSnapshot.resources(on: machine)
+
+        struct Candidate {
+            let placement: SurfaceResourcePlacement
+            let layout: RemoteWorkspacePlacement
+        }
+        let orderedKinds: [SurfaceResourceKind] = [.terminal, .browser, .display]
+        var candidates: [Candidate] = []
+        for kind in orderedKinds {
+            let kindOrder = kind == .terminal ? 0 : (kind == .browser ? 1 : 2)
+            for resource in resources where resource.kind == kind {
+                if let views = resource.remoteViews, !views.isEmpty {
+                    for view in views where view.workspace.id == workspaceID {
+                        workspace = workspace ?? view.workspace
+                        candidates.append(Candidate(
+                            placement: SurfaceResourcePlacement(resource: resource.id, remoteView: view),
+                            layout: RemoteWorkspacePlacement(
+                                screenID: view.screenID,
+                                paneID: view.paneID,
+                                screenIndex: view.screenIndex,
+                                paneIndex: view.paneIndex,
+                                tabIndex: view.index,
+                                focused: view.focused == true,
+                                kindOrder: kindOrder
+                            )
+                        ))
+                    }
+                } else if resource.remoteViews == nil, let resourceWorkspace = resource.remoteWorkspace,
+                          resourceWorkspace.id == workspaceID {
+                    workspace = workspace ?? resourceWorkspace
+                    candidates.append(Candidate(
+                        placement: SurfaceResourcePlacement(
+                            resource: resource.id,
+                            remoteWorkspaceID: workspaceID
+                        ),
+                        layout: RemoteWorkspacePlacement(kindOrder: kindOrder)
+                    ))
+                }
+            }
+        }
+
+        for member in SurfaceProjection.localDisplayMembers(resources: resources, projections: machineSnapshot.projections)
+            where member.workspaceID == workspaceID {
+            candidates.append(Candidate(
+                placement: SurfaceResourcePlacement(resource: member.resource.id, remoteWorkspaceID: workspaceID),
+                layout: RemoteWorkspacePlacement(kindOrder: 2)
+            ))
+        }
+
+        guard let workspace else {
+            throw SurfaceCatalogError.destinationNotFound(
+                "workspace \(workspaceID) on \(machine.rawValue)"
+            )
+        }
+        guard !candidates.isEmpty else {
+            throw SurfaceCatalogError.destinationNotFound(
+                "workspace \(workspaceID) on \(machine.rawValue) has no projectable resources"
+            )
+        }
+        let layout = RemoteWorkspaceLayout(placements: candidates.map(\.layout))
+        let placements = layout.rows.flatMap { row in
+            [candidates[row.shownIndex].placement] + row.hiddenIndices.map { candidates[$0].placement }
+        }
+        return SurfaceResourceGroup(
+            title: workspace.name,
+            placements: placements,
+            remoteWorkspaceID: workspaceID
+        )
+    }
+}

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -1177,7 +1177,7 @@ final class SurfaceCatalog {
     /// Record a pane that shows a resource (materialized by a provider, or adopted from an
     /// existing pane such as a local terminal the app created on its own).
     func record(_ projection: SurfaceProjection) {
-        insertSupersedingLocalPlaceholder(projection)
+        insertSupersedingLocalPlaceholder(cloudPlacementCoordinator.projectionInCurrentWorkspace(projection))
         reconcileCloudWorkspaceBinding(localWorkspaceID: projection.workspaceID)
         notifyChange()
     }
@@ -1273,13 +1273,13 @@ final class SurfaceCatalog {
         notifyChange()
     }
 
-    /// A pane moved to another workspace (tab transfer / drag between windows).
     func moveProjections(panelID: UUID, to workspaceID: UUID) {
         let moved = projections.filter { $0.panelID == panelID && $0.workspaceID != workspaceID }
         guard !moved.isEmpty else { return }
         projections.subtract(moved)
         for var projection in moved {
             projection.workspaceID = workspaceID
+            projection = cloudPlacementCoordinator.projectionInCurrentWorkspace(projection)
             projections.insert(projection)
         }
         reconcileCloudWorkspaceBinding(localWorkspaceID: workspaceID)

--- a/Sources/Surfaces/SurfaceProjection+WorkspaceMembership.swift
+++ b/Sources/Surfaces/SurfaceProjection+WorkspaceMembership.swift
@@ -1,0 +1,17 @@
+extension SurfaceProjection {
+    /// Explicit VNC panes have no daemon tab. Their live catalog projections name
+    /// their bound workspace; availability in the machine display pool never does.
+    /// A daemon placement of the same display already supplies that workspace row.
+    static func localDisplayMembers(resources: [SurfaceResource], projections: [SurfaceProjection]) -> [(resource: SurfaceResource, workspaceID: String)] {
+        let displays = Dictionary(uniqueKeysWithValues: resources.filter { $0.kind == .display }.map { ($0.id, $0) })
+        var seen: [SurfaceResourceID: Set<String>] = [:]
+        return projections.compactMap { projection in
+            guard projection.remoteTabID == nil,
+                  let workspaceID = projection.remoteWorkspaceID,
+                  let resource = displays[projection.resource],
+                  !resource.remoteWorkspaces.contains(where: { $0.id == workspaceID }),
+                  seen[resource.id, default: []].insert(workspaceID).inserted else { return nil }
+            return (resource, workspaceID)
+        }
+    }
+}

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -181,7 +181,7 @@ final class CloudWorkspaceRenameService {
             if let explicit = projection.remoteWorkspaceID?.trimmingCharacters(in: .whitespacesAndNewlines),
                !explicit.isEmpty {
                 remoteID = explicit
-            } else if resource.remoteWorkspaces.isEmpty {
+            } else if resource.remoteWorkspaces.isEmpty || (resource.kind == .display && projection.remoteTabID == nil) {
                 // A cloud display, port browser, or pool terminal may be projected
                 // without a daemon-workspace placement. It cannot establish a target,
                 // but it also cannot contradict an exact terminal/workspace anchor.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2768,6 +2768,7 @@
 		D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */; };
 		F11347000000000000000001 /* SurfaceCatalog+CloudPorts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11347000000000000000002 /* SurfaceCatalog+CloudPorts.swift */; };
 		DD3A13AD76F5196C5FC8C52A /* SurfaceCatalog+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660286CE22B478E887361407 /* SurfaceCatalog+Groups.swift */; };
+		00B9FC4EDB2E47F6819B01C4 /* SurfaceCatalog+WorkspaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8876F3CE1A40FB83FF5463 /* SurfaceCatalog+WorkspaceMembership.swift */; };
 		F7F3BED81BD5FE96D52055C0 /* SurfaceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA63D377742D3A6A0BAB499B /* SurfaceCatalog.swift */; };
 		31B62CAEA63AA5B0F737F227 /* SurfaceCatalogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CA02CE5FE3E9DC871AD810 /* SurfaceCatalogModel.swift */; };
 		D01100800000000000000002 /* SurfaceCatalogQueryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01100800000000000000001 /* SurfaceCatalogQueryService.swift */; };
@@ -2780,6 +2781,7 @@
 		875200000000000000000014 /* SurfacePaneMovement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875200000000000000000004 /* SurfacePaneMovement.swift */; };
 		A857C2803433CBC0C4A73119 /* SurfacePlacementSyncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E6488D5D32D552A9888D65 /* SurfacePlacementSyncing.swift */; };
 		6FEEA8C6D7092073E0DE9DEC /* SurfacePortEndpointCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B78E9F9B9C233418960CB37 /* SurfacePortEndpointCache.swift */; };
+		027446BA1E1B4E69B2DCDF8A /* SurfaceProjection+WorkspaceMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF4946E3C7A4AEEBD2E8933 /* SurfaceProjection+WorkspaceMembership.swift */; };
 		0F4B1E526E23283B5CA1FAAA /* SurfaceProjectionEndReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA8DF56A13E861D787CA4AE /* SurfaceProjectionEndReason.swift */; };
 		A9C10D000000000000000002 /* SurfaceProjectionMaterialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C10D000000000000000001 /* SurfaceProjectionMaterialization.swift */; };
 		EE1DE3F7E67DF1366F214AC7 /* SurfaceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED489C1C23533995AF55EA /* SurfaceProvider.swift */; };
@@ -6231,6 +6233,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupersededPhoneDismissBuffer.swift; sourceTree = "<group>"; };
 		F11347000000000000000002 /* SurfaceCatalog+CloudPorts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SurfaceCatalog+CloudPorts.swift"; sourceTree = "<group>"; };
 		660286CE22B478E887361407 /* SurfaceCatalog+Groups.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SurfaceCatalog+Groups.swift"; sourceTree = "<group>"; };
+		0B8876F3CE1A40FB83FF5463 /* SurfaceCatalog+WorkspaceMembership.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SurfaceCatalog+WorkspaceMembership.swift"; sourceTree = "<group>"; };
 		EA63D377742D3A6A0BAB499B /* SurfaceCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceCatalog.swift; sourceTree = "<group>"; };
 		66CA02CE5FE3E9DC871AD810 /* SurfaceCatalogModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceCatalogModel.swift; sourceTree = "<group>"; };
 		D01100800000000000000001 /* SurfaceCatalogQueryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceCatalogQueryService.swift; sourceTree = "<group>"; };
@@ -6243,6 +6246,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		875200000000000000000004 /* SurfacePaneMovement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfacePaneMovement.swift; sourceTree = "<group>"; };
 		A1E6488D5D32D552A9888D65 /* SurfacePlacementSyncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurfacePlacementSyncing.swift"; sourceTree = "<group>"; };
 		3B78E9F9B9C233418960CB37 /* SurfacePortEndpointCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfacePortEndpointCache.swift; sourceTree = "<group>"; };
+		7DF4946E3C7A4AEEBD2E8933 /* SurfaceProjection+WorkspaceMembership.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SurfaceProjection+WorkspaceMembership.swift"; sourceTree = "<group>"; };
 		ECA8DF56A13E861D787CA4AE /* SurfaceProjectionEndReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurfaceProjectionEndReason.swift"; sourceTree = "<group>"; };
 		A9C10D000000000000000001 /* SurfaceProjectionMaterialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceProjectionMaterialization.swift; sourceTree = "<group>"; };
 		AAED489C1C23533995AF55EA /* SurfaceProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceProvider.swift; sourceTree = "<group>"; };
@@ -7366,6 +7370,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C11323120000000000000001 /* SurfacePaneFactory+CloudManualMirror.swift */,
 				C11323220000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift */,
 				660286CE22B478E887361407 /* SurfaceCatalog+Groups.swift */,
+				7DF4946E3C7A4AEEBD2E8933 /* SurfaceProjection+WorkspaceMembership.swift */,
+				0B8876F3CE1A40FB83FF5463 /* SurfaceCatalog+WorkspaceMembership.swift */,
 				3FB8309C25B29D6CEE17BD64 /* SurfaceSocketCommands+VMFileDelivery.swift */,
 				F9E053B7E9AE536377476E4B /* CmuxTuiSurfaceProvider+FileDelivery.swift */,
 				DA32812C9009969F4AEA2380 /* CloudFileDelivery.swift */,
@@ -12846,6 +12852,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */,
 				F11347000000000000000001 /* SurfaceCatalog+CloudPorts.swift in Sources */,
 				DD3A13AD76F5196C5FC8C52A /* SurfaceCatalog+Groups.swift in Sources */,
+				00B9FC4EDB2E47F6819B01C4 /* SurfaceCatalog+WorkspaceMembership.swift in Sources */,
 				F7F3BED81BD5FE96D52055C0 /* SurfaceCatalog.swift in Sources */,
 				31B62CAEA63AA5B0F737F227 /* SurfaceCatalogModel.swift in Sources */,
 				D01100800000000000000002 /* SurfaceCatalogQueryService.swift in Sources */,
@@ -12855,6 +12862,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				875200000000000000000014 /* SurfacePaneMovement.swift in Sources */,
 				A857C2803433CBC0C4A73119 /* SurfacePlacementSyncing.swift in Sources */,
 				6FEEA8C6D7092073E0DE9DEC /* SurfacePortEndpointCache.swift in Sources */,
+				027446BA1E1B4E69B2DCDF8A /* SurfaceProjection+WorkspaceMembership.swift in Sources */,
 				0F4B1E526E23283B5CA1FAAA /* SurfaceProjectionEndReason.swift in Sources */,
 				A9C10D000000000000000002 /* SurfaceProjectionMaterialization.swift in Sources */,
 				EE1DE3F7E67DF1366F214AC7 /* SurfaceProvider.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 		62AABF1720674956200EC388 /* CloudWireGuardHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6544386D2BA373AF2133B58 /* CloudWireGuardHubTests.swift */; };
 		0B2534A7872AF46D59819D49 /* CloudWorkspaceLayoutTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183FE43D3F71A474726D6AA6 /* CloudWorkspaceLayoutTranslator.swift */; };
 		341E0463C183CD4C0CB655DE /* CloudWorkspaceLayoutTranslatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBB7EB399B58A6D076EAF1E /* CloudWorkspaceLayoutTranslatorTests.swift */; };
+		4779459FFFB041CB8FD46938 /* CloudWorkspaceMembershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F739BB5F7AEF47A6A38D6B7C /* CloudWorkspaceMembershipTests.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		9758A0029758A0029758A002 /* cmux-amp-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = 9758A0019758A0019758A001 /* cmux-amp-wrapper */; };
 		C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */; };
@@ -4388,6 +4389,7 @@
 		C6544386D2BA373AF2133B58 /* CloudWireGuardHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudWireGuardHubTests.swift; sourceTree = "<group>"; };
 		183FE43D3F71A474726D6AA6 /* CloudWorkspaceLayoutTranslator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWorkspaceLayoutTranslator.swift; sourceTree = "<group>"; };
 		FCBB7EB399B58A6D076EAF1E /* CloudWorkspaceLayoutTranslatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWorkspaceLayoutTranslatorTests.swift; sourceTree = "<group>"; };
+		F739BB5F7AEF47A6A38D6B7C /* CloudWorkspaceMembershipTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWorkspaceMembershipTests.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
 		9758A0019758A0019758A001 /* cmux-amp-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-amp-wrapper"; sourceTree = SOURCE_ROOT; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -10160,6 +10162,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				9A986C3063FCE5F28AA10ACA /* MachinesPanelUncappedPlanTests.swift */,
 				E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */,
 				99BEA5821E46487A94B4E8B8 /* CloudTreeOneMachineManyWorkspacesTests.swift */,
+				F739BB5F7AEF47A6A38D6B7C /* CloudWorkspaceMembershipTests.swift */,
 				F11347000000000000000004 /* CloudPortOpenRegressionTests.swift */,
 				F3E5958FB85E4B97957D4F73 /* CloudSidebarSurfaceRegressionTests.swift */,
 				64C68B378B6071B213B4AA57 /* LocalSurfaceProviderTests.swift */,
@@ -13928,6 +13931,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				2D7F228001C24ABD865AFD66 /* CloudVMStateSnapshotComparisonTests.swift in Sources */,
 				62AABF1720674956200EC388 /* CloudWireGuardHubTests.swift in Sources */,
 				341E0463C183CD4C0CB655DE /* CloudWorkspaceLayoutTranslatorTests.swift in Sources */,
+				4779459FFFB041CB8FD46938 /* CloudWorkspaceMembershipTests.swift in Sources */,
 				C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */,
 				8295A0058295A0058295A005 /* CmuxAlertContentTests.swift in Sources */,
 				947194719471947194719472 /* CmuxBundledBinPathIntegrationTests.swift in Sources */,

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -244,7 +244,6 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "machine:brave-otter/ws/ws_main",
             "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_1/tab:tab_term_1_0",
             "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_shared/tab:tab_term_shared_0",
-            "machine:brave-otter/ws/ws_main/resource:brave-otter/display/display:1",
             "machine:brave-otter/ws/ws_side",
             "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_2/tab:tab_term_2_0",
             "machine:brave-otter/ws/ws_side/resource:brave-otter/terminal/term_shared/tab:tab_term_shared_1",
@@ -279,7 +278,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         }
         #expect(mainCount == 2)
         #expect(sideCount == 2)
-        // The pinned display travels with its workspace's open/drag group; the implicit one does not.
+        // Only actual placements travel with a workspace's open/drag group.
         #expect(byID["machine:brave-otter/ws/ws_side"]?.dragGroup?.resources == [
             SurfaceResourceID(machine: machine, kind: .terminal, key: "term_2"), shared.id, desktop.id,
         ])

--- a/cmuxTests/CloudWorkspaceMembershipTests.swift
+++ b/cmuxTests/CloudWorkspaceMembershipTests.swift
@@ -123,6 +123,59 @@ struct CloudWorkspaceMembershipTests {
         try expectMembership(current, in: catalog)
     }
 
+    @Test("Explicit local VNC panes belong only to their current bound workspace")
+    func localDesktopMembership() async throws {
+        let first = UUID(), second = UUID(), viewer = UUID()
+        let coordinator = CloudPlacementCoordinator(binding: { id in
+            guard id == first || id == second else { return nil }
+            return WorkspaceCloudVMBinding(
+                vmID: "membership-test", isBase: false,
+                remoteWorkspaceID: id == first ? "ws_a" : "ws_b"
+            )
+        })
+        let catalog = SurfaceCatalog(cloudPlacementCoordinator: coordinator)
+        let provider = CloudPlacementTestProvider(machine: machine)
+        catalog.register(provider)
+        let current = try state(desktops: [:])
+        publish(current, to: catalog)
+        let desktop = SurfaceResourceID(machine: machine, kind: .display, key: "display:1")
+
+        func desktopRows(in workspace: String) throws -> [CloudTreeNode] {
+            let tree = CloudTreeNodeBuilder.flattened(CloudTreeNodeBuilder.nodes(
+                machines: [], snapshot: catalog.snapshot, localWorkspaces: [], includeLocalMachine: false
+            ))
+            let row = try #require(tree.first { $0.id == CloudTreeNodeBuilder.nodeID(workspace: workspace, machine: machine) })
+            return row.children.filter { if case .display = $0.kind { return true }; return false }
+        }
+
+        let opened = try await catalog.project(desktop, into: .workspace(id: first, placement: .split), focus: false)
+        await coordinator.waitForPendingMutations()
+        #expect(try desktopRows(in: "ws_a").count == 1)
+        #expect(try desktopRows(in: "ws_b").isEmpty)
+        let repeated = try await catalog.project(desktop, into: .workspace(id: first, placement: .split), focus: false)
+        #expect(repeated.reused && repeated.projection.panelID == opened.projection.panelID)
+        #expect(try desktopRows(in: "ws_a").count == 1)
+
+        // Refresh replaces daemon rows, while the live local pane remains real.
+        publish(current, to: catalog)
+        #expect(try desktopRows(in: "ws_a").count == 1)
+        catalog.moveProjections(panelID: opened.projection.panelID, to: second)
+        await coordinator.waitForPendingMutations()
+        #expect(try desktopRows(in: "ws_a").isEmpty)
+        #expect(try desktopRows(in: "ws_b").count == 1)
+
+        catalog.moveProjections(panelID: opened.projection.panelID, to: viewer)
+        await coordinator.waitForPendingMutations()
+        #expect(try desktopRows(in: "ws_a").isEmpty)
+        #expect(try desktopRows(in: "ws_b").isEmpty)
+        catalog.moveProjections(panelID: opened.projection.panelID, to: first)
+        await coordinator.waitForPendingMutations()
+        catalog.endProjections(panelID: opened.projection.panelID)
+        await coordinator.waitForPendingMutations()
+        try expectMembership(current, in: catalog)
+        #expect(provider.closedTabs.isEmpty, "a local VNC view has no daemon tab to close")
+    }
+
     private func state(
         desktops: [String: String], contentKind: String = "display",
         generation: String = "membership", focused: String = "a"

--- a/cmuxTests/CloudWorkspaceMembershipTests.swift
+++ b/cmuxTests/CloudWorkspaceMembershipTests.swift
@@ -44,8 +44,8 @@ struct CloudWorkspaceMembershipTests {
         try expectMembership(created, in: catalog)
     }
 
-    @Test("Closing a desktop pane removes only its workspace tab after the authoritative delta")
-    func closeDesktopPane() async throws {
+    @Test("Closing a desktop pane removes only its workspace tab after the authoritative delta", arguments: ["display", "screen"])
+    func closeDesktopPane(contentKind: String) async throws {
         let localWorkspace = UUID(), panel = UUID()
         let coordinator = CloudPlacementCoordinator(binding: { id in
             id == localWorkspace
@@ -55,13 +55,14 @@ struct CloudWorkspaceMembershipTests {
         let catalog = SurfaceCatalog(cloudPlacementCoordinator: coordinator)
         let provider = CloudPlacementTestProvider(machine: machine)
         catalog.register(provider)
-        let initial = try state(desktops: ["desk_a": "a", "desk_b": "b"])
+        let initial = try state(desktops: ["desk_a": "a", "desk_b": "b"], contentKind: contentKind)
         publish(initial, to: catalog)
         let display = SurfaceResourceID(machine: machine, kind: .display, key: "display:1")
         catalog.record(SurfaceProjection(
             resource: display, workspaceID: localWorkspace, panelID: panel,
             remoteWorkspaceID: "ws_a", remoteTabID: "desk_a"
         ))
+        publish(initial, to: catalog)
         try expectMembership(initial, in: catalog)
 
         catalog.endProjections(panelID: panel)
@@ -79,6 +80,18 @@ struct CloudWorkspaceMembershipTests {
         try expectMembership(detached, in: catalog)
         #expect(catalog.resources[display] != nil)
         #expect(catalog.resources[display]?.remoteWorkspaces.isEmpty == true)
+    }
+
+    @Test("Opening a machine display does not select or infer an unrelated daemon workspace")
+    func displayPoolOpenHasNoImplicitTab() throws {
+        let current = try state(desktops: ["desk_b": "b"])
+        let display = try #require(resources(current).first { $0.id.key == "display:1" })
+        #expect(CmuxTuiSurfaceProvider.defaultRemoteView(for: display) == nil)
+        let terminal = try #require(resources(current).first { $0.id.key == "term_a" })
+        #expect(CmuxTuiSurfaceProvider.defaultRemoteView(for: terminal)?.tabID == "tab_a")
+        let rename = CloudWorkspaceRenameService()
+        let projection = SurfaceProjection(resource: display.id, workspaceID: UUID(), panelID: UUID())
+        #expect(rename.inferredRemoteWorkspaceTarget(projections: [projection], resources: [display]) == nil)
     }
 
     @Test("Refresh, reconnect and focus changes preserve exact display membership", arguments: ["display", "screen"])

--- a/cmuxTests/CloudWorkspaceMembershipTests.swift
+++ b/cmuxTests/CloudWorkspaceMembershipTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Exercise the daemon graph -> catalog -> outline path, including the normal
+/// pane-close callback. Available machine displays never imply workspace tabs.
+@MainActor
+@Suite
+struct CloudWorkspaceMembershipTests {
+    private let machine = SurfaceMachineID.cloud("membership-test")
+
+    @Test("Terminal-only workspaces do not inherit available machine displays")
+    func terminalOnlyCreation() throws {
+        let catalog = SurfaceCatalog()
+        let initial = try state(desktops: [:])
+        publish(initial, to: catalog)
+        try expectMembership(initial, in: catalog)
+        #expect(catalog.snapshot.resources(on: machine).filter { $0.kind == .display }.count == 2)
+
+        // A newly created workspace comes from the next complete daemon graph.
+        var document = try #require(initial.snapshotObject())
+        document["workspaces"] = (document["workspaces"] as? [[String: Any]] ?? []) + [
+            ["id": "ws_new", "name": "workspace-3", "index": 2]
+        ]
+        document["screens"] = (document["screens"] as? [[String: Any]] ?? []) + [
+            ["id": "screen_new", "workspace_id": "ws_new"]
+        ]
+        document["panes"] = (document["panes"] as? [[String: Any]] ?? []) + [
+            ["id": "pane_new", "screen_id": "screen_new"]
+        ]
+        document["tabs"] = (document["tabs"] as? [[String: Any]] ?? []) + [
+            ["id": "tab_new", "pane_id": "pane_new", "content_kind": "terminal", "content_id": "term_new"]
+        ]
+        document["terminals"] = (document["terminals"] as? [[String: Any]] ?? []) + [
+            ["id": "term_new", "tab_id": "tab_new", "title": "terminal", "lifecycle": "running"]
+        ]
+        document["cursor"] = ["generation": "membership", "revision": "2"]
+        let created = try #require(CmuxTuiSnapshotParser.state(fromSnapshot: document, machine: machine))
+        publish(created, to: catalog)
+        try expectMembership(created, in: catalog)
+    }
+
+    @Test("Closing a desktop pane removes only its workspace tab after the authoritative delta")
+    func closeDesktopPane() async throws {
+        let localWorkspace = UUID(), panel = UUID()
+        let coordinator = CloudPlacementCoordinator(binding: { id in
+            id == localWorkspace
+                ? WorkspaceCloudVMBinding(vmID: "membership-test", isBase: false, remoteWorkspaceID: "ws_a")
+                : nil
+        })
+        let catalog = SurfaceCatalog(cloudPlacementCoordinator: coordinator)
+        let provider = CloudPlacementTestProvider(machine: machine)
+        catalog.register(provider)
+        let initial = try state(desktops: ["desk_a": "a", "desk_b": "b"])
+        publish(initial, to: catalog)
+        let display = SurfaceResourceID(machine: machine, kind: .display, key: "display:1")
+        catalog.record(SurfaceProjection(
+            resource: display, workspaceID: localWorkspace, panelID: panel,
+            remoteWorkspaceID: "ws_a", remoteTabID: "desk_a"
+        ))
+        try expectMembership(initial, in: catalog)
+
+        catalog.endProjections(panelID: panel)
+        await coordinator.waitForPendingMutations()
+        #expect(provider.closedTabs == ["desk_a"])
+        #expect(catalog.projection(forPanel: panel) == nil)
+        let closed = try removing("desk_a", from: initial)
+        publish(closed, to: catalog, delta: true)
+        try expectMembership(closed, in: catalog)
+        #expect(catalog.resources[display]?.remoteViews?.map(\.tabID) == ["desk_b"])
+
+        // Closing the last placement keeps the machine display discoverable.
+        let detached = try removing("desk_b", from: closed)
+        publish(detached, to: catalog, delta: true)
+        try expectMembership(detached, in: catalog)
+        #expect(catalog.resources[display] != nil)
+        #expect(catalog.resources[display]?.remoteWorkspaces.isEmpty == true)
+    }
+
+    @Test("Refresh, reconnect and focus changes preserve exact display membership", arguments: ["display", "screen"])
+    func authoritativeReconciliation(contentKind: String) throws {
+        let catalog = SurfaceCatalog()
+        let initial = try state(desktops: ["desk_a": "a"], contentKind: contentKind)
+        publish(initial, to: catalog)
+        let removed = try removing("desk_a", from: initial)
+        publish(removed, to: catalog, delta: true)
+        try expectMembership(removed, in: catalog)
+
+        catalog.markCloudStateStale(on: machine, reason: "reconnecting")
+        try expectMembership(removed, in: catalog)
+        // A late fleet summary must not put old placement information back.
+        catalog.updateMachine(info(initial))
+        try expectMembership(removed, in: catalog)
+        publish(removed, to: catalog)
+        try expectMembership(removed, in: catalog)
+
+        // A new daemon generation places the desktop only in B. Repeated full
+        // snapshots and switching workspace focus cannot copy or duplicate it.
+        for focused in ["b", "a", "b"] {
+            let reconnected = try state(
+                desktops: ["desk_reopened": "b"], contentKind: contentKind,
+                generation: "reconnected", focused: focused
+            )
+            publish(reconnected, to: catalog)
+            publish(reconnected, to: catalog)
+            try expectMembership(reconnected, in: catalog)
+        }
+    }
+
+    @Test("An explicit empty view list overrides stale legacy workspace metadata")
+    func detachedDisplayDoesNotUseLegacyWorkspace() throws {
+        let catalog = SurfaceCatalog()
+        let current = try state(desktops: [:])
+        var resources = resources(current)
+        let index = try #require(resources.firstIndex { $0.kind == .display })
+        resources[index].remoteViews = []
+        resources[index].remoteWorkspace = info(current).remoteWorkspaces?.first
+        catalog.replaceCloudState(current, resources: resources, info: info(current))
+        try expectMembership(current, in: catalog)
+    }
+
+    private func state(
+        desktops: [String: String], contentKind: String = "display",
+        generation: String = "membership", focused: String = "a"
+    ) throws -> CloudVMState {
+        let workspaceIDs = ["a", "b"]
+        var tabs: [[String: Any]] = workspaceIDs.map {
+            ["id": "tab_\($0)", "pane_id": "pane_\($0)", "content_kind": "terminal", "content_id": "term_\($0)", "index": 0]
+        }
+        tabs.append(["id": "tab_docs", "pane_id": "pane_a", "content_kind": "browser", "content_id": "docs", "index": 1])
+        for (tabID, workspace) in desktops.sorted(by: { $0.key < $1.key }) {
+            tabs.append(["id": tabID, "pane_id": "pane_\(workspace)", "content_kind": contentKind, "content_id": "display:1", "index": 2])
+        }
+        let document: [String: Any] = [
+            "cursor": ["generation": generation, "revision": "1"],
+            "workspaces": workspaceIDs.enumerated().map {
+                ["id": "ws_\($0.element)", "name": "workspace-\($0.offset + 1)", "index": $0.offset, "focused": $0.element == focused] as [String: Any]
+            },
+            "screens": workspaceIDs.map { ["id": "screen_\($0)", "workspace_id": "ws_\($0)"] },
+            "panes": workspaceIDs.map { ["id": "pane_\($0)", "screen_id": "screen_\($0)"] },
+            "tabs": tabs,
+            "terminals": workspaceIDs.map {
+                ["id": "term_\($0)", "tab_id": "tab_\($0)", "title": "terminal", "lifecycle": "running"]
+            },
+            "browsers": [["id": "docs", "tab_id": "tab_docs", "title": "Docs", "url": "http://localhost:3000"]],
+            "agents": []
+        ]
+        return try #require(CmuxTuiSnapshotParser.state(fromSnapshot: document, machine: machine))
+    }
+
+    private func removing(_ tabID: String, from state: CloudVMState) throws -> CloudVMState {
+        let previous = try #require(state.cursor)
+        let cursor = CloudVMCursor(generation: previous.generation, revision: previous.revision + 1)
+        let delta: [String: Any] = [
+            "kind": "delta", "previous_revision": String(previous.revision), "revision": String(cursor.revision),
+            "changes": [["kind": "delete", "resource": "tab", "id": tabID]]
+        ]
+        return try #require(CmuxTuiSnapshotParser.applying(
+            deltaPayload: JSONSerialization.data(withJSONObject: delta), cursor: cursor, to: state
+        ))
+    }
+
+    private func info(_ state: CloudVMState) -> SurfaceMachineInfo {
+        SurfaceMachineInfo(
+            id: machine, name: "Membership test", status: "running", image: nil, hasDesktop: true,
+            memoryMb: nil, diskMb: nil, linkState: .connected, linkError: nil,
+            cpuPercent: nil, memoryUsedMb: nil, diskUsedMb: nil,
+            remoteWorkspaces: state.workspaces.map {
+                SurfaceRemoteWorkspace(id: $0.id, name: $0.name, index: $0.index, focused: $0.focused)
+            }
+        )
+    }
+
+    private func resources(_ state: CloudVMState) -> [SurfaceResource] {
+        CmuxTuiSnapshotParser.mergingDisplays(
+            pool: ["display:1", "display:2"].map { CmuxTuiSnapshotParser.display(machine: machine, key: $0) },
+            parsed: CmuxTuiSnapshotParser.resources(from: state)
+        )
+    }
+
+    private func publish(_ state: CloudVMState, to catalog: SurfaceCatalog, delta: Bool = false) {
+        if delta {
+            catalog.applyCloudStateDelta(state, resources: resources(state), info: info(state))
+        } else {
+            catalog.replaceCloudState(state, resources: resources(state), info: info(state))
+        }
+    }
+
+    private func expectMembership(_ state: CloudVMState, in catalog: SurfaceCatalog) throws {
+        let tree = CloudTreeNodeBuilder.flattened(CloudTreeNodeBuilder.nodes(
+            machines: [], snapshot: catalog.snapshot, localWorkspaces: [], includeLocalMachine: false
+        ))
+        for workspace in state.workspaces {
+            let row = try #require(tree.first { $0.id == CloudTreeNodeBuilder.nodeID(workspace: workspace.id, machine: machine) })
+            let screens = Set(state.screens.filter { $0.workspaceID == workspace.id }.map(\.id))
+            let panes = Set(state.panes.filter { screens.contains($0.screenID) }.map(\.id))
+            let actualTabs = state.tabs.filter { panes.contains($0.paneID) }
+            let rowTabIDs: [String] = row.children.compactMap {
+                switch $0.kind {
+                case .terminal(let value): return value.remoteView?.tabID
+                case .browser(let value): return value.remoteView?.tabID
+                case .display(_, _, let view): return view?.tabID
+                default: return nil
+                }
+            }
+            #expect(row.children.count == actualTabs.count, "\(workspace.id) children must equal real layout tabs")
+            #expect(Set(rowTabIDs) == Set(actualTabs.map(\.id)))
+            #expect(row.children.allSatisfy { $0.children.isEmpty })
+            #expect(row.dragGroup?.placements.count == row.children.count)
+        }
+        let displays = try #require(tree.first { $0.id == CloudTreeNodeBuilder.nodeID(displaysPool: machine) })
+        #expect(displays.children.count == 2, "available displays remain at machine level")
+    }
+}

--- a/cmuxTests/CloudWorkspaceMembershipTests.swift
+++ b/cmuxTests/CloudWorkspaceMembershipTests.swift
@@ -164,6 +164,7 @@ struct CloudWorkspaceMembershipTests {
                 return []
             }
             #expect(Set(row.dragGroup?.resources ?? []) == Set(members.ids))
+            #expect(Set(try catalog.remoteWorkspaceGroup(machine: machine, workspaceID: workspace).resources) == Set(members.ids))
             return row.children.filter { if case .display = $0.kind { return true }; return false }
         }
 
@@ -193,6 +194,34 @@ struct CloudWorkspaceMembershipTests {
         await coordinator.waitForPendingMutations()
         try expectMembership(current, in: catalog)
         #expect(provider.closedTabs.isEmpty, "a local VNC view has no daemon tab to close")
+    }
+
+    @Test("Workspace groups open live local displays and reject a closed placement")
+    func localDisplayGroupOpen() async throws {
+        let source = UUID(), viewer = UUID()
+        let coordinator = CloudPlacementCoordinator(binding: { id in
+            id == source ? WorkspaceCloudVMBinding(vmID: "membership-test", isBase: false, remoteWorkspaceID: "ws_a") : nil
+        })
+        let catalog = SurfaceCatalog(cloudPlacementCoordinator: coordinator)
+        catalog.register(CloudPlacementTestProvider(machine: machine))
+        publish(try state(desktops: ["desk_b": "b"]), to: catalog)
+        let desktop = SurfaceResourceID(machine: machine, kind: .display, key: "display:1")
+        let original = try await catalog.project(desktop, into: .workspace(id: source, placement: .split), focus: false)
+        let group = SurfaceResourceGroup(title: "Desktop", placements: [
+            SurfaceResourcePlacement(resource: desktop, remoteWorkspaceID: "ws_a")
+        ])
+        let opened = try await catalog.projectGroup(
+            group, into: .workspace(id: viewer, placement: .split), focus: false, paneLookup: { _, _ in nil }
+        )
+        #expect(opened.map(\.resource) == [desktop])
+        #expect(catalog.projection(forPanel: opened[0].panelID)?.remoteWorkspaceID == nil)
+        catalog.endProjections(panelID: original.projection.panelID)
+        await coordinator.waitForPendingMutations()
+        await #expect(throws: (any Error).self) {
+            try await catalog.projectGroup(
+                group, into: .workspace(id: viewer, placement: .split), focus: false, paneLookup: { _, _ in nil }
+            )
+        }
     }
 
     @Test("A local VNC pane never adopts or closes another workspace's daemon tab")

--- a/cmuxTests/CloudWorkspaceMembershipTests.swift
+++ b/cmuxTests/CloudWorkspaceMembershipTests.swift
@@ -145,6 +145,12 @@ struct CloudWorkspaceMembershipTests {
                 machines: [], snapshot: catalog.snapshot, localWorkspaces: [], includeLocalMachine: false
             ))
             let row = try #require(tree.first { $0.id == CloudTreeNodeBuilder.nodeID(workspace: workspace, machine: machine) })
+            let lookup = CloudTreeNodeBuilder.lookupRemoteWorkspace(workspace, on: machine, snapshot: catalog.snapshot)
+            guard case .found(_, let members) = lookup else {
+                Issue.record("Workspace lookup must resolve the sidebar workspace")
+                return []
+            }
+            #expect(Set(row.dragGroup?.resources ?? []) == Set(members.ids))
             return row.children.filter { if case .display = $0.kind { return true }; return false }
         }
 
@@ -174,6 +180,30 @@ struct CloudWorkspaceMembershipTests {
         await coordinator.waitForPendingMutations()
         try expectMembership(current, in: catalog)
         #expect(provider.closedTabs.isEmpty, "a local VNC view has no daemon tab to close")
+    }
+
+    @Test("A local VNC pane never adopts or closes another workspace's daemon tab")
+    func localDesktopBesideRemotePlacement() async throws {
+        let workspace = UUID()
+        let coordinator = CloudPlacementCoordinator(binding: { _ in
+            WorkspaceCloudVMBinding(vmID: "membership-test", isBase: false, remoteWorkspaceID: "ws_a")
+        })
+        let catalog = SurfaceCatalog(cloudPlacementCoordinator: coordinator)
+        let provider = CloudPlacementTestProvider(machine: machine)
+        catalog.register(provider)
+        let current = try state(desktops: ["desk_b": "b"])
+        publish(current, to: catalog)
+        let desktop = SurfaceResourceID(machine: machine, kind: .display, key: "display:1")
+        let opened = try await catalog.project(desktop, into: .workspace(id: workspace, placement: .split), focus: false)
+        await coordinator.waitForPendingMutations()
+        let projection = try #require(catalog.projection(forPanel: opened.projection.panelID))
+        #expect(projection.remoteWorkspaceID == "ws_a")
+        #expect(projection.remoteTabID == nil)
+        #expect(provider.moved.isEmpty)
+        catalog.endProjections(panelID: projection.panelID)
+        await coordinator.waitForPendingMutations()
+        #expect(provider.closedTabs.isEmpty)
+        try expectMembership(current, in: catalog)
     }
 
     private func state(

--- a/cmuxTests/VMDefaultCloudCommandTests.swift
+++ b/cmuxTests/VMDefaultCloudCommandTests.swift
@@ -125,7 +125,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
                         "route": "ws://10.40.0.10:1337/v1/link",
                         "session": "cloud", "trusted_carrier": true,
                         "wireguard_hub_socket": "/tmp/cmux-wg-test.sock",
-                        "trusted_carrier": true,
                     ]
                 )
             case "workspace.create":
@@ -238,7 +237,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let bindings = requests.filter { $0["method"] as? String == "workspace.cloud_vm_bind" }
         let lastBinding = bindings.last?["params"] as? [String: Any]
         XCTAssertEqual(lastBinding?["remote_workspace_id"] as? String, "ws_cloud")
-        XCTAssertEqual(methods.filter { $0 == "vm.desktop_open" }.count, 1)
+        XCTAssertFalse(methods.contains("vm.desktop_open"), "New workspaces start with only the seeded terminal")
 
         // Exercise consumption of the saved identity in a new CLI process,
         // not just persistence. The mock rejects any unhandled enrollment path.
@@ -260,7 +259,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertFalse(secondMethods.contains("vm.create"))
         XCTAssertFalse(secondMethods.contains("surface.new_terminal"))
         XCTAssertEqual(secondMethods.filter { $0 == "surface.project" }.count, 1)
-        XCTAssertEqual(secondMethods.filter { $0 == "vm.desktop_open" }.count, 1)
+        XCTAssertFalse(secondMethods.contains("vm.desktop_open"), "Reopening the shell must not add a VNC split")
     }
 
     func testVMNewExplicitFreestyleProviderCreatesSeparateDetachedVM() throws {


### PR DESCRIPTION
## Summary

Fixes #12278. A terminal-only Cloud workspace now lists only its actual tabs. Closing its Desktop removes that workspace row while keeping the machine-level Displays section available.

- Remove the fallback that inserted every available display into workspaces without display tabs.
- Include explicit local VNC panes only in their current bound workspace. Opening a machine display cannot borrow another workspace’s daemon tab, and moving or closing that local pane cannot move or close that other tab.
- Share display membership with workspace lookup, drag groups, and group opening. Reject stale groups after their local display closes; honor explicit empty view lists and the daemon’s legacy `screen` content kind.
- Keep `vm new`, `vm shell`, and bare `vm open` terminal-only. Desktop opening remains available explicitly through Displays and `vm desktop`.

Daemon tabs remain authoritative. Local VNC panes supplement membership from live catalog projections; this does not create synthetic daemon tabs or persist a separate sidebar cache.

## Testing

Regression tests and fixes are separate commits. Before the fix, [membership regressions fail](https://github.com/manaflow-ai/cmux/actions/runs/34553419647), and [CLI creation/reopen regressions fail](https://github.com/manaflow-ai/cmux/actions/runs/34552611304) on unexpected desktop opens.

Passed hosted checks:
- [CLI terminal-only creation and reopening](https://github.com/manaflow-ai/cmux/actions/runs/34553842250).
- [Cloud tree projection suite](https://github.com/manaflow-ai/cmux/actions/runs/34553842400).
- [Expanded membership, VNC selection, and legacy screen closure](https://github.com/manaflow-ai/cmux/actions/runs/34554189038).
- [Placement coordinator suite](https://github.com/manaflow-ai/cmux/actions/runs/34554193278).

Final-HEAD group checks are running: [membership suite](https://github.com/manaflow-ai/cmux/actions/runs/34554491645), [machine-model suite](https://github.com/manaflow-ai/cmux/actions/runs/34554559731).

The tagged fleet build succeeded on `1583e5f169b5229a20d38f22fb2f145604699ca4`. Installed artifact signature, tag isolation, and Cloud origins were verified. Swift file-length and test-wiring checks pass. Localization audit covered changed sidebar/group actions and CLI behavior; no user-facing strings were added or changed.

## Demo Video

Live UI verification is incomplete. The fleet Macs checked had no logged-in GUI session, and the [hosted GUI Mac](https://github.com/manaflow-ai/cmux-loader/actions/runs/34553793938) never became reachable on the tailnet and was cancelled. The isolated agent auth profile is also incomplete. No authenticated UI screenshot or video is claimed.

## Dogfood

[Open the tagged build](http://127.0.0.1:17320/issue-12278-cloud-sidebar-membership). It uses the supported `--prod-auth` configuration for normal Cloud sign-in because the shared development backend is unavailable. It has not been launched locally.

Sign in, open a Cloud workspace, add and close a Desktop, then create a terminal-only workspace. Check that each workspace folder follows the layout and that refresh/workspace switching does not resurrect Desktop rows. Keep Displays available at machine level.

No merge has been performed; user dogfood approval is still required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud workspace membership, VNC placement sync, and default CLI open behavior; wrong logic could show stale desktop rows or skip expected splits, but daemon tabs remain authoritative and desktop is still explicit.
> 
> **Overview**
> Fixes Cloud sidebar workspace membership and stops implicitly opening VNC when attaching to a machine shell.
> 
> **CLI:** `vm new`, `vm shell`, and bare `vm open <machine>` now open only the terminal workspace (`openVMWorkspaceShell`). Automatic noVNC splits beside the shell are removed; desktop stays on `vm desktop`, Displays, and `vm open <m>:desktop`.
> 
> **Sidebar & membership:** Workspaces no longer inherit every machine-level display when they have no display tab. Membership comes from daemon tab placements plus **explicit local VNC panes** bound to the current remote workspace (`SurfaceProjection.localDisplayMembers`). Tree rows, drag groups, workspace lookup, and `remoteWorkspaceGroup` share that logic.
> 
> **Placement:** Local display panes without a daemon tab update workspace association on record/move/close without moving or closing another workspace’s tab; `defaultRemoteView` never picks a display tab from the pool. Reconciliation treats legacy `screen` tabs as displays.
> 
> **Tests:** New `CloudWorkspaceMembershipTests` and CLI/tree expectations updated for terminal-only create/reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1583e5f169b5229a20d38f22fb2f145604699ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud workspace views now display local VNC screens associated with each workspace.
  - Local display panes remain correctly associated when moved, closed, or reconnected.
  - Workspace membership and display placement are reconciled more accurately across refreshes.

- **Changes**
  - Opening or creating a cloud VM now opens its shell without automatically adding a desktop pane.
  - Desktop panes remain available on demand through `vm desktop` or `vm open <machine>:desktop`.
  - Workspace open and drag actions now include only actual placements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->