### PR TITLE
fix: keep main windows out of fullscreen tiling

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -254,9 +254,9 @@ final class CmuxMainWindow: NSWindow {
     ///
     /// Declaring `.fullScreenPrimary` here makes native fullscreen reachable
     /// regardless of the OS's implicit default. It is idempotent where AppKit
-    /// would have granted it anyway, and composes with the temporary
-    /// `.fullScreenDisallowsTiling` opt-out the window factory applies when
-    /// spawning a window out of an existing fullscreen Space.
+    /// would have granted it anyway. `.fullScreenDisallowsTiling` is also set
+    /// permanently so macOS Full Screen Tile does not trap cmux in a managed
+    /// tile Space that breaks Mission Control and horizontal Space swipes.
     override init(
         contentRect: NSRect,
         styleMask: NSWindow.StyleMask,
@@ -279,9 +279,11 @@ final class CmuxMainWindow: NSWindow {
 
     /// Returns `base` guaranteed to carry `.fullScreenPrimary` (and never
     /// `.fullScreenNone`) so a cmux main window can always enter a native
-    /// fullscreen Space. Pure and `nonisolated` so it can be unit-tested
-    /// without constructing a window; see ``init(contentRect:styleMask:backing:defer:)``
-    /// for why declaring the capability explicitly is required.
+    /// fullscreen Space, plus `.fullScreenDisallowsTiling` so AppKit does not
+    /// route the window into macOS Full Screen Tile. Pure and `nonisolated` so
+    /// it can be unit-tested without constructing a window; see
+    /// ``init(contentRect:styleMask:backing:defer:)`` for why declaring the
+    /// capability explicitly is required.
     nonisolated static func canonicalCollectionBehavior(
         _ base: NSWindow.CollectionBehavior
     ) -> NSWindow.CollectionBehavior {
@@ -291,6 +293,7 @@ final class CmuxMainWindow: NSWindow {
         // suppressed.
         behavior.remove(.fullScreenNone)
         behavior.insert(.fullScreenPrimary)
+        behavior.insert(.fullScreenDisallowsTiling)
         return behavior
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1102,7 +1102,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// instead of spawning the bundled `cmux diff` CLI, so shortcut-dispatch tests can
     /// assert routing without launching a subprocess.
     var debugOpenDiffViewerHandler: (() -> Void)?
-    var debugCreateMainWindowSourceIsNativeFullScreenOverride: Bool?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
     private var debugDetachedContextWindows: [NSWindow] = []
 
@@ -10313,16 +10312,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let sourceWindow = resolvedMainWindowSource(preferredSourceWindow)
             ?? sourceContext.flatMap { resolvedWindow(for: $0) }
         let existingFrame = sourceWindow?.frame
-        let sourceWindowIsNativeFullScreen: Bool = {
-#if DEBUG
-            if let debugCreateMainWindowSourceIsNativeFullScreenOverride {
-                return debugCreateMainWindowSourceIsNativeFullScreenOverride
-            }
-#endif
-            return sourceWindow?.styleMask.contains(.fullScreen) == true
-        }()
-        let shouldTemporarilyDisallowFullScreenTiling =
-            sessionWindowSnapshot == nil && sourceWindowIsNativeFullScreen
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         let persistedGeometryFrame = (restoredFrame == nil && sourceWindow == nil)
             ? resolvedPersistedWindowGeometryFrame()
@@ -10348,12 +10337,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.minSize = minimumWindowSize
         window.contentMinSize = minimumWindowSize
         window.animationBehavior = .none
-        // When creating a new window from an existing native fullscreen window,
-        // temporarily opt out of fullscreen tiling so AppKit doesn't place the
-        // new window into the active fullscreen Space.
-        if shouldTemporarilyDisallowFullScreenTiling {
-            window.collectionBehavior.insert(.fullScreenDisallowsTiling)
-        }
         window.title = ""
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
@@ -10464,23 +10447,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 activation: .runningApplication([.activateAllWindows]),
                 respectActivationSuppression: false
             )
-        }
-        if shouldTemporarilyDisallowFullScreenTiling {
-            let clearFullScreenTilingOptOut: () -> Void = { [weak window] in
-                guard let window else { return }
-                window.collectionBehavior.remove(.fullScreenDisallowsTiling)
-                if window.collectionBehavior.contains(.fullScreenDisallowsTiling) {
-                    var behavior = window.collectionBehavior
-                    behavior.remove(.fullScreenDisallowsTiling)
-                    window.collectionBehavior = behavior
-                }
-            }
-            RunLoop.main.perform {
-                clearFullScreenTilingOptOut()
-            }
-            DispatchQueue.main.async {
-                clearFullScreenTilingOptOut()
-            }
         }
         if let explicitInitialFrame {
             window.setFrame(explicitInitialFrame, display: true)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -206,7 +206,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
         AppDelegate.shared?.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
         AppDelegate.shared?.debugCloseMainWindowConfirmationHandler = nil
-        AppDelegate.shared?.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
         if AppDelegate.shared?.dismissNotificationsPopoverIfShown() == true {
             RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         }
@@ -1020,7 +1019,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(workspace.panels.count, initialPanelCount, "Unmatched chord suffix must not trigger the action")
     }
 
-    func testCreateMainWindowDoesNotDisallowFullScreenTilingByDefault() {
+    func testCreateMainWindowDisallowsFullScreenTilingByDefault() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -1036,43 +1035,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(
-            window.collectionBehavior.contains(.fullScreenDisallowsTiling),
-            "Main windows should still support standard macOS Split View when not created from a fullscreen source"
-        )
-    }
-
-    func testCreateMainWindowTemporarilyDisallowsFullScreenTilingFromFullscreenSource() {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
-
-        appDelegate.debugCreateMainWindowSourceIsNativeFullScreenOverride = true
-
-        let newWindowId = appDelegate.createMainWindow()
-        defer {
-            closeWindow(withId: newWindowId)
-        }
-
-        guard let newWindow = window(withId: newWindowId) else {
-            XCTFail("Expected new window")
-            return
-        }
-
         XCTAssertTrue(
-            newWindow.collectionBehavior.contains(.fullScreenDisallowsTiling),
-            "New windows should temporarily opt out of fullscreen tiling while opening from a fullscreen source"
-        )
-
-        appDelegate.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
-        waitUntil(timeout: 1.0) {
-            !newWindow.collectionBehavior.contains(.fullScreenDisallowsTiling)
-        }
-
-        XCTAssertFalse(
-            newWindow.collectionBehavior.contains(.fullScreenDisallowsTiling),
-            "The fullscreen tiling opt-out should be cleared after initial presentation so Split View keeps working"
+            window.collectionBehavior.contains(.fullScreenDisallowsTiling),
+            "Main windows should opt out of macOS Full Screen Tile so native fullscreen does not trap Space navigation"
         )
     }
 

--- a/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
+++ b/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
@@ -22,6 +22,8 @@ struct CmuxMainWindowFullScreenCapabilityTests {
     //
     // A CmuxMainWindow must therefore *declare* `.fullScreenPrimary` itself so
     // native fullscreen is reachable regardless of the OS's implicit default.
+    // It must also opt out of Full Screen Tile so Mission Control and Space
+    // navigation remain available while cmux is fullscreen.
     @Test func mainWindowDeclaresFullScreenPrimaryCapability() {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
@@ -43,6 +45,10 @@ struct CmuxMainWindowFullScreenCapabilityTests {
             !window.collectionBehavior.contains(.fullScreenNone),
             "Main window must never carry .fullScreenNone, which suppresses native fullscreen"
         )
+        #expect(
+            window.collectionBehavior.contains(.fullScreenDisallowsTiling),
+            "Main window must disallow Full Screen Tile so native fullscreen does not trap Space navigation"
+        )
     }
 
     // The capability decision is a pure, screen-agnostic transform so it runs
@@ -51,20 +57,19 @@ struct CmuxMainWindowFullScreenCapabilityTests {
     @Test func canonicalBehaviorAddsFullScreenPrimaryToEmptyBehavior() {
         let result = CmuxMainWindow.canonicalCollectionBehavior([])
         #expect(result.contains(.fullScreenPrimary))
+        #expect(result.contains(.fullScreenDisallowsTiling))
         #expect(!result.contains(.fullScreenNone))
     }
 
     @Test func canonicalBehaviorDropsStaleFullScreenNone() {
         let result = CmuxMainWindow.canonicalCollectionBehavior([.fullScreenNone])
         #expect(result.contains(.fullScreenPrimary))
+        #expect(result.contains(.fullScreenDisallowsTiling))
         #expect(!result.contains(.fullScreenNone))
     }
 
     @Test func canonicalBehaviorPreservesUnrelatedBehaviorBits() {
-        // The window factory may layer `.fullScreenDisallowsTiling` on top when
-        // spawning out of an existing fullscreen Space; canonicalization must
-        // not clobber that (or any other unrelated bit).
-        let base: NSWindow.CollectionBehavior = [.fullScreenDisallowsTiling, .moveToActiveSpace]
+        let base: NSWindow.CollectionBehavior = [.moveToActiveSpace]
         let result = CmuxMainWindow.canonicalCollectionBehavior(base)
         #expect(result.contains(.fullScreenPrimary))
         #expect(result.contains(.fullScreenDisallowsTiling))


### PR DESCRIPTION
## What this fixes

Main cmux windows could enter macOS Full Screen Tile because the app only applied `.fullScreenDisallowsTiling` temporarily while creating a window from an existing fullscreen window. Once that temporary flag was removed, macOS could place the window in a managed tile Space, which can wedge Mission Control and horizontal Space navigation as reported in #10894.

Main windows now permanently opt out of Full Screen Tile while retaining native fullscreen support through `.fullScreenPrimary`.

## Changes

- Require `.fullScreenDisallowsTiling` in `CmuxMainWindow.canonicalCollectionBehavior`.
- Remove the temporary fullscreen-source detection and delayed cleanup from `AppDelegate.createMainWindow`.
- Add regression assertions for direct window construction and canonical behavior.
- Remove the obsolete debug test seam and temporary-behavior test.

## Verification

- `git diff --check`
- Tagged Debug build: `./scripts/reload.sh --tag issue10894-windowserver` (still running locally)
- Focused fullscreen capability tests are covered by CI.

Fixes #10894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791688094&installation_model_id=21920&pr_number=12298&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12298&signature=a47070bc0d11a7f4f8e6fe1fb19d484a29a15d203f48710e5106f5fd45503796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit window collection-behavior change with regression tests; trades optional Split View tiling for stable Space navigation in fullscreen.
> 
> **Overview**
> **Main windows now permanently opt out of macOS Full Screen Tile** while keeping native fullscreen via `.fullScreenPrimary`, fixing Mission Control and Space navigation getting stuck (#10894).
> 
> Previously `.fullScreenDisallowsTiling` was only applied briefly when spawning a window from an existing native fullscreen window, then removed so Split View still worked. That let macOS move cmux into a managed tile Space after the flag cleared. The PR moves the opt-out into `CmuxMainWindow.canonicalCollectionBehavior` so every main window gets it at init, and deletes the fullscreen-source detection, post-create flag insertion, and delayed cleanup in `AppDelegate.createMainWindow`, along with the related debug override and tests.
> 
> Tests now assert tiling is disallowed by default on new main windows and that canonical behavior always includes the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5fef3418bc7854dd784b2faa3bcc2d590d506e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10894 by keeping main windows permanently out of macOS Full Screen Tile, which could wedge Mission Control and horizontal Space navigation when a window was created from an existing fullscreen window. Main windows now always carry `.fullScreenDisallowsTiling` while retaining native fullscreen support via `.fullScreenPrimary`.

- Adds `.fullScreenDisallowsTiling` to `CmuxMainWindow.canonicalCollectionBehavior` permanently.
- Removes the temporary fullscreen-source detection and delayed cleanup from `AppDelegate.createMainWindow`.
- Replaces the temporary-behavior and debug-seam tests with regression assertions for the permanent behavior.

<sup>Written for commit c5fef3418bc7854dd784b2faa3bcc2d590d506e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the main window from being placed in macOS Full Screen Tile Spaces.
  * Improved navigation between Spaces when using native fullscreen mode.
  * Removed inconsistent temporary fullscreen behavior during window creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->