### PR TITLE
Show Mac version gate warnings in Computers rows

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -74,6 +74,7 @@ struct DeviceTreeView: View {
                                 mutatingComputerIDs: store.computerVisibilityMutationIDs,
                                 setCaffeine: setCaffeine,
                                 caffeineMutatingComputerIDs: store.caffeineMutatingPairingIDs,
+                                gateWarningDeviceIDs: store.macVersionUpdateRequiredDeviceIDs,
                                 hide: hideComputer,
                                 unhide: unhideComputer
                             )
@@ -87,6 +88,7 @@ struct DeviceTreeView: View {
                                 visibleComputers: [],
                                 hiddenComputers: store.hiddenComputers,
                                 mutatingComputerIDs: store.computerVisibilityMutationIDs,
+                                gateWarningDeviceIDs: store.macVersionUpdateRequiredDeviceIDs,
                                 hide: hideComputer,
                                 unhide: unhideComputer
                             )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -65,6 +65,7 @@ private struct ComputerVisibilityRow: View {
     let isConnecting: Bool
     var setCaffeine: @MainActor (MacComputerSnapshot, Bool) -> Void = { _, _ in }
     var isCaffeineMutating: Bool = false
+    var gateWarningDeviceIDs: Set<String> = []
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var isBusy: Bool { isVisibilityMutating }
 
@@ -151,7 +152,8 @@ private struct ComputerVisibilityRow: View {
                 computer: computer,
                 style: style,
                 connect: { _ in connect(computer) },
-                isConnecting: isConnecting
+                isConnecting: isConnecting,
+                hasVersionGateWarning: gateWarningDeviceIDs.contains(computer.deviceId)
             )
         } else if let computer = item.hiddenComputer {
             hiddenLabel(computer)
@@ -221,6 +223,7 @@ struct ComputerVisibilityRows: View {
     var mutatingComputerIDs: Set<String> = []
     var setCaffeine: @MainActor (MacComputerSnapshot, Bool) -> Void = { _, _ in }
     var caffeineMutatingComputerIDs: Set<String> = []
+    var gateWarningDeviceIDs: Set<String> = []
     let hide: @MainActor (MacComputerSnapshot) -> Void
     let unhide: @MainActor (MobileHiddenComputer) -> Void
 
@@ -239,7 +242,8 @@ struct ComputerVisibilityRows: View {
                 connect: connect,
                 isConnecting: connectingComputerID == item.id,
                 setCaffeine: setCaffeine,
-                isCaffeineMutating: caffeineMutatingComputerIDs.contains(item.id)
+                isCaffeineMutating: caffeineMutatingComputerIDs.contains(item.id),
+                gateWarningDeviceIDs: gateWarningDeviceIDs
             )
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import CMUXMobileCore
 import CmuxMobileShell
 import CmuxMobileSupport
 import SwiftUI

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -66,6 +66,7 @@ private struct ComputerVisibilityRow: View {
     var setCaffeine: @MainActor (MacComputerSnapshot, Bool) -> Void = { _, _ in }
     var isCaffeineMutating: Bool = false
     var gateWarningDeviceIDs: Set<String> = []
+    @State private var showingHiddenVersionGateWarning = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var isBusy: Bool { isVisibilityMutating }
 
@@ -153,7 +154,9 @@ private struct ComputerVisibilityRow: View {
                 style: style,
                 connect: { _ in connect(computer) },
                 isConnecting: isConnecting,
-                hasVersionGateWarning: gateWarningDeviceIDs.contains(computer.deviceId)
+                hasVersionGateWarning: gateWarningDeviceIDs.contains(
+                    cmxCanonicalDeviceID(computer.deviceId)
+                )
             )
         } else if let computer = item.hiddenComputer {
             hiddenLabel(computer)
@@ -173,6 +176,33 @@ private struct ComputerVisibilityRow: View {
                        tag: computer.instanceTag
                    ) {
                     ComputerBuildBadge(label: buildLabel)
+                }
+                if gateWarningDeviceIDs.contains(cmxCanonicalDeviceID(computer.macDeviceID)) {
+                    Button {
+                        showingHiddenVersionGateWarning = true
+                    } label: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.orange)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        L10n.string(
+                            "computers.version.outdated.title",
+                            defaultValue: "Mac update required"
+                        )
+                    )
+                    .popover(isPresented: $showingHiddenVersionGateWarning) {
+                        Text(
+                            L10n.string(
+                                "mobile.pairing.guidance.macUpdateRequired",
+                                defaultValue: "Update cmux on this Mac to connect securely."
+                            )
+                        )
+                        .padding()
+                        .frame(idealWidth: 300, maxWidth: 340)
+                        .presentationCompactAdaptation(.popover)
+                    }
                 }
             }
             Spacer(minLength: 8)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -35,6 +35,10 @@ struct MacComputerRow: View {
     /// status dot). Re-entry is guarded by the owning list, not by disabling the
     /// button, so the row does not flash a dimmed state.
     var isConnecting: Bool = false
+    /// Whether the last authenticated attempt for this Mac was rejected by
+    /// the iOS minimum-version gate. This covers Macs absent from the
+    /// directory snapshot, which cannot expose a list-auth entry yet.
+    var hasVersionGateWarning: Bool = false
 
     @State private var showListAuthInfo = false
 
@@ -165,7 +169,8 @@ struct MacComputerRow: View {
     /// Mac. A row with no remembered version warns until its first hello
     /// records the build version in the durable overlay.
     private var showsListAuthWarning: Bool {
-        MobileMacListAuthState.shared.entry(deviceID: computer.deviceId)?.isOutdated == true
+        hasVersionGateWarning
+            || MobileMacListAuthState.shared.entry(deviceID: computer.deviceId)?.isOutdated == true
     }
 
     /// Outdated rows carry a compact warning triangle beside the name; the
@@ -212,19 +217,21 @@ struct MacComputerRow: View {
     }
 
     private var listAuthWarningMessage: String {
-        guard let entry = MobileMacListAuthState.shared.entry(deviceID: computer.deviceId),
-              entry.isOutdated,
-              let required = entry.requiredVersionDisplay
-        else {
-            return ""
+        if let entry = MobileMacListAuthState.shared.entry(deviceID: computer.deviceId),
+           entry.isOutdated,
+           let required = entry.requiredVersionDisplay {
+            let requirement = "cmux \(required) or later"
+            return String(
+                format: L10n.string(
+                    "mobile.macUpdate.requiredOnMacFormat",
+                    defaultValue: "Requires %@ on your Mac."
+                ),
+                requirement
+            )
         }
-        let requirement = "cmux \(required) or later"
-        return String(
-            format: L10n.string(
-                "mobile.macUpdate.requiredOnMacFormat",
-                defaultValue: "Requires %@ on your Mac."
-            ),
-            requirement
+        return L10n.string(
+            "mobile.pairing.guidance.macUpdateRequired",
+            defaultValue: "Update cmux on this Mac to connect securely."
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -229,6 +229,7 @@ struct MacComputerRow: View {
                 requirement
             )
         }
+        guard hasVersionGateWarning else { return "" }
         return L10n.string(
             "mobile.pairing.guidance.macUpdateRequired",
             defaultValue: "Update cmux on this Mac to connect securely."


### PR DESCRIPTION
The Computers list only showed the orange update warning when a Mac had a stale directory authentication entry. Macs rejected by the app-version gate were recorded in `macVersionUpdateRequiredDeviceIDs`, but that state never reached the row, so an INTERNAL phone could show a stable Mac with no warning after a rejected connection.

This passes the gate warning IDs from the shell store through `DeviceTreeView` and `ComputerVisibilityRows` into `MacComputerRow`. The row now uses the same explicit rejection state as the toolbar and keeps the existing detailed directory-auth message when available. Macs absent from the directory snapshot get the generic update guidance.

Validation:
- Fleet iOS archive succeeded on Xcode 26.2.
- Signed install succeeded on Aziz's connected iPhone (bundle `dev.cmux.ios.mwarn`).
- `git diff --check` passed.
- Local Swift package tests were unavailable because the checkout lacks a valid `GhosttyKit.xcframework` binary.
- Automatic sign-in/pairing did not complete because the staging backend was unreachable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791688486&installation_model_id=21920&pr_number=12299&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12299&signature=f19d3013a16147175222d52219caec2e431c1b54c831920f6d2b5551bd190330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring of existing store state into list rows; no auth or connection logic changes.
> 
> **Overview**
> Fixes a gap where Macs rejected by the iOS **minimum app-version gate** could still look healthy in the Computers list because warnings only came from stale **directory list-auth** entries.
> 
> The shell store’s `macVersionUpdateRequiredDeviceIDs` is now passed through `DeviceTreeView` → `ComputerVisibilityRows` → row UI. **Visible** Macs set `MacComputerRow.hasVersionGateWarning` so the existing orange triangle and popover also fire when the gate rejected the last auth attempt (including Macs missing from the directory snapshot). **Hidden** Macs get a matching triangle + generic “update cmux” popover when their device ID is in that set.
> 
> When list-auth still has version details, the row keeps the formatted “Requires cmux X or later” message; gate-only cases use the generic secure-connection guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43058170256ac76261b2f3aa6b926c34ae59253d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Computers list so Macs rejected by the iOS version gate show the update warning in their row instead of appearing stable after a rejected connection.

- Passes gate warning IDs from the shell store through `DeviceTreeView` and `ComputerVisibilityRows` into `MacComputerRow` and hidden row labels, matching device IDs via `cmxCanonicalDeviceID`.
- Rows now use the same explicit rejection state as the toolbar, including for Macs absent from the directory snapshot.
- Keeps the detailed directory-auth message when available; Macs without it get the generic update guidance, and hidden Macs get a popover with the same guidance.

<sup>Written for commit 735a5cc076894af5e9ec429da837d851921277ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added version-update warning indicators for Macs that require an iOS version update.
  * Warnings now appear for affected Macs in both visible and hidden computer lists, including Macs not present in the current directory view.
  * Hidden Macs display guidance to update cmux, while affected visible Macs show an alert indicator.
  * Improved warning text for Macs without a stored outdated-device entry, including a generic secure-connection update message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->