### PR TITLE
devbox: promote sh-cd099a44912648399e0420df9b4e7f4f (merged daemon 897bb7a9c)

### DIFF
--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -6587,7 +6587,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -6623,7 +6623,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -6659,7 +6659,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -6695,7 +6695,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -6730,7 +6730,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -6766,7 +6766,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "2xl",
         "cpu": 32,
@@ -6802,7 +6802,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -6810,7 +6810,7 @@
         "storageMb": 16384,
         "freestyleBase": "freestyle/ubuntu-sm"
       },
-      "defaultForLocalDev": true
+      "defaultForLocalDev": false
     },
     {
       "provider": "freestyle",
@@ -6839,7 +6839,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -6875,7 +6875,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -6911,7 +6911,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -6946,7 +6946,7 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -6982,6 +6982,437 @@
       "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 1769fd2979, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-5cef46dec54748e1a2bd75c35c3e9746, md=sh-d9bf3be5f074437989e158a87310a757, lg=sh-6e6503afd73d443aa61a01d23e7b5554, lgx=sh-fb11bb4f11ac47f4998f70336887509b, xl=sh-9f1185a8eea14f5f875364b80390c1a0, 2xl=sh-81e8fd0caf9148058cef7cec4754186c.",
       "cmuxTuiCommit": "1769fd2979bd2b09e63d503026a1c165e858d05b",
       "cmuxTuiSha256": "a348c7e12532f9cef2b6b163b289be3b64f7934ba3455638e5560c107ca487fd",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-sm",
+      "imageId": "sh-cd099a44912648399e0420df9b4e7f4f",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-md",
+      "imageId": "sh-f5be56c7d50048278a66f1b654153bd3",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-lg",
+      "imageId": "sh-50d26e0ace92459f9741708b1a312e0a",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-lgx",
+      "imageId": "sh-6835b528b6a949e38c8fc0c2bc8164ba",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-xl",
+      "imageId": "sh-882fde940e3440ffaa150a0a266f8d94",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-2xl",
+      "imageId": "sh-5896573bcc4e4d54b7b72f63737632be",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-sm-base",
+      "imageId": "sh-cd099a44912648399e0420df9b4e7f4f",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      },
+      "defaultForLocalDev": true
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-md-base",
+      "imageId": "sh-f5be56c7d50048278a66f1b654153bd3",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-lg-base",
+      "imageId": "sh-50d26e0ace92459f9741708b1a312e0a",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-lgx-base",
+      "imageId": "sh-6835b528b6a949e38c8fc0c2bc8164ba",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-xl-base",
+      "imageId": "sh-882fde940e3440ffaa150a0a266f8d94",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260911-032526-2xl-base",
+      "imageId": "sh-5896573bcc4e4d54b7b72f63737632be",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "3774a642b2d4d96e42de5ee965726fc93ee05db9",
+      "epoch": "2026-09-10-r2",
+      "devboxSource": {
+        "layers": "desktop",
+        "digest": "789b829baf9e61b69f74d6d33b008f989cf5ea26ff0ac0795a8a96cbe22823db",
+        "schema": 2
+      },
+      "builtAt": "2026-09-11T03:30:51.644Z",
+      "builderScriptVersion": "1fc0c4bac3dae2dd6c1b4ac3037568cd693ec13b37f12d4c459e6ad14956a5aa",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.267",
+        "@openai/codex": "0.154.0",
+        "opencode-ai": "1.18.30",
+        "@earendil-works/pi-coding-agent": "0.85.1",
+        "agent-browser": "0.37.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-10-r2 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as cmux; cmux (uid 1000, NOPASSWD sudo) is the work user and the daemon's session user, so terminals are non-root; hostname cmux (static, live, 127.0.1.1 alias; SSH host keys regenerated under it; journal reset); baked cmux-tui daemon 897bb7a9c0, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-11 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-cd099a44912648399e0420df9b4e7f4f, md=sh-f5be56c7d50048278a66f1b654153bd3, lg=sh-50d26e0ace92459f9741708b1a312e0a, lgx=sh-6835b528b6a949e38c8fc0c2bc8164ba, xl=sh-882fde940e3440ffaa150a0a266f8d94, 2xl=sh-5896573bcc4e4d54b7b72f63737632be.",
+      "cmuxTuiCommit": "897bb7a9c0d7efd6407dbe229d1c30f8b0158589",
+      "cmuxTuiSha256": "551da27dc459d1d2a399d235a81de8d704d40ad39f91bcc2628aaed99b272f96",
       "defaultForKind": true,
       "size": {
         "name": "2xl",


### PR DESCRIPTION
Post-merge promote for https://github.com/manaflow-ai/cmux/pull/12259. The image baked there pinned the pre-merge daemon; this bake pins the daemon main's artifacts run published for 897bb7a9c, whose attach replay is theme-portable. Manifest-only change; bake verified (network-announce-ok, websocket smoke) and derived across sm..2xl.

https://claude.ai/code/session_01Qbo7h8EMVTWizLKXD6ECRL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791689612&installation_model_id=21920&pr_number=12304&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12304&signature=c52b1a6123fd957b418c926cb28ea89bc49857b7813bd227b7a57dd97bca1861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4351232a79a283573e3672004b7f602fc37d0a21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the merged devbox image `sh-cd099a44912648399e0420df9b4e7f4f` (daemon `897bb7a9c`) so new devboxes get theme-portable attach replay, applying the local Ghostty theme on first attach. The old images pinned the pre-merge daemon; they are no longer the defaults, and the new image set (desktop and base kinds for sm..2xl) now provides the defaults, including for local dev.

<sup>Written for commit 4351232a79a283573e3672004b7f602fc37d0a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the default development environment image series.
  - The newer `freestyle-cmux-devbox-20260911-032526` image is now the default across desktop and base variants.
  - The new image’s small base variant is now the default for local development.
  - The previous `freestyle-cmux-devbox-20260911-025407` series is no longer selected by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->