### PR TITLE
Fix publication authorization latency and development WebSockets

### DIFF
--- a/web/app/api/freestyle/forward-auth/route.ts
+++ b/web/app/api/freestyle/forward-auth/route.ts
@@ -12,6 +12,7 @@ import {
   type PublicationRequestEvaluation,
 } from "../../../../services/vm-publications/auth";
 import type { CloudVmPublicationTarget } from "../../../../services/vm-publications/repository";
+import { tracePublicationAuthOperation, withPublicationAuthRequest } from "../../../../services/vm-publications/requestTelemetry";
 import {
   PUBLICATION_CALLBACK_PATH,
   PUBLICATION_SESSION_COOKIE,
@@ -58,14 +59,14 @@ const liveDependencies: ForwardAuthHandlerDependencies = {
   serviceSecret: env.CMUX_VM_PUBLICATION_FORWARD_AUTH_SECRET,
   authPageOrigin: normalizePublicationAuthOrigin(env.CMUX_VM_PUBLICATION_AUTH_ORIGIN) ??
     undefined,
-  resolve: (input) => runPublicationAuth(resolvePublicationForRequest(input)),
-  evaluate: (input) => runPublicationAuth(evaluatePublicationRequest(input)),
-  rateLimit: (input) => enforcePublicationSignInRateLimit({
+  resolve: (input) => tracePublicationAuthOperation("resolve_publication", () => runPublicationAuth(resolvePublicationForRequest(input))),
+  evaluate: (input) => tracePublicationAuthOperation("evaluate_access", () => runPublicationAuth(evaluatePublicationRequest(input))),
+  rateLimit: (input) => tracePublicationAuthOperation("rate_limit", () => enforcePublicationSignInRateLimit({
     ...input,
     ruleId: env.CMUX_VM_PUBLICATION_SIGN_IN_RATE_LIMIT_ID,
-  }),
-  begin: (input) => runPublicationAuth(beginPublicationAuthorization(input)),
-  complete: (input) => runPublicationAuth(completePublicationAuthorization(input)),
+  })),
+  begin: (input) => tracePublicationAuthOperation("begin_sign_in", () => runPublicationAuth(beginPublicationAuthorization(input))),
+  complete: (input) => tracePublicationAuthOperation("complete_sign_in", () => runPublicationAuth(completePublicationAuthorization(input))),
 };
 
 /**
@@ -102,7 +103,7 @@ export async function enforcePublicationSignInRateLimit(input: {
  * this route acts on is read from the resolved publication row instead.
  */
 export async function GET(request: Request): Promise<Response> {
-  return handleForwardAuthRequest(request, liveDependencies);
+  return withPublicationAuthRequest(request, () => handleForwardAuthRequest(request, liveDependencies));
 }
 
 /** Test seam for the trusted-edge HTTP contract; production uses `GET`. */

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -11,6 +11,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1045.0",
         "@base-ui-components/react": "^1.0.0-rc.0",
         "@effect/experimental": "0.57.9",
+        "@effect/opentelemetry": "0.59.2",
         "@effect/platform": "0.93.6",
         "@effect/sql": "0.48.6",
         "@effect/sql-pg": "0.49.7",
@@ -199,6 +200,8 @@
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.11.0", "", {}, "sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg=="],
 
     "@effect/experimental": ["@effect/experimental@0.57.9", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.93.6", "effect": "^3.19.8", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-+cR+G1FR1yciFlZULBlQ/PSFerWQCSx1Fz5bbT/PIlPmF+GRk2+qC2IZM4bMdUqqzrrTPocX8LBgHwA5vxZqAw=="],
+
+    "@effect/opentelemetry": ["@effect/opentelemetry@0.59.2", "", { "peerDependencies": { "@effect/platform": "^0.93.6", "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^3.19.9" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/resources", "@opentelemetry/sdk-logs", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-trace-base", "@opentelemetry/sdk-trace-node", "@opentelemetry/sdk-trace-web"] }, "sha512-yyBy+BQElgBwFOy72gCt8UHpiX0r0uPbwcC2ObLiK1Be1HfWQr0DTFdypYINiQ8QxsazfXS9HDzvV3GDjG1roQ=="],
 
     "@effect/platform": ["@effect/platform@0.93.6", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.8" } }, "sha512-I5lBGQWzWXP4zlIdPs7z7WHmEFVBQhn+74emr/h16GZX96EEJ6I1rjGaKyZF7mtukbMuo9wEckDPssM8vskZ/w=="],
 
@@ -432,13 +435,7 @@
 
     "@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
 
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ=="],
-
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w=="],
-
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ=="],
-
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.217.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "protobufjs": "8.0.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
 
@@ -579,24 +576,6 @@
     "@posthog/core": ["@posthog/core@1.39.6", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw=="],
 
     "@posthog/types": ["@posthog/types@1.392.1", "", {}, "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w=="],
-
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
-
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
 
@@ -1172,8 +1151,6 @@
 
     "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
 
     "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
@@ -1191,8 +1168,6 @@
     "browser-image-compression": ["browser-image-compression@2.0.2", "", { "dependencies": { "uzip": "0.20201231.0" } }, "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw=="],
 
     "browserslist": ["browserslist@4.28.4", "", { "dependencies": { "baseline-browser-mapping": "^2.10.38", "caniuse-lite": "^1.0.30001799", "electron-to-chromium": "^1.5.376", "node-releases": "^2.0.48", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw=="],
-
-    "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -1490,8 +1465,6 @@
 
     "icu-minify": ["icu-minify@4.13.1", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-nFYW2im0WJ3RUVZwabd71J8QTZRtkK1xxZBY7klg7a6KS/os17LZSj9q1VhbRSnk3S8Mv2I7F1izr/aEJ6cUsw=="],
 
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -1643,8 +1616,6 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
-
-    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -1853,8 +1824,6 @@
     "property-expr": ["property-expr@2.0.6", "", {}, "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
-
-    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -2191,20 +2160,6 @@
     "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.4", "", { "dependencies": { "@emnapi/runtime": "^1.11.3" } }, "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA=="],
 
     "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.4", "", { "dependencies": { "@emnapi/runtime": "^1.11.3" } }, "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA=="],
-
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
-
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
-
-    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
     "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 

--- a/web/db/effect.ts
+++ b/web/db/effect.ts
@@ -1,0 +1,47 @@
+import { PgClient } from "@effect/sql-pg";
+import * as PgDrizzle from "drizzle-orm/effect-postgres";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import { types } from "pg";
+import * as schema from "./schema";
+
+const database = PgDrizzle.makeWithDefaults({ schema });
+
+/** Effect-native PostgreSQL service shared by repositories in one workload. */
+export class Database extends Context.Tag("cmux/EffectDatabase")<
+  Database, Effect.Effect.Success<typeof database>
+>() {}
+
+export type DatabasePoolOptions = Omit<PgClient.PgClientConfig, "types"> & {
+  readonly maxConnections: number;
+  readonly applicationName: string;
+};
+
+/** The caller owns this layer's scope; no connection is created per query. */
+export function makeDatabaseLayer(options: DatabasePoolOptions) {
+  const client = PgClient.layer({
+    ...options,
+    minConnections: options.minConnections ?? 0,
+    idleTimeout: options.idleTimeout ?? "5 seconds",
+    connectTimeout: options.connectTimeout ?? "750 millis",
+    types: {
+      getTypeParser(typeId, format) {
+        // Drizzle owns date/time and interval decoding. Node-postgres must
+        // leave these values intact, including arrays and timezone offsets.
+        if ([1184, 1114, 1082, 1186, 1231, 1115, 1185, 1187, 1182].includes(typeId)) {
+          return (value: string) => value;
+        }
+        return types.getTypeParser(typeId, format);
+      },
+    },
+  });
+  // DefaultServices disables SQL/parameter logging and result caching.
+  return Layer.effect(Database, database).pipe(Layer.provideMerge(client));
+}
+
+/** Create once at the service composition root, reuse, then dispose on shutdown. */
+export function makeDatabaseRuntime(options: DatabasePoolOptions) {
+  return ManagedRuntime.make(makeDatabaseLayer(options));
+}

--- a/web/db/effect.ts
+++ b/web/db/effect.ts
@@ -1,4 +1,5 @@
 import { PgClient } from "@effect/sql-pg";
+import * as Statement from "@effect/sql/Statement";
 import * as PgDrizzle from "drizzle-orm/effect-postgres";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -6,6 +7,7 @@ import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import { types } from "pg";
 import * as schema from "./schema";
+import { tagCloudDbQuery } from "./queryTags";
 
 const database = PgDrizzle.makeWithDefaults({ schema });
 
@@ -38,7 +40,13 @@ export function makeDatabaseLayer(options: DatabasePoolOptions) {
     },
   });
   // DefaultServices disables SQL/parameter logging and result caching.
-  return Layer.effect(Database, database).pipe(Layer.provideMerge(client));
+  return Layer.effect(Database, database).pipe(
+    Layer.provideMerge(client),
+    Layer.provide(Statement.setTransformer((statement, sql) => Effect.sync(() => {
+      const [text, parameters] = statement.compile();
+      return sql.unsafe(tagCloudDbQuery(text), parameters);
+    }))),
+  );
 }
 
 /** Create once at the service composition root, reuse, then dispose on shutdown. */

--- a/web/db/effect.ts
+++ b/web/db/effect.ts
@@ -1,5 +1,7 @@
 import { PgClient } from "@effect/sql-pg";
 import * as Statement from "@effect/sql/Statement";
+import * as OtelResource from "@effect/opentelemetry/Resource";
+import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import * as PgDrizzle from "drizzle-orm/effect-postgres";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -42,6 +44,14 @@ export function makeDatabaseLayer(options: DatabasePoolOptions) {
   // DefaultServices disables SQL/parameter logging and result caching.
   return Layer.effect(Database, database).pipe(
     Layer.provideMerge(client),
+    // Effect SQL spans use the application's existing OpenTelemetry provider,
+    // so Axiom receives connection, transaction, and query timings under the
+    // same trace as the request-level authorization spans.
+    Layer.provide(
+      OtelTracer.layerGlobal.pipe(
+        Layer.provide(OtelResource.layer({ serviceName: options.applicationName })),
+      ),
+    ),
     Layer.provide(Statement.setTransformer((statement, sql) => Effect.sync(() => {
       const [text, parameters] = statement.compile();
       return sql.unsafe(tagCloudDbQuery(text), parameters);

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -16,10 +16,15 @@ const releaseDocsOrigin =
 const nightlyDocsOrigin =
   process.env.CMUX_NIGHTLY_DOCS_ORIGIN ?? "https://cmux-docs-nightly.vercel.app";
 // The embedded browser reaches a dev server through its per-instance
-// Tailscale Serve hostname. Next.js blocks cross-origin HMR and RSC resources
-// unless that hostname is explicitly allowed. Keep this opt-in and validated
-// so production and SSH-backed development retain the default protection.
+// Tailscale Serve hostname. Published development VMs also use generated
+// `*.cmux.sh` hostnames. Next.js blocks cross-origin HMR and RSC resources
+// unless those origins are explicitly allowed. This setting is used only by
+// `next dev`; production keeps the default protection.
 const directDevBackendAllowedHost = directDevBackendHost();
+const developmentPublicationOrigins = [
+  ...(directDevBackendAllowedHost ? [directDevBackendAllowedHost] : []),
+  "*.cmux.sh",
+];
 
 // Agent landing pages moved under /agents/<agent>. Keep the old top-level
 // slugs working with permanent redirects, for the bare English path and every
@@ -71,9 +76,7 @@ const nextConfig: NextConfig = {
         ? "tsconfig.next.json"
         : "tsconfig.json",
   },
-  allowedDevOrigins: directDevBackendAllowedHost
-    ? [directDevBackendAllowedHost]
-    : undefined,
+  allowedDevOrigins: developmentPublicationOrigins,
   cacheComponents: true,
   partialPrefetching: true,
   experimental: {

--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1045.0",
     "@base-ui-components/react": "^1.0.0-rc.0",
     "@effect/experimental": "0.57.9",
+    "@effect/opentelemetry": "0.59.2",
     "@effect/platform": "0.93.6",
     "@effect/sql": "0.48.6",
     "@effect/sql-pg": "0.49.7",

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -206,21 +206,17 @@ function admissionClient(): AdmissionClientState {
     state = {
       key,
       lookup: async (endpointId) => {
-        const query = sql.unsafe<AdmissionRow[]>(ADMISSION_SQL, [endpointId]);
-        // cancel() rejects the query whether still queued or executing, so
-        // the operation settles even through a pool or network stall.
-        const settleBound = setTimeout(() => {
-          try {
-            query.cancel();
-          } catch {
-            // Cancellation is best-effort; the statement timeout remains.
-          }
-        }, RELAY_ALLOW_LOOKUP_SETTLE_MS);
+        // PgBouncer rejects statement_timeout as a startup parameter. Set it
+        // locally inside a transaction instead, so the server cancels an
+        // executing query even if the client-side cancellation cannot connect.
         try {
-          const rows = await query;
+          const rows = await sql.begin(async (tx) => {
+            await tx.unsafe(`set local statement_timeout = ${RELAY_ALLOW_STATEMENT_TIMEOUT_MS}`);
+            return await tx.unsafe<AdmissionRow[]>(ADMISSION_SQL, [endpointId]);
+          });
           return rows[0] ?? null;
-        } finally {
-          clearTimeout(settleBound);
+        } catch {
+          return null;
         }
       },
       close: () => sql.end(),

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -39,9 +39,9 @@ export type RelayAllowAdmission = "allow" | "deny";
 export const RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS = 16;
 
 /**
- * Server-side statement_timeout, set as a session parameter on every
- * admission connection: Postgres cancels an executing statement and frees
- * the connection.
+ * Server-side statement_timeout for direct/RDS connections. PlanetScale's
+ * PgBouncer rejects this as a startup parameter, so the pooled URL path uses
+ * the client-side cancellation below instead.
  */
 export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
 
@@ -202,7 +202,6 @@ function admissionClient(): AdmissionClientState {
       prepare: false,
       connect_timeout: Math.ceil(CONNECT_TIMEOUT_MS / 1_000),
       idle_timeout: IDLE_TIMEOUT_SECONDS,
-      connection: { statement_timeout: RELAY_ALLOW_STATEMENT_TIMEOUT_MS },
     });
     state = {
       key,

--- a/web/services/vm-publications/OBSERVABILITY.md
+++ b/web/services/vm-publications/OBSERVABILITY.md
@@ -1,0 +1,44 @@
+# Publication authorization traces
+
+`requestTelemetry.ts` instruments `/api/freestyle/forward-auth`. Normal requests
+follow the existing trace sampling ratio. Every request taking at least 750 ms,
+or returning 5xx, also produces `cmux.publication_auth.outcome` through the
+priority sampler. It includes operation offsets, durations, and failure flags,
+even when the original request trace was not sampled. Its response carries the
+retained trace id. Export is flushed in `after()`, outside response latency.
+
+Use `cmux.publication_auth.duration_ms` for the full request duration. An outcome
+span records a completed decision, so its own span duration is not request
+latency. Parent and child operation timings overlap; do not sum them.
+
+Operation names and decision categories are fixed by code. Request URLs, cookie
+values, authorization codes, SQL parameters, and exception messages are not
+recorded here. At most 32 operation events are retained per request. Check
+`cmux.publication_auth.dropped_operations` before treating the list as complete.
+Database operation time currently includes connection wait and query execution.
+
+Find every retained slow or failed request:
+
+```apl
+['cmux-prod-otel-traces']
+| where name == 'cmux.publication_auth.outcome'
+| project _time, trace_id,
+    duration_ms = ['attributes.custom']['cmux.publication_auth.duration_ms'],
+    decision = ['attributes.custom']['cmux.publication_auth.decision'],
+    events
+```
+
+Estimate normal request latency from the sampled request spans, not the
+deliberately biased slow/failure stream. Do not combine the two streams: a
+sampled slow request has both records.
+
+```apl
+['cmux-prod-otel-traces']
+| where name == 'cmux.publication_auth.request'
+| extend ms = todouble(['attributes.custom']['cmux.publication_auth.duration_ms'])
+| summarize requests=count(), p50=percentile(ms, 50), p95=percentile(ms, 95), p99=percentile(ms, 99)
+```
+
+Preview export verification uses `cmux-preview-otel-traces` and service
+`cmux-publication-auth-verification`. Synthetic checks are not production
+performance measurements.

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -156,8 +156,15 @@ export function evaluatePublicationRequest(input: {
   return Effect.gen(function* () {
     const repository = yield* CloudVmPublicationRepository;
     const viewerResolver = yield* PublicationViewerResolver;
-    const target = yield* resolvePublicationForRequest(input);
-    if (!target) return { kind: "not_found" } as const satisfies PublicationRequestEvaluation;
+    const now = input.now ?? new Date();
+    const requestContext = yield* repository.findRequestContext({
+      providerTlsRuleId: input.providerTlsRuleId,
+      sessionTokenHash: isPublicationToken(input.sessionToken)
+        ? hashPublicationToken(input.sessionToken) : null,
+      now,
+    });
+    if (!requestContext) return { kind: "not_found" } as const satisfies PublicationRequestEvaluation;
+    const { session, ...target } = requestContext;
 
     if (target.publication.accessMode === "public") {
       // This can occur briefly during the fail-open-safe half of a protected ->
@@ -165,24 +172,16 @@ export function evaluatePublicationRequest(input: {
       return { kind: "allow" } as const satisfies PublicationRequestEvaluation;
     }
 
-    if (isPublicationToken(input.sessionToken)) {
-      const principal = yield* repository.findValidSession({
-        tokenHash: hashPublicationToken(input.sessionToken),
-        publicationId: target.publication.id,
-        hostname: target.publication.hostname,
-        now: input.now ?? new Date(),
-      });
-      if (principal) {
-        const owningTeamId = publicationOwningTeamId(target.vm);
-        // Only the owner of a personal VM can skip the identity lookup. Team
-        // VM ownership and email grants depend on current Stack identity.
-        const viewer: VmPublicationViewer | null =
-          owningTeamId !== null || principal.publication.accessMode === "team" || principal.session.userId !== principal.publication.ownerUserId
-            ? yield* viewerResolver.resolve(principal.session.userId)
-            : { userId: principal.session.userId, teamIds: [] };
-        if (yield* publicationAllowsViewer(principal.publication, viewer, input.now ?? new Date(), owningTeamId)) {
-          return { kind: "allow" } as const satisfies PublicationRequestEvaluation;
-        }
+    if (session) {
+      const owningTeamId = publicationOwningTeamId(target.vm);
+      // Only the owner of a personal VM can skip the identity lookup. Team
+      // VM ownership and email grants depend on current Stack identity.
+      const viewer: VmPublicationViewer | null =
+        owningTeamId !== null || target.publication.accessMode === "team" || session.userId !== target.publication.ownerUserId
+          ? yield* viewerResolver.resolve(session.userId)
+          : { userId: session.userId, teamIds: [] };
+      if (yield* publicationAllowsViewer(target.publication, viewer, now, owningTeamId)) {
+        return { kind: "allow" } as const satisfies PublicationRequestEvaluation;
       }
     }
 

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -5,8 +5,8 @@ import * as Layer from "effect/Layer";
 
 import { getStackServerApp } from "../../app/lib/stack";
 import type {
-  type CloudVmPublicationAuthTransaction,
-  type CloudVmPublicationTarget,
+  CloudVmPublicationAuthTransaction,
+  CloudVmPublicationTarget,
 } from "./repository";
 import {
   type VmPublicationPolicy,

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import { getStackServerApp } from "../../app/lib/stack";
-import {
+import type {
   type CloudVmPublicationAuthTransaction,
   type CloudVmPublicationTarget,
 } from "./repository";

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -5,8 +5,6 @@ import * as Layer from "effect/Layer";
 
 import { getStackServerApp } from "../../app/lib/stack";
 import {
-  CloudVmPublicationRepository,
-  CloudVmPublicationRepositoryLive,
   type CloudVmPublicationAuthTransaction,
   type CloudVmPublicationTarget,
 } from "./repository";
@@ -26,7 +24,9 @@ import {
   randomPublicationToken,
 } from "./security";
 import { normalizePublicationEmail } from "./managedHostnames";
-import { tracePublicationAuthOperation } from "./requestTelemetry";
+import { tracePublicationAuthOperation, withPublicationAuthEffectContext } from "./requestTelemetry";
+import { publicationDatabaseRuntime } from "./database";
+import { PublicationAuthRepository, PublicationAuthRepositoryLive } from "./authRepository";
 
 export const PUBLICATION_TRANSACTION_TTL_MS = 10 * 60 * 1_000;
 export const PUBLICATION_AUTH_CODE_TTL_MS = 60 * 1_000;
@@ -88,15 +88,15 @@ export const PublicationViewerResolverLive = Layer.succeed(
 );
 
 export const PublicationAuthRuntime = Layer.merge(
-  CloudVmPublicationRepositoryLive,
+  PublicationAuthRepositoryLive,
   PublicationViewerResolverLive,
 );
 
 export function runPublicationAuth<A, E>(
-  program: Effect.Effect<A, E, CloudVmPublicationRepository | PublicationViewerResolver>,
+  program: Effect.Effect<A, E, PublicationAuthRepository | PublicationViewerResolver>,
 ): Promise<A> {
-  return Effect.runPromise(
-    program.pipe(Effect.provide(PublicationAuthRuntime), Effect.either),
+  return publicationDatabaseRuntime().runPromise(
+    withPublicationAuthEffectContext(program.pipe(Effect.provide(PublicationAuthRuntime), Effect.either)),
   ).then((result) => {
     if (result._tag === "Left") throw result.left;
     return result.right;
@@ -155,7 +155,7 @@ export function evaluatePublicationRequest(input: {
   readonly now?: Date;
 }) {
   return Effect.gen(function* () {
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     const viewerResolver = yield* PublicationViewerResolver;
     const now = input.now ?? new Date();
     const requestContext = yield* repository.findRequestContext({
@@ -206,7 +206,7 @@ export function resolvePublicationForRequest(input: {
   readonly providerTlsRuleId: string;
 }) {
   return Effect.gen(function* () {
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     return yield* repository.findActivePublicationForRequest({
       providerTlsRuleId: input.providerTlsRuleId,
     });
@@ -252,7 +252,7 @@ export function completePublicationAuthorization(input: {
     ) {
       return { kind: "invalid" } as const;
     }
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     const now = input.now ?? new Date();
     const sessionToken = randomPublicationToken();
     const consumed = yield* repository.consumeAuthCodeAndCreateSession({
@@ -284,7 +284,7 @@ export function resolvePublicationAccess(input: {
     if (!isPublicationToken(input.transaction) || !isPublicationToken(input.state)) {
       return { kind: "invalid" } as const;
     }
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     const now = input.now ?? new Date();
     const pending = yield* repository.findPendingAuthTransaction({
       transactionHash: hashPublicationToken(input.transaction),
@@ -354,7 +354,7 @@ function publicationAllowsViewer(publication: VmPublicationPolicy & { readonly i
   return Effect.gen(function* () {
     if (vmPublicationAllowsViewer(publication, viewer, owningTeamId)) return true;
     if (!viewer) return false;
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     for (const value of viewer.verifiedEmails ?? []) {
       const email = normalizePublicationEmail(value);
       if (email && (yield* repository.hasEmailGrant({ publicationId: publication.id, email, now }))) return true;
@@ -371,7 +371,7 @@ export function beginPublicationAuthorization(input: {
   readonly now?: Date;
 }) {
   return Effect.gen(function* () {
-    const repository = yield* CloudVmPublicationRepository;
+    const repository = yield* PublicationAuthRepository;
     const transaction = randomPublicationToken();
     const state = randomPublicationToken();
     const verifier = randomPublicationToken();

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -26,6 +26,7 @@ import {
   randomPublicationToken,
 } from "./security";
 import { normalizePublicationEmail } from "./managedHostnames";
+import { tracePublicationAuthOperation } from "./requestTelemetry";
 
 export const PUBLICATION_TRANSACTION_TTL_MS = 10 * 60 * 1_000;
 export const PUBLICATION_AUTH_CODE_TTL_MS = 60 * 1_000;
@@ -53,7 +54,7 @@ export const PublicationViewerResolverLive = Layer.succeed(
   {
     resolve: (userId) =>
       Effect.tryPromise({
-        try: async () => {
+        try: () => tracePublicationAuthOperation("identity", async () => {
           const user = await getStackServerApp().getUser(userId);
           if (!user) return null;
           const teamIds: string[] = [];
@@ -77,7 +78,7 @@ export const PublicationViewerResolverLive = Layer.succeed(
             cursor = nextCursor;
           }
           throw new Error("Stack team pagination exceeded its page limit");
-        },
+        }),
         catch: (cause) => new PublicationIdentityError({
           operation: "resolvePublicationViewer",
           cause,

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -95,9 +95,9 @@ export const PublicationAuthRuntime = Layer.merge(
 export function runPublicationAuth<A, E>(
   program: Effect.Effect<A, E, PublicationAuthRepository | PublicationViewerResolver>,
 ): Promise<A> {
-  return publicationDatabaseRuntime().runPromise(
+  return publicationDatabaseRuntime().then(runtime => runtime.runPromise(
     withPublicationAuthEffectContext(program.pipe(Effect.provide(PublicationAuthRuntime), Effect.either)),
-  ).then((result) => {
+  )).then((result) => {
     if (result._tag === "Left") throw result.left;
     return result.right;
   });

--- a/web/services/vm-publications/authRepository.ts
+++ b/web/services/vm-publications/authRepository.ts
@@ -1,0 +1,359 @@
+import { and, asc, count, desc, eq, gt, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { Database } from "../../db/effect";
+import { tracePublicationAuthEffect } from "./requestTelemetry";
+import { cloudVmPublications, cloudVmDomains, cloudVms, cloudVmPublicationSessions, cloudVmPublicationAuthTransactions, cloudVmPublicationAuthCodes, cloudVmPublicationEmailGrants, accountDeletionTombstones } from "../../db/schema";
+import { accountDeletionAdvisoryLockKey, accountDeletionUserHash, isBlockingAccountDeletionTombstone } from "../account/deletionLock";
+import { PublicationDatabaseError, PublicationNotFoundError, PublicationConflictError, PublicationAuthArtifactError, PublicationAccountDeletionBlockedError, AUTH_ARTIFACT_SWEEP_LIMIT, AUTH_TRANSACTION_ABANDONED_AFTER_MS, MAX_PENDING_AUTH_TRANSACTIONS_PER_PUBLICATION, type CloudVmPublicationRepositoryShape } from "./repository";
+
+export type PublicationAuthRepositoryShape = Pick<CloudVmPublicationRepositoryShape, "hasEmailGrant"|"findActivePublicationForRequest"|"findRequestContext"|"createAuthTransaction"|"findPendingAuthTransaction"|"issueAuthCode"|"consumeAuthCodeAndCreateSession"|"findValidSession"|"revokePublicationSessions">;
+export class PublicationAuthRepository extends Context.Tag("cmux/PublicationAuthRepository")<PublicationAuthRepository, PublicationAuthRepositoryShape>() {}
+type AuthTx=Parameters<Parameters<Context.Tag.Service<Database>["transaction"]>[0]>[0];
+type RepositoryError=PublicationDatabaseError|PublicationNotFoundError|PublicationConflictError|PublicationAuthArtifactError|PublicationAccountDeletionBlockedError;
+function repositoryEffect<A,E>(operation:string, run:()=>Effect.Effect<A,E>):Effect.Effect<A,RepositoryError>{return tracePublicationAuthEffect(`database.${operation}`, Effect.suspend(run)).pipe(Effect.mapError(cause=>cause instanceof PublicationNotFoundError || cause instanceof PublicationConflictError || cause instanceof PublicationAuthArtifactError || cause instanceof PublicationAccountDeletionBlockedError ? cause : new PublicationDatabaseError({operation,cause})));}
+function databaseEffect<A,E>(operation:string, run:()=>Effect.Effect<A,E>):Effect.Effect<A,PublicationDatabaseError>{return tracePublicationAuthEffect(`database.${operation}`, Effect.suspend(run)).pipe(Effect.mapError(cause=>new PublicationDatabaseError({operation,cause})));}
+function normalizedHostname(value: string): string { return value.trim().toLowerCase().replace(/\.$/u, ""); }
+function assertAccountDeletionUserMutationAllowed(tx:AuthTx,userId:string){return Effect.gen(function*(){
+ yield* tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${accountDeletionAdvisoryLockKey(userId)}, 0))`);
+ const userIdHash=accountDeletionUserHash(userId);
+ const [deletion]=yield*tx.select({userIdHash:accountDeletionTombstones.userIdHash,status:accountDeletionTombstones.status,updatedAt:accountDeletionTombstones.updatedAt}).from(accountDeletionTombstones).where(eq(accountDeletionTombstones.userIdHash,userIdHash)).limit(1);
+ if(deletion?.userIdHash===userIdHash && isBlockingAccountDeletionTombstone(deletion))return yield*Effect.fail(new PublicationAccountDeletionBlockedError({userId}));
+});}
+function sweepAuthTransactions(tx: AuthTx, publicationId: string, now: Date) {
+    return Effect.gen(function* () {
+        yield* tx
+            .delete(cloudVmPublicationAuthTransactions)
+            .where(inArray(cloudVmPublicationAuthTransactions.transactionHash, tx
+            .select({ hash: cloudVmPublicationAuthTransactions.transactionHash })
+            .from(cloudVmPublicationAuthTransactions)
+            .where(and(eq(cloudVmPublicationAuthTransactions.publicationId, publicationId), lte(cloudVmPublicationAuthTransactions.expiresAt, now)))
+            .orderBy(asc(cloudVmPublicationAuthTransactions.expiresAt))
+            .limit(AUTH_ARTIFACT_SWEEP_LIMIT)));
+        const pendingWhere = and(eq(cloudVmPublicationAuthTransactions.publicationId, publicationId), gt(cloudVmPublicationAuthTransactions.expiresAt, now), isNull(cloudVmPublicationAuthTransactions.consumedAt));
+        const countPending = () => Effect.gen(function* () {
+            const [pending] = yield* tx
+                .select({ total: count() })
+                .from(cloudVmPublicationAuthTransactions)
+                .where(pendingWhere);
+            return pending?.total ?? 0;
+        });
+        if ((yield* countPending()) < MAX_PENDING_AUTH_TRANSACTIONS_PER_PUBLICATION)
+            return;
+        yield* tx
+            .delete(cloudVmPublicationAuthTransactions)
+            .where(and(pendingWhere, lte(cloudVmPublicationAuthTransactions.createdAt, new Date(now.getTime() - AUTH_TRANSACTION_ABANDONED_AFTER_MS))));
+        if ((yield* countPending()) >= MAX_PENDING_AUTH_TRANSACTIONS_PER_PUBLICATION) {
+            return yield* Effect.fail(new PublicationConflictError({ reason: "auth_transaction_limit" }));
+        }
+    });
+}
+
+function sweepPublicationSessions(tx: AuthTx, publicationId: string, now: Date) {
+    return Effect.gen(function* () {
+        yield* tx
+            .delete(cloudVmPublicationSessions)
+            .where(inArray(cloudVmPublicationSessions.tokenHash, tx
+            .select({ hash: cloudVmPublicationSessions.tokenHash })
+            .from(cloudVmPublicationSessions)
+            .where(and(eq(cloudVmPublicationSessions.publicationId, publicationId), or(lte(cloudVmPublicationSessions.expiresAt, now), isNotNull(cloudVmPublicationSessions.revokedAt))))
+            .orderBy(asc(cloudVmPublicationSessions.expiresAt))
+            .limit(AUTH_ARTIFACT_SWEEP_LIMIT)));
+    });
+}
+export const makePublicationAuthRepository=Effect.gen(function*(){
+const db=yield* Database;
+return {
+hasEmailGrant: (input) => databaseEffect("hasEmailGrant", () => Effect.gen(function* () {
+    const [grant] = yield* db.select({ id: cloudVmPublicationEmailGrants.id }).from(cloudVmPublicationEmailGrants).where(and(eq(cloudVmPublicationEmailGrants.publicationId, input.publicationId), eq(cloudVmPublicationEmailGrants.email, input.email), or(isNull(cloudVmPublicationEmailGrants.expiresAt), gt(cloudVmPublicationEmailGrants.expiresAt, input.now)))).limit(1);
+    return !!grant;
+})),
+findActivePublicationForRequest: (input) => databaseEffect("findActivePublicationForRequest", () => Effect.gen(function* () {
+    const [target] = yield* db.select({
+        publication: cloudVmPublications,
+        domain: cloudVmDomains,
+        vm: cloudVms,
+    })
+        .from(cloudVmPublications)
+        .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+        .innerJoin(cloudVms, eq(cloudVmPublications.vmId, cloudVms.id))
+        .where(and(eq(cloudVmPublications.providerTlsRuleId, input.providerTlsRuleId), eq(cloudVmPublications.state, "active"), isNull(cloudVmPublications.disabledAt), inArray(cloudVms.status, ["running", "paused"])))
+        .limit(1);
+    return target ?? null;
+})),
+findRequestContext: (input) => databaseEffect("findRequestContext", () => Effect.gen(function* () {
+    const [context] = yield* db.select({
+        publication: cloudVmPublications,
+        domain: cloudVmDomains,
+        vm: cloudVms,
+        session: cloudVmPublicationSessions,
+    })
+        .from(cloudVmPublications)
+        .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+        .innerJoin(cloudVms, eq(cloudVmPublications.vmId, cloudVms.id))
+        // Invalid sessions remain a missing session on a valid publication;
+        // they must not hide the publication or bypass its current policy.
+        .leftJoin(cloudVmPublicationSessions, and(input.sessionTokenHash === null
+        ? sql `false`
+        : eq(cloudVmPublicationSessions.tokenHash, input.sessionTokenHash), eq(cloudVmPublicationSessions.publicationId, cloudVmPublications.id), eq(cloudVmPublicationSessions.routingRevision, cloudVmPublications.routingRevision), gt(cloudVmPublicationSessions.expiresAt, input.now), isNull(cloudVmPublicationSessions.revokedAt)))
+        .where(and(eq(cloudVmPublications.providerTlsRuleId, input.providerTlsRuleId), eq(cloudVmPublications.state, "active"), isNull(cloudVmPublications.disabledAt), inArray(cloudVms.status, ["running", "paused"])))
+        .limit(1);
+    return context ?? null;
+})),
+createAuthTransaction: (input) => repositoryEffect("createAuthTransaction", () => Effect.gen(function* () {
+    return yield* db.transaction((tx) => Effect.gen(function* () {
+        const [target] = yield* tx
+            .select({
+            publication: cloudVmPublications,
+            domain: cloudVmDomains,
+        })
+            .from(cloudVmPublications)
+            .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+        .where(and(eq(cloudVmPublications.id, input.publicationId), eq(cloudVmPublications.state, "active"), isNull(cloudVmPublications.disabledAt)))
+            .for("update", { of: cloudVmPublications })
+            .limit(1);
+        if (!target)
+            return yield* Effect.fail(new PublicationNotFoundError({ resource: "publication" }));
+        if (target.publication.hostname !== normalizedHostname(input.hostname)) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_host_mismatch",
+            }));
+        }
+        yield* sweepAuthTransactions(tx, target.publication.id, input.now);
+        const [transaction] = yield* tx
+            .insert(cloudVmPublicationAuthTransactions)
+            .values({
+            transactionHash: input.transactionHash,
+            publicationId: target.publication.id,
+            routingRevision: target.publication.routingRevision,
+            pkceChallenge: input.pkceChallenge,
+            stateHash: input.stateHash,
+            hostname: target.publication.hostname,
+            returnPath: input.returnPath,
+            createdAt: input.now,
+            expiresAt: input.expiresAt,
+        })
+            .returning();
+        if (!transaction)
+            return yield* Effect.fail(new Error("auth transaction insert returned no row"));
+        return transaction;
+    }));
+})),
+findPendingAuthTransaction: (input) => databaseEffect("findPendingAuthTransaction", () => Effect.gen(function* () {
+    const [target] = yield* db.select({
+        transaction: cloudVmPublicationAuthTransactions,
+        publication: cloudVmPublications,
+        domain: cloudVmDomains,
+        vm: cloudVms,
+    })
+        .from(cloudVmPublicationAuthTransactions)
+        .innerJoin(cloudVmPublications, eq(cloudVmPublicationAuthTransactions.publicationId, cloudVmPublications.id))
+        .innerJoin(cloudVms, eq(cloudVmPublications.vmId, cloudVms.id))
+        .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+        .where(and(eq(cloudVmPublicationAuthTransactions.transactionHash, input.transactionHash), gt(cloudVmPublicationAuthTransactions.expiresAt, input.now), isNull(cloudVmPublicationAuthTransactions.consumedAt), eq(cloudVmPublicationAuthTransactions.routingRevision, cloudVmPublications.routingRevision), eq(cloudVmPublicationAuthTransactions.hostname, cloudVmPublications.hostname), eq(cloudVmPublications.state, "active"), isNull(cloudVmPublications.disabledAt)))
+        .limit(1);
+    return target ?? null;
+})),
+issueAuthCode: (input) => repositoryEffect("issueAuthCode", () => Effect.gen(function* () {
+    return yield* db.transaction((tx) => Effect.gen(function* () {
+        {
+            yield* assertAccountDeletionUserMutationAllowed(tx, input.userId);
+        }
+        const [transaction] = yield* tx
+            .select()
+            .from(cloudVmPublicationAuthTransactions)
+            .where(eq(cloudVmPublicationAuthTransactions.transactionHash, input.transactionHash))
+            .for("update")
+            .limit(1);
+        if (!transaction) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_invalid",
+            }));
+        }
+        if (transaction.consumedAt) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_replayed",
+            }));
+        }
+        if (transaction.expiresAt <= input.now) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_expired",
+            }));
+        }
+        if (transaction.stateHash !== input.stateHash) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_state_mismatch",
+            }));
+        }
+        const [publication] = yield* tx
+            .select()
+            .from(cloudVmPublications)
+            .where(eq(cloudVmPublications.id, transaction.publicationId))
+            .for("update")
+            .limit(1);
+        if (!publication ||
+            publication.state !== "active" ||
+            publication.disabledAt ||
+            publication.routingRevision !== transaction.routingRevision) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "publication_revision_changed",
+            }));
+        }
+        const [code] = yield* tx
+            .insert(cloudVmPublicationAuthCodes)
+            .values({
+            codeHash: input.codeHash,
+            transactionHash: transaction.transactionHash,
+            publicationId: publication.id,
+            userId: input.userId,
+            routingRevision: publication.routingRevision,
+            createdAt: input.now,
+            expiresAt: input.expiresAt,
+        })
+            .returning();
+        if (!code)
+            return yield* Effect.fail(new Error("authorization code insert returned no row"));
+        yield* tx
+            .update(cloudVmPublicationAuthTransactions)
+            .set({ consumedAt: input.now })
+            .where(and(eq(cloudVmPublicationAuthTransactions.transactionHash, transaction.transactionHash), isNull(cloudVmPublicationAuthTransactions.consumedAt)));
+        return {
+            code,
+            transaction: { ...transaction, consumedAt: input.now },
+        };
+    }));
+})),
+consumeAuthCodeAndCreateSession: (input) => repositoryEffect("consumeAuthCodeAndCreateSession", () => Effect.gen(function* () {
+    return yield* db.transaction((tx) => Effect.gen(function* () {
+        const [candidate] = yield* tx
+            .select({ userId: cloudVmPublicationAuthCodes.userId })
+            .from(cloudVmPublicationAuthCodes)
+            .where(and(eq(cloudVmPublicationAuthCodes.codeHash, input.codeHash), eq(cloudVmPublicationAuthCodes.transactionHash, input.transactionHash)))
+            .limit(1);
+        if (!candidate) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "authorization_code_invalid",
+            }));
+        }
+        {
+            yield* assertAccountDeletionUserMutationAllowed(tx, candidate.userId);
+        }
+        const [code] = yield* tx
+            .select()
+            .from(cloudVmPublicationAuthCodes)
+            .where(and(eq(cloudVmPublicationAuthCodes.codeHash, input.codeHash), eq(cloudVmPublicationAuthCodes.transactionHash, input.transactionHash)))
+            .for("update")
+            .limit(1);
+        if (!code) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "authorization_code_invalid",
+            }));
+        }
+        if (code.consumedAt) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "authorization_code_replayed",
+            }));
+        }
+        if (code.expiresAt <= input.now) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "authorization_code_expired",
+            }));
+        }
+        const [transaction] = yield* tx
+            .select()
+            .from(cloudVmPublicationAuthTransactions)
+            .where(eq(cloudVmPublicationAuthTransactions.transactionHash, code.transactionHash))
+            .limit(1);
+        if (!transaction || !transaction.consumedAt) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_invalid",
+            }));
+        }
+        if (transaction.stateHash !== input.stateHash) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_state_mismatch",
+            }));
+        }
+        if (transaction.pkceChallenge !== input.pkceChallenge) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_pkce_mismatch",
+            }));
+        }
+        if (transaction.hostname !== normalizedHostname(input.hostname)) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_host_mismatch",
+            }));
+        }
+        const [target] = yield* tx
+            .select({
+            publication: cloudVmPublications,
+            domain: cloudVmDomains,
+        })
+            .from(cloudVmPublications)
+            .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+            .where(eq(cloudVmPublications.id, code.publicationId))
+            .for("update", { of: cloudVmPublications })
+            .limit(1);
+        if (!target ||
+            target.publication.state !== "active" ||
+            target.publication.disabledAt ||
+            target.publication.routingRevision !== code.routingRevision ||
+            target.publication.routingRevision !== transaction.routingRevision) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "publication_revision_changed",
+            }));
+        }
+        if (target.publication.hostname !== transaction.hostname) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({
+                reason: "transaction_host_mismatch",
+            }));
+        }
+        yield* sweepPublicationSessions(tx, target.publication.id, input.now);
+        const [session] = yield* tx
+            .insert(cloudVmPublicationSessions)
+            .values({
+            tokenHash: input.sessionTokenHash,
+            publicationId: target.publication.id,
+            userId: code.userId,
+            routingRevision: target.publication.routingRevision,
+            createdAt: input.now,
+            expiresAt: input.sessionExpiresAt,
+        })
+            .returning();
+        if (!session)
+            return yield* Effect.fail(new Error("publication session insert returned no row"));
+        yield* tx
+            .update(cloudVmPublicationAuthCodes)
+            .set({ consumedAt: input.now })
+            .where(and(eq(cloudVmPublicationAuthCodes.codeHash, code.codeHash), isNull(cloudVmPublicationAuthCodes.consumedAt)));
+        return {
+            session,
+            publication: target.publication,
+            returnPath: transaction.returnPath,
+        };
+    }));
+})),
+findValidSession: (input) => databaseEffect("findValidSession", () => Effect.gen(function* () {
+    const [principal] = yield* db.select({
+        session: cloudVmPublicationSessions,
+        publication: cloudVmPublications,
+        domain: cloudVmDomains,
+    })
+        .from(cloudVmPublicationSessions)
+        .innerJoin(cloudVmPublications, eq(cloudVmPublicationSessions.publicationId, cloudVmPublications.id))
+        .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+        .where(and(eq(cloudVmPublicationSessions.tokenHash, input.tokenHash), eq(cloudVmPublicationSessions.publicationId, input.publicationId), gt(cloudVmPublicationSessions.expiresAt, input.now), isNull(cloudVmPublicationSessions.revokedAt), eq(cloudVmPublicationSessions.routingRevision, cloudVmPublications.routingRevision), eq(cloudVmPublications.state, "active"), isNull(cloudVmPublications.disabledAt), eq(cloudVmPublications.hostname, normalizedHostname(input.hostname))))
+        .limit(1);
+    return principal ?? null;
+})),
+revokePublicationSessions: (input) => databaseEffect("revokePublicationSessions", () => Effect.gen(function* () {
+    const revoked = yield* db.update(cloudVmPublicationSessions)
+        .set({ revokedAt: input.now })
+        .where(and(eq(cloudVmPublicationSessions.publicationId, input.publicationId), isNull(cloudVmPublicationSessions.revokedAt)))
+        .returning({ tokenHash: cloudVmPublicationSessions.tokenHash });
+    return revoked.length;
+}))
+} satisfies PublicationAuthRepositoryShape;
+});
+export const PublicationAuthRepositoryLive=Layer.effect(PublicationAuthRepository,makePublicationAuthRepository);

--- a/web/services/vm-publications/authRepository.ts
+++ b/web/services/vm-publications/authRepository.ts
@@ -160,6 +160,20 @@ issueAuthCode: (input) => repositoryEffect("issueAuthCode", () => Effect.gen(fun
         {
             yield* assertAccountDeletionUserMutationAllowed(tx, input.userId);
         }
+        const [transactionHint] = yield* tx
+            .select()
+            .from(cloudVmPublicationAuthTransactions)
+            .where(eq(cloudVmPublicationAuthTransactions.transactionHash, input.transactionHash))
+            .limit(1);
+        if (!transactionHint) {
+            return yield* Effect.fail(new PublicationAuthArtifactError({ reason: "transaction_invalid" }));
+        }
+        const [lockedPublication] = yield* tx
+            .select()
+            .from(cloudVmPublications)
+            .where(eq(cloudVmPublications.id, transactionHint.publicationId))
+            .for("update")
+            .limit(1);
         const [transaction] = yield* tx
             .select()
             .from(cloudVmPublicationAuthTransactions)
@@ -186,12 +200,7 @@ issueAuthCode: (input) => repositoryEffect("issueAuthCode", () => Effect.gen(fun
                 reason: "transaction_state_mismatch",
             }));
         }
-        const [publication] = yield* tx
-            .select()
-            .from(cloudVmPublications)
-            .where(eq(cloudVmPublications.id, transaction.publicationId))
-            .for("update")
-            .limit(1);
+        const publication = lockedPublication;
         if (!publication ||
             publication.state !== "active" ||
             publication.disabledAt ||

--- a/web/services/vm-publications/database.ts
+++ b/web/services/vm-publications/database.ts
@@ -5,7 +5,7 @@ import { Signer } from "@aws-sdk/rds-signer";
 import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 
 const globals = globalThis as typeof globalThis & {
-  __cmuxPublicationEffectDatabase?: { key: string; runtime: ReturnType<typeof makeDatabaseRuntime> };
+  __cmuxPublicationEffectDatabase?: { key: string; runtime: ReturnType<typeof makeDatabaseRuntime>; expiresAt: number };
 };
 
 /** One Effect-owned database pool per server instance, separate from background traffic. */
@@ -17,7 +17,7 @@ export async function publicationDatabaseRuntime() {
   }
   const key = `${cloudDbConfigKey(config)}:publication-auth:${configuredMax}`;
   const current = globals.__cmuxPublicationEffectDatabase;
-  if (current?.key === key) return current.runtime;
+  if (current?.key === key && current.expiresAt > Date.now()) return current.runtime;
   const connection = config.driver === "url"
     ? { url: Redacted.make(config.url) }
     : {
@@ -33,7 +33,10 @@ export async function publicationDatabaseRuntime() {
     maxConnections: Number(configuredMax),
     applicationName: "cmux-publication-auth",
   });
-  globals.__cmuxPublicationEffectDatabase = { key, runtime };
+  // PlanetScale passwords remain valid for the lifetime of the application.
+  // RDS IAM passwords are short-lived, so refresh the Effect layer before the
+  // token reaches its expiry instead of reusing a dead credential.
+  globals.__cmuxPublicationEffectDatabase = { key, runtime, expiresAt: config.driver === "url" ? Number.POSITIVE_INFINITY : Date.now() + 10 * 60_000 };
   if (current) void current.runtime.dispose();
   return runtime;
 }

--- a/web/services/vm-publications/database.ts
+++ b/web/services/vm-publications/database.ts
@@ -1,0 +1,34 @@
+import * as Redacted from "effect/Redacted";
+import { cloudDbConfig, cloudDbConfigKey } from "../../db/config";
+import { makeDatabaseRuntime } from "../../db/effect";
+
+const globals = globalThis as typeof globalThis & {
+  __cmuxPublicationEffectDatabase?: { key: string; runtime: ReturnType<typeof makeDatabaseRuntime> };
+};
+
+/** One Effect-owned database pool per server instance, separate from background traffic. */
+export function publicationDatabaseRuntime() {
+  const config = cloudDbConfig();
+  if (config.driver !== "url") throw new Error("Publication Effect database requires a PostgreSQL connection URL");
+  const configuredMax = process.env.CMUX_PUBLICATION_AUTH_DB_POOL_MAX?.trim() ?? "5";
+  if (!/^\d+$/u.test(configuredMax) || Number(configuredMax) < 1 || Number(configuredMax) > 32) {
+    throw new Error("CMUX_PUBLICATION_AUTH_DB_POOL_MAX must be between 1 and 32");
+  }
+  const key = `${cloudDbConfigKey(config)}:publication-auth:${configuredMax}`;
+  const current = globals.__cmuxPublicationEffectDatabase;
+  if (current?.key === key) return current.runtime;
+  const runtime = makeDatabaseRuntime({
+    url: Redacted.make(config.url),
+    maxConnections: Number(configuredMax),
+    applicationName: "cmux-publication-auth",
+  });
+  globals.__cmuxPublicationEffectDatabase = { key, runtime };
+  if (current) void current.runtime.dispose();
+  return runtime;
+}
+
+export async function closePublicationAuthDb(): Promise<void> {
+  const current = globals.__cmuxPublicationEffectDatabase;
+  globals.__cmuxPublicationEffectDatabase = undefined;
+  await current?.runtime.dispose();
+}

--- a/web/services/vm-publications/database.ts
+++ b/web/services/vm-publications/database.ts
@@ -1,15 +1,16 @@
 import * as Redacted from "effect/Redacted";
 import { cloudDbConfig, cloudDbConfigKey } from "../../db/config";
 import { makeDatabaseRuntime } from "../../db/effect";
+import { Signer } from "@aws-sdk/rds-signer";
+import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 
 const globals = globalThis as typeof globalThis & {
   __cmuxPublicationEffectDatabase?: { key: string; runtime: ReturnType<typeof makeDatabaseRuntime> };
 };
 
 /** One Effect-owned database pool per server instance, separate from background traffic. */
-export function publicationDatabaseRuntime() {
+export async function publicationDatabaseRuntime() {
   const config = cloudDbConfig();
-  if (config.driver !== "url") throw new Error("Publication Effect database requires a PostgreSQL connection URL");
   const configuredMax = process.env.CMUX_PUBLICATION_AUTH_DB_POOL_MAX?.trim() ?? "5";
   if (!/^\d+$/u.test(configuredMax) || Number(configuredMax) < 1 || Number(configuredMax) > 32) {
     throw new Error("CMUX_PUBLICATION_AUTH_DB_POOL_MAX must be between 1 and 32");
@@ -17,8 +18,18 @@ export function publicationDatabaseRuntime() {
   const key = `${cloudDbConfigKey(config)}:publication-auth:${configuredMax}`;
   const current = globals.__cmuxPublicationEffectDatabase;
   if (current?.key === key) return current.runtime;
+  const connection = config.driver === "url"
+    ? { url: Redacted.make(config.url) }
+    : {
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      username: config.user,
+      ssl: { rejectUnauthorized: config.sslRejectUnauthorized, ...(config.sslCaPem ? { ca: config.sslCaPem } : {}) },
+      password: Redacted.make(await new Signer({ hostname: config.host, port: config.port, username: config.user, region: config.awsRegion, credentials: awsCredentialsProvider({ roleArn: config.awsRoleArn, clientConfig: { region: config.awsRegion } }) }).getAuthToken()),
+    };
   const runtime = makeDatabaseRuntime({
-    url: Redacted.make(config.url),
+    ...connection,
     maxConnections: Number(configuredMax),
     applicationName: "cmux-publication-auth",
   });

--- a/web/services/vm-publications/repository.ts
+++ b/web/services/vm-publications/repository.ts
@@ -745,9 +745,8 @@ async function requirePublicationRevision(
   return publication;
 }
 
-export const CloudVmPublicationRepositoryLive = Layer.succeed(
-  CloudVmPublicationRepository,
-  {
+export function makeCloudVmPublicationRepository(getDb: typeof cloudDb): CloudVmPublicationRepositoryShape {
+  return {
     claimProviderForwardAuth: (input) =>
       repositoryEffect("claimProviderForwardAuth", async () => {
         if (input.leaseExpiresAt <= input.now) {
@@ -755,7 +754,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
             reason: "forward_auth_bootstrap_lost",
           });
         }
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           await tx
             .insert(cloudVmPublicationProviderConfigs)
             .values({
@@ -812,7 +811,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     completeProviderForwardAuth: (input) =>
       repositoryEffect("completeProviderForwardAuth", async () => {
-        const [config] = await cloudDb()
+        const [config] = await getDb()
           .update(cloudVmPublicationProviderConfigs)
           .set({
             providerForwardAuthId: input.providerForwardAuthId,
@@ -841,7 +840,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     releaseProviderForwardAuthClaim: (input) =>
       databaseEffect("releaseProviderForwardAuthClaim", async () => {
-        const released = await cloudDb()
+        const released = await getDb()
           .update(cloudVmPublicationProviderConfigs)
           .set({
             provisioningLeaseId: null,
@@ -864,7 +863,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     getProviderForwardAuth: (provider) =>
       databaseEffect("getProviderForwardAuth", async () => {
-        const [config] = await cloudDb()
+        const [config] = await getDb()
           .select()
           .from(cloudVmPublicationProviderConfigs)
           .where(eq(cloudVmPublicationProviderConfigs.provider, provider))
@@ -874,7 +873,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     replaceProviderForwardAuth: (input) =>
       repositoryEffect("replaceProviderForwardAuth", async () => {
-        const [config] = await cloudDb()
+        const [config] = await getDb()
           .update(cloudVmPublicationProviderConfigs)
           .set({
             providerForwardAuthId: input.providerForwardAuthId,
@@ -902,7 +901,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
     createDomain: (input) =>
       repositoryEffect("createDomain", async () => {
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             try {
               await assertAccountDeletionUserMutationAllowed(
                 tx,
@@ -946,7 +945,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
     updateDomainState: (input) =>
       repositoryEffect("updateDomainState", async () => {
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             const [current] = await tx
               .select()
               .from(cloudVmDomains)
@@ -1020,7 +1019,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findOwnedDomain: (input) =>
       databaseEffect("findOwnedDomain", async () => {
-        const [domain] = await cloudDb()
+        const [domain] = await getDb()
           .select()
           .from(cloudVmDomains)
           .where(
@@ -1035,7 +1034,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findOwnedDomainByHostname: (input) =>
       databaseEffect("findOwnedDomainByHostname", async () => {
-        const rows = await cloudDb()
+        const rows = await getDb()
           .select()
           .from(cloudVmDomains)
           .where(
@@ -1057,7 +1056,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
       databaseEffect(
         "listOwnedDomains",
         async () =>
-          await cloudDb()
+          await getDb()
             .select()
             .from(cloudVmDomains)
             .where(eq(cloudVmDomains.ownerUserId, ownerUserId))
@@ -1066,16 +1065,16 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     reserveManagedPublication: (input) => repositoryEffect("reserveManagedPublication", () => reserveManagedPublication(input).catch((cause) => { throw accountDeletionError(cause); })),
     listEmailGrants: (publicationId) => databaseEffect("listEmailGrants", async () =>
-      cloudDb().select().from(cloudVmPublicationEmailGrants).where(eq(cloudVmPublicationEmailGrants.publicationId, publicationId))),
+      getDb().select().from(cloudVmPublicationEmailGrants).where(eq(cloudVmPublicationEmailGrants.publicationId, publicationId))),
     hasEmailGrant: (input) => databaseEffect("hasEmailGrant", async () => {
-      const [grant] = await cloudDb().select({ id: cloudVmPublicationEmailGrants.id }).from(cloudVmPublicationEmailGrants).where(and(
+      const [grant] = await getDb().select({ id: cloudVmPublicationEmailGrants.id }).from(cloudVmPublicationEmailGrants).where(and(
         eq(cloudVmPublicationEmailGrants.publicationId, input.publicationId), eq(cloudVmPublicationEmailGrants.email, input.email),
         or(isNull(cloudVmPublicationEmailGrants.expiresAt), gt(cloudVmPublicationEmailGrants.expiresAt, input.now)),
       )).limit(1);
       return !!grant;
     }),
     setEmailGrant: (input) => repositoryEffect("setEmailGrant", async () => {
-      await cloudDb().transaction(async (tx) => {
+      await getDb().transaction(async (tx) => {
         try { await assertAccountDeletionUserMutationAllowed(tx, input.ownerUserId); }
         catch (cause) { throw accountDeletionError(cause); }
         const [publication] = await tx.select().from(cloudVmPublications).where(and(
@@ -1098,7 +1097,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
         const hostname = normalizedHostname(input.hostname);
         const vmScope = requireVmAccountScope(input);
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             try {
               await assertAccountDeletionUserMutationAllowed(
                 tx,
@@ -1197,7 +1196,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
           throw new PublicationConflictError({ reason: "hostname_taken" });
         }
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             try {
               await assertAccountDeletionUserMutationAllowed(
                 tx,
@@ -1292,7 +1291,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
             reason: "publication_operation_lost",
           });
         }
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           try {
             await assertAccountDeletionUserMutationAllowed(
               tx,
@@ -1393,13 +1392,13 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     releaseVmPublicationOperation: (input) =>
       databaseEffect("releaseVmPublicationOperation", async () => {
-        const [publication] = await cloudDb()
+        const [publication] = await getDb()
           .select({ vmId: cloudVmPublications.vmId })
           .from(cloudVmPublications)
           .where(eq(cloudVmPublications.id, input.publicationId))
           .limit(1);
         if (!publication) return false;
-        const [released] = await cloudDb()
+        const [released] = await getDb()
           .update(cloudVmPublicationVmGuards)
           .set({
             operationLeaseId: null,
@@ -1418,7 +1417,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
           });
         if (!released) return false;
         if (!released.teardownStartedAt) {
-          await cloudDb()
+          await getDb()
             .delete(cloudVmPublicationVmGuards)
             .where(
               and(
@@ -1441,7 +1440,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
         ) {
           throw new PublicationNotFoundError({ resource: "vm" });
         }
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const [vm] = await tx
             .select()
             .from(cloudVms)
@@ -1547,7 +1546,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
     recordProvisioningTlsRule: (input) =>
       repositoryEffect("recordProvisioningTlsRule", async () => {
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             const publication = await requirePublicationRevision(tx, input);
             if (
               publication.state !== "provisioning" &&
@@ -1597,7 +1596,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
     activatePublication: (input) =>
       repositoryEffect("activatePublication", async () => {
         try {
-          return await cloudDb().transaction(async (tx) => {
+          return await getDb().transaction(async (tx) => {
             const publication = await requirePublicationRevision(tx, input);
             if (
               !(["provisioning", "unavailable"] as const).includes(
@@ -1646,7 +1645,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
     commitAccessPolicy: (input) =>
       repositoryEffect("commitAccessPolicy", async () => {
         const teamId = normalizedTeamId(input.accessMode, input.teamId);
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const publication = await requirePublicationRevision(tx, input);
           if (publication.state !== "active") {
             throw new PublicationConflictError({
@@ -1679,7 +1678,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     recordAppliedForwardAuth: (input) =>
       repositoryEffect("recordAppliedForwardAuth", async () => {
-        const [updated] = await cloudDb()
+        const [updated] = await getDb()
           .update(cloudVmPublications)
           .set({
             providerForwardAuthId: input.providerForwardAuthId,
@@ -1706,7 +1705,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     markPublicationUnavailable: (input) =>
       repositoryEffect("markPublicationUnavailable", async () => {
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const publication = await requirePublicationRevision(tx, input);
           if (
             publication.state === "disabled" ||
@@ -1733,7 +1732,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     beginDisablePublication: (input) =>
       repositoryEffect("beginDisablePublication", async () => {
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const [publication] = await tx
             .select()
             .from(cloudVmPublications)
@@ -1770,7 +1769,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     finishDisablePublication: (input) =>
       repositoryEffect("finishDisablePublication", async () => {
-        const [updated] = await cloudDb()
+        const [updated] = await getDb()
           .update(cloudVmPublications)
           .set({
             state: "disabled",
@@ -1794,7 +1793,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findOwnedPublication: (input) =>
       databaseEffect("findOwnedPublication", async () => {
-        const [target] = await cloudDb()
+        const [target] = await getDb()
           .select({
             publication: cloudVmPublications,
             domain: cloudVmDomains,
@@ -1818,7 +1817,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findOwnedPublicationByHostname: (input) =>
       databaseEffect("findOwnedPublicationByHostname", async () => {
-        const [target] = await cloudDb()
+        const [target] = await getDb()
           .select({
             publication: cloudVmPublications,
             domain: cloudVmDomains,
@@ -1844,7 +1843,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
       databaseEffect(
         "listOwnedPublications",
         async () =>
-          await cloudDb()
+          await getDb()
             .select({
               publication: cloudVmPublications,
               domain: cloudVmDomains,
@@ -1864,7 +1863,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
       databaseEffect(
         "listOwnedPublicationsForDomain",
         async () =>
-          await cloudDb()
+          await getDb()
             .select({
               publication: cloudVmPublications,
               domain: cloudVmDomains,
@@ -1888,7 +1887,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
       databaseEffect(
         "listPublicationsForAccountDeletion",
         async () =>
-          await cloudDb()
+          await getDb()
             .select({
               publicationId: cloudVmPublications.id,
               provider: cloudVms.provider,
@@ -1917,7 +1916,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findActivePublicationForRequest: (input) =>
       databaseEffect("findActivePublicationForRequest", async () => {
-        const [target] = await cloudDb()
+        const [target] = await getDb()
           .select({
             publication: cloudVmPublications,
             domain: cloudVmDomains,
@@ -1946,7 +1945,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findRequestContext: (input) =>
       databaseEffect("findRequestContext", async () => {
-        const [context] = await cloudDb()
+        const [context] = await getDb()
           .select({
             publication: cloudVmPublications,
             domain: cloudVmDomains,
@@ -1979,7 +1978,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     createAuthTransaction: (input) =>
       repositoryEffect("createAuthTransaction", async () => {
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const [target] = await tx
             .select({
               publication: cloudVmPublications,
@@ -2030,7 +2029,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findPendingAuthTransaction: (input) =>
       databaseEffect("findPendingAuthTransaction", async () => {
-        const [target] = await cloudDb()
+        const [target] = await getDb()
           .select({
             transaction: cloudVmPublicationAuthTransactions,
             publication: cloudVmPublications,
@@ -2076,7 +2075,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     issueAuthCode: (input) =>
       repositoryEffect("issueAuthCode", async () => {
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           try {
             await assertAccountDeletionUserMutationAllowed(tx, input.userId);
           } catch (cause) {
@@ -2164,7 +2163,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     consumeAuthCodeAndCreateSession: (input) =>
       repositoryEffect("consumeAuthCodeAndCreateSession", async () => {
-        return await cloudDb().transaction(async (tx) => {
+        return await getDb().transaction(async (tx) => {
           const [candidate] = await tx
             .select({ userId: cloudVmPublicationAuthCodes.userId })
             .from(cloudVmPublicationAuthCodes)
@@ -2315,7 +2314,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     findValidSession: (input) =>
       databaseEffect("findValidSession", async () => {
-        const [principal] = await cloudDb()
+        const [principal] = await getDb()
           .select({
             session: cloudVmPublicationSessions,
             publication: cloudVmPublications,
@@ -2357,7 +2356,7 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
 
     revokePublicationSessions: (input) =>
       databaseEffect("revokePublicationSessions", async () => {
-        const revoked = await cloudDb()
+        const revoked = await getDb()
           .update(cloudVmPublicationSessions)
           .set({ revokedAt: input.now })
           .where(
@@ -2369,7 +2368,11 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
           .returning({ tokenHash: cloudVmPublicationSessions.tokenHash });
         return revoked.length;
       }),
-  },
+  };
+}
+
+export const CloudVmPublicationRepositoryLive = Layer.succeed(
+  CloudVmPublicationRepository, makeCloudVmPublicationRepository(cloudDb),
 );
 
 export async function runCloudVmPublicationRepositoryEffect<A, E>(

--- a/web/services/vm-publications/repository.ts
+++ b/web/services/vm-publications/repository.ts
@@ -57,6 +57,11 @@ export type CloudVmPublicationTarget = {
   readonly vm: typeof cloudVms.$inferSelect;
 };
 
+/** Current routing and session state read from the same database snapshot. */
+export type CloudVmPublicationRequestContext = CloudVmPublicationTarget & {
+  readonly session: CloudVmPublicationSessionRow | null;
+};
+
 export type CloudVmPublicationAuthTransaction = {
   readonly transaction: CloudVmPublicationAuthTransactionRow;
   readonly publication: CloudVmPublicationRow;
@@ -396,6 +401,12 @@ export type CloudVmPublicationRepositoryShape = {
     CloudVmPublicationTarget | null,
     PublicationDatabaseError
   >;
+
+  readonly findRequestContext: (input: {
+    readonly providerTlsRuleId: string;
+    readonly sessionTokenHash: string | null;
+    readonly now: Date;
+  }) => Effect.Effect<CloudVmPublicationRequestContext | null, PublicationDatabaseError>;
 
   readonly createAuthTransaction: (input: {
     readonly publicationId: string;
@@ -1930,6 +1941,39 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
           )
           .limit(1);
         return target ?? null;
+      }),
+
+    findRequestContext: (input) =>
+      databaseEffect("findRequestContext", async () => {
+        const [context] = await cloudDb()
+          .select({
+            publication: cloudVmPublications,
+            domain: cloudVmDomains,
+            vm: cloudVms,
+            session: cloudVmPublicationSessions,
+          })
+          .from(cloudVmPublications)
+          .leftJoin(cloudVmDomains, eq(cloudVmPublications.domainId, cloudVmDomains.id))
+          .innerJoin(cloudVms, eq(cloudVmPublications.vmId, cloudVms.id))
+          // Invalid sessions remain a missing session on a valid publication;
+          // they must not hide the publication or bypass its current policy.
+          .leftJoin(cloudVmPublicationSessions, and(
+            input.sessionTokenHash === null
+              ? sql`false`
+              : eq(cloudVmPublicationSessions.tokenHash, input.sessionTokenHash),
+            eq(cloudVmPublicationSessions.publicationId, cloudVmPublications.id),
+            eq(cloudVmPublicationSessions.routingRevision, cloudVmPublications.routingRevision),
+            gt(cloudVmPublicationSessions.expiresAt, input.now),
+            isNull(cloudVmPublicationSessions.revokedAt),
+          ))
+          .where(and(
+            eq(cloudVmPublications.providerTlsRuleId, input.providerTlsRuleId),
+            eq(cloudVmPublications.state, "active"),
+            isNull(cloudVmPublications.disabledAt),
+            inArray(cloudVms.status, ["running", "paused"]),
+          ))
+          .limit(1);
+        return context ?? null;
       }),
 
     createAuthTransaction: (input) =>

--- a/web/services/vm-publications/repository.ts
+++ b/web/services/vm-publications/repository.ts
@@ -37,6 +37,7 @@ import {
 } from "../account/deletionLock";
 import type { ProviderId } from "../vms/drivers";
 import { reserveManagedPublication, type ManagedPublicationInput } from "./managedRepository";
+import { tracePublicationAuthOperation } from "./requestTelemetry";
 
 export type CloudVmDomainRow = typeof cloudVmDomains.$inferSelect;
 export type CloudVmPublicationRow = typeof cloudVmPublications.$inferSelect;
@@ -498,7 +499,7 @@ function repositoryEffect<A>(
   run: () => Promise<A>,
 ): Effect.Effect<A, RepositoryError> {
   return Effect.tryPromise({
-    try: run,
+    try: () => tracePublicationAuthOperation(`database.${operation}`, run),
     catch: (cause) =>
       isRepositoryDomainError(cause)
         ? cause
@@ -511,7 +512,7 @@ function databaseEffect<A>(
   run: () => Promise<A>,
 ): Effect.Effect<A, PublicationDatabaseError> {
   return Effect.tryPromise({
-    try: run,
+    try: () => tracePublicationAuthOperation(`database.${operation}`, run),
     catch: (cause) => new PublicationDatabaseError({ operation, cause }),
   });
 }

--- a/web/services/vm-publications/requestTelemetry.ts
+++ b/web/services/vm-publications/requestTelemetry.ts
@@ -1,6 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { SpanStatusCode, type Span } from "@opentelemetry/api";
 import { after } from "next/server";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import { runWithCloudDbQueryTags } from "../../db/queryTags";
 import { forceFlushTraces, withPrioritySpan, withSpan, withTraceIdHeaders } from "../telemetry";
 
@@ -12,6 +15,7 @@ const ROUTE = "/api/freestyle/forward-auth";
 type Operation = { operation: string; offset_ms: number; duration_ms: number; failed: boolean };
 type RequestState = { now: () => number; startedAt: number; operations: Operation[]; dropped: number };
 const requests = new AsyncLocalStorage<RequestState>();
+class EffectRequestState extends Context.Tag("cmux/PublicationAuthTrace")<EffectRequestState, RequestState>() {}
 const rounded = (value: number) => Math.round(value * 100) / 100;
 
 function recordOperation(state: RequestState, operation: Operation): void {
@@ -22,6 +26,27 @@ function recordOperation(state: RequestState, operation: Operation): void {
 function decision(status: number): string {
   if (status >= 500) return "unavailable";
   return ({ 204: "allow", 302: "redirect", 400: "invalid", 401: "unauthorized", 404: "not_found", 429: "rate_limited" } as Record<number, string>)[status] ?? "other";
+}
+
+/** Capture at the HTTP boundary; fibers retain their own request state. */
+export function withPublicationAuthEffectContext<A, E, R>(program: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> {
+  const state = requests.getStore();
+  return state ? program.pipe(Effect.provideService(EffectRequestState, state)) : program;
+}
+
+export function tracePublicationAuthEffect<A, E, R>(operation: string, program: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> {
+  return Effect.gen(function* () {
+    const context = yield* Effect.serviceOption(EffectRequestState);
+    if (context._tag === "None") return yield* program;
+    const state = context.value;
+    const startedAt = state.now();
+    return yield* program.pipe(Effect.onExit(exit => Effect.sync(() => recordOperation(state, {
+      operation,
+      offset_ms: rounded(startedAt - state.startedAt),
+      duration_ms: rounded(state.now() - startedAt),
+      failed: Exit.isFailure(exit),
+    }))));
+  });
 }
 
 /** Operation names come from fixed call sites, never URLs, SQL, or user input. */

--- a/web/services/vm-publications/requestTelemetry.ts
+++ b/web/services/vm-publications/requestTelemetry.ts
@@ -1,0 +1,110 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { after } from "next/server";
+import { runWithCloudDbQueryTags } from "../../db/queryTags";
+import { forceFlushTraces, withPrioritySpan, withSpan, withTraceIdHeaders } from "../telemetry";
+
+// Leave room before the provider's 1500ms deadline. These are diagnostic
+// thresholds, not permission caches or retries.
+const SLOW_REQUEST_MS = 750;
+const MAX_OPERATION_RECORDS = 32;
+const ROUTE = "/api/freestyle/forward-auth";
+type Operation = { operation: string; offset_ms: number; duration_ms: number; failed: boolean };
+type RequestState = { now: () => number; startedAt: number; operations: Operation[]; dropped: number };
+const requests = new AsyncLocalStorage<RequestState>();
+const rounded = (value: number) => Math.round(value * 100) / 100;
+
+function recordOperation(state: RequestState, operation: Operation): void {
+  if (state.operations.length < MAX_OPERATION_RECORDS) state.operations.push(operation);
+  else state.dropped++;
+}
+
+function decision(status: number): string {
+  if (status >= 500) return "unavailable";
+  return ({ 204: "allow", 302: "redirect", 400: "invalid", 401: "unauthorized", 404: "not_found", 429: "rate_limited" } as Record<number, string>)[status] ?? "other";
+}
+
+/** Operation names come from fixed call sites, never URLs, SQL, or user input. */
+export async function tracePublicationAuthOperation<A>(operation: string, run: () => Promise<A>): Promise<A> {
+  const state = requests.getStore();
+  if (!state) return run();
+  const startedAt = state.now();
+  // Box failures inside withSpan: generic exception recording can expose SQL
+  // parameters or credentials embedded in provider messages. This path records
+  // only the failing operation; the original error still reaches its handler.
+  const result = await withSpan("cmux-publication-auth", `cmux.publication_auth.${operation}`, {}, async span => {
+    let failed = false;
+    try {
+      return { ok: true as const, value: await run() };
+    } catch (error) {
+      failed = true;
+      span.setStatus({ code: SpanStatusCode.ERROR, message: "authorization operation failed" });
+      return { ok: false as const, error };
+    } finally {
+      const record = { operation, offset_ms: rounded(startedAt - state.startedAt), duration_ms: rounded(state.now() - startedAt), failed };
+      span.setAttributes(record);
+      recordOperation(state, record);
+    }
+  });
+  if (!result.ok) throw result.error;
+  return result.value;
+}
+
+/** Sample ordinary traffic; retain an outcome with all measured stages for every slow/5xx request. */
+export async function withPublicationAuthRequest(
+  request: Request,
+  run: () => Promise<Response>,
+  options: { readonly now?: () => number } = {},
+): Promise<Response> {
+  const now = options.now ?? (() => performance.now());
+  const state: RequestState = { now, startedAt: now(), operations: [], dropped: 0 };
+  return withSpan("cmux-publication-auth", "cmux.publication_auth.request", {
+    "http.route": ROUTE,
+    "cmux.subsystem": "publication-auth",
+  }, async span => {
+    const response = await requests.run(state, () => runWithCloudDbQueryTags({ source: "app", route: ROUTE }, async () => {
+      try {
+        return await run();
+      } catch {
+        recordOperation(state, { operation: "handler", offset_ms: 0, duration_ms: rounded(now() - state.startedAt), failed: true });
+        return new Response(null, { status: 503, headers: { "cache-control": "no-store" } });
+      }
+    }));
+    const durationMs = rounded(now() - state.startedAt);
+    const slow = durationMs >= SLOW_REQUEST_MS;
+    const failed = response.status >= 500;
+    const attributes = {
+      "http.route": ROUTE,
+      "http.response.status_code": response.status,
+      "cmux.subsystem": "publication-auth",
+      "cmux.publication_auth.duration_ms": durationMs,
+      "cmux.publication_auth.slow": slow,
+      "cmux.publication_auth.failed": failed,
+      "cmux.publication_auth.decision": decision(response.status),
+      "cmux.publication_auth.callback": /^\/_cmux\/auth\/callback(?:\?|$)/u.test(request.headers.get("x-forwarded-uri") ?? ""),
+      "cmux.publication_auth.dropped_operations": state.dropped,
+    };
+    const annotate = (target: Span) => {
+      target.setAttributes(attributes);
+      for (const operation of state.operations) target.addEvent("authorization.operation", operation);
+      const totals = new Map<string, number>();
+      for (const operation of state.operations) totals.set(operation.operation, (totals.get(operation.operation) ?? 0) + operation.duration_ms);
+      for (const [operation, duration] of totals) target.setAttribute(`cmux.publication_auth.stage_ms.${operation}`, rounded(duration));
+      if (failed) target.setStatus({ code: SpanStatusCode.ERROR, message: "authorization unavailable" });
+    };
+    annotate(span);
+    let result = withTraceIdHeaders(response, span);
+    if (slow || failed) {
+      // A root rejected by head sampling cannot be promoted. The priority
+      // outcome retains stage offsets/durations and links back to that root.
+      result = await withPrioritySpan("cmux-publication-auth", "cmux.publication_auth.outcome", attributes, async retained => {
+        annotate(retained);
+        return withTraceIdHeaders(response, retained);
+      });
+    }
+    if (slow || failed || span.isRecording()) {
+      try { after(() => forceFlushTraces()); } catch { /* Standalone test/script, no request lifecycle. */ }
+    }
+    return result;
+  });
+}

--- a/web/tests/db-effect-runtime.test.ts
+++ b/web/tests/db-effect-runtime.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { Database, makeDatabaseRuntime } from "../db/effect";
+
+const enabled = process.env.CMUX_DB_TEST === "1";
+const dbTest = enabled ? test : test.skip;
+const runtime = enabled ? makeDatabaseRuntime({
+  url: Redacted.make(process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL!),
+  maxConnections: 2,
+  applicationName: "cmux-effect-runtime-test",
+}) : undefined;
+
+afterAll(async () => { await runtime?.dispose(); });
+
+describe("shared Effect database runtime", () => {
+  dbTest("reuses the same database service across concurrent request boundaries", async () => {
+    const databases = await Promise.all(Array.from({ length: 12 }, () => runtime!.runPromise(Database)));
+    for (const database of databases) expect(database).toBe(databases[0]);
+    const values = await Promise.all(Array.from({ length: 12 }, () => runtime!.runPromise(Effect.gen(function* () {
+      const db = yield* Database;
+      const rows = yield* db.execute<{ value: number }>(sql`select 1 as value`);
+      return rows[0]?.value;
+    }))));
+    expect(values).toEqual(Array.from({ length: 12 }, () => 1));
+  });
+
+  dbTest("rolls back a native Effect transaction when a typed failure occurs", async () => {
+    const failure = { _tag: "RejectedTestChange" } as const;
+    await runtime!.runPromise(Effect.gen(function* () {
+      const db = yield* Database;
+      // The outer transaction owns the temporary table. The nested transaction
+      // must roll back its insert while keeping that outer transaction usable.
+      yield* db.transaction(tx => Effect.gen(function* () {
+        yield* tx.execute(sql`create temporary table effect_rollback_probe (value integer) on commit drop`);
+        const result = yield* tx.transaction(nested => Effect.gen(function* () {
+          yield* nested.execute(sql`insert into effect_rollback_probe values (1)`);
+          return yield* Effect.fail(failure);
+        })).pipe(Effect.either);
+        expect(result._tag).toBe("Left");
+        if (result._tag !== "Left") throw new Error("expected transaction rejection");
+        expect(result.left).toMatchObject(failure);
+        const rows = yield* tx.execute<{ count: number }>(sql`select count(*)::integer as count from effect_rollback_probe`);
+        expect(rows[0]?.count).toBe(0);
+      }));
+    }));
+  });
+});

--- a/web/tests/next-monorepo-root.test.ts
+++ b/web/tests/next-monorepo-root.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../services/iroh/publicationPolicy";
 
 describe("Next monorepo module boundary", () => {
+  test("allows generated cmux development publication origins for HMR", () => {
+    expect(nextConfig.allowedDevOrigins).toContain("*.cmux.sh");
+  });
+
   test("keeps runtime imports inside web while generated consumers remain identical", () => {
     const webRoot = path.dirname(fileURLToPath(new URL("../next.config.ts", import.meta.url)));
     const webCatalogPath = fileURLToPath(

--- a/web/tests/vm-managed-publications-db-behavior.test.ts
+++ b/web/tests/vm-managed-publications-db-behavior.test.ts
@@ -19,7 +19,7 @@ const owners: string[] = [];
 beforeAll(async () => {
   if (process.env.CMUX_DB_TEST !== "1") return;
   db = postgres(process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL!, { max: 6 });
-  repository = { ...await Effect.runPromise(CloudVmPublicationRepository.pipe(Effect.provide(CloudVmPublicationRepositoryLive))), ...await publicationDatabaseRuntime().runPromise(makePublicationAuthRepository) };
+  repository = { ...await Effect.runPromise(CloudVmPublicationRepository.pipe(Effect.provide(CloudVmPublicationRepositoryLive))), ...await (await publicationDatabaseRuntime()).runPromise(makePublicationAuthRepository) };
 });
 afterAll(async () => {
   if (!db) return;

--- a/web/tests/vm-managed-publications-db-behavior.test.ts
+++ b/web/tests/vm-managed-publications-db-behavior.test.ts
@@ -5,6 +5,8 @@ import * as Effect from "effect/Effect";
 import { closeCloudDbForTests } from "../db/client";
 import { reserveManagedPublication, type ManagedPublicationInput } from "../services/vm-publications/managedRepository";
 import { CloudVmPublicationRepository, CloudVmPublicationRepositoryLive, type CloudVmPublicationRepositoryShape } from "../services/vm-publications/repository";
+import { PublicationAuthRepository, makePublicationAuthRepository } from "../services/vm-publications/authRepository";
+import { publicationDatabaseRuntime, closePublicationAuthDb } from "../services/vm-publications/database";
 import { evaluatePublicationRequest, resolvePublicationAccess, PublicationViewerResolver } from "../services/vm-publications/auth";
 import { hashPublicationToken, publicationPkceChallenge, randomPublicationToken } from "../services/vm-publications/security";
 
@@ -17,7 +19,7 @@ const owners: string[] = [];
 beforeAll(async () => {
   if (process.env.CMUX_DB_TEST !== "1") return;
   db = postgres(process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL!, { max: 6 });
-  repository = await Effect.runPromise(CloudVmPublicationRepository.pipe(Effect.provide(CloudVmPublicationRepositoryLive)));
+  repository = { ...await Effect.runPromise(CloudVmPublicationRepository.pipe(Effect.provide(CloudVmPublicationRepositoryLive))), ...await publicationDatabaseRuntime().runPromise(makePublicationAuthRepository) };
 });
 afterAll(async () => {
   if (!db) return;
@@ -27,6 +29,7 @@ afterAll(async () => {
     await db`delete from cloud_vms where user_id = ${owner}`;
   }
   await closeCloudDbForTests();
+  await closePublicationAuthDb();
   await db.end();
 });
 
@@ -88,7 +91,7 @@ describe("managed port publications in Postgres", () => {
     await Effect.runPromise(repository.setEmailGrant(grant));
     let verifiedEmails = ["guest@example.com"];
     const check = (ruleId: string, at = now) => Effect.runPromise(evaluatePublicationRequest({ providerTlsRuleId: ruleId, sessionToken, method: "POST", now: at }).pipe(
-      Effect.provideService(CloudVmPublicationRepository, repository),
+      Effect.provideService(PublicationAuthRepository, repository),
       Effect.provideService(PublicationViewerResolver, { resolve: () => Effect.succeed({ userId: guest, teamIds: [], verifiedEmails }) }),
     ));
     expect(await check(first.publication.providerTlsRuleId!)).toEqual({ kind: "allow" });
@@ -126,14 +129,14 @@ describe("managed port publications in Postgres", () => {
     });
     const check = () => Effect.runPromise(evaluatePublicationRequest({
       providerTlsRuleId: target.publication.providerTlsRuleId!, sessionToken, method: "POST", now,
-    }).pipe(Effect.provideService(CloudVmPublicationRepository, repository), services));
+    }).pipe(Effect.provideService(PublicationAuthRepository, repository), services));
     expect(await check()).toEqual({ kind: "allow" });
     teamIds = [];
     expect(await check()).toEqual({ kind: "unauthorized" });
     const handoff = await Effect.runPromise(resolvePublicationAccess({
       transaction, state, now,
       user: { userId: input.ownerUserId, teamIds: [team], identity: "owner@example.com" },
-    }).pipe(Effect.provideService(CloudVmPublicationRepository, repository), services));
+    }).pipe(Effect.provideService(PublicationAuthRepository, repository), services));
     expect(handoff.kind).toBe("denied");
     // An explicit grant remains an independent publication-only audience.
     await Effect.runPromise(repository.setEmailGrant({

--- a/web/tests/vm-publication-auth.test.ts
+++ b/web/tests/vm-publication-auth.test.ts
@@ -36,6 +36,31 @@ const domain = { hostname: "example.com" };
 const target = { publication, domain, vm: { providerVmId: "vm-1", userId: publication.ownerUserId, billingTeamId: publication.ownerUserId } };
 
 describe("Cloud VM publication auth exchange", () => {
+  test("concurrent owner checks use one publication/session read per request", async () => {
+    const sessionToken = randomPublicationToken();
+    const reads: unknown[] = [];
+    const repository = authRepository({
+      findRequestContext: (input) => {
+        reads.push(input);
+        return Effect.succeed({
+          ...target,
+          session: { userId: publication.ownerUserId },
+        } as never);
+      },
+      findActivePublicationForRequest: () => Effect.die("unexpected separate publication read"),
+      findValidSession: () => Effect.die("unexpected separate session read"),
+    });
+    const results = await Promise.all(Array.from({ length: 32 }, () => run(
+      evaluatePublicationRequest({ providerTlsRuleId: "tls-rule-1", method: "GET", sessionToken, now }),
+      repository,
+      { resolve: () => Effect.die("owner access must not call Stack") },
+    )));
+    expect(results).toEqual(Array.from({ length: 32 }, () => ({ kind: "allow" })));
+    expect(reads).toEqual(Array.from({ length: 32 }, () => ({
+      providerTlsRuleId: "tls-rule-1", sessionTokenHash: hashPublicationToken(sessionToken), now,
+    })));
+  });
+
   test("removes a personal-mode owner's team VM session when team membership ends", async () => {
     const teamTarget = { ...target, vm: { ...target.vm, userId: publication.ownerUserId, billingTeamId: "team-1" } };
     const repository = authRepository({

--- a/web/tests/vm-publication-auth.test.ts
+++ b/web/tests/vm-publication-auth.test.ts
@@ -64,8 +64,7 @@ describe("Cloud VM publication auth exchange", () => {
   test("removes a personal-mode owner's team VM session when team membership ends", async () => {
     const teamTarget = { ...target, vm: { ...target.vm, userId: publication.ownerUserId, billingTeamId: "team-1" } };
     const repository = authRepository({
-      findActivePublicationForRequest: () => Effect.succeed(teamTarget as never),
-      findValidSession: () => Effect.succeed({ session: { userId: publication.ownerUserId }, publication, domain } as never),
+      findRequestContext: () => Effect.succeed({ ...teamTarget, session: { userId: publication.ownerUserId } } as never),
       hasEmailGrant: () => Effect.succeed(false),
     });
     let teamIds = ["team-1"];
@@ -100,7 +99,7 @@ describe("Cloud VM publication auth exchange", () => {
   test("starts a PKCE-bound transaction and redirects only safe browser methods", async () => {
     const created: { current: Record<string, unknown> | null } = { current: null };
     const repository = authRepository({
-      findActivePublicationForRequest: () => Effect.succeed(target as never),
+      findRequestContext: () => Effect.succeed({ ...target, session: null } as never),
       createAuthTransaction: (input) => {
         created.current = input as unknown as Record<string, unknown>;
         return Effect.succeed(input as never);
@@ -154,7 +153,7 @@ describe("Cloud VM publication auth exchange", () => {
 
   test("evaluation reports that sign-in is required without minting a transaction", async () => {
     const repository = authRepository({
-      findActivePublicationForRequest: () => Effect.succeed(target as never),
+      findRequestContext: () => Effect.succeed({ ...target, session: null } as never),
       createAuthTransaction: () => Effect.die("evaluation must not write"),
     });
     const evaluation = await run(
@@ -173,12 +172,7 @@ describe("Cloud VM publication auth exchange", () => {
     const sessionToken = randomPublicationToken();
     let transactionCreated = false;
     const personalRepository = authRepository({
-      findActivePublicationForRequest: () => Effect.succeed(target as never),
-      findValidSession: () => Effect.succeed({
-        session: { userId: publication.ownerUserId },
-        publication,
-        domain,
-      } as never),
+      findRequestContext: () => Effect.succeed({ ...target, session: { userId: publication.ownerUserId } } as never),
       createAuthTransaction: () => {
         transactionCreated = true;
         return Effect.die("unexpected transaction");
@@ -205,14 +199,8 @@ describe("Cloud VM publication auth exchange", () => {
       teamId: "team-1",
     };
     const teamRepository = authRepository({
-      findActivePublicationForRequest: () => Effect.succeed({
-        ...target,
-        publication: teamPublication,
-      } as never),
-      findValidSession: () => Effect.succeed({
-        session: { userId: "viewer-1" },
-        publication: teamPublication,
-        domain,
+      findRequestContext: () => Effect.succeed({
+        ...target, publication: teamPublication, session: { userId: "viewer-1" },
       } as never),
       createAuthTransaction: (input) => Effect.succeed(input as never),
     });

--- a/web/tests/vm-publication-auth.test.ts
+++ b/web/tests/vm-publication-auth.test.ts
@@ -3,7 +3,6 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import {
-  CloudVmPublicationRepository,
   type CloudVmPublicationRepositoryShape,
 } from "../services/vm-publications/repository";
 import {
@@ -20,6 +19,8 @@ import {
   publicationPkceChallenge,
   randomPublicationToken,
 } from "../services/vm-publications/security";
+
+import { PublicationAuthRepository as CloudVmPublicationRepository } from "../services/vm-publications/authRepository";
 
 const now = new Date("2026-09-02T12:00:00.000Z");
 const publication = {

--- a/web/tests/vm-publication-pool-db.test.ts
+++ b/web/tests/vm-publication-pool-db.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { cloudDb, closeCloudDbForTests } from "../db/client";
+import { closePublicationAuthDb, publicationAuthDb } from "../services/vm-publications/database";
+
+const dbTest = process.env.CMUX_DB_TEST === "1" ? test : test.skip;
+const originalMax = process.env.CMUX_DB_POOL_MAX;
+beforeAll(() => { process.env.CMUX_DB_POOL_MAX = "1"; });
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await closePublicationAuthDb();
+  if (originalMax === undefined) delete process.env.CMUX_DB_POOL_MAX;
+  else process.env.CMUX_DB_POOL_MAX = originalMax;
+});
+
+describe("publication authorization capacity", () => {
+  dbTest("authorization can run while the shared one-connection pool is occupied", async () => {
+    let release!: () => void;
+    let acquired!: () => void;
+    const held = new Promise<void>(resolve => { release = resolve; });
+    const ready = new Promise<void>(resolve => { acquired = resolve; });
+    const background = cloudDb().transaction(async tx => {
+      await tx.execute(sql`select 1`);
+      acquired();
+      await held;
+    });
+    await ready;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const completed = await Promise.race([
+        publicationAuthDb().execute(sql`select 1`).then(() => true),
+        new Promise<boolean>(resolve => { timer = setTimeout(() => resolve(false), 1000); }),
+      ]);
+      expect(completed).toBe(true);
+    } finally {
+      clearTimeout(timer);
+      release();
+      await background;
+    }
+  });
+});

--- a/web/tests/vm-publication-pool-db.test.ts
+++ b/web/tests/vm-publication-pool-db.test.ts
@@ -30,7 +30,7 @@ describe("publication authorization capacity", () => {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const completed = await Promise.race([
-        publicationDatabaseRuntime().runPromise(Effect.flatMap(Database, db => db.execute(sql`select 1`))).then(() => true),
+        publicationDatabaseRuntime().then(runtime => runtime.runPromise(Effect.flatMap(Database, db => db.execute(sql`select 1`)))).then(() => true),
         new Promise<boolean>(resolve => { timer = setTimeout(() => resolve(false), 1000); }),
       ]);
       expect(completed).toBe(true);

--- a/web/tests/vm-publication-pool-db.test.ts
+++ b/web/tests/vm-publication-pool-db.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
+import * as Effect from "effect/Effect";
+import { Database } from "../db/effect";
 import { cloudDb, closeCloudDbForTests } from "../db/client";
-import { closePublicationAuthDb, publicationAuthDb } from "../services/vm-publications/database";
+import { closePublicationAuthDb, publicationDatabaseRuntime } from "../services/vm-publications/database";
 
 const dbTest = process.env.CMUX_DB_TEST === "1" ? test : test.skip;
 const originalMax = process.env.CMUX_DB_POOL_MAX;
@@ -28,7 +30,7 @@ describe("publication authorization capacity", () => {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const completed = await Promise.race([
-        publicationAuthDb().execute(sql`select 1`).then(() => true),
+        publicationDatabaseRuntime().runPromise(Effect.flatMap(Database, db => db.execute(sql`select 1`))).then(() => true),
         new Promise<boolean>(resolve => { timer = setTimeout(() => resolve(false), 1000); }),
       ]);
       expect(completed).toBe(true);

--- a/web/tests/vm-publication-telemetry.test.ts
+++ b/web/tests/vm-publication-telemetry.test.ts
@@ -67,6 +67,18 @@ describe("publication authorization telemetry", () => {
     expect(exporter.getFinishedSpans()).toHaveLength(0);
   });
 
+  test("bounds retained operation records even when the handler throws", async () => {
+    const response = await withPublicationAuthRequest(request(), async () => {
+      for (let i = 0; i < 40; i++) await tracePublicationAuthOperation("identity", async () => undefined);
+      throw new Error("private-credential");
+    });
+    expect(response.status).toBe(503);
+    const span = exporter.getFinishedSpans()[0]!;
+    expect(span.events).toHaveLength(32);
+    expect(span.attributes["cmux.publication_auth.dropped_operations"]).toBe(9);
+    expect(JSON.stringify(span.events)).not.toContain("private-credential");
+  });
+
   test("keeps operation records separate for concurrent requests", async () => {
     await Promise.all(["database.findRequestContext", "identity"].map(operation =>
       withPublicationAuthRequest(request(), async () => {

--- a/web/tests/vm-publication-telemetry.test.ts
+++ b/web/tests/vm-publication-telemetry.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { context, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { buildCmuxTraceSampler } from "../services/observability/sampler";
+import { TRACE_ID_RESPONSE_HEADER } from "../services/telemetry";
+import { tracePublicationAuthOperation, withPublicationAuthRequest } from "../services/vm-publications/requestTelemetry";
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider({
+  sampler: buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "0" }),
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+trace.setGlobalTracerProvider(provider);
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+beforeEach(() => exporter.reset());
+afterAll(async () => { await provider.shutdown(); trace.disable(); context.disable(); });
+
+function request() {
+  return new Request("https://cmux.com/api/freestyle/forward-auth?code=private-code", {
+    headers: { cookie: "private-cookie", authorization: "Bearer private-credential" },
+  });
+}
+
+describe("publication authorization telemetry", () => {
+  test("keeps a slow request and its operation timings even when success sampling is zero", async () => {
+    let now = 0;
+    const response = await withPublicationAuthRequest(request(), async () => {
+      await tracePublicationAuthOperation("database.findRequestContext", async () => { now += 900; });
+      await tracePublicationAuthOperation("identity", async () => { now += 50; });
+      return new Response(null, { status: 204 });
+    }, { now: () => now });
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const span = spans[0]!;
+    expect(span.name).toBe("cmux.publication_auth.outcome");
+    expect(span.attributes["cmux.publication_auth.duration_ms"]).toBe(950);
+    expect(span.attributes["cmux.publication_auth.slow"]).toBe(true);
+    expect(span.events.map(event => event.attributes?.operation)).toEqual(["database.findRequestContext", "identity"]);
+    expect(response.headers.get(TRACE_ID_RESPONSE_HEADER)).toBe(span.spanContext().traceId);
+    const serialized = JSON.stringify(spans.map(span => ({ attributes: span.attributes, events: span.events })));
+    for (const secret of ["private-code", "private-cookie", "private-credential"]) expect(serialized).not.toContain(secret);
+  });
+
+  test("keeps an infrastructure failure without exporting exception secrets", async () => {
+    const response = await withPublicationAuthRequest(request(), async () => {
+      try {
+        await tracePublicationAuthOperation("database.findRequestContext", async () => {
+          throw new Error("database unavailable: private-cookie private-credential");
+        });
+      } catch {
+        return new Response(null, { status: 503 });
+      }
+      throw new Error("unreachable");
+    });
+    expect(response.status).toBe(503);
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.events[0]!.attributes?.failed).toBe(true);
+    expect(JSON.stringify(spans[0]!.events)).not.toContain("private-");
+  });
+
+  test("does not force ordinary successful or denied requests into the priority stream", async () => {
+    for (const status of [204, 302, 401, 404]) {
+      await withPublicationAuthRequest(request(), async () => new Response(null, { status }), { now: () => 0 });
+    }
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
+  });
+
+  test("keeps operation records separate for concurrent requests", async () => {
+    await Promise.all(["database.findRequestContext", "identity"].map(operation =>
+      withPublicationAuthRequest(request(), async () => {
+        await tracePublicationAuthOperation(operation, async () => { await Promise.resolve(); });
+        return new Response(null, { status: 503 });
+      }),
+    ));
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(2);
+    expect(spans.map(span => span.events.map(event => event.attributes?.operation)).sort()).toEqual([
+      ["database.findRequestContext"], ["identity"],
+    ]);
+  });
+});

--- a/web/tests/vm-publications-db-behavior.test.ts
+++ b/web/tests/vm-publications-db-behavior.test.ts
@@ -8,6 +8,9 @@ import {
 } from "bun:test";
 import { createHash, randomUUID } from "node:crypto";
 import * as Effect from "effect/Effect";
+import * as Statement from "@effect/sql/Statement";
+import { makePublicationAuthRepository } from "../services/vm-publications/authRepository";
+import { publicationDatabaseRuntime, closePublicationAuthDb } from "../services/vm-publications/database";
 import postgres, { type Sql } from "postgres";
 
 import { closeCloudDbForTests, cloudDb } from "../db/client";
@@ -141,6 +144,7 @@ beforeAll(async () => {
       return yield* CloudVmPublicationRepository;
     }).pipe(Effect.provide(CloudVmPublicationRepositoryLive)),
   );
+  repository = { ...repository, ...await publicationDatabaseRuntime().runPromise(makePublicationAuthRepository) };
 });
 
 beforeEach(async () => {
@@ -165,10 +169,59 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await closeCloudDbForTests();
+  await closePublicationAuthDb();
   await sql?.end({ timeout: 5 });
 });
 
 describe("Cloud VM publication persistence", () => {
+  dbTest("keeps the pending sign-in cap under simultaneous writers", async () => {
+    const repo = requiredRepository();
+    const sql = requiredSql();
+    const target = await createActivePublication({ suffix: "auth-concurrent-cap" });
+    const rows = Array.from({ length: MAX_PENDING_AUTH_TRANSACTIONS_PER_PUBLICATION - 1 }, (_, index) => ({
+      transaction_hash: createHash("sha256").update(`cap-seed-${index}`).digest("hex"),
+      publication_id: target.publication.id,
+      routing_revision: target.publication.routingRevision,
+      pkce_challenge: "P".repeat(43), state_hash: "a".repeat(64),
+      hostname: target.publication.hostname, return_path: "/", created_at: NOW,
+      expires_at: new Date(NOW.getTime() + 600_000),
+    }));
+    await sql`insert into cloud_vm_publication_auth_transactions ${sql(rows)}`;
+    let unlock!: () => void;
+    let locked!: () => void;
+    const ready = new Promise<void>(resolve => { locked = resolve; });
+    const release = new Promise<void>(resolve => { unlock = resolve; });
+    const lock = sql.begin(async tx => {
+      await tx`lock table cloud_vm_publication_auth_transactions in share mode`;
+      locked(); await release;
+    });
+    await ready;
+    const contenders = Promise.allSettled(Array.from({ length: 4 }, (_, index) => runRepository(repo.createAuthTransaction({
+      publicationId: target.publication.id, hostname: target.publication.hostname,
+      transactionHash: createHash("sha256").update(`cap-contender-${index}`).digest("hex"),
+      pkceChallenge: "P".repeat(43), stateHash: "b".repeat(64), returnPath: "/",
+      now: NOW, expiresAt: new Date(NOW.getTime() + 600_000),
+    }))));
+    try {
+      const deadline = Date.now() + 3000;
+      let waiting = 0;
+      while (waiting < 4 && Date.now() < deadline) {
+        const [row] = await sql`select count(*)::integer as waiting from pg_stat_activity
+          where datname=current_database() and application_name='cmux-publication-auth' and wait_event_type='Lock'`;
+        waiting = row.waiting;
+        if (waiting < 4) await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      expect(waiting).toBe(4);
+    } finally { unlock(); await lock; }
+    const results = await contenders;
+    expect(results.filter(result => result.status === "fulfilled")).toHaveLength(1);
+    for (const result of results) if (result.status === "rejected") {
+      expect(result.reason).toMatchObject({ _tag: "PublicationConflictError", reason: "auth_transaction_limit" });
+    }
+    const [count] = await sql`select count(*)::integer as total from cloud_vm_publication_auth_transactions where publication_id=${target.publication.id}`;
+    expect(count.total).toBe(MAX_PENDING_AUTH_TRANSACTIONS_PER_PUBLICATION);
+  });
+
   dbTest("reads current publication and session together without admitting stale or foreign sessions", async () => {
     const repo = requiredRepository();
     const sql = requiredSql();
@@ -181,18 +234,14 @@ describe("Cloud VM publication persistence", () => {
       ${target.publication.routingRevision}, ${NOW}, ${new Date(NOW.getTime() + 60_000)})`;
     const input = { providerTlsRuleId: "tls-rule-request-context", sessionTokenHash: tokenHash, now: NOW };
     const statements: string[] = [];
-    const driver = cloudDb().$client;
-    const previousDebug = driver.options.debug;
-    driver.options.debug = (_connection, statement) => { statements.push(statement); };
-    try {
-      const result = await runRepository(repo.findRequestContext(input));
-      expect(result?.publication.id).toBe(target.publication.id);
-      expect(result?.session?.tokenHash).toBe(tokenHash);
-      expect(statements).toHaveLength(1);
-      expect(statements[0]?.trim().toLowerCase().startsWith("select ")).toBe(true);
-    } finally {
-      driver.options.debug = previousDebug;
-    }
+    const result = await runRepository(repo.findRequestContext(input).pipe(Statement.withTransformer(statement => Effect.sync(() => {
+      statements.push(statement.compile()[0]);
+      return statement;
+    }))));
+    expect(result?.publication.id).toBe(target.publication.id);
+    expect(result?.session?.tokenHash).toBe(tokenHash);
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.trim().toLowerCase().startsWith("select ")).toBe(true);
     expect((await runRepository(repo.findRequestContext({ ...input, sessionTokenHash: null })))?.session).toBeNull();
     expect((await runRepository(repo.findRequestContext({ ...input, now: new Date(NOW.getTime() + 60_000) })))?.session).toBeNull();
     const wrongPublication = await runRepository(repo.findRequestContext({ ...input, providerTlsRuleId: foreign.publication.providerTlsRuleId! }));

--- a/web/tests/vm-publications-db-behavior.test.ts
+++ b/web/tests/vm-publications-db-behavior.test.ts
@@ -144,7 +144,7 @@ beforeAll(async () => {
       return yield* CloudVmPublicationRepository;
     }).pipe(Effect.provide(CloudVmPublicationRepositoryLive)),
   );
-  repository = { ...repository, ...await publicationDatabaseRuntime().runPromise(makePublicationAuthRepository) };
+  repository = { ...repository, ...await (await publicationDatabaseRuntime()).runPromise(makePublicationAuthRepository) };
 });
 
 beforeEach(async () => {

--- a/web/tests/vm-publications-db-behavior.test.ts
+++ b/web/tests/vm-publications-db-behavior.test.ts
@@ -169,6 +169,47 @@ afterAll(async () => {
 });
 
 describe("Cloud VM publication persistence", () => {
+  dbTest("reads current publication and session together without admitting stale or foreign sessions", async () => {
+    const repo = requiredRepository();
+    const sql = requiredSql();
+    const target = await createActivePublication({ suffix: "request-context" });
+    const foreign = await createActivePublication({ suffix: "request-foreign" });
+    const tokenHash = createHash("sha256").update("request-session").digest("hex");
+    await sql`insert into cloud_vm_publication_sessions (
+      token_hash, publication_id, user_id, routing_revision, created_at, expires_at
+    ) values (${tokenHash}, ${target.publication.id}, ${target.publication.ownerUserId},
+      ${target.publication.routingRevision}, ${NOW}, ${new Date(NOW.getTime() + 60_000)})`;
+    const input = { providerTlsRuleId: "tls-rule-request-context", sessionTokenHash: tokenHash, now: NOW };
+    const statements: string[] = [];
+    const driver = cloudDb().$client;
+    const previousDebug = driver.options.debug;
+    driver.options.debug = (_connection, statement) => { statements.push(statement); };
+    try {
+      const result = await runRepository(repo.findRequestContext(input));
+      expect(result?.publication.id).toBe(target.publication.id);
+      expect(result?.session?.tokenHash).toBe(tokenHash);
+      expect(statements).toHaveLength(1);
+      expect(statements[0]?.trim().toLowerCase().startsWith("select ")).toBe(true);
+    } finally {
+      driver.options.debug = previousDebug;
+    }
+    expect((await runRepository(repo.findRequestContext({ ...input, sessionTokenHash: null })))?.session).toBeNull();
+    expect((await runRepository(repo.findRequestContext({ ...input, now: new Date(NOW.getTime() + 60_000) })))?.session).toBeNull();
+    const wrongPublication = await runRepository(repo.findRequestContext({ ...input, providerTlsRuleId: foreign.publication.providerTlsRuleId! }));
+    expect(wrongPublication?.publication.id).toBe(foreign.publication.id);
+    expect(wrongPublication?.session).toBeNull();
+    await sql`update cloud_vm_publication_sessions set revoked_at=${NOW} where token_hash=${tokenHash}`;
+    expect((await runRepository(repo.findRequestContext(input)))?.session).toBeNull();
+    await sql`update cloud_vm_publication_sessions set revoked_at=null where token_hash=${tokenHash}`;
+    await sql`update cloud_vm_publications set routing_revision=routing_revision+1 where id=${target.publication.id}`;
+    expect((await runRepository(repo.findRequestContext(input)))?.session).toBeNull();
+    await sql`update cloud_vm_publications set state='disabled', disabled_at=${NOW} where id=${target.publication.id}`;
+    expect(await runRepository(repo.findRequestContext(input))).toBeNull();
+    await sql`update cloud_vm_publications set state='active', disabled_at=null where id=${target.publication.id}`;
+    await sql`update cloud_vms set status='destroyed' where id=${target.vm.id}`;
+    expect(await runRepository(repo.findRequestContext(input))).toBeNull();
+  });
+
   dbTest(
     "serializes bootstrap of the account-shared forward-auth resource",
     async () => {


### PR DESCRIPTION
## Summary
- Use Drizzle Effect Postgres with a shared, bounded publication authorization runtime.
- Read publication and session state together, serialize pending sign-in capacity, and retain current revocation and one-use code guarantees.
- Keep slow and failed authorization outcomes with safe stage timing in Axiom.
- Allow generated `*.cmux.sh` origins for development HMR and remove the PlanetScale PgBouncer-incompatible relay startup parameter.

## Testing
- `bun run typecheck`
- `bun run lint:complexity`
- Focused authorization, route, telemetry, Next config, and Effect database tests: 30 passed
- Isolated Postgres publication suites: 25 passed
- End-to-end local protected flow: anonymous 302, valid session 204, revoked session 302
- End-to-end protected WebSocket forward: authorization 204 and HMR upgrade 101

## Notes
- Production is unchanged.
- The tagged build and live dev backend are ready for dogfood.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791691284&installation_model_id=21920&pr_number=12307&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12307&signature=b24dcf8cc6dba6466ca821ecd270a2e0b7d0937e04136731aa9f792783437d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the security-critical forward-auth path and swaps persistence to a new Effect repository/runtime; behavior is heavily tested but any regression could affect access control or latency under load.
> 
> **Overview**
> Moves Freestyle **publication forward-auth** onto a **dedicated Effect Postgres runtime** (`PublicationAuthRepository`, bounded pool via `CMUX_PUBLICATION_AUTH_DB_POOL_MAX`) so authorization no longer competes with the shared app DB pool for connections.
> 
> **`evaluatePublicationRequest`** now loads publication and optional session in **one** `findRequestContext` query (routing revision, expiry, revocation) instead of separate publication + session reads, cutting DB round-trips on the hot path.
> 
> The forward-auth route is wrapped in **`withPublicationAuthRequest`** / **`tracePublicationAuthOperation`**: per-stage timings, priority **outcome** spans for requests ≥750ms or 5xx (with trace id on the response), and export flush in `after()`—documented in `OBSERVABILITY.md`. Handler throws map to **503** at the boundary.
> 
> **Dev-only:** `next dev` **`allowedDevOrigins`** adds **`*.cmux.sh`** for published VM HMR. **Relay allow** drops Postgres **`statement_timeout`** on the pooled URL path so PlanetScale PgBouncer is not sent a rejected startup parameter (client-side settle bounds remain).
> 
> Adds **`@effect/opentelemetry`**, shared **`db/effect.ts`** layer with OTel SQL spans, and tests for telemetry, pool isolation, concurrent sign-in caps, and request-context semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9cc27d96977756b21647ae89f461bad3c97fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes publication authorization latency by moving it to a dedicated Effect Postgres runtime with a bounded pool and consolidated database reads, while allowing generated `*.cmux.sh` origins for development HMR.

- Authorization reads publication and session state in one query, serializes pending sign-in capacity checks, and supports IAM database auth.
- Revocation and one-use code guarantees are retained; client-side cancellation preserves query deadlines where PlanetScale's PgBouncer rejects server-side `statement_timeout`.
- Slow and failed authorization outcomes, plus Effect runtime database spans, are traced in Axiom without affecting response latency.
- `next dev` allows `*.cmux.sh` origins for HMR; the PlanetScale-incompatible relay startup parameter is removed.
- Production behavior is unchanged; all tests pass.

<sup>Written for commit 4911e4d4485e1e6dfc422d99a3b70e4cd02e07f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable publication authorization with improved session, transaction, expiration, and access validation.
  * Added tracing for authorization requests, including slow and failed request diagnostics while protecting sensitive information.
  * Added support for development publication origins under `*.cmux.sh`.
  * Added observability documentation and improved database runtime management.

* **Bug Fixes**
  * Improved database pooling, transaction behavior, and query timeout handling for authorization requests.
  * Improved handling of authorization service failures with consistent unavailable responses.
  * Prevented sensitive credentials and error details from appearing in telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->