### PR TITLE
Prevent terminal flicker and delayed nested layout on workspace switches

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1846,9 +1846,22 @@ struct ContentView: View {
     }
 
     private func terminalContent(appearance: WindowAppearanceSnapshot) -> some View {
-        let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
-        let mountedWorkspaces = tabManager.tabs.filter { mountedWorkspaceIdSet.contains($0.id) }
         let selectedWorkspaceId = tabManager.selectedTabId
+        // Selection reaches body before onChange reconciles the mount cache.
+        // Resolve that first render from the current selection too; otherwise
+        // SwiftUI rebuilds the old workspace as hidden content before mounting
+        // the destination, exposing a blank transition and doing extra layout.
+        let presentationMountedIds: [UUID]
+        if let selectedWorkspaceId, !mountedWorkspaceIds.contains(selectedWorkspaceId) {
+            presentationMountedIds = resolvedMountedWorkspaceIds(
+                tabs: tabManager.tabs,
+                selectedId: selectedWorkspaceId
+            )
+        } else {
+            presentationMountedIds = mountedWorkspaceIds
+        }
+        let mountedWorkspaceIdSet = Set(presentationMountedIds)
+        let mountedWorkspaces = tabManager.tabs.filter { mountedWorkspaceIdSet.contains($0.id) }
 
         return ZStack {
             ZStack {
@@ -3575,25 +3588,25 @@ struct ContentView: View {
         installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
     }
 
+    private func resolvedMountedWorkspaceIds(tabs: [Workspace], selectedId: UUID?) -> [UUID] {
+        let pinnedIds = tabManager.mountedBackgroundWorkspaceLoadIds
+            .union(tabManager.debugPinnedWorkspaceLoadIds)
+        let selectedCount = selectedId == nil ? 0 : 1
+        return WorkspaceMountPlan(
+            current: mountedWorkspaceIds,
+            selected: selectedId,
+            pinnedIds: pinnedIds,
+            orderedTabIds: tabs.map { $0.id },
+            maxMounted: max(WorkspaceMountPlan.maxMountedWorkspaces, selectedCount + pinnedIds.count)
+        ).mountedWorkspaceIds
+    }
+
     private func reconcileMountedWorkspaceIds(tabs: [Workspace]? = nil, selectedId: UUID? = nil) {
         let currentTabs = tabs ?? tabManager.tabs
         let orderedTabIds = currentTabs.map { $0.id }
         let effectiveSelectedId = selectedId ?? tabManager.selectedTabId
-        let pinnedIds = tabManager.mountedBackgroundWorkspaceLoadIds
-            .union(tabManager.debugPinnedWorkspaceLoadIds)
-        let selectedCount = effectiveSelectedId == nil ? 0 : 1
-        let maxMounted = max(
-            WorkspaceMountPlan.maxMountedWorkspaces,
-            selectedCount + pinnedIds.count
-        )
         let previousMountedIds = mountedWorkspaceIds
-        mountedWorkspaceIds = WorkspaceMountPlan(
-            current: mountedWorkspaceIds,
-            selected: effectiveSelectedId,
-            pinnedIds: pinnedIds,
-            orderedTabIds: orderedTabIds,
-            maxMounted: maxMounted
-        ).mountedWorkspaceIds
+        mountedWorkspaceIds = resolvedMountedWorkspaceIds(tabs: currentTabs, selectedId: effectiveSelectedId)
         let removedIds = previousMountedIds.filter { !mountedWorkspaceIds.contains($0) }
         let portalRenderingChanges = WorkspacePortalRenderingPlan(
             previousStatesByWorkspaceId: lastReconciledPortalRenderingStatesByWorkspaceId,

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1129,7 +1129,11 @@ final class WindowTerminalPortal: NSObject {
         // carries the exact geometry the last pass left behind, so it dies
         // here in one cheap comparison; any real change differs somewhere
         // and syncs fully.
-        guard ensureInstalled() else { return }
+        // Installation must not consume this pass's layout change before the
+        // settlement check. Otherwise its second hierarchy sync immediately
+        // sees the signature the first one just wrote and publishes a transient
+        // terminal size during workspace reveal.
+        guard ensureInstalled(syncLayout: false) else { return }
         let hierarchyWasAlreadySettled = synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
         reconcileVisibleHostedViewsAfterGeometrySync(reason: "portal.externalGeometrySync")

--- a/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
+++ b/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
@@ -407,6 +407,107 @@ struct GhosttyTerminalViewVisibilityPolicyTests {
         )
     }
 
+    @Test func workspaceRevealKeepsTerminalSizeUntilAnUnchangedGeometryPass() async throws {
+        let size = NSSize(width: 480, height: 320)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        let container = PortalBindLayoutCountingView(frame: NSRect(origin: .zero, size: size))
+        let anchor = NSView(frame: container.bounds)
+        window.contentView = container
+        container.addSubview(anchor)
+        let panel = TerminalPanel(workspaceId: UUID())
+        defer {
+            TerminalWindowPortalRegistry.detach(hostedView: panel.hostedView)
+            window.close()
+            panel.surface.teardownSurface()
+        }
+
+        window.orderFront(nil)
+        window.displayIfNeeded()
+        TerminalWindowPortalRegistry.bind(
+            hostedView: panel.hostedView,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: panel.surface.id,
+            expectedGeneration: panel.surface.portalBindingGeneration()
+        )
+        panel.hostedView.setVisibleInUI(true)
+        await flushPortalReconciliationPasses()
+        window.displayIfNeeded()
+        container.layoutSubtreeIfNeeded()
+        panel.hostedView.layoutSubtreeIfNeeded()
+        _ = panel.hostedView.reconcileGeometryNow()
+        _ = panel.hostedView.surfaceView.forceRefreshSurface()
+        @MainActor func terminalSize() throws -> CGSize {
+            let sample = try #require(panel.surface.rawSizingSample())
+            return CGSize(width: CGFloat(sample.surfaceWidthPx), height: CGFloat(sample.surfaceHeightPx))
+        }
+        let initialTerminalSize = try terminalSize()
+        try #require(initialTerminalSize.width > 0)
+        let portal = try #require(
+            TerminalWindowPortalRegistry.portalsByWindowId[ObjectIdentifier(window)]
+        )
+
+        panel.hostedView.setVisibleInUI(false)
+        TerminalWindowPortalRegistry.hideHostedView(panel.hostedView)
+        anchor.frame.size.width = 280
+        _ = portal.updateEntryVisibility(
+            forHostedId: ObjectIdentifier(panel.hostedView),
+            visibleInUI: true
+        )
+        panel.hostedView.setVisibleInUI(true)
+        container.needsLayout = true
+        container.resetLayoutCount()
+
+        // Deliver the same external geometry pass used by workspace reveal
+        // synchronously, before its queued follow-up. The override only selects
+        // notification delivery; the native surface is not in a live resize.
+        portal.isWindowLiveResizeActiveOverrideForTesting = true
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+        portal.isWindowLiveResizeActiveOverrideForTesting = false
+        #expect(container.layoutCount > 0)
+        #expect(panel.hostedView.frame.width == 280)
+        #expect(
+            try terminalSize() == initialTerminalSize,
+            "The pass that changes layout must not publish an intermediate terminal size"
+        )
+
+        // The next layout restores the workspace's original pane geometry.
+        // There is no reason to resize its native surface or notify its PTY.
+        anchor.frame.size = size
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window, forceImmediate: false)
+        await flushPortalReconciliationPasses()
+        #expect(panel.hostedView.frame.size == size)
+        #expect(try terminalSize() == initialTerminalSize)
+
+        // Finishing settlement must also unblock later, intentional resizes.
+        anchor.frame.size.width = 360
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window, forceImmediate: false)
+        await flushPortalReconciliationPasses()
+        // Native size publication also waits for AppKit's display/layout
+        // turn. Main-queue barriers alone do not drive that turn in an async test.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while (try terminalSize()).width >= initialTerminalSize.width,
+              clock.now < deadline {
+            window.displayIfNeeded()
+            panel.hostedView.layoutSubtreeIfNeeded()
+            _ = panel.hostedView.reconcileGeometryNow()
+            try await clock.sleep(for: .milliseconds(10))
+        }
+        #expect(panel.hostedView.frame.width == 360)
+        #expect((try terminalSize()).width < initialTerminalSize.width)
+        #expect(
+            (try terminalSize()).width ==
+                floor(panel.hostedView.surfaceView.bounds.width * window.backingScaleFactor)
+        )
+    }
+
     private func attentionStrokeHexes(in view: NSView) -> [String] {
         shapeLayers(in: view.layer).compactMap { layer in
             guard let strokeColor = layer.strokeColor,

--- a/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
+++ b/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
@@ -498,7 +498,7 @@ struct GhosttyTerminalViewVisibilityPolicyTests {
             window.displayIfNeeded()
             panel.hostedView.layoutSubtreeIfNeeded()
             _ = panel.hostedView.reconcileGeometryNow()
-            try await clock.sleep(for: .milliseconds(10))
+            await flushPortalReconciliationPasses()
         }
         #expect(panel.hostedView.frame.width == 360)
         #expect((try terminalSize()).width < initialTerminalSize.width)


### PR DESCRIPTION
Workspace shortcuts could render the destination with temporary terminal sizes and nested panes at equal widths, then visibly correct them after the panes appeared.

The change preserves the portal geometry stability check during installation, includes a newly selected workspace in its first presentation render, and initializes fractional split frames directly from saved ratios during AppKit resizing. The Bonsplit change removes the deferred initial correction for ordinary restored splits. Existing retry limits, workspace retention, imposed sizes, and divider drag ownership are preserved; no timers or tree scans were added.

Validation:
- Native terminal sizing regression failed before the fix and passed afterward. 16 visibility tests and 36 portal lifecycle tests passed.
- Ten layout/mount tests passed, including real-window switching and the background mount bound.
- Six focused Bonsplit tests passed on macOS 26.5.1. The test-only commit fails the first-width assertions; the fix passes. Bonsplit’s full hosted CI suite also passes.
- Tagged app `wslay` built successfully from this head: https://github.com/manaflow-ai/cmux/actions/runs/34650878983.
- The user verified the updated app with real Codex panes and explicitly approved merging on September 11: “Works well, merge to main!” Local logs show the right-hand splits starting at their saved 60/40 and 43/57 ratios.
- Earlier matching-compiler comparisons measured 360 switches per version without a slowdown in the portal/mount changes: https://github.com/manaflow-ai/cmux-loader/actions/runs/34572855085 and https://github.com/manaflow-ai/cmux-loader/actions/runs/34573368227. The [final nested-layout comparison](https://github.com/manaflow-ai/cmux-loader/actions/runs/34652959588) passed. Mixed timings over 180 matched switches per version: baseline/fixed mean 363.14/369.33 ms (+1.7%), median 346.19/368.50 ms (+6.4%), p95 464.43/438.12 ms (-5.7%). This run does not establish that every latency measure is unchanged. Fixed had zero extra terminal resize notifications; baseline had four. Automated recording of this round was blocked by macOS capture permissions; human dogfood provides the visual acceptance.

Bonsplit dependency https://github.com/manaflow-ai/bonsplit/pull/239 is merged with a merge commit, preserving the tested pinned commit as an ancestor of the fork’s main branch.

Review disposition: the fixed-sleep test finding was addressed with native/run-loop reconciliation. The minor suggestion to recompute the mount plan on every render was not adopted: the cache-hit behavior is unchanged by this PR, pin changes still use the existing reconciliation handlers, and unconditional plan calculation adds work to ordinary renders. The selected-workspace cache miss is covered by the layout and mount tests.
