### PR TITLE
jobs: single Apply button linking to YC posting

### DIFF
--- a/web/app/[locale]/(landing)/jobs/job-role-page.tsx
+++ b/web/app/[locale]/(landing)/jobs/job-role-page.tsx
@@ -20,7 +20,6 @@ export type JobRoleNamespace =
 
 const focusRingClass =
   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-foreground";
-const applicationEmail = "founders@cmux.com";
 const ycJobUrls = {
   foundingEngineer:
     "https://www.ycombinator.com/companies/cmux/jobs/RcX3bDA-founding-engineer",
@@ -165,9 +164,6 @@ function JobRoleSection({
   const t = useTranslations(namespace);
   const whatYoullDo = t.raw("whatYoullDoItems") as string[];
   const excitedItems = t.raw("excitedItems") as string[];
-  const applyHref = `mailto:${applicationEmail}?subject=${encodeURIComponent(
-    t("applyEmailSubject"),
-  )}`;
 
   return (
     <section
@@ -235,23 +231,14 @@ function JobRoleSection({
             </dl>
 
             <a
-              href={applyHref}
+              href={ycUrl}
+              target="_blank"
+              rel="noopener noreferrer"
               aria-label={t("applyAriaLabel")}
               className={`mt-7 inline-flex min-h-11 w-full items-center justify-center gap-2 bg-foreground px-4 py-3 text-sm font-medium transition-colors hover:bg-foreground/85 ${focusRingClass}`}
               style={{ color: "var(--background)", textDecoration: "none" }}
             >
               {t("applyCta")}
-              <ArrowIcon />
-            </a>
-
-            <a
-              href={ycUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 border border-foreground/15 px-4 py-3 text-sm font-medium transition-colors hover:bg-foreground/5 ${focusRingClass}`}
-              style={{ textDecoration: "none" }}
-            >
-              YC Work at a Startup
               <ArrowIcon />
             </a>
           </div>

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -149,9 +149,8 @@
     "benefits": "تأمين صحي وأسنان ونظر",
     "locationLabel": "الموقع",
     "location": "سان فرانسيسكو",
-    "applyAriaLabel": "التقديم عبر البريد الإلكتروني لوظيفة Founding Engineer",
-    "applyEmailSubject": "التقديم لوظيفة Founding Engineer في cmux",
-    "applyCta": "إرسال بريد إلكتروني",
+    "applyAriaLabel": "التقديم لوظيفة Founding Engineer",
+    "applyCta": "قدّم الآن",
     "foundingChromiumEngineer": {
       "metaTitle": "وظيفة Founding Chromium Engineer في cmux",
       "metaDescription": "انضم إلى cmux كمهندس Chromium مؤسس لتتولى نسختنا المشتقة من Chromium وتحضر cmux إلى Windows وLinux باستخدام C++ وRust.",
@@ -184,9 +183,8 @@
       "benefits": "تأمين صحي وأسنان ونظر",
       "locationLabel": "الموقع",
       "location": "سان فرانسيسكو",
-      "applyAriaLabel": "التقديم عبر البريد الإلكتروني لوظيفة Founding Chromium Engineer",
-      "applyEmailSubject": "التقديم لوظيفة Founding Chromium Engineer في cmux",
-      "applyCta": "إرسال بريد إلكتروني"
+      "applyAriaLabel": "التقديم لوظيفة Founding Chromium Engineer",
+      "applyCta": "قدّم الآن"
     },
     "foundingDesigner": {
       "metaTitle": "وظيفة Founding Designer في cmux",
@@ -220,9 +218,8 @@
       "benefits": "تأمين صحي وأسنان ونظر",
       "locationLabel": "الموقع",
       "location": "سان فرانسيسكو",
-      "applyAriaLabel": "التقديم عبر البريد الإلكتروني لوظيفة Founding Designer",
-      "applyEmailSubject": "التقديم لوظيفة Founding Designer في cmux",
-      "applyCta": "إرسال بريد إلكتروني"
+      "applyAriaLabel": "التقديم لوظيفة Founding Designer",
+      "applyCta": "قدّم الآن"
     }
   },
   "home": {

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -149,9 +149,8 @@
     "benefits": "Zdravstveno, stomatološko i osiguranje vida",
     "locationLabel": "Lokacija",
     "location": "San Francisco",
-    "applyAriaLabel": "Prijavite se e-mailom za Founding Engineer poziciju",
-    "applyEmailSubject": "Prijava za Founding Engineer u cmuxu",
-    "applyCta": "Pošalji e-mail",
+    "applyAriaLabel": "Prijavite se za Founding Engineer poziciju",
+    "applyCta": "Prijavi se",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer u cmuxu",
       "metaDescription": "Pridružite se cmuxu kao founding Chromium inženjer: preuzmite naš Chromium fork i donesite cmux na Windows i Linux s C++ i Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Zdravstveno, stomatološko i osiguranje vida",
       "locationLabel": "Lokacija",
       "location": "San Francisco",
-      "applyAriaLabel": "Prijavite se e-mailom za Founding Chromium Engineer poziciju",
-      "applyEmailSubject": "Prijava za Founding Chromium Engineer u cmuxu",
-      "applyCta": "Pošalji e-mail"
+      "applyAriaLabel": "Prijavite se za Founding Chromium Engineer poziciju",
+      "applyCta": "Prijavi se"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer u cmuxu",
@@ -220,9 +218,8 @@
       "benefits": "Zdravstveno, stomatološko i osiguranje vida",
       "locationLabel": "Lokacija",
       "location": "San Francisco",
-      "applyAriaLabel": "Prijavite se e-mailom za Founding Designer poziciju",
-      "applyEmailSubject": "Prijava za Founding Designer u cmuxu",
-      "applyCta": "Pošalji e-mail"
+      "applyAriaLabel": "Prijavite se za Founding Designer poziciju",
+      "applyCta": "Prijavi se"
     }
   },
   "home": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -149,9 +149,8 @@
     "benefits": "Sundheds-, tand- og synsforsikring",
     "locationLabel": "Placering",
     "location": "San Francisco",
-    "applyAriaLabel": "Søg stillingen som Founding Engineer via e-mail",
-    "applyEmailSubject": "Ansøgning som Founding Engineer hos cmux",
-    "applyCta": "Send e-mail",
+    "applyAriaLabel": "Søg stillingen som Founding Engineer",
+    "applyCta": "Ansøg",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer hos cmux",
       "metaDescription": "Bliv founding Chromium engineer hos cmux: ej vores Chromium-fork og bring cmux til Windows og Linux med C++ og Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Sundheds-, tand- og synsforsikring",
       "locationLabel": "Placering",
       "location": "San Francisco",
-      "applyAriaLabel": "Søg stillingen som Founding Chromium Engineer via e-mail",
-      "applyEmailSubject": "Ansøgning som Founding Chromium Engineer hos cmux",
-      "applyCta": "Send e-mail"
+      "applyAriaLabel": "Søg stillingen som Founding Chromium Engineer",
+      "applyCta": "Ansøg"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer hos cmux",
@@ -220,9 +218,8 @@
       "benefits": "Sundheds-, tand- og synsforsikring",
       "locationLabel": "Placering",
       "location": "San Francisco",
-      "applyAriaLabel": "Søg stillingen som Founding Designer via e-mail",
-      "applyEmailSubject": "Ansøgning som Founding Designer hos cmux",
-      "applyCta": "Send e-mail"
+      "applyAriaLabel": "Søg stillingen som Founding Designer",
+      "applyCta": "Ansøg"
     }
   },
   "home": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -149,9 +149,8 @@
     "benefits": "Kranken-, Zahn- und Sehkraftversicherung",
     "locationLabel": "Standort",
     "location": "San Francisco",
-    "applyAriaLabel": "Per E-Mail als Founding Engineer bewerben",
-    "applyEmailSubject": "Bewerbung als Founding Engineer bei cmux",
-    "applyCta": "E-Mail senden",
+    "applyAriaLabel": "Als Founding Engineer bewerben",
+    "applyCta": "Bewerben",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer bei cmux",
       "metaDescription": "Kommen Sie zu cmux als Founding Chromium Engineer: Verantworten Sie unseren Chromium-Fork und bringen Sie cmux mit C++ und Rust auf Windows und Linux.",
@@ -184,9 +183,8 @@
       "benefits": "Kranken-, Zahn- und Sehkraftversicherung",
       "locationLabel": "Standort",
       "location": "San Francisco",
-      "applyAriaLabel": "Per E-Mail als Founding Chromium Engineer bewerben",
-      "applyEmailSubject": "Bewerbung als Founding Chromium Engineer bei cmux",
-      "applyCta": "E-Mail senden"
+      "applyAriaLabel": "Als Founding Chromium Engineer bewerben",
+      "applyCta": "Bewerben"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer bei cmux",
@@ -220,9 +218,8 @@
       "benefits": "Kranken-, Zahn- und Sehkraftversicherung",
       "locationLabel": "Standort",
       "location": "San Francisco",
-      "applyAriaLabel": "Per E-Mail als Founding Designer bewerben",
-      "applyEmailSubject": "Bewerbung als Founding Designer bei cmux",
-      "applyCta": "E-Mail senden"
+      "applyAriaLabel": "Als Founding Designer bewerben",
+      "applyCta": "Bewerben"
     }
   },
   "home": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -671,9 +671,8 @@
     "benefits": "Health, dental, and vision insurance",
     "locationLabel": "Location",
     "location": "San Francisco",
-    "applyAriaLabel": "Apply for a founding engineer role by email",
-    "applyEmailSubject": "Founding Engineer at cmux",
-    "applyCta": "Email",
+    "applyAriaLabel": "Apply for a founding engineer role",
+    "applyCta": "Apply",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer jobs at cmux",
       "metaDescription": "Join cmux as a founding Chromium engineer to own our fork of Chromium and bring cmux to Windows and Linux with C++ and Rust.",
@@ -706,9 +705,8 @@
       "benefits": "Health, dental, and vision insurance",
       "locationLabel": "Location",
       "location": "San Francisco",
-      "applyAriaLabel": "Apply for a founding chromium engineer role by email",
-      "applyEmailSubject": "Founding Chromium Engineer at cmux",
-      "applyCta": "Email"
+      "applyAriaLabel": "Apply for a founding chromium engineer role",
+      "applyCta": "Apply"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer jobs at cmux",
@@ -742,9 +740,8 @@
       "benefits": "Health, dental, and vision insurance",
       "locationLabel": "Location",
       "location": "San Francisco",
-      "applyAriaLabel": "Apply for a founding designer role by email",
-      "applyEmailSubject": "Founding Designer at cmux",
-      "applyCta": "Email"
+      "applyAriaLabel": "Apply for a founding designer role",
+      "applyCta": "Apply"
     }
   },
   "pricing": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -149,9 +149,8 @@
     "benefits": "Seguro médico, dental y de la vista",
     "locationLabel": "Ubicación",
     "location": "San Francisco",
-    "applyAriaLabel": "Solicitar por correo el puesto de Founding Engineer",
-    "applyEmailSubject": "Solicitud para Founding Engineer en cmux",
-    "applyCta": "Enviar correo",
+    "applyAriaLabel": "Solicitar el puesto de Founding Engineer",
+    "applyCta": "Aplicar",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer en cmux",
       "metaDescription": "Únete a cmux como ingeniero fundador de Chromium para hacerte cargo de nuestro fork de Chromium y llevar cmux a Windows y Linux con C++ y Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Seguro médico, dental y de la vista",
       "locationLabel": "Ubicación",
       "location": "San Francisco",
-      "applyAriaLabel": "Solicitar por correo el puesto de Founding Chromium Engineer",
-      "applyEmailSubject": "Solicitud para Founding Chromium Engineer en cmux",
-      "applyCta": "Enviar correo"
+      "applyAriaLabel": "Solicitar el puesto de Founding Chromium Engineer",
+      "applyCta": "Aplicar"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer en cmux",
@@ -220,9 +218,8 @@
       "benefits": "Seguro médico, dental y de la vista",
       "locationLabel": "Ubicación",
       "location": "San Francisco",
-      "applyAriaLabel": "Solicitar por correo el puesto de Founding Designer",
-      "applyEmailSubject": "Solicitud para Founding Designer en cmux",
-      "applyCta": "Enviar correo"
+      "applyAriaLabel": "Solicitar el puesto de Founding Designer",
+      "applyCta": "Aplicar"
     }
   },
   "home": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -149,9 +149,8 @@
     "benefits": "Assurance santé, dentaire et optique",
     "locationLabel": "Lieu",
     "location": "San Francisco",
-    "applyAriaLabel": "Postuler par e-mail au poste de Founding Engineer",
-    "applyEmailSubject": "Candidature Founding Engineer chez cmux",
-    "applyCta": "Envoyer un e-mail",
+    "applyAriaLabel": "Postuler au poste de Founding Engineer",
+    "applyCta": "Postuler",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer chez cmux",
       "metaDescription": "Rejoignez cmux comme ingénieur fondateur Chromium pour prendre en charge notre fork de Chromium et apporter cmux sur Windows et Linux avec C++ et Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Assurance santé, dentaire et optique",
       "locationLabel": "Lieu",
       "location": "San Francisco",
-      "applyAriaLabel": "Postuler par e-mail au poste de Founding Chromium Engineer",
-      "applyEmailSubject": "Candidature Founding Chromium Engineer chez cmux",
-      "applyCta": "Envoyer un e-mail"
+      "applyAriaLabel": "Postuler au poste de Founding Chromium Engineer",
+      "applyCta": "Postuler"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer chez cmux",
@@ -220,9 +218,8 @@
       "benefits": "Assurance santé, dentaire et optique",
       "locationLabel": "Lieu",
       "location": "San Francisco",
-      "applyAriaLabel": "Postuler par e-mail au poste de Founding Designer",
-      "applyEmailSubject": "Candidature Founding Designer chez cmux",
-      "applyCta": "Envoyer un e-mail"
+      "applyAriaLabel": "Postuler au poste de Founding Designer",
+      "applyCta": "Postuler"
     }
   },
   "home": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -149,9 +149,8 @@
     "benefits": "Assicurazione sanitaria, dentistica e oftalmica",
     "locationLabel": "Sede",
     "location": "San Francisco",
-    "applyAriaLabel": "Candidati via e-mail al ruolo di Founding Engineer",
-    "applyEmailSubject": "Candidatura Founding Engineer in cmux",
-    "applyCta": "Invia e-mail",
+    "applyAriaLabel": "Candidati al ruolo di Founding Engineer",
+    "applyCta": "Candidati",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer in cmux",
       "metaDescription": "Unisciti a cmux come founding Chromium engineer per gestire il nostro fork di Chromium e portare cmux su Windows e Linux con C++ e Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Assicurazione sanitaria, dentistica e oftalmica",
       "locationLabel": "Sede",
       "location": "San Francisco",
-      "applyAriaLabel": "Candidati via e-mail al ruolo di Founding Chromium Engineer",
-      "applyEmailSubject": "Candidatura Founding Chromium Engineer in cmux",
-      "applyCta": "Invia e-mail"
+      "applyAriaLabel": "Candidati al ruolo di Founding Chromium Engineer",
+      "applyCta": "Candidati"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer in cmux",
@@ -220,9 +218,8 @@
       "benefits": "Assicurazione sanitaria, dentistica e oftalmica",
       "locationLabel": "Sede",
       "location": "San Francisco",
-      "applyAriaLabel": "Candidati via e-mail al ruolo di Founding Designer",
-      "applyEmailSubject": "Candidatura Founding Designer in cmux",
-      "applyCta": "Invia e-mail"
+      "applyAriaLabel": "Candidati al ruolo di Founding Designer",
+      "applyCta": "Candidati"
     }
   },
   "home": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -671,9 +671,8 @@
     "benefits": "医療・歯科・眼科保険",
     "locationLabel": "勤務地",
     "location": "サンフランシスコ",
-    "applyAriaLabel": "メールで Founding Engineer に応募する",
-    "applyEmailSubject": "cmux Founding Engineer への応募",
-    "applyCta": "メールする",
+    "applyAriaLabel": "Founding Engineer に応募する",
+    "applyCta": "応募する",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer の採用情報 — cmux",
       "metaDescription": "ファウンディング Chromium エンジニアとして cmux に参加し、Chromium フォークを担い、C++ と Rust で Windows と Linux に cmux を届けませんか。",
@@ -706,9 +705,8 @@
       "benefits": "医療・歯科・眼科保険",
       "locationLabel": "勤務地",
       "location": "サンフランシスコ",
-      "applyAriaLabel": "メールで Founding Chromium Engineer に応募する",
-      "applyEmailSubject": "cmux Founding Chromium Engineer への応募",
-      "applyCta": "メールする"
+      "applyAriaLabel": "Founding Chromium Engineer に応募する",
+      "applyCta": "応募する"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer の採用情報 — cmux",
@@ -742,9 +740,8 @@
       "benefits": "医療・歯科・眼科保険",
       "locationLabel": "勤務地",
       "location": "サンフランシスコ",
-      "applyAriaLabel": "メールで Founding Designer に応募する",
-      "applyEmailSubject": "cmux Founding Designer への応募",
-      "applyCta": "メールする"
+      "applyAriaLabel": "Founding Designer に応募する",
+      "applyCta": "応募する"
     }
   },
   "pricing": {

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -149,9 +149,8 @@
     "benefits": "ធានារ៉ាប់រងសុខភាព ធ្មេញ និងភ្នែក",
     "locationLabel": "ទីតាំង",
     "location": "សាន់ហ្វ្រាន់ស៊ីស្កូ",
-    "applyAriaLabel": "ដាក់ពាក្យ Founding Engineer តាមអ៊ីមែល",
-    "applyEmailSubject": "ដាក់ពាក្យ Founding Engineer នៅ cmux",
-    "applyCta": "ផ្ញើអ៊ីមែល",
+    "applyAriaLabel": "ដាក់ពាក្យ Founding Engineer",
+    "applyCta": "ដាក់ពាក្យ",
     "foundingChromiumEngineer": {
       "metaTitle": "ការងារ Founding Chromium Engineer នៅ cmux",
       "metaDescription": "ចូលរួមជាមួយ cmux ជាវិស្វករ Chromium ស្ថាបនិក ដើម្បីទទួលបន្ទុក Chromium fork របស់យើង និងនាំ cmux ទៅ Windows និង Linux ជាមួយ C++ និង Rust។",
@@ -184,9 +183,8 @@
       "benefits": "ធានារ៉ាប់រងសុខភាព ធ្មេញ និងភ្នែក",
       "locationLabel": "ទីតាំង",
       "location": "សាន់ហ្វ្រាន់ស៊ីស្កូ",
-      "applyAriaLabel": "ដាក់ពាក្យ Founding Chromium Engineer តាមអ៊ីមែល",
-      "applyEmailSubject": "ដាក់ពាក្យ Founding Chromium Engineer នៅ cmux",
-      "applyCta": "ផ្ញើអ៊ីមែល"
+      "applyAriaLabel": "ដាក់ពាក្យ Founding Chromium Engineer",
+      "applyCta": "ដាក់ពាក្យ"
     },
     "foundingDesigner": {
       "metaTitle": "ការងារ Founding Designer នៅ cmux",
@@ -220,9 +218,8 @@
       "benefits": "ធានារ៉ាប់រងសុខភាព ធ្មេញ និងភ្នែក",
       "locationLabel": "ទីតាំង",
       "location": "សាន់ហ្វ្រាន់ស៊ីស្កូ",
-      "applyAriaLabel": "ដាក់ពាក្យ Founding Designer តាមអ៊ីមែល",
-      "applyEmailSubject": "ដាក់ពាក្យ Founding Designer នៅ cmux",
-      "applyCta": "ផ្ញើអ៊ីមែល"
+      "applyAriaLabel": "ដាក់ពាក្យ Founding Designer",
+      "applyCta": "ដាក់ពាក្យ"
     }
   },
   "home": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -149,9 +149,8 @@
     "benefits": "건강·치과·안과 보험",
     "locationLabel": "근무지",
     "location": "샌프란시스코",
-    "applyAriaLabel": "이메일로 Founding Engineer에 지원하기",
-    "applyEmailSubject": "cmux Founding Engineer 지원",
-    "applyCta": "이메일 보내기",
+    "applyAriaLabel": "Founding Engineer에 지원하기",
+    "applyCta": "지원하기",
     "foundingChromiumEngineer": {
       "metaTitle": "cmux Founding Chromium Engineer 채용",
       "metaDescription": "파운딩 Chromium 엔지니어로 cmux에 합류해 Chromium 포크를 담당하고 C++와 Rust로 Windows와 Linux에 cmux를 선보이세요.",
@@ -184,9 +183,8 @@
       "benefits": "건강·치과·안과 보험",
       "locationLabel": "근무지",
       "location": "샌프란시스코",
-      "applyAriaLabel": "이메일로 Founding Chromium Engineer에 지원하기",
-      "applyEmailSubject": "cmux Founding Chromium Engineer 지원",
-      "applyCta": "이메일 보내기"
+      "applyAriaLabel": "Founding Chromium Engineer에 지원하기",
+      "applyCta": "지원하기"
     },
     "foundingDesigner": {
       "metaTitle": "cmux Founding Designer 채용",
@@ -220,9 +218,8 @@
       "benefits": "건강·치과·안과 보험",
       "locationLabel": "근무지",
       "location": "샌프란시스코",
-      "applyAriaLabel": "이메일로 Founding Designer에 지원하기",
-      "applyEmailSubject": "cmux Founding Designer 지원",
-      "applyCta": "이메일 보내기"
+      "applyAriaLabel": "Founding Designer에 지원하기",
+      "applyCta": "지원하기"
     }
   },
   "home": {

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -149,9 +149,8 @@
     "benefits": "Helse-, tann- og synsforsikring",
     "locationLabel": "Sted",
     "location": "San Francisco",
-    "applyAriaLabel": "Søk på Founding Engineer-stillingen via e-post",
-    "applyEmailSubject": "Søknad som Founding Engineer hos cmux",
-    "applyCta": "Send e-post",
+    "applyAriaLabel": "Søk på Founding Engineer-stillingen",
+    "applyCta": "Søk",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer hos cmux",
       "metaDescription": "Bli founding Chromium engineer i cmux: eie vår Chromium-fork og bring cmux til Windows og Linux med C++ og Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Helse-, tann- og synsforsikring",
       "locationLabel": "Sted",
       "location": "San Francisco",
-      "applyAriaLabel": "Søk på Founding Chromium Engineer-stillingen via e-post",
-      "applyEmailSubject": "Søknad som Founding Chromium Engineer hos cmux",
-      "applyCta": "Send e-post"
+      "applyAriaLabel": "Søk på Founding Chromium Engineer-stillingen",
+      "applyCta": "Søk"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer hos cmux",
@@ -220,9 +218,8 @@
       "benefits": "Helse-, tann- og synsforsikring",
       "locationLabel": "Sted",
       "location": "San Francisco",
-      "applyAriaLabel": "Søk på Founding Designer-stillingen via e-post",
-      "applyEmailSubject": "Søknad som Founding Designer hos cmux",
-      "applyCta": "Send e-post"
+      "applyAriaLabel": "Søk på Founding Designer-stillingen",
+      "applyCta": "Søk"
     }
   },
   "home": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -149,9 +149,8 @@
     "benefits": "Ubezpieczenie zdrowotne, dentystyczne i okulistyczne",
     "locationLabel": "Lokalizacja",
     "location": "San Francisco",
-    "applyAriaLabel": "Aplikuj e-mailem na stanowisko Founding Engineer",
-    "applyEmailSubject": "Aplikacja na Founding Engineer w cmux",
-    "applyCta": "Wyślij e-mail",
+    "applyAriaLabel": "Aplikuj na stanowisko Founding Engineer",
+    "applyCta": "Aplikuj",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer w cmux",
       "metaDescription": "Dołącz do cmux jako founding Chromium engineer: przejmij nasz fork Chromium i przenieś cmux na Windows i Linuxa z C++ i Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Ubezpieczenie zdrowotne, dentystyczne i okulistyczne",
       "locationLabel": "Lokalizacja",
       "location": "San Francisco",
-      "applyAriaLabel": "Aplikuj e-mailem na stanowisko Founding Chromium Engineer",
-      "applyEmailSubject": "Aplikacja na Founding Chromium Engineer w cmux",
-      "applyCta": "Wyślij e-mail"
+      "applyAriaLabel": "Aplikuj na stanowisko Founding Chromium Engineer",
+      "applyCta": "Aplikuj"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer w cmux",
@@ -220,9 +218,8 @@
       "benefits": "Ubezpieczenie zdrowotne, dentystyczne i okulistyczne",
       "locationLabel": "Lokalizacja",
       "location": "San Francisco",
-      "applyAriaLabel": "Aplikuj e-mailem na stanowisko Founding Designer",
-      "applyEmailSubject": "Aplikacja na Founding Designer w cmux",
-      "applyCta": "Wyślij e-mail"
+      "applyAriaLabel": "Aplikuj na stanowisko Founding Designer",
+      "applyCta": "Aplikuj"
     }
   },
   "home": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -149,9 +149,8 @@
     "benefits": "Seguro de saúde, odontológico e oftalmológico",
     "locationLabel": "Localização",
     "location": "São Francisco",
-    "applyAriaLabel": "Candidatar-se por e-mail à vaga de Founding Engineer",
-    "applyEmailSubject": "Candidatura para Founding Engineer na cmux",
-    "applyCta": "Enviar e-mail",
+    "applyAriaLabel": "Candidatar-se à vaga de Founding Engineer",
+    "applyCta": "Candidatar-se",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer na cmux",
       "metaDescription": "Junte-se ao cmux como engenheiro fundador de Chromium para assumir nosso fork do Chromium e levar o cmux ao Windows e Linux com C++ e Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Seguro de saúde, odontológico e oftalmológico",
       "locationLabel": "Localização",
       "location": "São Francisco",
-      "applyAriaLabel": "Candidatar-se por e-mail à vaga de Founding Chromium Engineer",
-      "applyEmailSubject": "Candidatura para Founding Chromium Engineer na cmux",
-      "applyCta": "Enviar e-mail"
+      "applyAriaLabel": "Candidatar-se à vaga de Founding Chromium Engineer",
+      "applyCta": "Candidatar-se"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer na cmux",
@@ -220,9 +218,8 @@
       "benefits": "Seguro de saúde, odontológico e oftalmológico",
       "locationLabel": "Localização",
       "location": "São Francisco",
-      "applyAriaLabel": "Candidatar-se por e-mail à vaga de Founding Designer",
-      "applyEmailSubject": "Candidatura para Founding Designer na cmux",
-      "applyCta": "Enviar e-mail"
+      "applyAriaLabel": "Candidatar-se à vaga de Founding Designer",
+      "applyCta": "Candidatar-se"
     }
   },
   "home": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -149,9 +149,8 @@
     "benefits": "Медицинская, стоматологическая страховка и страховка зрения",
     "locationLabel": "Место работы",
     "location": "Сан-Франциско",
-    "applyAriaLabel": "Подать заявку на Founding Engineer по электронной почте",
-    "applyEmailSubject": "Заявка на Founding Engineer в cmux",
-    "applyCta": "Написать по e-mail",
+    "applyAriaLabel": "Подать заявку на Founding Engineer",
+    "applyCta": "Откликнуться",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer в cmux",
       "metaDescription": "Станьте founding-инженером по Chromium в cmux: возглавьте наш форк Chromium и перенесите cmux на Windows и Linux с помощью C++ и Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Медицинская, стоматологическая страховка и страховка зрения",
       "locationLabel": "Место работы",
       "location": "Сан-Франциско",
-      "applyAriaLabel": "Подать заявку на Founding Chromium Engineer по электронной почте",
-      "applyEmailSubject": "Заявка на Founding Chromium Engineer в cmux",
-      "applyCta": "Написать по e-mail"
+      "applyAriaLabel": "Подать заявку на Founding Chromium Engineer",
+      "applyCta": "Откликнуться"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer в cmux",
@@ -220,9 +218,8 @@
       "benefits": "Медицинская, стоматологическая страховка и страховка зрения",
       "locationLabel": "Место работы",
       "location": "Сан-Франциско",
-      "applyAriaLabel": "Подать заявку на Founding Designer по электронной почте",
-      "applyEmailSubject": "Заявка на Founding Designer в cmux",
-      "applyCta": "Написать по e-mail"
+      "applyAriaLabel": "Подать заявку на Founding Designer",
+      "applyCta": "Откликнуться"
     }
   },
   "home": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -149,9 +149,8 @@
     "benefits": "ประกันสุขภาพ ทันตกรรม และสายตา",
     "locationLabel": "สถานที่",
     "location": "ซานฟรานซิสโก",
-    "applyAriaLabel": "สมัครงาน Founding Engineer ทางอีเมล",
-    "applyEmailSubject": "สมัครงาน Founding Engineer ที่ cmux",
-    "applyCta": "ส่งอีเมล",
+    "applyAriaLabel": "สมัครงาน Founding Engineer",
+    "applyCta": "สมัคร",
     "foundingChromiumEngineer": {
       "metaTitle": "งาน Founding Chromium Engineer ที่ cmux",
       "metaDescription": "ร่วมงานกับ cmux ในฐานะวิศวกร Chromium ผู้ก่อตั้ง เพื่อดูแล Chromium fork ของเราและพา cmux ไปสู่ Windows และ Linux ด้วย C++ และ Rust",
@@ -184,9 +183,8 @@
       "benefits": "ประกันสุขภาพ ทันตกรรม และสายตา",
       "locationLabel": "สถานที่",
       "location": "ซานฟรานซิสโก",
-      "applyAriaLabel": "สมัครงาน Founding Chromium Engineer ทางอีเมล",
-      "applyEmailSubject": "สมัครงาน Founding Chromium Engineer ที่ cmux",
-      "applyCta": "ส่งอีเมล"
+      "applyAriaLabel": "สมัครงาน Founding Chromium Engineer",
+      "applyCta": "สมัคร"
     },
     "foundingDesigner": {
       "metaTitle": "งาน Founding Designer ที่ cmux",
@@ -220,9 +218,8 @@
       "benefits": "ประกันสุขภาพ ทันตกรรม และสายตา",
       "locationLabel": "สถานที่",
       "location": "ซานฟรานซิสโก",
-      "applyAriaLabel": "สมัครงาน Founding Designer ทางอีเมล",
-      "applyEmailSubject": "สมัครงาน Founding Designer ที่ cmux",
-      "applyCta": "ส่งอีเมล"
+      "applyAriaLabel": "สมัครงาน Founding Designer",
+      "applyCta": "สมัคร"
     }
   },
   "home": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -149,9 +149,8 @@
     "benefits": "Sağlık, diş ve göz sigortası",
     "locationLabel": "Konum",
     "location": "San Francisco",
-    "applyAriaLabel": "Founding Engineer roluna e-posta ile başvurun",
-    "applyEmailSubject": "cmux Founding Engineer başvurusu",
-    "applyCta": "E-posta gönder",
+    "applyAriaLabel": "Founding Engineer roluna başvurun",
+    "applyCta": "Başvur",
     "foundingChromiumEngineer": {
       "metaTitle": "cmux Founding Chromium Engineer pozisyonu",
       "metaDescription": "Kurucu Chromium mühendisi olarak cmux'a katılın: Chromium fork'umuzu üstlenin ve C++ ve Rust ile cmux'u Windows ve Linux'a taşıyın.",
@@ -184,9 +183,8 @@
       "benefits": "Sağlık, diş ve göz sigortası",
       "locationLabel": "Konum",
       "location": "San Francisco",
-      "applyAriaLabel": "Founding Chromium Engineer rolüne e-posta ile başvurun",
-      "applyEmailSubject": "cmux Founding Chromium Engineer başvurusu",
-      "applyCta": "E-posta gönder"
+      "applyAriaLabel": "Founding Chromium Engineer rolüne başvurun",
+      "applyCta": "Başvur"
     },
     "foundingDesigner": {
       "metaTitle": "cmux Founding Designer pozisyonu",
@@ -220,9 +218,8 @@
       "benefits": "Sağlık, diş ve göz sigortası",
       "locationLabel": "Konum",
       "location": "San Francisco",
-      "applyAriaLabel": "Founding Designer roluna e-posta ile başvurun",
-      "applyEmailSubject": "cmux Founding Designer başvurusu",
-      "applyCta": "E-posta gönder"
+      "applyAriaLabel": "Founding Designer roluna başvurun",
+      "applyCta": "Başvur"
     }
   },
   "home": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -149,9 +149,8 @@
     "benefits": "Медичне, стоматологічне страхування та страхування зору",
     "locationLabel": "Місце",
     "location": "Сан-Франциско",
-    "applyAriaLabel": "Подати заявку на Founding Engineer електронною поштою",
-    "applyEmailSubject": "Заявка на Founding Engineer у cmux",
-    "applyCta": "Надіслати e-mail",
+    "applyAriaLabel": "Подати заявку на Founding Engineer",
+    "applyCta": "Подати заявку",
     "foundingChromiumEngineer": {
       "metaTitle": "Founding Chromium Engineer у cmux",
       "metaDescription": "Станьте founding-інженером з Chromium у cmux: очоліть наш форк Chromium і перенесіть cmux на Windows і Linux за допомогою C++ і Rust.",
@@ -184,9 +183,8 @@
       "benefits": "Медичне, стоматологічне страхування та страхування зору",
       "locationLabel": "Місце",
       "location": "Сан-Франциско",
-      "applyAriaLabel": "Подати заявку на Founding Chromium Engineer електронною поштою",
-      "applyEmailSubject": "Заявка на Founding Chromium Engineer у cmux",
-      "applyCta": "Надіслати e-mail"
+      "applyAriaLabel": "Подати заявку на Founding Chromium Engineer",
+      "applyCta": "Подати заявку"
     },
     "foundingDesigner": {
       "metaTitle": "Founding Designer у cmux",
@@ -220,9 +218,8 @@
       "benefits": "Медичне, стоматологічне страхування та страхування зору",
       "locationLabel": "Місце",
       "location": "Сан-Франциско",
-      "applyAriaLabel": "Подати заявку на Founding Designer електронною поштою",
-      "applyEmailSubject": "Заявка на Founding Designer у cmux",
-      "applyCta": "Надіслати e-mail"
+      "applyAriaLabel": "Подати заявку на Founding Designer",
+      "applyCta": "Подати заявку"
     }
   },
   "home": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -149,9 +149,8 @@
     "benefits": "医疗、牙科和视力保险",
     "locationLabel": "地点",
     "location": "旧金山",
-    "applyAriaLabel": "通过电子邮件申请 Founding Engineer 职位",
-    "applyEmailSubject": "申请 cmux 创始工程师",
-    "applyCta": "发送邮件",
+    "applyAriaLabel": "申请 Founding Engineer 职位",
+    "applyCta": "申请",
     "foundingChromiumEngineer": {
       "metaTitle": "cmux 创始 Chromium 工程师招聘",
       "metaDescription": "加入 cmux 担任创始 Chromium 工程师，负责我们的 Chromium 分支，用 C++ 和 Rust 把 cmux 带到 Windows 和 Linux。",
@@ -184,9 +183,8 @@
       "benefits": "医疗、牙科和视力保险",
       "locationLabel": "地点",
       "location": "旧金山",
-      "applyAriaLabel": "通过电子邮件申请 Founding Chromium Engineer 职位",
-      "applyEmailSubject": "申请 cmux Founding Chromium Engineer",
-      "applyCta": "发送邮件"
+      "applyAriaLabel": "申请 Founding Chromium Engineer 职位",
+      "applyCta": "申请"
     },
     "foundingDesigner": {
       "metaTitle": "cmux 创始设计师招聘",
@@ -220,9 +218,8 @@
       "benefits": "医疗、牙科和视力保险",
       "locationLabel": "地点",
       "location": "旧金山",
-      "applyAriaLabel": "通过电子邮件申请 Founding Designer 职位",
-      "applyEmailSubject": "申请 cmux 创始设计师",
-      "applyCta": "发送邮件"
+      "applyAriaLabel": "申请 Founding Designer 职位",
+      "applyCta": "申请"
     }
   },
   "home": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -149,9 +149,8 @@
     "benefits": "醫療、牙科與視力保險",
     "locationLabel": "地點",
     "location": "舊金山",
-    "applyAriaLabel": "以電子郵件申請 Founding Engineer 職位",
-    "applyEmailSubject": "申請 cmux 創始工程師",
-    "applyCta": "寄送電子郵件",
+    "applyAriaLabel": "申請 Founding Engineer 職位",
+    "applyCta": "申請",
     "foundingChromiumEngineer": {
       "metaTitle": "cmux 創始 Chromium 工程師職缺",
       "metaDescription": "加入 cmux 擔任創始 Chromium 工程師，掌管我們的 Chromium 分支，用 C++ 和 Rust 把 cmux 帶到 Windows 和 Linux。",
@@ -184,9 +183,8 @@
       "benefits": "醫療、牙科與視力保險",
       "locationLabel": "地點",
       "location": "舊金山",
-      "applyAriaLabel": "以電子郵件申請 Founding Chromium Engineer 職位",
-      "applyEmailSubject": "申請 cmux Founding Chromium Engineer",
-      "applyCta": "寄送電子郵件"
+      "applyAriaLabel": "申請 Founding Chromium Engineer 職位",
+      "applyCta": "申請"
     },
     "foundingDesigner": {
       "metaTitle": "cmux 創始設計師職缺",
@@ -220,9 +218,8 @@
       "benefits": "醫療、牙科與視力保險",
       "locationLabel": "地點",
       "location": "舊金山",
-      "applyAriaLabel": "以電子郵件申請 Founding Designer 職位",
-      "applyEmailSubject": "申請 cmux 創始設計師",
-      "applyCta": "寄送電子郵件"
+      "applyAriaLabel": "申請 Founding Designer 職位",
+      "applyCta": "申請"
     }
   },
   "home": {

--- a/web/tests/jobs-page.test.tsx
+++ b/web/tests/jobs-page.test.tsx
@@ -112,18 +112,8 @@ describe("jobs page", () => {
     expect(html).toContain("San Francisco");
     expect(html).toContain('id="founding-engineer"');
     expect(html).toContain('id="founding-designer"');
-    expect(html.match(/>Email</g)).toHaveLength(3);
-    expect(html).not.toContain("Email founders@cmux.com");
-    expect(html).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        enMessages.jobs.applyEmailSubject,
-      )}"`,
-    );
-    expect(html).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        enMessages.jobs.foundingDesigner.applyEmailSubject,
-      )}"`,
-    );
+    expect(html.match(/>Apply</g)).toHaveLength(3);
+    expect(html).not.toContain("mailto:founders@cmux.com");
     expect(html).toContain(
       'href="https://www.ycombinator.com/companies/cmux/jobs/RcX3bDA-founding-engineer"',
     );
@@ -133,7 +123,7 @@ describe("jobs page", () => {
     expect(html).toContain(
       'href="https://www.ycombinator.com/companies/cmux/jobs/T4rJNKX-founding-chromium-engineer"',
     );
-    expect(html.match(/>YC Work at a Startup</g)).toHaveLength(3);
+    expect(html).not.toContain("YC Work at a Startup");
     expect(html).not.toContain("About cmux");
     expect(html).not.toContain("Open roles");
     expect(html).not.toContain("Who we're looking for");
@@ -166,16 +156,8 @@ describe("jobs page", () => {
     );
     expect(html).toContain("デザインコンポーネントを知り尽くしている");
     expect(html).toContain("次のような経験や姿勢があると、特にうれしいです：");
-    expect(html.match(/>メールする</g)).toHaveLength(3);
-    expect(html).not.toContain("founders@cmux.com にメールする");
-    expect(html).toContain(
-      `subject=${encodeURIComponent(jaMessages.jobs.applyEmailSubject)}`,
-    );
-    expect(html).toContain(
-      `subject=${encodeURIComponent(
-        jaMessages.jobs.foundingDesigner.applyEmailSubject,
-      )}`,
-    );
+    expect(html.match(/>応募する</g)).toHaveLength(3);
+    expect(html).not.toContain("mailto:founders@cmux.com");
     expect(html).not.toContain("cmux について");
     expect(html).not.toContain("募集中のポジション");
     expect(html).not.toContain("興味がありますか？");
@@ -192,34 +174,16 @@ describe("jobs page", () => {
     expect(simplified).toContain("我们正在招聘");
     expect(simplified).toContain("Founding Designer");
     expect(simplified).toContain("设计覆盖整个技术栈的前沿开发者工具");
-    expect(simplified.match(/>发送邮件</g)).toHaveLength(3);
-    expect(simplified).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        messagesByLocale["zh-CN"].jobs.applyEmailSubject,
-      )}"`,
-    );
-    expect(simplified).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        messagesByLocale["zh-CN"].jobs.foundingDesigner.applyEmailSubject,
-      )}"`,
-    );
+    expect(simplified.match(/>申请</g)).toHaveLength(3);
+    expect(simplified).not.toContain("mailto:founders@cmux.com");
 
     activeLocale = "zh-TW";
     const traditional = renderToStaticMarkup(<JobsPage />);
     expect(traditional).toContain("我們正在招募");
     expect(traditional).toContain("Founding Designer");
     expect(traditional).toContain("打造橫跨整個技術堆疊的前沿開發者工具");
-    expect(traditional.match(/>寄送電子郵件</g)).toHaveLength(3);
-    expect(traditional).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        messagesByLocale["zh-TW"].jobs.applyEmailSubject,
-      )}"`,
-    );
-    expect(traditional).toContain(
-      `href="mailto:founders@cmux.com?subject=${encodeURIComponent(
-        messagesByLocale["zh-TW"].jobs.foundingDesigner.applyEmailSubject,
-      )}"`,
-    );
+    expect(traditional.match(/>申請</g)).toHaveLength(3);
+    expect(traditional).not.toContain("mailto:founders@cmux.com");
   });
 
   test("keeps jobs copy complete and localized for every configured locale", () => {
@@ -255,17 +219,8 @@ describe("jobs page", () => {
         new RegExp(`<p[^>]*>${escapeRegExp(catalog.jobs.section)}<\\/p>`),
       );
       expect(html).toContain(`aria-label="${catalog.jobs.details}"`);
-      expect(html).toContain(
-        `mailto:founders@cmux.com?subject=${encodeURIComponent(
-          catalog.jobs.applyEmailSubject,
-        )}`,
-      );
-      expect(html).toContain(
-        `mailto:founders@cmux.com?subject=${encodeURIComponent(
-          catalog.jobs.foundingDesigner.applyEmailSubject,
-        )}`,
-      );
-      expect(html.match(/>YC Work at a Startup</g)).toHaveLength(3);
+      expect(html).not.toContain("mailto:founders@cmux.com");
+      expect(html).not.toContain("YC Work at a Startup");
       expect(catalog.jobs).not.toHaveProperty("aboutTitle");
       expect(catalog.jobs).not.toHaveProperty("applyTitle");
       expect(catalog.jobs.foundingDesigner).not.toHaveProperty("aboutTitle");
@@ -325,13 +280,8 @@ describe("jobs page", () => {
     );
     expect(html).toContain("Typography, motion, and systems thinking");
     expect(html).toContain("$130k–$170k + 0.5%–1.5% equity");
-    expect(html.match(/>Email</g)).toHaveLength(3);
-    expect(html).not.toContain("Email founders@cmux.com");
-    expect(html).toContain(
-      `subject=${encodeURIComponent(
-        enMessages.jobs.foundingDesigner.applyEmailSubject,
-      )}`,
-    );
+    expect(html.match(/>Apply</g)).toHaveLength(3);
+    expect(html).not.toContain("mailto:founders@cmux.com");
     expect(html).not.toContain("About cmux");
     expect(html).not.toContain("Interested?");
   });
@@ -344,13 +294,8 @@ describe("jobs page", () => {
     expect(html).toContain("Founding Designer");
     expect(html).toContain("デザインコンポーネントを知り尽くしている");
     expect(html).toContain("タイポグラフィ、モーション、システム思考");
-    expect(html.match(/>メールする</g)).toHaveLength(3);
-    expect(html).not.toContain("founders@cmux.com にメールする");
-    expect(html).toContain(
-      `subject=${encodeURIComponent(
-        jaMessages.jobs.foundingDesigner.applyEmailSubject,
-      )}`,
-    );
+    expect(html.match(/>応募する</g)).toHaveLength(3);
+    expect(html).not.toContain("mailto:founders@cmux.com");
     expect(html).not.toContain("cmux について");
     expect(html).not.toContain("興味がありますか？");
     expect(html).not.toContain("What you'll do");


### PR DESCRIPTION
## What
Removes the mailto Email CTA and the secondary "YC Work at a Startup" link from each role's details card on /jobs. Each role now has a single primary Apply button linking directly to that role's YC Work at a Startup posting (the same 3 URLs merged in #12248).

## i18n
- Drops the now-unused applyEmailSubject strings from all 19 locale catalogs.
- applyCta changes from "Email" to "Apply" (localized per catalog); applyAriaLabel loses the "by email" qualifier in all locales.

## Tests
- web/tests/jobs-page.test.tsx updated: asserts the 3 Apply buttons, the YC hrefs, and the absence of mailto:founders@cmux.com and "YC Work at a Startup".
- Jobs suite green locally: 11 pass, 0 fail, 763 assertions (bun test tests/jobs-page.test.tsx).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791692514&installation_model_id=21920&pr_number=12311&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12311&signature=c69f92d1ba138856ee6bef0c5f040aa547ec1efedd3445989e3ad61799fdc021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page CTA and copy-only i18n changes with updated tests; no auth, APIs, or data handling.
> 
> **Overview**
> Job role pages on `/jobs` now use **one primary Apply button per role** that opens the matching **Y Combinator Work at a Startup** posting in a new tab, instead of a `mailto:` founders email CTA plus a separate YC link.
> 
> `job-role-page.tsx` drops the `applicationEmail` / `applyHref` logic; the details card link uses `ycUrl` with `target="_blank"` and `rel="noopener noreferrer"`. All **19 locale catalogs** remove `applyEmailSubject`, retitle **`applyCta`** from email wording to localized **Apply**, and soften **`applyAriaLabel`** so it no longer says “by email.” **`jobs-page.test.tsx`** expects three Apply buttons, the three YC URLs, and no `mailto:founders@cmux.com` or “YC Work at a Startup” secondary links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0221d046daef00447fc6e346333b210719542729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the mailto email CTA and secondary "YC Work at a Startup" link on each job role card with a single Apply button that links directly to that role's YC Work at a Startup posting.

- Removes the now-unused applyEmailSubject strings from all 19 locale catalogs.
- Updates applyCta and applyAriaLabel in every locale to drop the email qualifier.
- Updates the jobs page tests to assert three Apply buttons, the YC hrefs, and the absence of the mailto link and "YC Work at a Startup".

<sup>Written for commit 0221d046daef00447fc6e346333b210719542729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Job application buttons now link directly to the relevant external job listing and open in a new tab.
  - Application wording across supported languages now uses generic “Apply” labels instead of email-specific text.

- **Bug Fixes**
  - Removed the separate secondary startup-jobs link from job pages.

- **Tests**
  - Updated coverage for external application links and localized apply labels across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->