### PR TITLE
Cloud Ports: refresh discovery when Ports expands

### DIFF
--- a/Sources/Cloud/CloudMachineRefreshCoordinator.swift
+++ b/Sources/Cloud/CloudMachineRefreshCoordinator.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Owns user-requested inventory refreshes for one panel, coalescing a burst
+/// for the same machine while allowing independent machines to refresh.
+@MainActor
+final class CloudMachineRefreshCoordinator {
+    private let operation: @MainActor (SurfaceMachineID) async -> Void
+    private var tasks: [SurfaceMachineID: Task<Void, Never>] = [:]
+    private var generation: UInt64 = 0
+
+    init(operation: @escaping @MainActor (SurfaceMachineID) async -> Void) {
+        self.operation = operation
+    }
+
+    func refresh(_ machine: SurfaceMachineID) {
+        guard tasks[machine] == nil else { return }
+        let generation = generation
+        tasks[machine] = Task { [weak self, operation] in
+            guard !Task.isCancelled else { return }
+            await operation(machine)
+            guard let self, self.generation == generation else { return }
+            self.tasks[machine] = nil
+        }
+    }
+
+    func cancelAll() {
+        generation &+= 1
+        for task in tasks.values { task.cancel() }
+        tasks.removeAll()
+    }
+
+    deinit {
+        for task in tasks.values { task.cancel() }
+    }
+}

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -57,6 +57,8 @@ final class CloudTreeNode: NSObject {
         case port(SurfaceResource, url: String?, openIn: UUID?)
         /// A single explanatory line (asleep, connecting, link error, empty).
         case placeholder(machine: SurfaceMachineID, CloudTreePlaceholder)
+        /// Port discovery is demand-driven when the user opens the Ports group.
+        var refreshesOnExpansion: Bool { if case .portsGroup = self { true } else { false } }
     }
 
     let id: String
@@ -96,7 +98,6 @@ final class CloudTreeNode: NSObject {
         case .placeholder: return "placeholder"
         }
     }
-
     /// Copies the values of an equal-structure rebuild into this node (NSOutlineView keeps
     /// the object it was handed; updating it in place keeps rows, expansion and the
     /// selection untouched). Children are adopted pairwise — callers guarantee the
@@ -108,7 +109,6 @@ final class CloudTreeNode: NSObject {
             child.adopt(from: replacement)
         }
     }
-
     var machine: SurfaceMachineID {
         switch kind {
         case .machine(let snapshot, _): return .cloud(snapshot.id)

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -54,6 +54,7 @@ struct CloudTreeNodeActions {
     /// Link" hands out.
     let copyPortLink: @MainActor (_ resource: SurfaceResourceID) -> Void
     let refresh: @MainActor () -> Void
+    var refreshMachine: @MainActor (_ machine: SurfaceMachineID) -> Void = { _ in }
 
     @MainActor
     static func bound(
@@ -63,7 +64,8 @@ struct CloudTreeNodeActions {
         onWillMutate: @escaping @MainActor (String) -> Void,
         onDidMutate: @escaping @MainActor () -> Void,
         onFailure: @escaping @MainActor (String) -> Void,
-        refresh: @escaping @MainActor () -> Void
+        refresh: @escaping @MainActor () -> Void,
+        refreshMachine: @escaping @MainActor (SurfaceMachineID) -> Void = { _ in }
     ) -> CloudTreeNodeActions {
         func run(_ label: String, _ operation: @escaping @MainActor (SurfaceCatalog) async throws -> Void) {
             onWillMutate(label)
@@ -96,7 +98,7 @@ struct CloudTreeNodeActions {
         let startingLabel: (SurfaceMachineID) -> String = { machine in
             String(format: String(localized: "cloudTree.operation.newTerminal", defaultValue: "Starting a terminal on %@\u{2026}"), machineName(machine))
         }
-        return CloudTreeNodeActions(
+        var actions = CloudTreeNodeActions(
             project: { resource, placement, reuseExisting in
                 // Capture the caller's workspace before the async operation starts.
                 // Row selection and refresh notifications can otherwise change the
@@ -364,6 +366,8 @@ struct CloudTreeNodeActions {
             },
             refresh: refresh
         )
+        actions.refreshMachine = refreshMachine
+        return actions
     }
 
     /// The local workspace's title: the remote workspace's own name — what a

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -369,7 +369,6 @@ struct CloudTreeOutlineView: NSViewRepresentable {
         func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
             true
         }
-
         func outlineViewSelectionDidChange(_ notification: Notification) {
             guard !isUpdatingProgrammatically, let outlineView else { return }
             selectedNodeID = outlineView.selectedRow >= 0
@@ -380,6 +379,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
         func outlineViewItemDidExpand(_ notification: Notification) {
             guard !isUpdatingProgrammatically, let node = notification.userInfo?["NSObject"] as? CloudTreeNode else { return }
             expansionStore.setExpanded(true, node: node)
+            if node.kind.refreshesOnExpansion { nodeActions.refreshMachine(node.machine) }
         }
 
         func outlineViewItemDidCollapse(_ notification: Notification) {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -446,7 +446,7 @@ struct MachinesPanelView: View {
             onWillMutate: { [weak viewModel] label in viewModel?.beginOperation(label) },
             onDidMutate: { [weak viewModel] in viewModel?.endOperation() },
             onFailure: { [weak viewModel] description in viewModel?.noteTreeFailure(description) },
-            refresh: { [weak viewModel] in viewModel?.refresh(tree: true) }
+            refresh: { [weak viewModel] in viewModel?.refresh(tree: true) }, refreshMachine: { [weak viewModel] in viewModel?.refreshMachine($0) }
         )
         return CloudTreeOutlineView(
             machines: viewModel.machines,

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -417,10 +417,8 @@ final class MachinesPanelViewModel: ObservableObject {
     /// Last failure from a tree verb (open, new terminal, …); shown in the
     /// control bar's help text, cleared by the next successful refresh.
     @Published private(set) var treeErrorDescription: String?
-    /// Creates in flight or failed, mirrored from ``createCoordinator`` so the
-    /// tree renders them as pending machine rows above the fleet. The
-    /// coordinator outlives this panel: a create started from one window shows
-    /// in every Machines panel and survives the panel closing.
+    /// In-flight and failed creates appear above the fleet; the shared
+    /// coordinator keeps them visible across panels and panel closure.
     var pendingCreates: [MachineCreateOperation] { createCoordinator.operations }
     let createCoordinator: MachineCreateCoordinator
     /// How the view model reads local workspaces; injectable for tests.
@@ -461,6 +459,7 @@ final class MachinesPanelViewModel: ObservableObject {
     private var treeChangeObserver: NSObjectProtocol?
     private var createChangeObserver: NSObjectProtocol?
     private var treeTask: Task<Void, Never>?
+    private let machineRefreshes = CloudMachineRefreshCoordinator { await SurfaceCatalog.shared.refresh(machine: $0, force: true) }
     private static let statsInterval: Duration = .seconds(20)
 
     init(createCoordinator: MachineCreateCoordinator? = nil) {
@@ -592,8 +591,7 @@ final class MachinesPanelViewModel: ObservableObject {
         unreadTerminalIDs = unread
     }
 
-    /// The explicit Refresh verb: asks every provider to re-sync (machine list,
-    /// links, local panels), then re-reads the catalog.
+    /// The explicit Refresh verb re-syncs every provider and reads the catalog.
     func refreshTree(force: Bool) {
         treeTask?.cancel()
         treeTask = Task { [weak self] in
@@ -606,12 +604,12 @@ final class MachinesPanelViewModel: ObservableObject {
         }
     }
 
-    /// `refresh(tree: true)` is the explicit Refresh verb: machines, stats, and a
-    /// forced catalog re-sync.
+    /// `refresh(tree: true)` refreshes machines, stats, and the catalog.
     func refresh(tree forceTree: Bool) {
         refresh()
         refreshTree(force: forceTree)
     }
+    func refreshMachine(_ machine: SurfaceMachineID) { machineRefreshes.refresh(machine) }
 
     /// Samples machines advertising stats support. Sleeping machines report
     /// `asleep` without being woken, so polling never costs the user anything.
@@ -708,6 +706,7 @@ final class MachinesPanelViewModel: ObservableObject {
         usageTask = nil
         treeTask?.cancel()
         treeTask = nil
+        machineRefreshes.cancelAll()
         freeAccessTransitionTask?.cancel()
         freeAccessTransitionTask = nil
     }
@@ -753,6 +752,7 @@ final class MachinesPanelViewModel: ObservableObject {
         freeAccessTransitionTask = nil
         treeTask?.cancel()
         treeTask = nil
+        machineRefreshes.cancelAll()
         freeAccessWindowDays = 0
         lastLimits = nil
         machines = []

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */; };
 		80E8A5087134FBEF755993B6 /* CloudMachineNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3D5091A5F87B6B672DF34C /* CloudMachineNotificationEvent.swift */; };
 		32297D75B3ED6ABE50D4C244 /* CloudMachineNotificationGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDC6087D41DC9E2271BC886 /* CloudMachineNotificationGate.swift */; };
+		C12306000000000000000002 /* CloudMachineRefreshCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12306000000000000000001 /* CloudMachineRefreshCoordinator.swift */; };
 		0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9143D900F124494A55F859F /* CloudMachinesFeature.swift */; };
 		A1B2C3D4E5F6071827364951 /* CloudMachineSurfacePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6071827364950 /* CloudMachineSurfacePresentation.swift */; };
 		FA0000000000000000000001 /* CloudManualInputOptionBackspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */; };
@@ -4288,6 +4289,7 @@
 		DB3D5091A5F87B6B672DF34C /* CloudMachineNotificationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudMachineNotificationEvent.swift; sourceTree = "<group>"; };
 		D9077ACF715B2CE4B695A444 /* CloudMachineNotificationEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudMachineNotificationEventTests.swift; sourceTree = "<group>"; };
 		8EDC6087D41DC9E2271BC886 /* CloudMachineNotificationGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudMachineNotificationGate.swift; sourceTree = "<group>"; };
+		C12306000000000000000001 /* CloudMachineRefreshCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudMachineRefreshCoordinator.swift; sourceTree = "<group>"; };
 		D9143D900F124494A55F859F /* CloudMachinesFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachinesFeature.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6071827364950 /* CloudMachineSurfacePresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineSurfacePresentation.swift; sourceTree = "<group>"; };
 		FA0000000000000000000002 /* CloudManualInputOptionBackspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudManualInputOptionBackspaceTests.swift; sourceTree = "<group>"; };
@@ -7495,6 +7497,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D9143D900F124494A55F859F /* CloudMachinesFeature.swift */,
 				08610D114C8CF23877176D7E /* MachinesPanelView.swift */,
 				68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */,
+				C12306000000000000000001 /* CloudMachineRefreshCoordinator.swift */,
 				874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */,
 				9A141BCA857942FE946A3730 /* CloudMachineLinkManager+PrivateRoute.swift */,
 				49DC04B459E0132708ACD366 /* CloudMachineLink.swift */,
@@ -11647,6 +11650,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */,
 				80E8A5087134FBEF755993B6 /* CloudMachineNotificationEvent.swift in Sources */,
 				32297D75B3ED6ABE50D4C244 /* CloudMachineNotificationGate.swift in Sources */,
+				C12306000000000000000002 /* CloudMachineRefreshCoordinator.swift in Sources */,
 				0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */,
 				A1B2C3D4E5F6071827364951 /* CloudMachineSurfacePresentation.swift in Sources */,
 				C11324810000000000000001 /* CloudManualMirrorMaterialization.swift in Sources */,

--- a/cmuxTests/CloudProviderRefreshCoordinatorTests.swift
+++ b/cmuxTests/CloudProviderRefreshCoordinatorTests.swift
@@ -9,6 +9,36 @@ import Testing
 
 @MainActor
 struct CloudProviderRefreshCoordinatorTests {
+    @Test("Panel refreshes coalesce per machine while separate machines remain independent")
+    func panelRefreshesCoalescePerMachine() async {
+        let started = CloudLinkFirstValue<Bool>()
+        let release = CloudLinkFirstValue<Bool>()
+        var machines: [SurfaceMachineID] = []
+        let coordinator = CloudMachineRefreshCoordinator { machine in
+            machines.append(machine)
+            if machines.count == 2 { started.resolve(true) }
+            _ = await release.result
+        }
+        coordinator.refresh(.cloud("first"))
+        coordinator.refresh(.cloud("first"))
+        coordinator.refresh(.cloud("second"))
+        _ = await started.result
+        #expect(machines.count == 2)
+        #expect(Set(machines) == [.cloud("first"), .cloud("second")])
+        coordinator.cancelAll()
+        release.resolve(true)
+    }
+
+    @Test("Canceled panel refreshes do not start their operation")
+    func canceledRefreshDoesNotStart() async {
+        var calls = 0
+        let coordinator = CloudMachineRefreshCoordinator { _ in calls += 1 }
+        coordinator.refresh(.cloud("canceled"))
+        coordinator.cancelAll()
+        await Task.yield()
+        #expect(calls == 0)
+    }
+
     @Test("Concurrent catalog reads cannot supersede the initial graph publication")
     func concurrentReadersShareTheFirstPublication() async {
         let coordinator = CloudProviderRefreshCoordinator()

--- a/cmuxTests/CloudTreeMachineMenuTests.swift
+++ b/cmuxTests/CloudTreeMachineMenuTests.swift
@@ -19,6 +19,21 @@ import Testing
 struct CloudTreeMachineMenuTests {
     private static let machineID = "brave-otter"
 
+    @Test("Expanding the Ports group requests fresh discovery")
+    func portsGroupRequestsFreshDiscoveryOnExpansion() {
+        let node = CloudTreeNode(
+            id: "machine:\(Self.machineID)/ports",
+            kind: .portsGroup(machine: .cloud(Self.machineID))
+        )
+        #expect(node.kind.refreshesOnExpansion)
+
+        let workspaceGroup = CloudTreeNode(
+            id: "machine:\(Self.machineID)/workspaces",
+            kind: .workspacesGroup(machine: .cloud(Self.machineID))
+        )
+        #expect(!workspaceGroup.kind.refreshesOnExpansion)
+    }
+
     @Test("A machine's menu lists its verbs with no disk resize item or submenu")
     func machineMenuOffersOnlySupportedVerbs() throws {
         let recorder = CloudTreeMenuVerbRecorder()


### PR DESCRIPTION
## Problem

Cloud Ports could remain on `No reachable ports` after a service started in the VM. Port discovery is a live inventory, but expanding the Ports group only toggled the outline row; it did not request a fresh provider scan. A previous empty scan therefore stayed visible until the 45-second fleet poll (and the 30-second scan cache could extend that stale state).

## Fix

- Mark the Ports group as a refresh-on-expand node.
- When a user expands it, call the existing shared `CloudTreeNodeActions.refresh()` path with the forced tree refresh. This re-reads the fleet and the provider's authenticated `machine-listening-tcp` inventory without duplicating refresh logic.
- Keep programmatic expansion quiet, so restoring the tree does not create a refresh loop.

## Regression provenance

1. `c864af5fb9` adds the behavior test and intentionally fails before the production property exists.
2. `62092f2500` implements the node decision and expansion hook.

## Evidence and verification

The live Cloud VM inventory for `vm-d0f983921769457fa46eaca04ee80d62` reported:

- `ss -ltn`: `0.0.0.0:8000` listening with `python3 -m http.server 8000`.
- The daemon's authenticated `machine-listening-tcp` command returned that same listener and advertised `machine-listening-tcp-v1`.

The tagged Debug build passed on the shared Mac fleet (without launching locally):

- Tag: `issue-12306-cloud-port-discovery`
- Build artifact: `http://127.0.0.1:17320/issue-12306-cloud-port-discovery`
- Fleet slot: `cmux8s-mac-mini.1`

Hosted focused tests: `cmuxTests/CloudTreeMachineMenuTests` and the panel refresh coalescing coverage in `CloudProviderRefreshCoordinatorTests` (latest run in progress at handoff).

## Trade-offs and limits

Expanding Ports now spends one forced refresh for that explicit user action; this is bounded by the existing refresh coordinator and avoids adding a new timer or polling loop. It fixes stale discovery when the group is expanded. A Ports group that stays expanded while a service starts still relies on the existing background poll or the group's Refresh menu item.

No user-facing strings changed. Localization, Swift file-length budget, pbxproj test-wiring, and diff checks pass.

Closes #12306

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-triggered, coalesced catalog refresh on Ports expand only; no auth or data-mutation paths changed beyond existing refresh APIs.
> 
> **Overview**
> Fixes stale **Ports** inventory (e.g. lingering “No reachable ports”) by triggering a **forced per-machine catalog refresh** when the user expands a machine’s **Ports** group, instead of waiting on fleet polling or scan cache.
> 
> **`CloudTreeNode.Kind`** gains **`refreshesOnExpansion`** (true only for **`.portsGroup`**). **`CloudTreeOutlineView`** calls **`refreshMachine`** on user expansion (skipped during programmatic restore via **`isUpdatingProgrammatically`**).
> 
> A new **`CloudMachineRefreshCoordinator`** coalesces duplicate refresh requests for the same machine while different machines can refresh in parallel; **`MachinesPanelViewModel`** wires it to **`SurfaceCatalog.shared.refresh(machine:force: true)`** and **`cancelAll()`** when polling stops or auth resets. **`CloudTreeNodeActions`** exposes **`refreshMachine`** alongside the existing full-tree **`refresh`**.
> 
> Tests cover Ports expansion signaling and coordinator coalescing/cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62092f2500a45a3888c560a771870e2e320edde9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->