### PR TITLE
Fix cloud terminal reconnect stalls during output bursts

### DIFF
--- a/Sources/Cloud/CloudTuiManualIOConnection.swift
+++ b/Sources/Cloud/CloudTuiManualIOConnection.swift
@@ -39,6 +39,8 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
     private var startContinuation: CheckedContinuation<Void, Error>?
     private var pendingLine = Data()
     private var pendingLineSearchOffset = 0
+    // This storage is queue-owned and reused for every socket read.
+    private var readBuffer = [UInt8](repeating: 0, count: Self.readChunkBytes)
     private var pendingWrites: [Data] = []
     private var pendingWriteOffset = 0
     private var pendingWriteBytes = 0
@@ -247,7 +249,6 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
 
     private func readAvailableLocked() {
         guard !closed, isConnected, descriptor >= 0, nextFrameContinuation != nil else { return }
-        var bytes = [UInt8](repeating: 0, count: Self.readChunkBytes)
         while !closed {
             while let newline = pendingLine[
                 pendingLine.index(pendingLine.startIndex, offsetBy: pendingLineSearchOffset)...
@@ -276,9 +277,11 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
                 closeLocked()
                 return
             }
-            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            let count = readBuffer.withUnsafeMutableBytes { buffer in
+                Darwin.read(descriptor, buffer.baseAddress, buffer.count)
+            }
             if count > 0 {
-                pendingLine.append(bytes, count: count)
+                pendingLine.append(readBuffer, count: count)
                 continue
             }
             if count == 0 {

--- a/Sources/Cloud/CloudTuiManualIOConnection.swift
+++ b/Sources/Cloud/CloudTuiManualIOConnection.swift
@@ -8,29 +8,37 @@ import Foundation
 /// utility queue so Ghostty's main actor and input path never wait on a file
 /// descriptor or parse a large output burst.
 // @unchecked Sendable is safe here because every mutable descriptor/source/
-// framing field is accessed only on `queue`; the AsyncStream continuation is
-// the sole cross-thread handoff and carries immutable `Data` values.
+// framing field and pending demand are accessed only on `queue`. Continuations
+// hand immutable frames back to the single async consumer.
 final class CloudTuiManualIOConnection: @unchecked Sendable {
     private static let maximumLineBytes = 16 * 1024 * 1024
-    // One frame can be a protocol-sized replay. Keep the stream's retained
-    // payload bounded to four such frames; a fifth frame closes the attachment
-    // and lets the owner reconnect from a fresh snapshot instead of growing
-    // memory while the main actor is stalled.
-    private static let maximumBufferedFrames = 4
+    private static let readChunkBytes = 16 * 1024
 
     private let socketPath: String
     private let queue: DispatchQueue
     private let commandBuilder: CloudTuiManualIOCommand
-    let events: AsyncStream<CloudTuiManualIOFrame>
-    private let eventsContinuation: AsyncStream<CloudTuiManualIOFrame>.Continuation
+
+    /// Single-consumer stream. Each next() requests one frame, so a busy renderer
+    /// applies socket backpressure instead of overflowing a decoded-frame queue.
+    var events: AsyncStream<CloudTuiManualIOFrame> {
+        AsyncStream(unfolding: { [weak self] in
+            await self?.nextFrame()
+        }, onCancel: { [weak self] in
+            self?.close()
+        })
+    }
+
+    private var nextFrameContinuation: CheckedContinuation<CloudTuiManualIOFrame?, Never>?
     private var descriptor: Int32 = -1
     private var isConnected = false
     private var readSource: DispatchSourceRead?
+    private var readSourceSuspended = false
     private var writeSource: DispatchSourceWrite?
     private var writeSourceSuspended = true
     private var descriptorLease: CloudTuiManualIODescriptorLease?
     private var startContinuation: CheckedContinuation<Void, Error>?
     private var pendingLine = Data()
+    private var pendingLineSearchOffset = 0
     private var pendingWrites: [Data] = []
     private var pendingWriteOffset = 0
     private var pendingWriteBytes = 0
@@ -48,15 +56,25 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         self.socketPath = socketPath
         self.queue = queue
         self.commandBuilder = commandBuilder
-        // A stalled Ghostty parser must not let a remote output burst grow an
-        // unbounded in-memory queue. Dropping a frame would corrupt the VT
-        // stream, so the bounded overflow edge closes this attachment and lets
-        // the owner reconnect from a fresh snapshot.
-        (events, eventsContinuation) = AsyncStream<CloudTuiManualIOFrame>.makeStream(
-            bufferingPolicy: .bufferingOldest(Self.maximumBufferedFrames)
-        )
-        eventsContinuation.onTermination = { [weak self] _ in
-            self?.close()
+    }
+
+    private func nextFrame() async -> CloudTuiManualIOFrame? {
+        guard !Task.isCancelled else {
+            close()
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                guard !closed, nextFrameContinuation == nil else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                nextFrameContinuation = continuation
+                resumeReadSourceLocked()
+                // A previous read may already contain the next complete line;
+                // do not depend on another socket-readability notification.
+                readAvailableLocked()
+            }
         }
     }
 
@@ -169,6 +187,9 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         // descriptor and close it exactly once.
         source.activate()
         writeSource.activate()
+        if nextFrameContinuation == nil {
+            suspendReadSourceLocked()
+        }
 
         var address = try Self.unixAddress(path: socketPath)
         let addressLength = socklen_t(Self.unixAddressLength(address: address))
@@ -214,6 +235,7 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         let continuation = startContinuation
         startContinuation = nil
         continuation?.resume()
+        readAvailableLocked()
     }
 
     private func failStartLocked(_ error: Error) {
@@ -224,35 +246,39 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
     }
 
     private func readAvailableLocked() {
-        guard !closed, isConnected, descriptor >= 0 else { return }
-        var bytes = [UInt8](repeating: 0, count: 16 * 1024)
+        guard !closed, isConnected, descriptor >= 0, nextFrameContinuation != nil else { return }
+        var bytes = [UInt8](repeating: 0, count: Self.readChunkBytes)
         while !closed {
-            let count = Darwin.read(descriptor, &bytes, bytes.count)
-            if count > 0 {
-                pendingLine.append(bytes, count: count)
-                guard pendingLine.count <= Self.maximumLineBytes else {
+            while let newline = pendingLine[
+                pendingLine.index(pendingLine.startIndex, offsetBy: pendingLineSearchOffset)...
+            ].firstIndex(of: 0x0A) {
+                guard pendingLine.distance(from: pendingLine.startIndex, to: newline) <= Self.maximumLineBytes else {
                     closeLocked()
                     return
                 }
-                while let newline = pendingLine.firstIndex(of: 0x0A) {
-                    let line = Data(pendingLine[..<newline])
-                    pendingLine.removeSubrange(...newline)
-                    if !line.isEmpty {
-                        guard let frame = CloudTuiManualIOFrameDecoder().decode(line) else {
-                            continue
-                        }
-                        switch eventsContinuation.yield(frame) {
-                        case .enqueued:
-                            break
-                        case .dropped, .terminated:
-                            closeLocked()
-                            return
-                        @unknown default:
-                            closeLocked()
-                            return
-                        }
-                    }
-                }
+                let line = Data(pendingLine[..<newline])
+                pendingLine.removeSubrange(...newline)
+                pendingLineSearchOffset = 0
+                guard !line.isEmpty,
+                      let frame = CloudTuiManualIOFrameDecoder().decode(line) else { continue }
+                let continuation = nextFrameContinuation
+                nextFrameContinuation = nil
+                suspendReadSourceLocked()
+                continuation?.resume(returning: frame)
+                return
+            }
+            // Only newly read bytes need scanning while a large line arrives.
+            pendingLineSearchOffset = pendingLine.count
+            // Retain at most one protocol-sized unfinished line plus one read
+            // chunk. Complete frames stay in the socket until next() requests
+            // them; kernel/link backpressure bounds a stalled consumer's memory.
+            guard pendingLine.count <= Self.maximumLineBytes else {
+                closeLocked()
+                return
+            }
+            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            if count > 0 {
+                pendingLine.append(bytes, count: count)
                 continue
             }
             if count == 0 {
@@ -264,6 +290,18 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
             closeLocked()
             return
         }
+    }
+
+    private func resumeReadSourceLocked() {
+        guard readSourceSuspended, let readSource else { return }
+        readSourceSuspended = false
+        readSource.resume()
+    }
+
+    private func suspendReadSourceLocked() {
+        guard !readSourceSuspended, let readSource else { return }
+        readSourceSuspended = true
+        readSource.suspend()
     }
 
     private func flushWritesLocked() {
@@ -320,6 +358,7 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         closed = true
         isConnected = false
         pendingLine.removeAll(keepingCapacity: false)
+        pendingLineSearchOffset = 0
         pendingWrites.removeAll(keepingCapacity: false)
         pendingWriteOffset = 0
         pendingWriteBytes = 0
@@ -334,6 +373,10 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         }
         writeSource?.cancel()
         let source = readSource
+        if readSourceSuspended {
+            readSourceSuspended = false
+            source?.resume()
+        }
         readSource = nil
         self.descriptor = -1
         source?.cancel()
@@ -346,7 +389,9 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
         }
         let continuation = startContinuation
         startContinuation = nil
-        eventsContinuation.finish()
+        let frameContinuation = nextFrameContinuation
+        nextFrameContinuation = nil
+        frameContinuation?.resume(returning: nil)
         continuation?.resume(throwing: CancellationError())
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -752,6 +752,7 @@
 		C11322C10000000000000001 /* CloudTuiLegacySnapshotParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11322C20000000000000001 /* CloudTuiLegacySnapshotParser.swift */; };
 		C11324110000000000000001 /* CloudTuiManualIOCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11324120000000000000001 /* CloudTuiManualIOCommand.swift */; };
 		C11322D10000000000000001 /* CloudTuiManualIOConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11322D20000000000000001 /* CloudTuiManualIOConnection.swift */; };
+		A838AA211BDA47268C683501 /* CloudTuiManualIOConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838AA211BDA47268C683502 /* CloudTuiManualIOConnectionTests.swift */; };
 		C11324310000000000000001 /* CloudTuiManualIODescriptorLease.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11324320000000000000001 /* CloudTuiManualIODescriptorLease.swift */; };
 		C11324410000000000000001 /* CloudTuiManualIOFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11324420000000000000001 /* CloudTuiManualIOFrame.swift */; };
 		C11324010000000000000001 /* CloudTuiManualIOFrameDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11324020000000000000001 /* CloudTuiManualIOFrameDecoder.swift */; };
@@ -4337,6 +4338,7 @@
 		C11322C20000000000000001 /* CloudTuiLegacySnapshotParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiLegacySnapshotParser.swift; sourceTree = "<group>"; };
 		C11324120000000000000001 /* CloudTuiManualIOCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIOCommand.swift; sourceTree = "<group>"; };
 		C11322D20000000000000001 /* CloudTuiManualIOConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIOConnection.swift; sourceTree = "<group>"; };
+		A838AA211BDA47268C683502 /* CloudTuiManualIOConnectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIOConnectionTests.swift; sourceTree = "<group>"; };
 		C11324320000000000000001 /* CloudTuiManualIODescriptorLease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIODescriptorLease.swift; sourceTree = "<group>"; };
 		C11324420000000000000001 /* CloudTuiManualIOFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIOFrame.swift; sourceTree = "<group>"; };
 		C11324020000000000000001 /* CloudTuiManualIOFrameDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIOFrameDecoder.swift; sourceTree = "<group>"; };
@@ -10194,6 +10196,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				EC905DADF2BA91C8C865D37B /* PaneFocusTestWindow.swift */,
 				E960400B0C66CA43D219BC5B /* PaneFocusFindResponderTests.swift */,
 				FCBB7EB399B58A6D076EAF1E /* CloudWorkspaceLayoutTranslatorTests.swift */,
+				A838AA211BDA47268C683502 /* CloudTuiManualIOConnectionTests.swift */,
 				64CB7AF7545F56E95A91B154 /* CloudNotificationSyncTests.swift */,
 				5C2A7143303749BE82E51F69 /* CloudProviderRefreshCoordinatorTests.swift */,
 				7EFB9C9E7B5D4F39873871A1 /* CloudVMStateSnapshotComparisonTests.swift */,
@@ -13945,6 +13948,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B5C68F2FAFD21A103AFF429D /* CloudTreeMachineMenuTests.swift in Sources */,
 				C986A0030000000000000001 /* CloudTreeNativeDragOwnershipTests.swift in Sources */,
 				45F29E8BB64E4EE4BF204AC7 /* CloudTreeOneMachineManyWorkspacesTests.swift in Sources */,
+				A838AA211BDA47268C683501 /* CloudTuiManualIOConnectionTests.swift in Sources */,
 				7A0CE1000000000000000106 /* CloudTunnelBackendSelectorTests.swift in Sources */,
 				7A0CE1000000000000000730 /* CloudTunnelBannerTests.swift in Sources */,
 				7A0CE1000000000000000602 /* CloudTunnelBroadcastTests.swift in Sources */,

--- a/cmuxTests/CloudTuiManualIOConnectionTests.swift
+++ b/cmuxTests/CloudTuiManualIOConnectionTests.swift
@@ -61,6 +61,39 @@ import Testing
         }
     }
 
+    @Test func cancellingWhileWaitingForTheRestOfALineFinishes() async throws {
+        try await Self.withConnection { connection, peer in
+            var sendBuffer: Int32 = 4096
+            setsockopt(peer, SOL_SOCKET, SO_SNDBUF, &sendBuffer, socklen_t(MemoryLayout<Int32>.size))
+            let consumer = Task {
+                var iterator = connection.events.makeAsyncIterator()
+                return await iterator.next()
+            }
+            // More than the peer can buffer: completion proves the consumer
+            // has started reading and is waiting for an unfinished JSON line.
+            try await Self.blocking { try Self.write(peer, Data(repeating: 0x20, count: 128 * 1024)) }
+            consumer.cancel()
+            #expect(await consumer.value == nil)
+        }
+    }
+
+    @Test func oversizedLineClosesInsteadOfDeliveringLaterOutput() async throws {
+        try await Self.withConnection { connection, peer in
+            async let writer: Void = Self.blocking {
+                do {
+                    try Self.write(peer, Data(repeating: 0x20, count: 16 * 1024 * 1024 + 1))
+                    try Self.write(peer, Data("\n".utf8) + Self.outputLine(Data("after-limit".utf8)))
+                    shutdown(peer, SHUT_WR)
+                } catch let error as NSError where error.code == Int(EPIPE) || error.code == Int(ECONNRESET) {
+                    // A protocol limit violation is supposed to close the peer.
+                }
+            }
+            var iterator = connection.events.makeAsyncIterator()
+            #expect(await iterator.next() == nil)
+            try await writer
+        }
+    }
+
     @Test func closingWithBufferedOutputReleasesTheSocket() async throws {
         try await Self.withConnection { connection, peer in
             try Self.write(peer, Self.outputLine(Data("first".utf8)) + Self.outputLine(Data("second".utf8)))

--- a/cmuxTests/CloudTuiManualIOConnectionTests.swift
+++ b/cmuxTests/CloudTuiManualIOConnectionTests.swift
@@ -74,6 +74,8 @@ import Testing
             try await Self.blocking { try Self.write(peer, Data(repeating: 0x20, count: 128 * 1024)) }
             consumer.cancel()
             #expect(await consumer.value == nil)
+            let remaining = try await Self.blocking { try Self.readLine(peer) }
+            #expect(remaining.isEmpty)
         }
     }
 

--- a/cmuxTests/CloudTuiManualIOConnectionTests.swift
+++ b/cmuxTests/CloudTuiManualIOConnectionTests.swift
@@ -1,0 +1,158 @@
+import Darwin
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct CloudTuiManualIOConnectionTests {
+    @Test func burstSurvivesAConsumerWaitingForAnInputRoundTrip() async throws {
+        try await Self.withConnection { connection, peer in
+            let chunks = (0..<100).map { Data("\u{1b}[?2026hchunk-\($0)\u{1b}[?2026l".utf8) }
+            try Self.write(peer, chunks.reduce(into: Data()) { $0.append(Self.outputLine($1)) })
+            var iterator = connection.events.makeAsyncIterator()
+            var received: [Data] = []
+            if case let .output(_, bytes, _) = await iterator.next() {
+                received.append(bytes)
+            }
+
+            // Keep consumption stopped until the peer receives input. This is
+            // a causal gate, not a timing delay: the reader must permit writes
+            // while its consumer is busy, without dropping the queued burst.
+            connection.send(line: Data("input-round-trip\n".utf8))
+            let input = try await Self.blocking { try Self.readLine(peer) }
+            #expect(input == Data("input-round-trip\n".utf8))
+            shutdown(peer, SHUT_WR)
+            while let frame = await iterator.next() {
+                if case let .output(_, bytes, _) = frame { received.append(bytes) }
+            }
+            #expect(received == chunks)
+        }
+    }
+
+    @Test func preservesLargeFramesAcrossSocketReads() async throws {
+        try await Self.withConnection { connection, peer in
+            let chunks = (0..<8).map { Data(repeating: UInt8($0), count: 64 * 1024) }
+            async let writer: Void = Self.blocking {
+                for chunk in chunks { try Self.write(peer, Self.outputLine(chunk)) }
+                shutdown(peer, SHUT_WR)
+            }
+            var received: [Data] = []
+            for await frame in connection.events {
+                if case let .output(_, bytes, _) = frame { received.append(bytes) }
+            }
+            try await writer
+            #expect(received == chunks)
+        }
+    }
+
+    @Test func cancellingAnIdleConsumerClosesTheSocket() async throws {
+        try await Self.withConnection { connection, peer in
+            let consumer = Task {
+                var iterator = connection.events.makeAsyncIterator()
+                return await iterator.next()
+            }
+            consumer.cancel()
+            #expect(await consumer.value == nil)
+            let remaining = try await Self.blocking { try Self.readLine(peer) }
+            #expect(remaining.isEmpty)
+        }
+    }
+
+    @Test func closingWithBufferedOutputReleasesTheSocket() async throws {
+        try await Self.withConnection { connection, peer in
+            try Self.write(peer, Self.outputLine(Data("first".utf8)) + Self.outputLine(Data("second".utf8)))
+            var iterator = connection.events.makeAsyncIterator()
+            #expect(await iterator.next() != nil)
+            connection.close()
+            while await iterator.next() != nil {}
+            let remaining = try await Self.blocking { try Self.readLine(peer) }
+            #expect(remaining.isEmpty)
+        }
+    }
+
+    @Test func ignoresMalformedLinesWithoutLosingTheNextFrame() async throws {
+        try await Self.withConnection { connection, peer in
+            try Self.write(peer, Data("\nnot-json\n{}\n".utf8) + Self.outputLine(Data("valid".utf8)))
+            shutdown(peer, SHUT_WR)
+            var iterator = connection.events.makeAsyncIterator()
+            #expect(await iterator.next() == .output(surfaceID: 1, bytes: Data("valid".utf8)))
+            #expect(await iterator.next() == nil)
+        }
+    }
+
+    private static func outputLine(_ bytes: Data) -> Data {
+        Data("{\"event\":\"output\",\"surface\":1,\"data\":\"\(bytes.base64EncodedString())\"}\n".utf8)
+    }
+
+    private static func withConnection(
+        _ body: (CloudTuiManualIOConnection, Int32) async throws -> Void
+    ) async throws {
+        let path = "/tmp/cmux-io-\(UUID().uuidString.prefix(12)).sock"
+        let listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listener >= 0 else { throw socketError() }
+        defer { Darwin.close(listener); unlink(path) }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8CString)
+        withUnsafeMutableBytes(of: &address.sun_path) { target in
+            pathBytes.withUnsafeBytes { target.copyBytes(from: $0) }
+        }
+        let bound = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(listener, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(listener, 1) == 0 else { throw socketError() }
+        let connection = CloudTuiManualIOConnection(socketPath: path)
+        defer { connection.close() }
+        try await connection.start()
+        let peer = accept(listener, nil, nil)
+        guard peer >= 0 else { throw socketError() }
+        defer { Darwin.close(peer) }
+        var noSignal: Int32 = 1
+        setsockopt(peer, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout<Int32>.size))
+        // Deadlines fail broken fixtures instead of leaving a CI worker hung.
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        setsockopt(peer, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(peer, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        try await body(connection, peer)
+    }
+
+    private static func write(_ descriptor: Int32, _ data: Data) throws {
+        try data.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let count = Darwin.write(descriptor, raw.baseAddress!.advanced(by: offset), raw.count - offset)
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else { throw socketError() }
+                offset += count
+            }
+        }
+    }
+
+    private static func readLine(_ descriptor: Int32) throws -> Data {
+        var result = Data()
+        var byte: UInt8 = 0
+        while true {
+            let count = Darwin.read(descriptor, &byte, 1)
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else { throw socketError() }
+            if count == 0 { return result }
+            result.append(byte)
+            if byte == 0x0A { return result }
+        }
+    }
+
+    /// Blocking peer I/O stays off Swift's cooperative executor and the client's
+    /// dispatch queue. Each test owns its descriptors until these jobs finish.
+    private static func blocking<T: Sendable>(_ operation: @escaping @Sendable () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global().async { continuation.resume(with: Result { try operation() }) }
+        }
+    }
+
+    private static func socketError() -> NSError { NSError(domain: NSPOSIXErrorDomain, code: Int(errno)) }
+}


### PR DESCRIPTION
## Summary

Bursty cloud-terminal output can fill the four-frame `AsyncStream` queue and close the attachment even when those frames contain only a few hundred bytes. The resulting reconnect/replay cycle introduces pauses while using a remote terminal.

Make event delivery demand-driven: each iterator `next()` requests one decoded frame, and the read dispatch source pauses while the consumer processes it. Remaining bytes stay in the bounded socket/framing buffers, preserving output order and keeping the independent input-write path usable. Retain the 16 MiB line limit and balance suspended-source cancellation. Track the newline scan offset so an unfinished large line is scanned once as it arrives.

## Testing

- Separate regression commit: the original connection delivers only 5/100 chunks and fails the input round trip while consumption is paused.
- Fixed connection: seven Swift Testing tests pass in both Debug and Release, compiling the actual six transport source files in an isolated Swift 6 package. Covers burst ordering with an input round trip, large frames across reads, cancellation before and during a partial read, close while output is buffered, malformed lines, and oversized-line rejection.
- Replayed the captured Codex startup stream as one burst: all 106 output frames / 3,888 bytes arrive with both an immediate consumer and a 5 ms-per-frame consumer.
- Xcode test wiring lint passes; the suite is included in the existing `cmuxTests` target.
- Full tagged macOS app build passed from `c7b64be70` with Xcode 26.2, after installing the pinned Zig/Rust dependencies and verified GhosttyKit. `./scripts/reload.sh --tag cloud-terminal-backpressure` completed successfully.

## Demo Video

No GUI recording yet. This change is verified at the socket/event-stream boundary; it does not claim to fix a specific graphical artifact. The regression fixture provides a deterministic executable reproduction without a cloud account.

## Checklist

- [x] Tested the transport change locally
- [x] Added behavior regression coverage
- [x] Audited localization: no user-facing strings changed
- [x] Full tagged app build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cloud terminal socket transport and async frame delivery; behavior change is intentional but regression-tested and affects live remote terminal I/O.
> 
> **Overview**
> Fixes cloud terminal pauses during output bursts by changing how **`CloudTuiManualIOConnection`** delivers decoded frames.
> 
> Instead of a **four-frame buffered `AsyncStream`** that closed the attachment when the renderer fell behind, **`events`** is now a single-consumer stream where each **`next()`** pulls one frame via **`nextFrame()`** and a continuation. The read dispatch source **only runs while a consumer is waiting**, suspends after handing off a frame, and leaves further bytes in the socket/framing buffer so **kernel backpressure** bounds memory instead of forcing reconnect/replay.
> 
> Read path tweaks include a **reused 16 KiB read buffer**, a **newline scan offset** for partial large lines, unchanged **16 MiB line cap**, and **read-source resume** on close (matching write-source handling). **`cmuxTests`** adds **`CloudTuiManualIOConnectionTests`** for bursts with input round-trips, large frames, cancellation, oversize lines, close, and malformed lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21b3206dbcbefae0ceae6888e3f714c9323c929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Manual I/O connections now deliver frames on demand, improving responsiveness and reducing unnecessary buffering.
  - Improved handling of burst traffic, large and oversized frames, consumer cancellation, malformed input, and socket closures.
  - Subsequent valid frames continue to be processed after malformed input.

- **Tests**
  - Added comprehensive coverage for manual I/O connection behavior across normal, high-volume, cancellation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->