### PR TITLE
feat: add optional Cloud VPN setup pane

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,1658 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "cloud.vpn.setup.heading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Cloud machines from any app"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-Maschinen aus jeder App verwenden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser les machines Cloud depuis toute app"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar máquinas Cloud desde cualquier app"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ほかのアプリからCloudマシンを使う"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从任何应用使用 Cloud 机器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從任何 App 使用 Cloud 機器"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 앱에서 Cloud 머신 사용"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام أجهزة Cloud من أي تطبيق"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional access to each VM's private address and original ports, such as 10.40.0.10:3000."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optionaler Zugriff auf die private Adresse und die ursprünglichen Ports jeder VM, etwa 10.40.0.10:3000."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès facultatif à chaque adresse privée et aux ports d’origine des VM, comme 10.40.0.10:3000."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso opcional a la dirección privada y los puertos originales de cada VM, como 10.40.0.10:3000."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各VMのプライベートアドレスと元のポート（例：10.40.0.10:3000）にアクセスするための任意の設定です。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选设置，用于访问每台 VM 的私有地址和原始端口，例如 10.40.0.10:3000。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選用設定，可存取每台 VM 的私有位址和原始連接埠，例如 10.40.0.10:3000。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 VM의 비공개 주소와 원래 포트(예: 10.40.0.10:3000)에 접근하기 위한 선택 설정입니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وصول اختياري إلى العنوان الخاص والمنافذ الأصلية لكل جهاز افتراضي، مثل 10.40.0.10:3000."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.howItWorks.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How it works"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "So funktioniert es"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionnement"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cómo funciona"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仕組み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作原理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運作方式"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작동 방식"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طريقة العمل"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.howItWorks.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Safari, Chrome, and other apps to your Cloud machines. Each machine keeps its private IP address and original ports. Only traffic to your Cloud network uses this encrypted connection. cmux terminals, Ports, and Desktop work without it."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden Sie Safari, Chrome und andere Apps mit Ihren Cloud-Maschinen. Jede Maschine behält ihre private IP-Adresse und ihre Ports. Nur Datenverkehr zu Ihrem Cloud-Netzwerk verwendet diese verschlüsselte Verbindung. Terminals, Ports und Desktop in cmux funktionieren auch ohne sie."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez Safari, Chrome et les autres apps à vos machines Cloud. Chaque machine conserve son adresse IP privée et ses ports. Seul le trafic vers votre réseau Cloud utilise cette connexion chiffrée. Les terminaux, Ports et Bureau de cmux fonctionnent sans elle."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecta Safari, Chrome y otras apps a tus máquinas Cloud. Cada máquina conserva su dirección IP privada y sus puertos. Solo el tráfico hacia tu red Cloud usa esta conexión cifrada. Los terminales, Puertos y Escritorio de cmux funcionan sin ella."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safari、ChromeなどのアプリをCloudマシンに接続します。各マシンはプライベートIPアドレスと元のポートを保持します。この暗号化された接続を使うのはCloudネットワーク宛ての通信だけです。cmuxのターミナル、ポート、デスクトップは、この接続がなくても使えます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 Safari、Chrome 和其他应用连接到您的 Cloud 机器。每台机器保留其私有 IP 地址和原始端口。只有发往 Cloud 网络的流量使用此加密连接。cmux 终端、端口和桌面无需此连接也可使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將 Safari、Chrome 和其他 App 連接至您的 Cloud 機器。每台機器保留其私有 IP 位址和原始連接埠。只有傳送至 Cloud 網路的流量會使用此加密連線。cmux 終端機、連接埠和桌面不需要此連線也能使用。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safari, Chrome 및 다른 앱을 Cloud 머신에 연결합니다. 각 머신은 비공개 IP 주소와 원래 포트를 유지합니다. Cloud 네트워크로 향하는 트래픽만 이 암호화된 연결을 사용합니다. cmux 터미널, 포트 및 데스크탑은 이 연결 없이도 작동합니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط Safari وChrome والتطبيقات الأخرى بأجهزة Cloud. يحتفظ كل جهاز بعنوان IP الخاص ومنافذه الأصلية. تستخدم حركة البيانات المتجهة إلى شبكة Cloud فقط هذا الاتصال المشفر. تعمل طرفيات cmux والمنافذ وسطح المكتب بدونه."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.permission.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The VPN software is included in cmux. You do not need another app. macOS may require your password or Touch ID during approval."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die VPN-Software ist in cmux enthalten. Sie brauchen keine weitere App. macOS kann bei der Genehmigung Ihr Passwort oder Touch ID verlangen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le logiciel VPN est inclus dans cmux. Aucune autre app n’est nécessaire. macOS peut demander votre mot de passe ou Touch ID lors de l’autorisation."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El software VPN está incluido en cmux. No necesitas otra app. macOS puede solicitar tu contraseña o Touch ID durante la autorización."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPNソフトウェアはcmuxに含まれています。別のアプリは不要です。承認時にmacOSがパスワードまたはTouch IDを求めることがあります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 已包含 VPN 软件，无需其他应用。批准时，macOS 可能要求您输入密码或使用触控 ID。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 已包含 VPN 軟體，不需要其他 App。核准時，macOS 可能要求您輸入密碼或使用 Touch ID。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN 소프트웨어는 cmux에 포함되어 있습니다. 다른 앱은 필요하지 않습니다. 승인 시 macOS에서 암호 또는 Touch ID를 요청할 수 있습니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برنامج VPN مضمن في cmux. لا تحتاج إلى تطبيق آخر. قد يطلب macOS كلمة المرور أو Touch ID أثناء الموافقة."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.status.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private network status"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status des privaten Netzwerks"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État du réseau privé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de la red privada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライベートネットワークの状態"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私有网络状态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私有網路狀態"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비공개 네트워크 상태"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالة الشبكة الخاصة"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.status.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off. Your Cloud panes continue to work through cmux's built-in route."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus. Ihre Cloud-Bereiche funktionieren weiterhin über die integrierte Verbindung von cmux."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé. Vos volets Cloud continuent de fonctionner via la connexion intégrée de cmux."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivada. Tus paneles Cloud siguen funcionando mediante la conexión integrada de cmux."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ。Cloudペインは引き続きcmux内蔵の接続経路で動作します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已关闭。Cloud 面板仍通过 cmux 内置连接工作。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已關閉。Cloud 面板仍透過 cmux 內建連線運作。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "꺼짐. Cloud 패널은 cmux의 내장 연결을 통해 계속 작동합니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوقف. تستمر لوحات Cloud في العمل عبر اتصال cmux المضمن."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続済み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已連線"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결됨"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متصل"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En espera"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待機中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기 중"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قيد الانتظار"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs attention"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktion erforderlich"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action requise"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere atención"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応が必要"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要处理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要處理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조치 필요"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب إجراءً"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已关闭"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已關閉"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "꺼짐"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوقف"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.disconnect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trennen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecter"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中斷連線"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 해제"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قطع الاتصال"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.connect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Cloud VPN"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-VPN verbinden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecter le VPN Cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar VPN de Cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPNに接続"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 Cloud VPN"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連接 Cloud VPN"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN 연결"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توصيل VPN الخاص بـ Cloud"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open System Settings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemeinstellungen öffnen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Réglages Système"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Ajustes del Sistema"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定を開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开系统设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開系統設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 설정 열기"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح إعدادات النظام"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First-time setup"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ersteinrichtung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Première configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración inicial"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "初回設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首次设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首次設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최초 설정"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعداد الأولي"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.extension": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Click Connect Cloud VPN. When macOS asks, allow the cmux network extension in System Settings."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Klicken Sie auf Cloud-VPN verbinden. Erlauben Sie auf Aufforderung von macOS die cmux-Netzwerkerweiterung in den Systemeinstellungen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Cliquez sur Connecter le VPN Cloud. Lorsque macOS le demande, autorisez l’extension réseau cmux dans Réglages Système."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Haz clic en Conectar VPN de Cloud. Cuando macOS lo solicite, permite la extensión de red de cmux en Ajustes del Sistema."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 「Cloud VPNに接続」をクリックします。macOSに求められたら、システム設定でcmuxのネットワーク機能拡張を許可します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 点击“连接 Cloud VPN”。macOS 提示时，在系统设置中允许 cmux 网络扩展。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 按一下「連接 Cloud VPN」。macOS 提示時，請在系統設定中允許 cmux 網路延伸功能。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Cloud VPN 연결을 클릭합니다. macOS에서 요청하면 시스템 설정에서 cmux 네트워크 확장을 허용합니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. انقر على توصيل VPN الخاص بـ Cloud. عندما يطلب macOS ذلك، اسمح بامتداد شبكة cmux في إعدادات النظام."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open General > Login Items & Extensions > Network Extensions, then enable cmux."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen Sie Allgemein > Anmeldeobjekte & Erweiterungen > Netzwerkerweiterungen und aktivieren Sie cmux."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez Général > Ouverture et extensions > Extensions réseau, puis activez cmux."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre General > Ítems de inicio y extensiones > Extensiones de red y activa cmux."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「一般」>「ログイン項目と機能拡張」>「ネットワーク機能拡張」を開き、cmuxを有効にします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开“通用”>“登录项与扩展”>“网络扩展”，然后启用 cmux。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開「一般」>「登入項目與延伸功能」>「網路延伸功能」，然後啟用 cmux。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반 > 로그인 항목 및 확장 프로그램 > 네트워크 확장을 열고 cmux를 활성화합니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح عام > عناصر الدخول والامتدادات > امتدادات الشبكة، ثم فعّل cmux."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.settingsLegacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Privacy & Security and allow the cmux extension."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen Sie Datenschutz & Sicherheit und erlauben Sie die cmux-Erweiterung."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez Confidentialité et sécurité et autorisez l’extension cmux."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre Privacidad y seguridad y permite la extensión de cmux."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「プライバシーとセキュリティ」を開き、cmuxの機能拡張を許可します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开“隐私与安全性”，然后允许 cmux 扩展。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開「隱私權與安全性」，然後允許 cmux 延伸功能。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인정보 보호 및 보안을 열고 cmux 확장을 허용합니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح الخصوصية والأمان واسمح بامتداد cmux."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.configuration": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Allow cmux to add a VPN configuration named cmux Cloud. This is a separate macOS permission."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Erlauben Sie cmux, eine VPN-Konfiguration namens cmux Cloud hinzuzufügen. Dies ist eine separate macOS-Berechtigung."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Autorisez cmux à ajouter une configuration VPN nommée cmux Cloud. Il s’agit d’une autorisation macOS distincte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Permite que cmux añada una configuración VPN llamada cmux Cloud. Este es un permiso independiente de macOS."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. cmux Cloudという名前のVPN構成の追加を許可します。これは別のmacOS権限です。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 允许 cmux 添加名为 cmux Cloud 的 VPN 配置。这是单独的 macOS 权限。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 允許 cmux 加入名為 cmux Cloud 的 VPN 設定。這是另一項 macOS 權限。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. cmux가 cmux Cloud라는 VPN 구성을 추가하도록 허용합니다. 이는 별도의 macOS 권한입니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. اسمح لـ cmux بإضافة إعداد VPN باسم cmux Cloud. هذا إذن منفصل في macOS."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.steps.return": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Return to this pane. The connection continues automatically after approval. Disconnect here when finished. Quitting cmux or signing out also disconnects it."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Kehren Sie zu diesem Bereich zurück. Die Verbindung wird nach der Genehmigung automatisch fortgesetzt. Trennen Sie sie hier, wenn Sie fertig sind. Das Beenden von cmux oder Abmelden trennt sie ebenfalls."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Revenez à ce volet. La connexion reprend automatiquement après autorisation. Déconnectez-la ici lorsque vous avez terminé. Quitter cmux ou fermer la session la déconnecte aussi."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Vuelve a este panel. La conexión continúa automáticamente tras la autorización. Desconéctala aquí cuando termines. Salir de cmux o cerrar sesión también la desconecta."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. このペインに戻ります。承認後、接続は自動的に続行されます。使い終わったらここで切断してください。cmuxの終了やサインアウトでも切断されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 返回此面板。批准后连接会自动继续。完成后可在此断开连接。退出 cmux 或退出登录也会断开连接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 返回此面板。核准後連線會自動繼續。完成後可在此中斷連線。結束 cmux 或登出也會中斷連線。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 이 패널로 돌아옵니다. 승인 후 연결이 자동으로 계속됩니다. 사용을 마치면 여기에서 연결을 해제하세요. cmux를 종료하거나 로그아웃해도 연결이 해제됩니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. ارجع إلى هذه اللوحة. يستمر الاتصال تلقائيًا بعد الموافقة. اقطع الاتصال هنا عند الانتهاء. يؤدي إنهاء cmux أو تسجيل الخروج أيضًا إلى قطع الاتصال."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.address.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private addresses"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private Adressen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adresses privées"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direcciones privadas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライベートアドレス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私有地址"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私有位址"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비공개 주소"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "العناوين الخاصة"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.address.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each machine has its own private IP. Two machines may both expose port 3000, for example 10.40.0.10:3000 and 10.40.0.11:3000. Right-click a Cloud port and choose Copy Private Address URL after connecting. These addresses are private, not public share links."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jede Maschine hat eine eigene private IP. Zwei Maschinen können beide Port 3000 verwenden, etwa 10.40.0.10:3000 und 10.40.0.11:3000. Klicken Sie nach dem Verbinden mit der rechten Maustaste auf einen Cloud-Port und wählen Sie URL der privaten Adresse kopieren. Diese Adressen sind privat und keine öffentlichen Freigabelinks."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chaque machine a sa propre IP privée. Deux machines peuvent utiliser le port 3000, par exemple 10.40.0.10:3000 et 10.40.0.11:3000. Après connexion, faites un clic droit sur un port Cloud et choisissez Copier l’URL de l’adresse privée. Ces adresses sont privées, ce ne sont pas des liens publics de partage."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada máquina tiene su propia IP privada. Dos máquinas pueden usar el puerto 3000, como 10.40.0.10:3000 y 10.40.0.11:3000. Después de conectar, haz clic derecho en un puerto Cloud y elige Copiar URL de dirección privada. Estas direcciones son privadas, no enlaces públicos para compartir."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各マシンには個別のプライベートIPがあります。2台のマシンがどちらもポート3000を使えます（例：10.40.0.10:3000と10.40.0.11:3000）。接続後にCloudポートを右クリックし、「プライベートアドレスURLをコピー」を選びます。これらはプライベートアドレスで、公開共有リンクではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每台机器都有自己的私有 IP。两台机器可以同时使用端口 3000，例如 10.40.0.10:3000 和 10.40.0.11:3000。连接后右键点击 Cloud 端口，选择“复制私有地址 URL”。这些地址是私有地址，不是公开分享链接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每台機器都有自己的私有 IP。兩台機器可以同時使用連接埠 3000，例如 10.40.0.10:3000 和 10.40.0.11:3000。連線後對 Cloud 連接埠按右鍵，選擇「複製私有位址 URL」。這些位址是私有位址，不是公開分享連結。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 머신에는 고유한 비공개 IP가 있습니다. 두 머신 모두 포트 3000을 사용할 수 있습니다(예: 10.40.0.10:3000 및 10.40.0.11:3000). 연결 후 Cloud 포트를 오른쪽 클릭하고 비공개 주소 URL 복사를 선택하세요. 이 주소는 비공개이며 공개 공유 링크가 아닙니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لكل جهاز عنوان IP خاص به. يمكن لجهازين استخدام المنفذ 3000، مثل 10.40.0.10:3000 و10.40.0.11:3000. بعد الاتصال، انقر بزر الماوس الأيمن على منفذ Cloud واختر نسخ رابط العنوان الخاص. هذه عناوين خاصة وليست روابط مشاركة عامة."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This copy of cmux does not include a signed VPN extension. Use a cmux release with Cloud VPN support. Cloud terminals, Ports, and Desktop remain available without the VPN."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese cmux-Version enthält keine signierte VPN-Erweiterung. Verwenden Sie eine cmux-Version mit Cloud-VPN-Unterstützung. Cloud-Terminals, Ports und Desktop bleiben ohne VPN verfügbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette copie de cmux ne contient pas d’extension VPN signée. Utilisez une version de cmux qui prend en charge le VPN Cloud. Les terminaux Cloud, Ports et Bureau restent disponibles sans VPN."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta copia de cmux no incluye una extensión VPN firmada. Usa una versión de cmux compatible con VPN de Cloud. Los terminales Cloud, Puertos y Escritorio siguen disponibles sin VPN."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このcmuxには署名済みのVPN機能拡張が含まれていません。Cloud VPN対応のcmuxリリースを使用してください。Cloudのターミナル、ポート、デスクトップはVPNなしでも使えます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 cmux 副本未包含已签名的 VPN 扩展。请使用支持 Cloud VPN 的 cmux 版本。Cloud 终端、端口和桌面无需 VPN 仍可使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 cmux 副本未包含已簽署的 VPN 延伸功能。請使用支援 Cloud VPN 的 cmux 版本。Cloud 終端機、連接埠和桌面不需要 VPN 仍可使用。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 cmux에는 서명된 VPN 확장이 포함되어 있지 않습니다. Cloud VPN을 지원하는 cmux 릴리스를 사용하세요. Cloud 터미널, 포트 및 데스크탑은 VPN 없이도 사용할 수 있습니다."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا تتضمن هذه النسخة من cmux امتداد VPN موقعًا. استخدم إصدار cmux يدعم VPN الخاص بـ Cloud. تظل طرفيات Cloud والمنافذ وسطح المكتب متاحة بدون VPN."
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-VPN"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN Cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN de Cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドVPN"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云端 VPN"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雲端 VPN"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 VPN"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شبكة Cloud الخاصة"
+          }
+        }
+      }
+    },
+    "machines.menu.setupVPN": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Up cmux VPN…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-VPN einrichten…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurer le VPN cmux…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar VPN de cmux…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux VPNを設定…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置 cmux VPN…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定 cmux VPN…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux VPN 설정…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعداد VPN الخاص بـ cmux…"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.entry.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional private IP access for other apps"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optionaler Zugriff auf private IPs für andere Apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès facultatif aux IP privées pour les autres apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso opcional a IP privadas para otras apps"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ほかのアプリからプライベートIPへアクセスする任意の設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为其他应用提供可选的私有 IP 访问"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為其他 App 提供選用的私有 IP 存取"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 앱의 비공개 IP 접근을 위한 선택 설정"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وصول اختياري إلى عناوين IP الخاصة للتطبيقات الأخرى"
+          }
+        }
+      }
+    },
+    "cloud.vpn.setup.openUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN setup is unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-VPN-Einrichtung ist nicht verfügbar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La configuration du VPN Cloud est indisponible"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La configuración de VPN de Cloud no está disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN設定は利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN 设置不可用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法使用 Cloud VPN 設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN 설정을 사용할 수 없습니다"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعداد VPN الخاص بـ Cloud غير متاح"
+          }
+        }
+      }
+    } ,
     "cli.vm.help.baseCreate": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3500,7 +3500,7 @@
           }
         }
       }
-    },
+    } ,
     "cli.vm.help.baseCreate": {
       "extractionState": "manual",
       "localizations": {
@@ -3915,20 +3915,20 @@
       }
     },
     "cloudTree.error.invalidPreviewURL": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The Cloud service returned an unusable preview address. Refresh and retry."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud サービスから使用できないプレビューアドレスが返されました。更新して再試行してください。"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": {
+        "stringUnit": {
+          "state": "translated",
+          "value": "The Cloud service returned an unusable preview address. Refresh and retry."
+        }
+      },
+      "ja": {
+        "stringUnit": {
+          "state": "translated",
+          "value": "Cloud サービスから使用できないプレビューアドレスが返されました。更新して再試行してください。"
+        }
+      },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -3971,23 +3971,9 @@
             "value": "Cloud 서비스가 유효하지 않은 미리보기 주소를 반환했습니다. 새로고침 후 다시 시도하세요."
           }
         }
-      }
-    },
-    "cli.claude-hook.notification.body.error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Claude reported an error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Claude がエラーを報告しました"
-          }
-        },
+    }
+  },
+    "cli.claude-hook.notification.body.error": {"extractionState": "manual", "localizations": {"en": {"stringUnit": {"state": "translated", "value": "Claude reported an error"}}, "ja": {"stringUnit": {"state": "translated", "value": "Claude がエラーを報告しました"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -4029,24 +4015,12 @@
             "state": "translated",
             "value": "Claude가 오류를 보고했습니다"
           }
-        }
-      }
-    },
+        }}},
     "cli.notification.invalidPayload": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid notification payload"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知のペイロードが無効です"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "Invalid notification payload" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "通知のペイロードが無効です" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77279,18 +77253,8 @@
     "cli.localTmux.error.cleanupSelector": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux cleanup does not take a session selector"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux cleanup ではセッションセレクターを指定できません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux cleanup does not take a session selector" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux cleanup ではセッションセレクターを指定できません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77338,18 +77302,8 @@
     "cli.localTmux.error.clientListFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not inspect attached clients."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux は接続中のクライアントを確認できませんでした。"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not inspect attached clients." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux は接続中のクライアントを確認できませんでした。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77397,18 +77351,8 @@
     "cli.localTmux.error.clientNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux client not found for session %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッション %@ の local-tmux クライアントが見つかりません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux client not found for session %@: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッション %@ の local-tmux クライアントが見つかりません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77456,18 +77400,8 @@
     "cli.localTmux.error.listFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not list sessions; liveness is unknown."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux はセッションを一覧表示できなかったため、生存状態を確認できません。"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not list sessions; liveness is unknown." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux はセッションを一覧表示できなかったため、生存状態を確認できません。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77515,18 +77449,8 @@
     "cli.localTmux.error.listingIncomplete": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session listing was incomplete; liveness is unknown."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux のセッション一覧が不完全なため、生存状態を確認できません。"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session listing was incomplete; liveness is unknown." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のセッション一覧が不完全なため、生存状態を確認できません。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77574,18 +77498,8 @@
     "cli.localTmux.error.closeFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux close failed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の終了に失敗しました"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux close failed" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の終了に失敗しました" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77633,18 +77547,8 @@
     "cli.localTmux.error.createDirectory": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not create local-tmux state directory"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態ディレクトリを作成できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "could not create local-tmux state directory" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態ディレクトリを作成できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77692,18 +77596,8 @@
     "cli.localTmux.error.cwdInvalid": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux working directory is not an accessible directory: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の作業ディレクトリにアクセスできません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux working directory is not an accessible directory: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の作業ディレクトリにアクセスできません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77751,18 +77645,8 @@
     "cli.localTmux.error.detachOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux --client/--all are only valid with detach"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の --client/--all は detach でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --client/--all are only valid with detach" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --client/--all は detach でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77810,18 +77694,8 @@
     "cli.localTmux.error.attachOrStartOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux workspace and attachment options are only valid with start or attach"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux のワークスペースとアタッチ用オプションは start または attach でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux workspace and attachment options are only valid with start or attach" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のワークスペースとアタッチ用オプションは start または attach でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77869,18 +77743,8 @@
     "cli.localTmux.error.detachSelectorConflict": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux detach accepts either --client or --all, not both"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux detach では --client と --all のどちらか一方を指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux detach accepts either --client or --all, not both" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux detach では --client と --all のどちらか一方を指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77928,18 +77792,8 @@
     "cli.localTmux.error.duplicateName": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: session name was supplied more than once"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: セッション名が複数回指定されています"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: session name was supplied more than once" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: セッション名が複数回指定されています" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77987,18 +77841,8 @@
     "cli.localTmux.error.headlessOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux --headless is only valid with attach or start"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の --headless は attach または start でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --headless is only valid with attach or start" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --headless は attach または start でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78046,18 +77890,8 @@
     "cli.localTmux.error.insecurePath": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux state path is not owned by the current user or is group/world accessible: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態パスが現在のユーザー所有でないか、グループ/全ユーザーに公開されています: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state path is not owned by the current user or is group/world accessible: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態パスが現在のユーザー所有でないか、グループ/全ユーザーに公開されています: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78105,18 +77939,8 @@
     "cli.localTmux.error.interactiveExit": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux interactive client exited with status %d"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の対話クライアントがステータス %d で終了しました"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux interactive client exited with status %d" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の対話クライアントがステータス %d で終了しました" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78164,18 +77988,8 @@
     "cli.localTmux.error.interactiveStart": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not start an interactive client"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の対話クライアントを起動できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not start an interactive client" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の対話クライアントを起動できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78223,18 +78037,8 @@
     "cli.localTmux.error.existingSessionCommand": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session already exists; use attach or close it before supplying a new command"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションは既に存在します。新しいコマンドを指定する前に attach または close を使用してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session already exists; use attach or close it before supplying a new command" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションは既に存在します。新しいコマンドを指定する前に attach または close を使用してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78282,18 +78086,8 @@
     "cli.localTmux.error.existingSessionCwd": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session already exists with a different working directory; use attach or close it first"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "別の作業ディレクトリを持つ local-tmux セッションが既に存在します。先に attach または close を使用してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session already exists with a different working directory; use attach or close it first" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "別の作業ディレクトリを持つ local-tmux セッションが既に存在します。先に attach または close を使用してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78341,18 +78135,8 @@
     "cli.localTmux.error.invalidFocus": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: --focus must be true or false"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: --focus は true または false で指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: --focus must be true or false" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: --focus は true または false で指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78400,18 +78184,8 @@
     "cli.localTmux.error.invalidID": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: --id must be a UUID"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: --id は UUID で指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: --id must be a UUID" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: --id は UUID で指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78459,18 +78233,8 @@
     "cli.localTmux.error.invalidName": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session names must contain only letters, numbers, underscore, or dash (1–128 characters)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux のセッション名には英数字、アンダースコア、ハイフンのみ使用できます（1～128文字）"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session names must contain only letters, numbers, underscore, or dash (1–128 characters)" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のセッション名には英数字、アンダースコア、ハイフンのみ使用できます（1～128文字）" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78518,18 +78282,8 @@
     "cli.localTmux.error.invalidState": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux state is invalid: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態が無効です: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state is invalid: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態が無効です: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78577,18 +78331,8 @@
     "cli.localTmux.error.listSelector": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux list does not take a session selector"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux list ではセッションセレクターを指定できません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux list does not take a session selector" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux list ではセッションセレクターを指定できません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78636,18 +78380,8 @@
     "cli.localTmux.error.lockFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not lock local-tmux state: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態をロックできませんでした: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "could not lock local-tmux state: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態をロックできませんでした: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78695,18 +78429,8 @@
     "cli.localTmux.error.multipleClients": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session has multiple clients; pass --client <id> or --all to detach explicitly"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションに複数のクライアントがあります。明示的に切断するには --client <id> または --all を指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session has multiple clients; pass --client <id> or --all to detach explicitly" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションに複数のクライアントがあります。明示的に切断するには --client <id> または --all を指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78754,18 +78478,8 @@
     "cli.localTmux.error.newClientOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux --new-client is only valid with attach"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の --new-client は attach でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --new-client is only valid with attach" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --new-client は attach でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78813,18 +78527,8 @@
     "cli.localTmux.error.noClients": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session has no attached clients: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションに接続中のクライアントがありません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session has no attached clients: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションに接続中のクライアントがありません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78872,18 +78576,8 @@
     "cli.localTmux.error.operationFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ failed (exit %d)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ に失敗しました（終了コード %d）"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ failed (exit %d)" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ に失敗しました（終了コード %d）" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78931,18 +78625,8 @@
     "cli.localTmux.error.persistState": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not persist %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ を保存できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "could not persist %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ を保存できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78990,18 +78674,8 @@
     "cli.localTmux.error.pruneOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux --prune is only valid with cleanup"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の --prune は cleanup でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --prune is only valid with cleanup" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --prune は cleanup でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79049,18 +78723,8 @@
     "cli.localTmux.error.requiresApp": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ requires a running cmux app; use --headless for a direct tmux client"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ には実行中の cmux アプリが必要です。直接 tmux クライアントを使うには --headless を指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ requires a running cmux app; use --headless for a direct tmux client" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ には実行中の cmux アプリが必要です。直接 tmux クライアントを使うには --headless を指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79108,18 +78772,8 @@
     "cli.localTmux.error.requiresValue": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: %@ requires a value"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: %@ には値が必要です"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: %@ requires a value" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: %@ には値が必要です" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79167,18 +78821,8 @@
     "cli.localTmux.error.runFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not run tmux"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux で tmux を実行できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not run tmux" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で tmux を実行できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79226,18 +78870,8 @@
     "cli.localTmux.error.selectorConflict": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: use either a session name or --id, not both"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: セッション名または --id のどちらか一方を指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: use either a session name or --id, not both" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: セッション名または --id のどちらか一方を指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79285,18 +78919,8 @@
     "cli.localTmux.error.selectorRequired": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ requires a session name or --id\n%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux %@ にはセッション名または --id が必要です\n%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ requires a session name or --id\n%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ にはセッション名または --id が必要です\n%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79344,18 +78968,8 @@
     "cli.localTmux.error.sessionIDNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session not found for id %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "指定された ID の local-tmux セッションが見つかりません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session not found for id %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "指定された ID の local-tmux セッションが見つかりません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79403,18 +79017,8 @@
     "cli.localTmux.error.sessionIdentityChanged": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session identity changed; refusing to operate on replacement session: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションの識別子が変更されたため、置き換えられたセッションへの操作を拒否しました: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session identity changed; refusing to operate on replacement session: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションの識別子が変更されたため、置き換えられたセッションへの操作を拒否しました: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79462,18 +79066,8 @@
     "cli.localTmux.error.sessionIdentityUnavailable": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not verify the tmux session identity: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux で tmux セッションの識別子を確認できませんでした: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not verify the tmux session identity: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で tmux セッションの識別子を確認できませんでした: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79521,18 +79115,8 @@
     "cli.localTmux.error.sessionNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session not found: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションが見つかりません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session not found: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションが見つかりません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79580,18 +79164,8 @@
     "cli.localTmux.error.sessionNotRunning": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux session is no longer running: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux セッションは実行されていません: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session is no longer running: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションは実行されていません: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79639,18 +79213,8 @@
     "cli.localTmux.error.socketPathTooLong": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux state directory is too long for a Unix socket: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態ディレクトリが Unix ソケットには長すぎます: %@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state directory is too long for a Unix socket: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態ディレクトリが Unix ソケットには長すぎます: %@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79698,18 +79262,8 @@
     "cli.localTmux.error.stateOperationFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux state could not be accessed safely"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の状態に安全にアクセスできませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state could not be accessed safely" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態に安全にアクセスできませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79757,18 +79311,8 @@
     "cli.localTmux.error.surfaceNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux surface target was not found"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux のサーフェス対象が見つかりません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux surface target was not found" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のサーフェス対象が見つかりません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79816,18 +79360,8 @@
     "cli.localTmux.error.startID": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux start accepts a name, not --id"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux start では --id ではなく名前を指定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux start accepts a name, not --id" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux start では --id ではなく名前を指定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79875,18 +79409,8 @@
     "cli.localTmux.error.startOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux --cwd and --command are only valid with start"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の --cwd と --command は start でのみ使用できます"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --cwd and --command are only valid with start" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --cwd と --command は start でのみ使用できます" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79934,18 +79458,8 @@
     "cli.localTmux.error.startRequiresName": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux start requires a session name"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux start にはセッション名が必要です"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux start requires a session name" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux start にはセッション名が必要です" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79993,18 +79507,8 @@
     "cli.localTmux.error.timedOut": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux command timed out"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux コマンドがタイムアウトしました"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux command timed out" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux コマンドがタイムアウトしました" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80052,18 +79556,8 @@
     "cli.localTmux.error.tmuxMissing": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux requires tmux. Install tmux or configure an executable tmux path"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux には tmux が必要です。tmux をインストールするか、実行可能な tmux のパスを設定してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux requires tmux. Install tmux or configure an executable tmux path" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux には tmux が必要です。tmux をインストールするか、実行可能な tmux のパスを設定してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80111,18 +79605,8 @@
     "cli.localTmux.error.tmuxAliasAttachOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "the tmux alias only supports attach; use local-tmux for other session operations"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "tmux エイリアスは attach のみをサポートします。他のセッション操作には local-tmux を使用してください"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "the tmux alias only supports attach; use local-tmux for other session operations" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "tmux エイリアスは attach のみをサポートします。他のセッション操作には local-tmux を使用してください" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80170,18 +79654,8 @@
     "cli.localTmux.error.targetNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not resolve %@ target %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux で %@ の対象 %@ を解決できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not resolve %@ target %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で %@ の対象 %@ を解決できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80229,18 +79703,8 @@
     "cli.localTmux.error.livenessUnavailable": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not verify the existing surface; no new client was created"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux で既存サーフェスを確認できなかったため、新しいクライアントは作成されませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not verify the existing surface; no new client was created" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で既存サーフェスを確認できなかったため、新しいクライアントは作成されませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80288,18 +79752,8 @@
     "cli.localTmux.error.workspaceNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux workspace target was not found"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux のワークスペース対象が見つかりません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux workspace target was not found" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のワークスペース対象が見つかりません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80347,18 +79801,8 @@
     "cli.localTmux.error.workspaceRequiredForTarget": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux pane or surface targets require a workspace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux の pane または surface 対象にはワークスペースが必要です"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux pane or surface targets require a workspace" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の pane または surface 対象にはワークスペースが必要です" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80406,18 +79850,8 @@
     "cli.localTmux.error.unexpectedArgument": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: unexpected argument '%@'"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: 予期しない引数 '%@'"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: unexpected argument '%@'" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: 予期しない引数 '%@'" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80465,18 +79899,8 @@
     "cli.localTmux.error.unknownFlag": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: unknown flag '%@'\n%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux: 不明なフラグ '%@'\n%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: unknown flag '%@'\n%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: 不明なフラグ '%@'\n%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80524,18 +79948,8 @@
     "cli.localTmux.error.unknownSubcommand": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown local-tmux subcommand '%@'.\n%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不明な local-tmux サブコマンド '%@' です。\n%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "Unknown local-tmux subcommand '%@'.\n%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "不明な local-tmux サブコマンド '%@' です。\n%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80583,18 +79997,8 @@
     "cli.localTmux.error.writeState": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "could not write %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ に書き込めませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "could not write %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ に書き込めませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80642,18 +80046,8 @@
     "cli.localTmux.error.workspaceCreateFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local-tmux could not create a workspace for %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 用のワークスペースを local-tmux で作成できませんでした"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not create a workspace for %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ 用のワークスペースを local-tmux で作成できませんでした" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80701,18 +80095,8 @@
     "cli.localTmux.output.attached": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK session=%@ surface=%@ mode=local-tmux"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK session=%@ surface=%@ mode=local-tmux"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "OK session=%@ surface=%@ mode=local-tmux" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "OK session=%@ surface=%@ mode=local-tmux" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -80760,12 +80144,7 @@
     "cli.localTmux.output.closed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK closed session=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "OK closed session=%@" } },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -80819,12 +80198,7 @@
     "cli.localTmux.output.detached": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK detached session=%@ client=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "OK detached session=%@ client=%@" } },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -80878,12 +80252,7 @@
     "cli.localTmux.output.detachedAll": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK detached all clients from session=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "OK detached all clients from session=%@" } },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -81116,18 +80485,8 @@
     "cli.localTmux.output.idSuffix": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " id=%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " id=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": " id=%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": " id=%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81175,18 +80534,8 @@
     "cli.localTmux.output.noSessions": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No local tmux sessions"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "local tmux セッションはありません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "No local tmux sessions" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "local tmux セッションはありません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81234,18 +80583,8 @@
     "cli.localTmux.output.noStale": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No stale local tmux sessions"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "古い local tmux セッションはありません"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "No stale local tmux sessions" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "古い local tmux セッションはありません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81293,18 +80632,8 @@
     "cli.localTmux.output.record": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK session=%@ id=%@ state=%@ socket=%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK session=%@ id=%@ state=%@ socket=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "OK session=%@ id=%@ state=%@ socket=%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "OK session=%@ id=%@ state=%@ socket=%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81531,18 +80860,8 @@
     "cli.localTmux.output.sessionRow": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ [%@] clients=%lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ [%@] clients=%lld"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81590,18 +80909,8 @@
     "cli.localTmux.output.status": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ [%@] clients=%lld socket=%@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ [%@] clients=%lld socket=%@"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld socket=%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld socket=%@" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81649,18 +80958,8 @@
     "cli.localTmux.state.detached": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "detached"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切断済み"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "detached" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "切断済み" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81708,18 +81007,8 @@
     "cli.localTmux.state.live": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "live"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "稼働中"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "live" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "稼働中" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81767,18 +81056,8 @@
     "cli.localTmux.state.stale": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "stale"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "古い"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "stale" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "古い" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81826,18 +81105,8 @@
     "cli.localTmux.state.unknown": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "unknown"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不明"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "unknown" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "不明" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81885,18 +81154,8 @@
     "cli.localTmux.target.pane": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "pane"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペイン"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "pane" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ペイン" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -81944,18 +81203,8 @@
     "cli.localTmux.target.surface": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "surface"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サーフェス"
-          }
-        },
+        "en": { "stringUnit": { "state": "translated", "value": "surface" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "サーフェス" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -484887,21 +484136,7 @@
         }
       }
     },
-    "cloudTree.port.forwardListenerFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux could not open a local port for the forward: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux は転送用のローカルポートを開けませんでした: %@"
-          }
-        },
+    "cloudTree.port.forwardListenerFailed": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not open a local port for the forward: %@"}},"ja":{"stringUnit":{"state":"translated","value":"cmux は転送用のローカルポートを開けませんでした: %@"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -484943,24 +484178,8 @@
             "state": "translated",
             "value": "cmux가 포트 포워딩을 위한 로컬 포트를 열 수 없습니다: %@"
           }
-        }
-      }
-    },
-    "cloudTree.port.forwardListenerCancelled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The local port forward was closed before it started."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルポート転送は開始前に閉じられました。"
-          }
-        },
+        }}},
+    "cloudTree.port.forwardListenerCancelled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The local port forward was closed before it started."}},"ja":{"stringUnit":{"state":"translated","value":"ローカルポート転送は開始前に閉じられました。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485002,24 +484221,8 @@
             "state": "translated",
             "value": "로컬 포트 포워딩이 시작되기 전에 닫혔습니다."
           }
-        }
-      }
-    },
-    "cloudTree.port.noPort": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has no port to open."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ には開くポートがありません。"
-          }
-        },
+        }}},
+    "cloudTree.port.noPort": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"%@ has no port to open."}},"ja":{"stringUnit":{"state":"translated","value":"%@ には開くポートがありません。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485061,24 +484264,8 @@
             "state": "translated",
             "value": "%@에 열 수 있는 포트가 없습니다."
           }
-        }
-      }
-    },
-    "cloudTree.port.noPrivateAddress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has no private network address yet; refresh the machine list and retry."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ にはまだプライベートネットワークアドレスがありません。マシン一覧を更新して再試行してください。"
-          }
-        },
+        }}},
+    "cloudTree.port.noPrivateAddress": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"%@ has no private network address yet; refresh the machine list and retry."}},"ja":{"stringUnit":{"state":"translated","value":"%@ にはまだプライベートネットワークアドレスがありません。マシン一覧を更新して再試行してください。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485120,24 +484307,8 @@
             "state": "translated",
             "value": "%@에 아직 사설 네트워크 주소가 없습니다. 머신 목록을 새로고침한 후 다시 시도하세요."
           }
-        }
-      }
-    },
-    "cloudTree.error.hubUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This cmux build has no user-space WireGuard hub, so it cannot reach ports on Cloud machines."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この cmux ビルドにはユーザー空間 WireGuard ハブがないため、クラウドマシンのポートに接続できません。"
-          }
-        },
+        }}},
+    "cloudTree.error.hubUnavailable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This cmux build has no user-space WireGuard hub, so it cannot reach ports on Cloud machines."}},"ja":{"stringUnit":{"state":"translated","value":"この cmux ビルドにはユーザー空間 WireGuard ハブがないため、クラウドマシンのポートに接続できません。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485179,24 +484350,8 @@
             "state": "translated",
             "value": "이 cmux 빌드에는 사용자 공간 WireGuard 허브가 없어 Cloud 머신의 포트에 접근할 수 없습니다."
           }
-        }
-      }
-    },
-    "cloudTree.tunnel.connectedPinned": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. `cmux vpn down` turns it off."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。`cmux vpn down` でオフになります。"
-          }
-        },
+        }}},
+    "cloudTree.tunnel.connectedPinned": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. `cmux vpn down` turns it off."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。`cmux vpn down` でオフになります。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485238,24 +484393,8 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel이 켜져 있습니다: 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있습니다. `cmux vpn down`으로 끌 수 있습니다."
           }
-        }
-      }
-    },
-    "cloudTree.tunnel.connected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. It stops on its own when idle."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。アイドル状態になると自動的に停止します。"
-          }
-        },
+        }}},
+    "cloudTree.tunnel.connected": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. It stops on its own when idle."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。アイドル状態になると自動的に停止します。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485297,24 +484436,8 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel이 켜져 있습니다: 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있습니다. 유휴 상태가 되면 자동으로 중지됩니다."
           }
-        }
-      }
-    },
-    "cloudTree.tunnel.openSystemSettings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open System Settings"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム設定を開く"
-          }
-        },
+        }}},
+    "cloudTree.tunnel.openSystemSettings": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Open System Settings"}},"ja":{"stringUnit":{"state":"translated","value":"システム設定を開く"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485356,24 +484479,8 @@
             "state": "translated",
             "value": "시스템 설정 열기"
           }
-        }
-      }
-    },
-    "cloudTree.tunnel.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The cmux Cloud Tunnel is a macOS network extension that gives every app on this Mac a route to your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux クラウドトンネルは、この Mac のすべてのアプリにクラウド VM ネットワークへの経路を与える macOS のネットワーク機能拡張です。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"
-          }
-        },
+        }}},
+    "cloudTree.tunnel.help": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The cmux Cloud Tunnel is a macOS network extension that gives every app on this Mac a route to your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルは、この Mac のすべてのアプリにクラウド VM ネットワークへの経路を与える macOS のネットワーク機能拡張です。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485415,24 +484522,8 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel은 이 Mac의 모든 앱에 Cloud VM 네트워크로 가는 경로를 제공하는 macOS 네트워크 확장 프로그램입니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다."
           }
-        }
-      }
-    },
-    "cloudTree.operation.copyPortLink": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing the link…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リンクを準備しています…"
-          }
-        },
+        }}},
+    "cloudTree.operation.copyPortLink": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Preparing the link…"}},"ja":{"stringUnit":{"state":"translated","value":"リンクを準備しています…"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485474,24 +484565,8 @@
             "state": "translated",
             "value": "링크 준비 중…"
           }
-        }
-      }
-    },
-    "cloudTree.menu.copyLink": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Link"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リンクをコピー"
-          }
-        },
+        }}},
+    "cloudTree.menu.copyLink": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy Link"}},"ja":{"stringUnit":{"state":"translated","value":"リンクをコピー"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485533,24 +484608,8 @@
             "state": "translated",
             "value": "링크 복사"
           }
-        }
-      }
-    },
-    "cloudTree.menu.copyPrivateURL": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Private Address URL"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プライベートアドレスの URL をコピー"
-          }
-        },
+        }}},
+    "cloudTree.menu.copyPrivateURL": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy Private Address URL"}},"ja":{"stringUnit":{"state":"translated","value":"プライベートアドレスの URL をコピー"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485592,24 +484651,8 @@
             "state": "translated",
             "value": "사설 주소 URL 복사"
           }
-        }
-      }
-    },
-    "cli.vpn.appManaged.explain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This installs the cmux Cloud Tunnel network extension and a macOS VPN configuration named “cmux Cloud”, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel. The first time, macOS asks you to allow the extension in System Settings › General › Login Items & Extensions."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これにより、cmux クラウドトンネルのネットワーク機能拡張と「cmux Cloud」という名前の macOS VPN 構成がインストールされ、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。初回は、macOS が「システム設定」›「一般」›「ログイン項目と機能拡張」で機能拡張の許可を求めます。"
-          }
-        },
+        }}},
+    "cli.vpn.appManaged.explain": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This installs the cmux Cloud Tunnel network extension and a macOS VPN configuration named “cmux Cloud”, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel. The first time, macOS asks you to allow the extension in System Settings › General › Login Items & Extensions."}},"ja":{"stringUnit":{"state":"translated","value":"これにより、cmux クラウドトンネルのネットワーク機能拡張と「cmux Cloud」という名前の macOS VPN 構成がインストールされ、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。初回は、macOS が「システム設定」›「一般」›「ログイン項目と機能拡張」で機能拡張の許可を求めます。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485651,24 +484694,8 @@
             "state": "translated",
             "value": "이 작업은 cmux Cloud Tunnel 네트워크 확장 프로그램과 “cmux Cloud”라는 이름의 macOS VPN 구성을 설치하여, 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있도록 합니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다. 최초 실행 시, macOS가 시스템 설정 › 일반 › 로그인 항목 및 확장 프로그램에서 확장 프로그램을 허용하도록 요청합니다."
           }
-        }
-      }
-    },
-    "cloudTree.link.tunnelStopping": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The cmux Cloud Tunnel is stopping…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux クラウドトンネルを停止しています…"
-          }
-        },
+        }}},
+    "cloudTree.link.tunnelStopping": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The cmux Cloud Tunnel is stopping…"}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルを停止しています…"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485710,24 +484737,8 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel을 중지하는 중…"
           }
-        }
-      }
-    },
-    "cloudTree.error.localForwardURLUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux could not build a local address for this port forward."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux はこのポート転送用のローカルアドレスを作成できませんでした。"
-          }
-        },
+        }}},
+    "cloudTree.error.localForwardURLUnavailable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not build a local address for this port forward."}},"ja":{"stringUnit":{"state":"translated","value":"cmux はこのポート転送用のローカルアドレスを作成できませんでした。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485769,24 +484780,8 @@
             "state": "translated",
             "value": "cmux가 이 포트 포워딩을 위한 로컬 주소를 구성할 수 없습니다."
           }
-        }
-      }
-    },
-    "cli.vpn.appManaged.explainReconnect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This turns the cmux Cloud Tunnel back on, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これにより cmux クラウドトンネルが再びオンになり、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"
-          }
-        },
+        }}},
+    "cli.vpn.appManaged.explainReconnect": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This turns the cmux Cloud Tunnel back on, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."}},"ja":{"stringUnit":{"state":"translated","value":"これにより cmux クラウドトンネルが再びオンになり、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -485828,9 +484823,7 @@
             "state": "translated",
             "value": "이 작업은 cmux Cloud Tunnel을 다시 켜서 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있도록 합니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다."
           }
-        }
-      }
-    },
+        }}},
     "agentRestore.admission.invalid": {
       "extractionState": "manual",
       "localizations": {
@@ -494890,20 +493883,10 @@
       }
     },
     "cloudTree.displays.loading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovering displays…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ディスプレイを検出中…"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Discovering displays…" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出中…" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -494946,23 +493929,13 @@
             "value": "디스플레이 감지 중…"
           }
         }
-      }
-    },
+    }
+  },
     "cloudTree.displays.failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn’t discover displays. Refresh to retry."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ディスプレイを検出できませんでした。更新して再試行してください。"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Couldn’t discover displays. Refresh to retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出できませんでした。更新して再試行してください。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495005,23 +493978,13 @@
             "value": "디스플레이를 감지할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-      }
-    },
+    }
+  },
     "cloudTree.displays.asleep": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Displays unavailable while the machine sleeps"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "マシンがスリープ中はディスプレイを利用できません"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Displays unavailable while the machine sleeps" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "マシンがスリープ中はディスプレイを利用できません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495064,23 +494027,13 @@
             "value": "머신이 절전 모드인 동안에는 디스플레이를 사용할 수 없습니다."
           }
         }
-      }
-    },
+    }
+  },
     "cloudTree.displays.unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Display discovery unavailable. Refresh to retry."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ディスプレイ検出を利用できません。更新して再試行してください。"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "Display discovery unavailable. Refresh to retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイ検出を利用できません。更新して再試行してください。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495123,23 +494076,13 @@
             "value": "디스플레이 감지 기능을 사용할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-      }
-    },
+    }
+  },
     "cloudTree.displays.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No displays available"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用可能なディスプレイはありません"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "No displays available" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "利用可能なディスプレイはありません" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495182,23 +494125,13 @@
             "value": "사용할 수 있는 디스플레이가 없습니다."
           }
         }
-      }
-    },
+    }
+  },
     "cloudTree.workspace.pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New workspace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新しいワークスペース"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "New workspace" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "新しいワークスペース" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495241,23 +494174,13 @@
             "value": "새 워크스페이스"
           }
         }
-      }
-    },
+    }
+  },
     "cli.vm.open.sessionsUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The machine’s sessions are unavailable. Refresh and retry."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "マシンのセッションを利用できません。更新して再試行してください。"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "The machine’s sessions are unavailable. Refresh and retry." } },
+      "ja": { "stringUnit": { "state": "translated", "value": "マシンのセッションを利用できません。更新して再試行してください。" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495300,23 +494223,13 @@
             "value": "머신의 세션을 사용할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-      }
-    },
+    }
+  },
     "cli.vm.tree.noDisplays": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(none available)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "（利用可能なものはありません）"
-          }
-        },
+    "extractionState": "manual",
+    "localizations": {
+      "en": { "stringUnit": { "state": "translated", "value": "(none available)" } },
+      "ja": { "stringUnit": { "state": "translated", "value": "（利用可能なものはありません）" } },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495359,8 +494272,8 @@
             "value": "(사용 가능한 항목 없음)"
           }
         }
-      }
-    },
+    }
+  },
     "cloudTunnel.error.cloudMachinesOff": {
       "extractionState": "manual",
       "localizations": {
@@ -495538,146 +494451,8 @@
         }
       }
     },
-    "cli.coderouter.error.notFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعذر العثور على أداة سطر الأوامر المطلوبة. ثبّت الأمر ثم أعد المحاولة."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traženi CLI nije pronađen. Instalirajte naredbu i pokušajte ponovo."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Den nødvendige CLI blev ikke fundet. Installer kommandoen, og prøv igen."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die erforderliche CLI wurde nicht gefunden. Installieren Sie den Befehl und versuchen Sie es erneut."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required CLI not found. Install the command and retry."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontró la CLI necesaria. Instala el comando y vuelve a intentarlo."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La CLI requise est introuvable. Installez la commande, puis réessayez."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La CLI richiesta non è stata trovata. Installa il comando e riprova."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "必要な CLI が見つかりません。コマンドをインストールして、もう一度お試しください。"
-          }
-        },
-        "km": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "រកមិនឃើញ CLI ដែលត្រូវការ។ សូមដំឡើងពាក្យបញ្ជា ហើយព្យាយាមម្ដងទៀត។"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "필요한 CLI를 찾을 수 없습니다. 명령을 설치한 후 다시 시도하세요."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fant ikke den nødvendige CLI-en. Installer kommandoen og prøv igjen."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie znaleziono wymaganej CLI. Zainstaluj polecenie i spróbuj ponownie."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A CLI necessária não foi encontrada. Instale o comando e tente novamente."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не удалось найти необходимый CLI. Установите команду и повторите попытку."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบ CLI ที่จำเป็น โปรดติดตั้งคำสั่งแล้วลองอีกครั้ง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gerekli CLI bulunamadı. Komutu yükleyip tekrar deneyin."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не знайдено потрібний CLI. Установіть команду та повторіть спробу."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到所需的 CLI。请安装该命令后重试。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到必要的 CLI。請安裝該命令後再試一次。"
-          }
-        }
-      }
-    },
-    "featureFlags.cloudVM.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows Cloud VM entrypoints in the new-workspace dropdown and command palette."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新規ワークスペースのドロップダウンとコマンドパレットにクラウドVMのエントリーポイントを表示します。"
-          }
-        },
+    "cli.coderouter.error.notFound": {"extractionState":"manual","localizations":{"ar":{"stringUnit":{"state":"translated","value":"تعذر العثور على أداة سطر الأوامر المطلوبة. ثبّت الأمر ثم أعد المحاولة."}},"bs":{"stringUnit":{"state":"translated","value":"Traženi CLI nije pronađen. Instalirajte naredbu i pokušajte ponovo."}},"da":{"stringUnit":{"state":"translated","value":"Den nødvendige CLI blev ikke fundet. Installer kommandoen, og prøv igen."}},"de":{"stringUnit":{"state":"translated","value":"Die erforderliche CLI wurde nicht gefunden. Installieren Sie den Befehl und versuchen Sie es erneut."}},"en":{"stringUnit":{"state":"translated","value":"Required CLI not found. Install the command and retry."}},"es":{"stringUnit":{"state":"translated","value":"No se encontró la CLI necesaria. Instala el comando y vuelve a intentarlo."}},"fr":{"stringUnit":{"state":"translated","value":"La CLI requise est introuvable. Installez la commande, puis réessayez."}},"it":{"stringUnit":{"state":"translated","value":"La CLI richiesta non è stata trovata. Installa il comando e riprova."}},"ja":{"stringUnit":{"state":"translated","value":"必要な CLI が見つかりません。コマンドをインストールして、もう一度お試しください。"}},"km":{"stringUnit":{"state":"translated","value":"រកមិនឃើញ CLI ដែលត្រូវការ។ សូមដំឡើងពាក្យបញ្ជា ហើយព្យាយាមម្ដងទៀត។"}},"ko":{"stringUnit":{"state":"translated","value":"필요한 CLI를 찾을 수 없습니다. 명령을 설치한 후 다시 시도하세요."}},"nb":{"stringUnit":{"state":"translated","value":"Fant ikke den nødvendige CLI-en. Installer kommandoen og prøv igjen."}},"pl":{"stringUnit":{"state":"translated","value":"Nie znaleziono wymaganej CLI. Zainstaluj polecenie i spróbuj ponownie."}},"pt-BR":{"stringUnit":{"state":"translated","value":"A CLI necessária não foi encontrada. Instale o comando e tente novamente."}},"ru":{"stringUnit":{"state":"translated","value":"Не удалось найти необходимый CLI. Установите команду и повторите попытку."}},"th":{"stringUnit":{"state":"translated","value":"ไม่พบ CLI ที่จำเป็น โปรดติดตั้งคำสั่งแล้วลองอีกครั้ง"}},"tr":{"stringUnit":{"state":"translated","value":"Gerekli CLI bulunamadı. Komutu yükleyip tekrar deneyin."}},"uk":{"stringUnit":{"state":"translated","value":"Не знайдено потрібний CLI. Установіть команду та повторіть спробу."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"未找到所需的 CLI。请安装该命令后重试。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"找不到必要的 CLI。請安裝該命令後再試一次。"}}}},
+    "featureFlags.cloudVM.description": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Shows Cloud VM entrypoints in the new-workspace dropdown and command palette."}},"ja":{"stringUnit":{"state":"translated","value":"新規ワークスペースのドロップダウンとコマンドパレットにクラウドVMのエントリーポイントを表示します。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495719,24 +494494,8 @@
             "state": "translated",
             "value": "새 워크스페이스 드롭다운 및 명령 팔레트에 Cloud VM 진입점을 표시합니다."
           }
-        }
-      }
-    },
-    "featureFlags.cloudVM.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud VM UI"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラウドVM UI"
-          }
-        },
+        }}},
+    "featureFlags.cloudVM.title": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud VM UI"}},"ja":{"stringUnit":{"state":"translated","value":"クラウドVM UI"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495778,24 +494537,8 @@
             "state": "translated",
             "value": "클라우드 VM UI"
           }
-        }
-      }
-    },
-    "cloud.managed.tunnelDisabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud private-network access is disabled by your organization."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud のプライベートネットワークアクセスは組織によって無効になっています。"
-          }
-        },
+        }}},
+    "cloud.managed.tunnelDisabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud private-network access is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"Cloud のプライベートネットワークアクセスは組織によって無効になっています。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495837,24 +494580,8 @@
             "state": "translated",
             "value": "조직에 의해 Cloud 사설 네트워크 접근이 비활성화되었습니다."
           }
-        }
-      }
-    },
-    "machines.managedPolicy.disconnectedDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud VM access ended because your organization disabled cmux Cloud."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "組織が cmux Cloud を無効にしたため、Cloud VM へのアクセスは終了しました。"
-          }
-        },
+        }}},
+    "machines.managedPolicy.disconnectedDetail": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud VM access ended because your organization disabled cmux Cloud."}},"ja":{"stringUnit":{"state":"translated","value":"組織が cmux Cloud を無効にしたため、Cloud VM へのアクセスは終了しました。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495896,24 +494623,8 @@
             "state": "translated",
             "value": "조직에서 cmux Cloud를 비활성화했기 때문에 Cloud VM 접근이 종료되었습니다."
           }
-        }
-      }
-    },
-    "managedPolicy.remoteConnections.disabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remote connections are disabled by your organization."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リモート接続は組織によって無効になっています。"
-          }
-        },
+        }}},
+    "managedPolicy.remoteConnections.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Remote connections are disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"リモート接続は組織によって無効になっています。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -495955,24 +494666,8 @@
             "state": "translated",
             "value": "조직에 의해 원격 연결이 비활성화되었습니다."
           }
-        }
-      }
-    },
-    "managedPolicy.fileTransfer.disabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File transfer is disabled by your organization."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイル転送は組織によって無効になっています。"
-          }
-        },
+        }}},
+    "managedPolicy.fileTransfer.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"File transfer is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"ファイル転送は組織によって無効になっています。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -496014,24 +494709,8 @@
             "state": "translated",
             "value": "조직에 의해 파일 전송이 비활성화되었습니다."
           }
-        }
-      }
-    },
-    "managedPolicy.irohNetworking.disabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux relay networking is disabled by your organization."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux のリレーネットワークは組織によって無効になっています。"
-          }
-        },
+        }}},
+    "managedPolicy.irohNetworking.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux relay networking is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"cmux のリレーネットワークは組織によって無効になっています。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -496073,24 +494752,8 @@
             "state": "translated",
             "value": "조직에 의해 cmux 릴레이 네트워킹이 비활성화되었습니다."
           }
-        }
-      }
-    },
-    "agentRestore.admission.unavailable.hookStoreUnreadable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux could not read its saved session records for this agent, so it cannot tell whether the session is already running. Retry 'cmux restore --surface'."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このエージェントの保存済みセッション記録を読み取れなかったため、セッションがすでに実行中かどうかを cmux で判断できません。「cmux restore --surface」を再試行してください。"
-          }
-        },
+        }}},
+    "agentRestore.admission.unavailable.hookStoreUnreadable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not read its saved session records for this agent, so it cannot tell whether the session is already running. Retry 'cmux restore --surface'."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントの保存済みセッション記録を読み取れなかったため、セッションがすでに実行中かどうかを cmux で判断できません。「cmux restore --surface」を再試行してください。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -496132,24 +494795,8 @@
             "state": "translated",
             "value": "cmux가 이 에이전트에 대해 저장된 세션 기록을 읽을 수 없어 세션이 이미 실행 중인지 알 수 없습니다. 'cmux restore --surface'를 다시 시도하세요."
           }
-        }
-      }
-    },
-    "agentRestore.admission.unavailable.timedOut": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux could not finish checking whether this agent session is already running before the time limit. Retry 'cmux restore --surface'."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このエージェントセッションがすでに実行中かどうかの確認が制限時間内に終わりませんでした。「cmux restore --surface」を再試行してください。"
-          }
-        },
+        }}},
+    "agentRestore.admission.unavailable.timedOut": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not finish checking whether this agent session is already running before the time limit. Retry 'cmux restore --surface'."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントセッションがすでに実行中かどうかの確認が制限時間内に終わりませんでした。「cmux restore --surface」を再試行してください。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -496191,24 +494838,8 @@
             "state": "translated",
             "value": "cmux가 시간 제한 내에 이 에이전트 세션의 중복 실행 여부를 확인하지 못했습니다. 'cmux restore --surface'를 다시 시도하세요."
           }
-        }
-      }
-    },
-    "agentRestore.unverifiable.notice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux could not verify whether this agent session is already running, so it did not resume the session automatically. Run 'cmux restore --surface' to resume it here."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このエージェントセッションがすでに実行中かどうかを cmux で確認できなかったため、セッションを自動的に再開しませんでした。このターミナルで再開するには「cmux restore --surface」を実行してください。"
-          }
-        },
+        }}},
+    "agentRestore.unverifiable.notice": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not verify whether this agent session is already running, so it did not resume the session automatically. Run 'cmux restore --surface' to resume it here."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントセッションがすでに実行中かどうかを cmux で確認できなかったため、セッションを自動的に再開しませんでした。このターミナルで再開するには「cmux restore --surface」を実行してください。"}},
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -496250,9 +494881,7 @@
             "state": "translated",
             "value": "cmux가 이 에이전트 세션의 중복 실행 여부를 확인할 수 없어 세션을 자동으로 재개하지 않았습니다. 여기서 재개하려면 'cmux restore --surface'를 실행하세요."
           }
-        }
-      }
-    },
+        }}}  ,
     "cli.surface.open.tabAndSide": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57,6 +57,72 @@
             "state": "translated",
             "value": "استخدام أجهزة Cloud من أي تطبيق"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koristite Cloud mašine iz bilo koje aplikacije"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brug Cloud-maskiner fra alle apps"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa le macchine Cloud da qualsiasi app"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ប្រើម៉ាស៊ីន Cloud ពីកម្មវិធីណាមួយ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bruk Cloud-maskiner fra alle apper"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Używaj maszyn Cloud z dowolnej aplikacji"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use máquinas Cloud em qualquer app"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используйте Cloud-машины из любого приложения"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้เครื่อง Cloud จากทุกแอป"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud makinelerini her uygulamadan kullanın"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Використовуйте Cloud-машини з будь-якої програми"
+          }
         }
       }
     },
@@ -115,6 +181,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "وصول اختياري إلى العنوان الخاص والمنافذ الأصلية لكل جهاز افتراضي، مثل 10.40.0.10:3000."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcionalni pristup privatnoj adresi i izvornim portovima svake VM, na primjer 10.40.0.10:3000."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfri adgang til hver VM’s private adresse og oprindelige porte, f.eks. 10.40.0.10:3000."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso facoltativo all’indirizzo privato e alle porte originali di ogni VM, ad esempio 10.40.0.10:3000."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចូលប្រើអាសយដ្ឋានឯកជន និងច្រកដើមរបស់ VM នីមួយៗ ដូចជា 10.40.0.10:3000 ជាជម្រើស។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfri tilgang til hver VMs private adresse og opprinnelige porter, som 10.40.0.10:3000."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcjonalny dostęp do prywatnego adresu i oryginalnych portów każdej maszyny VM, na przykład 10.40.0.10:3000."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acesso opcional ao endereço privado e às portas originais de cada VM, como 10.40.0.10:3000."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательный доступ к частному адресу и исходным портам каждой VM, например 10.40.0.10:3000."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเข้าถึงที่ไม่บังคับไปยังที่อยู่ส่วนตัวและพอร์ตเดิมของ VM แต่ละเครื่อง เช่น 10.40.0.10:3000"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Her VM’nin özel adresine ve özgün bağlantı noktalarına isteğe bağlı erişim; örneğin 10.40.0.10:3000."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необов’язковий доступ до приватної адреси та початкових портів кожної VM, наприклад 10.40.0.10:3000."
           }
         }
       }
@@ -175,6 +307,72 @@
             "state": "translated",
             "value": "طريقة العمل"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kako radi"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sådan fungerer det"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Come funziona"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "របៀបដំណើរការ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slik fungerer det"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak to działa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como funciona"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как это работает"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วิธีการทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nasıl çalışır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Як це працює"
+          }
         }
       }
     },
@@ -233,6 +431,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "اربط Safari وChrome والتطبيقات الأخرى بأجهزة Cloud. يحتفظ كل جهاز بعنوان IP الخاص ومنافذه الأصلية. تستخدم حركة البيانات المتجهة إلى شبكة Cloud فقط هذا الاتصال المشفر. تعمل طرفيات cmux والمنافذ وسطح المكتب بدونه."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povežite Safari, Chrome i druge aplikacije sa Cloud mašinama. Svaka mašina zadržava privatnu IP adresu i izvorne portove. Samo saobraćaj prema Cloud mreži koristi ovu šifrovanu vezu. cmux terminali, portovi i radna površina rade i bez nje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbind Safari, Chrome og andre apps med dine Cloud-maskiner. Hver maskine beholder sin private IP-adresse og sine oprindelige porte. Kun trafik til dit Cloud-netværk bruger denne krypterede forbindelse. cmux-terminaler, porte og skrivebord fungerer uden den."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega Safari, Chrome e le altre app alle tue macchine Cloud. Ogni macchina mantiene il proprio IP privato e le porte originali. Solo il traffico verso la rete Cloud usa questa connessione crittografata. Terminali, porte e desktop di cmux funzionano anche senza."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ភ្ជាប់ Safari, Chrome និងកម្មវិធីផ្សេងទៀតទៅម៉ាស៊ីន Cloud របស់អ្នក។ ម៉ាស៊ីននីមួយៗរក្សា IP ឯកជន និងច្រកដើមរបស់ខ្លួន។ មានតែចរាចរណ៍ទៅបណ្តាញ Cloud ប៉ុណ្ណោះដែលប្រើការភ្ជាប់បានអ៊ិនគ្រីបនេះ។ Terminal, Ports និង Desktop របស់ cmux ដំណើរការដោយមិនចាំបាច់ប្រើវា។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koble Safari, Chrome og andre apper til Cloud-maskinene dine. Hver maskin beholder sin private IP-adresse og opprinnelige porter. Bare trafikk til Cloud-nettverket bruker denne krypterte forbindelsen. cmux-terminaler, porter og skrivebord fungerer uten den."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz Safari, Chrome i inne aplikacje z maszynami Cloud. Każda maszyna zachowuje prywatny adres IP i oryginalne porty. Tylko ruch do sieci Cloud korzysta z tego szyfrowanego połączenia. Terminale, porty i pulpit cmux działają bez niego."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte Safari, Chrome e outros apps às suas máquinas Cloud. Cada máquina mantém seu IP privado e suas portas originais. Somente o tráfego para sua rede Cloud usa esta conexão criptografada. Terminais, portas e área de trabalho do cmux funcionam sem ela."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите Safari, Chrome и другие приложения к вашим Cloud-машинам. Каждая машина сохраняет частный IP-адрес и исходные порты. Только трафик к вашей Cloud-сети использует это зашифрованное соединение. Терминалы, порты и рабочий стол cmux работают и без него."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อ Safari, Chrome และแอปอื่นกับเครื่อง Cloud ของคุณ แต่ละเครื่องยังคงมี IP ส่วนตัวและพอร์ตเดิม การรับส่งข้อมูลไปยังเครือข่าย Cloud เท่านั้นที่ใช้การเชื่อมต่อเข้ารหัสนี้ เทอร์มินัล พอร์ต และเดสก์ท็อปของ cmux ใช้งานได้โดยไม่ต้องใช้การเชื่อมต่อนี้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safari, Chrome ve diğer uygulamaları Cloud makinelerinize bağlayın. Her makine özel IP adresini ve özgün bağlantı noktalarını korur. Yalnızca Cloud ağınıza giden trafik bu şifreli bağlantıyı kullanır. cmux terminalleri, bağlantı noktaları ve masaüstü onsuz da çalışır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключіть Safari, Chrome та інші програми до своїх Cloud-машин. Кожна машина зберігає приватну IP-адресу та початкові порти. Лише трафік до Cloud-мережі використовує це зашифроване з’єднання. Термінали, порти й робочий стіл cmux працюють без нього."
           }
         }
       }
@@ -293,6 +557,72 @@
             "state": "translated",
             "value": "برنامج VPN مضمن في cmux. لا تحتاج إلى تطبيق آخر. قد يطلب macOS كلمة المرور أو Touch ID أثناء الموافقة."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN softver je uključen u cmux. Nije potrebna druga aplikacija. macOS može zatražiti lozinku ili Touch ID tokom odobravanja."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN-softwaren er inkluderet i cmux. Du behøver ingen anden app. macOS kan bede om din adgangskode eller Touch ID under godkendelsen."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il software VPN è incluso in cmux. Non serve un’altra app. macOS potrebbe chiedere la password o Touch ID durante l’autorizzazione."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "កម្មវិធី VPN មាននៅក្នុង cmux។ អ្នកមិនត្រូវការកម្មវិធីផ្សេងទៀតទេ។ macOS អាចស្នើពាក្យសម្ងាត់ ឬ Touch ID ក្នុងពេលអនុម័ត។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN-programvaren er inkludert i cmux. Du trenger ingen annen app. macOS kan be om passord eller Touch ID under godkjenningen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oprogramowanie VPN jest zawarte w cmux. Nie potrzebujesz innej aplikacji. macOS może poprosić o hasło lub Touch ID podczas zatwierdzania."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O software VPN vem incluído no cmux. Você não precisa de outro app. O macOS pode pedir sua senha ou Touch ID durante a aprovação."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN-программа уже входит в cmux. Другие приложения не нужны. Во время подтверждения macOS может запросить пароль или Touch ID."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซอฟต์แวร์ VPN รวมอยู่ใน cmux แล้ว ไม่ต้องใช้แอปอื่น macOS อาจขอรหัสผ่านหรือ Touch ID ระหว่างการอนุมัติ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN yazılımı cmux içinde bulunur. Başka bir uygulama gerekmez. macOS onay sırasında parolanızı veya Touch ID’yi isteyebilir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програмне забезпечення VPN входить до cmux. Інша програма не потрібна. Під час схвалення macOS може попросити пароль або Touch ID."
+          }
         }
       }
     },
@@ -351,6 +681,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "حالة الشبكة الخاصة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status privatne mreže"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status for privat netværk"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato della rete privata"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ស្ថានភាពបណ្តាញឯកជន"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status for privat nettverk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stan sieci prywatnej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status da rede privada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Состояние частной сети"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สถานะเครือข่ายส่วนตัว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel ağ durumu"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стан приватної мережі"
           }
         }
       }
@@ -411,6 +807,72 @@
             "state": "translated",
             "value": "متوقف. تستمر لوحات Cloud في العمل عبر اتصال cmux المضمن."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isključeno. Cloud paneli i dalje rade preko ugrađene cmux veze."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fra. Dine Cloud-paneler fungerer stadig via cmux’ indbyggede forbindelse."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivata. I pannelli Cloud continuano a funzionare tramite la connessione integrata di cmux."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បិទ។ ផ្ទាំង Cloud របស់អ្នកនៅតែដំណើរការតាមការភ្ជាប់ដែលមានស្រាប់របស់ cmux។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Av. Cloud-panelene dine fortsetter å fungere gjennom cmux sin innebygde forbindelse."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłączona. Panele Cloud nadal działają przez wbudowane połączenie cmux."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativada. Seus painéis Cloud continuam funcionando pela conexão integrada do cmux."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключено. Панели Cloud продолжают работать через встроенное соединение cmux."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดอยู่ แผง Cloud ยังคงทำงานผ่านการเชื่อมต่อในตัวของ cmux"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapalı. Cloud panelleriniz cmux’un yerleşik bağlantısıyla çalışmaya devam eder."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнено. Панелі Cloud продовжують працювати через вбудоване з’єднання cmux."
+          }
         }
       }
     },
@@ -469,6 +931,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "متصل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povezano"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbundet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessa"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានភ្ជាប់"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilkoblet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączono"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключено"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlandı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключено"
           }
         }
       }
@@ -529,6 +1057,72 @@
             "state": "translated",
             "value": "قيد الانتظار"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čekanje"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Venter"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In attesa"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "កំពុងរង់ចាំ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Venter"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oczekiwanie"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aguardando"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังรอ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekliyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очікування"
+          }
         }
       }
     },
@@ -587,6 +1181,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "يتطلب إجراءً"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Potrebna pažnja"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kræver opmærksomhed"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Richiede attenzione"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ត្រូវការការយកចិត្តទុកដាក់"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krever handling"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wymaga uwagi"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requer atenção"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется действие"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต้องดำเนินการ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İlgilenilmeli"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потрібна увага"
           }
         }
       }
@@ -647,6 +1307,72 @@
             "state": "translated",
             "value": "متوقف"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isključeno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivata"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បិទ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Av"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłączona"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключено"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapalı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнено"
+          }
         }
       }
     },
@@ -705,6 +1431,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "قطع الاتصال"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prekini vezu"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afbryd"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnetti"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្តាច់"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koble fra"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozłącz"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดการเชื่อมต่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantıyı kes"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Від’єднати"
           }
         }
       }
@@ -765,6 +1557,72 @@
             "state": "translated",
             "value": "إلغاء"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otkaži"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បោះបង់"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отменить"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยกเลิก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İptal"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
+          }
         }
       }
     },
@@ -823,6 +1681,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "توصيل VPN الخاص بـ Cloud"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poveži Cloud VPN"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbind Cloud VPN"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connetti VPN Cloud"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ភ្ជាប់ Cloud VPN"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koble til Cloud VPN"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz z Cloud VPN"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar Cloud VPN"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключить Cloud VPN"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อ Cloud VPN"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN’e bağlan"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключити Cloud VPN"
           }
         }
       }
@@ -883,6 +1807,72 @@
             "state": "translated",
             "value": "فتح إعدادات النظام"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori Postavke sistema"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Systemindstillinger"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni di Sistema"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើកការកំណត់ប្រព័ន្ធ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne Systeminnstillinger"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ustawienia systemowe"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Ajustes do Sistema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть системные настройки"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่าระบบ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem Ayarlarını aç"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Системні параметри"
+          }
         }
       }
     },
@@ -941,6 +1931,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "الإعداد الأولي"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prvo podešavanje"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Første opsætning"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prima configurazione"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការរៀបចំលើកដំបូង"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Førstegangsoppsett"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pierwsza konfiguracja"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primeira configuração"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Первая настройка"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่าครั้งแรก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İlk kurulum"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перше налаштування"
           }
         }
       }
@@ -1001,6 +2057,72 @@
             "state": "translated",
             "value": "1. انقر على توصيل VPN الخاص بـ Cloud. عندما يطلب macOS ذلك، اسمح بامتداد شبكة cmux في إعدادات النظام."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Kliknite Poveži Cloud VPN. Kada macOS zatraži, dozvolite cmux mrežni dodatak u Postavkama sistema."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Klik på Forbind Cloud VPN. Når macOS spørger, skal du tillade cmux-netværksudvidelsen i Systemindstillinger."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Fai clic su Connetti VPN Cloud. Quando macOS lo richiede, consenti l’estensione di rete cmux nelle Impostazioni di Sistema."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. ចុច ភ្ជាប់ Cloud VPN។ ពេល macOS ស្នើ សូមអនុញ្ញាតផ្នែកបន្ថែមបណ្តាញ cmux ក្នុងការកំណត់ប្រព័ន្ធ។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Klikk Koble til Cloud VPN. Når macOS spør, tillat cmux-nettverksutvidelsen i Systeminnstillinger."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Kliknij Połącz z Cloud VPN. Gdy macOS poprosi, zezwól na rozszerzenie sieci cmux w Ustawieniach systemowych."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Clique em Conectar Cloud VPN. Quando o macOS pedir, permita a extensão de rede do cmux nos Ajustes do Sistema."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Нажмите Подключить Cloud VPN. Когда macOS попросит, разрешите сетевое расширение cmux в системных настройках."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. คลิก เชื่อมต่อ Cloud VPN เมื่อ macOS ขอ ให้อนุญาตส่วนขยายเครือข่าย cmux ในการตั้งค่าระบบ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Cloud VPN’e bağlan’a tıklayın. macOS istediğinde Sistem Ayarları’nda cmux ağ uzantısına izin verin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Натисніть Підключити Cloud VPN. Коли macOS попросить, дозвольте мережеве розширення cmux у Системних параметрах."
+          }
         }
       }
     },
@@ -1059,6 +2181,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "افتح عام > عناصر الدخول والامتدادات > امتدادات الشبكة، ثم فعّل cmux."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvorite Opšte > Stavke za prijavu i dodaci > Mrežni dodaci, pa omogućite cmux."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Generelt > Loginemner og udvidelser > Netværksudvidelser, og aktivér cmux."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Generali > Elementi login ed estensioni > Estensioni di rete, quindi abilita cmux."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើក ទូទៅ > ធាតុចូល និងផ្នែកបន្ថែម > ផ្នែកបន្ថែមបណ្តាញ ហើយបើក cmux។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne Generelt > Påloggingselementer og utvidelser > Nettverksutvidelser, og aktiver cmux."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ogólne > Elementy logowania i rozszerzenia > Rozszerzenia sieciowe, a następnie włącz cmux."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra Geral > Itens de Início e Extensões > Extensões de Rede e ative o cmux."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте Основные > Объекты входа и расширения > Сетевые расширения и включите cmux."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิด ทั่วไป > รายการเข้าสู่ระบบและส่วนขยาย > ส่วนขยายเครือข่าย แล้วเปิดใช้ cmux"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel > Giriş Öğeleri ve Uzantılar > Ağ Uzantıları’nı açın ve cmux’u etkinleştirin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте Загальні > Об’єкти входу та розширення > Мережеві розширення й увімкніть cmux."
           }
         }
       }
@@ -1119,6 +2307,72 @@
             "state": "translated",
             "value": "افتح الخصوصية والأمان واسمح بامتداد cmux."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvorite Privatnost i sigurnost i dozvolite cmux dodatak."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Anonymitet og sikkerhed, og tillad cmux-udvidelsen."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Privacy e sicurezza e consenti l’estensione cmux."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើក ឯកជនភាព និងសុវត្ថិភាព ហើយអនុញ្ញាតផ្នែកបន្ថែម cmux។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne Personvern og sikkerhet og tillat cmux-utvidelsen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Prywatność i ochrona i zezwól na rozszerzenie cmux."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra Privacidade e Segurança e permita a extensão do cmux."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте Конфиденциальность и безопасность и разрешите расширение cmux."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิด ความเป็นส่วนตัวและความปลอดภัย แล้วอนุญาตส่วนขยาย cmux"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gizlilik ve Güvenlik’i açın ve cmux uzantısına izin verin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте Конфіденційність і безпека та дозвольте розширення cmux."
+          }
         }
       }
     },
@@ -1177,6 +2431,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "2. اسمح لـ cmux بإضافة إعداد VPN باسم cmux Cloud. هذا إذن منفصل في macOS."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Dozvolite cmux-u da doda VPN konfiguraciju pod imenom cmux Cloud. Ovo je posebna macOS dozvola."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Tillad cmux at tilføje en VPN-konfiguration med navnet cmux Cloud. Dette er en separat macOS-tilladelse."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Consenti a cmux di aggiungere una configurazione VPN chiamata cmux Cloud. È un’autorizzazione macOS separata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. អនុញ្ញាតឱ្យ cmux បន្ថែមការកំណត់ VPN ឈ្មោះ cmux Cloud។ នេះជាសិទ្ធិ macOS ផ្សេងមួយ។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Tillat cmux å legge til en VPN-konfigurasjon kalt cmux Cloud. Dette er en separat macOS-tillatelse."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Zezwól cmux dodać konfigurację VPN o nazwie cmux Cloud. To osobne uprawnienie macOS."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Permita que o cmux adicione uma configuração VPN chamada cmux Cloud. Esta é uma permissão separada do macOS."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Разрешите cmux добавить VPN-конфигурацию с именем cmux Cloud. Это отдельное разрешение macOS."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. อนุญาตให้ cmux เพิ่มการกำหนดค่า VPN ชื่อ cmux Cloud นี่เป็นสิทธิ์ macOS แยกต่างหาก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. cmux’un cmux Cloud adlı bir VPN yapılandırması eklemesine izin verin. Bu ayrı bir macOS iznidir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Дозвольте cmux додати конфігурацію VPN з назвою cmux Cloud. Це окремий дозвіл macOS."
           }
         }
       }
@@ -1237,6 +2557,72 @@
             "state": "translated",
             "value": "3. ارجع إلى هذه اللوحة. يستمر الاتصال تلقائيًا بعد الموافقة. اقطع الاتصال هنا عند الانتهاء. يؤدي إنهاء cmux أو تسجيل الخروج أيضًا إلى قطع الاتصال."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Vratite se na ovaj panel. Veza se nastavlja automatski nakon odobrenja. Ovdje prekinite vezu kada završite. Izlazak iz cmux-a ili odjava takođe prekida vezu."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Gå tilbage til dette panel. Forbindelsen fortsætter automatisk efter godkendelsen. Afbryd her, når du er færdig. Hvis du afslutter cmux eller logger ud, afbrydes forbindelsen også."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Torna a questo pannello. La connessione continua automaticamente dopo l’autorizzazione. Disconnettila qui quando hai finito. Anche uscire da cmux o effettuare il logout la disconnette."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. ត្រឡប់ទៅផ្ទាំងនេះ។ ការភ្ជាប់នឹងបន្តដោយស្វ័យប្រវត្តិបន្ទាប់ពីអនុម័ត។ ផ្តាច់នៅទីនេះពេលបញ្ចប់។ ការបិទ cmux ឬចាកចេញក៏ផ្តាច់ការភ្ជាប់ដែរ។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Gå tilbake til dette panelet. Forbindelsen fortsetter automatisk etter godkjenning. Koble fra her når du er ferdig. Avslutning av cmux eller utlogging kobler også fra."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Wróć do tego panelu. Połączenie będzie kontynuowane automatycznie po zatwierdzeniu. Po zakończeniu rozłącz je tutaj. Zamknięcie cmux lub wylogowanie również rozłączy połączenie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Volte a este painel. A conexão continuará automaticamente após a aprovação. Desconecte aqui quando terminar. Sair do cmux ou encerrar a sessão também desconecta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Вернитесь в эту панель. После подтверждения соединение продолжится автоматически. Завершив работу, отключите его здесь. Выход из cmux или системы также отключает соединение."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. กลับมาที่แผงนี้ การเชื่อมต่อจะดำเนินต่อโดยอัตโนมัติหลังการอนุมัติ ตัดการเชื่อมต่อที่นี่เมื่อเสร็จแล้ว การออกจาก cmux หรือออกจากระบบจะตัดการเชื่อมต่อด้วย"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Bu panele dönün. Onaydan sonra bağlantı otomatik olarak devam eder. Bitirdiğinizde buradan bağlantıyı kesin. cmux’tan çıkmak veya oturumu kapatmak da bağlantıyı keser."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Поверніться до цієї панелі. Після схвалення з’єднання продовжиться автоматично. Завершивши роботу, від’єднайте його тут. Вихід із cmux або системи також від’єднає з’єднання."
+          }
         }
       }
     },
@@ -1295,6 +2681,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "العناوين الخاصة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privatne adrese"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private adresser"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indirizzi privati"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "អាសយដ្ឋានឯកជន"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private adresser"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prywatne adresy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endereços privados"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частные адреса"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ที่อยู่ส่วนตัว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel adresler"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приватні адреси"
           }
         }
       }
@@ -1355,6 +2807,72 @@
             "state": "translated",
             "value": "لكل جهاز عنوان IP خاص به. يمكن لجهازين استخدام المنفذ 3000، مثل 10.40.0.10:3000 و10.40.0.11:3000. بعد الاتصال، انقر بزر الماوس الأيمن على منفذ Cloud واختر نسخ رابط العنوان الخاص. هذه عناوين خاصة وليست روابط مشاركة عامة."
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svaka mašina ima svoju privatnu IP adresu. Dvije mašine mogu koristiti port 3000, na primjer 10.40.0.10:3000 i 10.40.0.11:3000. Nakon povezivanja kliknite desnim dugmetom na Cloud port i izaberite Kopiraj URL privatne adrese. Ovo su privatne adrese, a ne javne veze za dijeljenje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hver maskine har sin egen private IP. To maskiner kan begge bruge port 3000, f.eks. 10.40.0.10:3000 og 10.40.0.11:3000. Højreklik på en Cloud-port efter tilslutning, og vælg Kopiér URL til privat adresse. Adresserne er private, ikke offentlige delelinks."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogni macchina ha il proprio IP privato. Due macchine possono usare entrambe la porta 3000, ad esempio 10.40.0.10:3000 e 10.40.0.11:3000. Dopo la connessione fai clic destro su una porta Cloud e scegli Copia URL indirizzo privato. Sono indirizzi privati, non link pubblici."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ម៉ាស៊ីននីមួយៗមាន IP ឯកជនផ្ទាល់ខ្លួន។ ម៉ាស៊ីនពីរអាចប្រើច្រក 3000 ដូចគ្នា ឧទាហរណ៍ 10.40.0.10:3000 និង 10.40.0.11:3000។ បន្ទាប់ពីភ្ជាប់ ចុចខាងស្តាំលើច្រក Cloud ហើយជ្រើស ចម្លង URL អាសយដ្ឋានឯកជន។ ទាំងនេះជាអាសយដ្ឋានឯកជន មិនមែនតំណចែករំលែកសាធារណៈទេ។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hver maskin har sin egen private IP. To maskiner kan bruke port 3000, for eksempel 10.40.0.10:3000 og 10.40.0.11:3000. Høyreklikk en Cloud-port etter tilkobling og velg Kopier URL for privat adresse. Adressene er private, ikke offentlige delingslenker."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Każda maszyna ma własny prywatny adres IP. Dwie maszyny mogą używać portu 3000, na przykład 10.40.0.10:3000 i 10.40.0.11:3000. Po połączeniu kliknij prawym przyciskiem port Cloud i wybierz Kopiuj URL prywatnego adresu. To prywatne adresy, nie publiczne linki udostępniania."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada máquina tem seu próprio IP privado. Duas máquinas podem usar a porta 3000, por exemplo 10.40.0.10:3000 e 10.40.0.11:3000. Depois de conectar, clique com o botão direito em uma porta Cloud e escolha Copiar URL do endereço privado. Esses endereços são privados, não links públicos de compartilhamento."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У каждой машины свой частный IP. Две машины могут использовать порт 3000, например 10.40.0.10:3000 и 10.40.0.11:3000. После подключения щёлкните правой кнопкой мыши порт Cloud и выберите Скопировать URL частного адреса. Это частные адреса, а не публичные ссылки."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แต่ละเครื่องมี IP ส่วนตัวของตนเอง สองเครื่องสามารถใช้พอร์ต 3000 ได้ เช่น 10.40.0.10:3000 และ 10.40.0.11:3000 หลังเชื่อมต่อ คลิกขวาที่พอร์ต Cloud แล้วเลือกคัดลอก URL ที่อยู่ส่วนตัว ที่อยู่เหล่านี้เป็นส่วนตัว ไม่ใช่ลิงก์สาธารณะ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Her makinenin kendi özel IP’si vardır. İki makine 3000 bağlantı noktasını kullanabilir; örneğin 10.40.0.10:3000 ve 10.40.0.11:3000. Bağlandıktan sonra bir Cloud portuna sağ tıklayın ve Özel Adres URL’sini Kopyala’yı seçin. Bunlar özel adreslerdir, herkese açık paylaşım bağlantıları değildir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кожна машина має власну приватну IP-адресу. Дві машини можуть використовувати порт 3000, наприклад 10.40.0.10:3000 і 10.40.0.11:3000. Після підключення клацніть правою кнопкою миші порт Cloud і виберіть Копіювати URL приватної адреси. Це приватні адреси, а не публічні посилання для спільного доступу."
+          }
         }
       }
     },
@@ -1413,6 +2931,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "لا تتضمن هذه النسخة من cmux امتداد VPN موقعًا. استخدم إصدار cmux يدعم VPN الخاص بـ Cloud. تظل طرفيات Cloud والمنافذ وسطح المكتب متاحة بدون VPN."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ova kopija cmux-a nema potpisani VPN dodatak. Koristite cmux izdanje sa Cloud VPN podrškom. Cloud terminali, portovi i radna površina ostaju dostupni bez VPN-a."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne cmux-kopi indeholder ikke en signeret VPN-udvidelse. Brug en cmux-udgave med Cloud VPN-understøttelse. Cloud-terminaler, porte og skrivebord er stadig tilgængelige uden VPN."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa copia di cmux non include un’estensione VPN firmata. Usa una versione di cmux con supporto Cloud VPN. Terminali Cloud, porte e desktop restano disponibili senza VPN."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux ច្បាប់នេះមិនមានផ្នែកបន្ថែម VPN ដែលបានចុះហត្ថលេខាទេ។ ប្រើកំណែ cmux ដែលគាំទ្រ Cloud VPN។ Terminal, Ports និង Desktop របស់ Cloud នៅតែប្រើបានដោយគ្មាន VPN។"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne cmux-kopien har ingen signert VPN-utvidelse. Bruk en cmux-versjon med Cloud VPN-støtte. Cloud-terminaler, porter og skrivebord er tilgjengelige uten VPN."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta kopia cmux nie zawiera podpisanego rozszerzenia VPN. Użyj wydania cmux z obsługą Cloud VPN. Terminale Cloud, porty i pulpit pozostają dostępne bez VPN."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta cópia do cmux não inclui uma extensão VPN assinada. Use uma versão do cmux com suporte a Cloud VPN. Terminais Cloud, portas e área de trabalho continuam disponíveis sem VPN."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В этой копии cmux нет подписанного VPN-расширения. Используйте выпуск cmux с поддержкой Cloud VPN. Cloud-терминалы, порты и рабочий стол доступны без VPN."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux รุ่นนี้ไม่มีส่วนขยาย VPN ที่ลงนามแล้ว ใช้รุ่น cmux ที่รองรับ Cloud VPN เทอร์มินัล Cloud พอร์ต และเดสก์ท็อปยังใช้ได้โดยไม่ต้องมี VPN"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu cmux kopyasında imzalı VPN uzantısı bulunmuyor. Cloud VPN destekli bir cmux sürümü kullanın. Cloud terminalleri, portlar ve masaüstü VPN olmadan da kullanılabilir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ця копія cmux не містить підписаного VPN-розширення. Використовуйте випуск cmux із підтримкою Cloud VPN. Cloud-термінали, порти й робочий стіл доступні без VPN."
           }
         }
       }
@@ -1473,6 +3057,72 @@
             "state": "translated",
             "value": "شبكة Cloud الخاصة"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN Cloud"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN"
+          }
         }
       }
     },
@@ -1531,6 +3181,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "إعداد VPN الخاص بـ cmux…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podesi cmux VPN…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstil cmux VPN…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configura VPN cmux…"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រៀបចំ cmux VPN…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurer cmux VPN…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skonfiguruj cmux VPN…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar cmux VPN…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настроить VPN cmux…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตั้งค่า cmux VPN…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux VPN’i ayarla…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштувати VPN cmux…"
           }
         }
       }
@@ -1591,6 +3307,72 @@
             "state": "translated",
             "value": "وصول اختياري إلى عناوين IP الخاصة للتطبيقات الأخرى"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcionalni pristup privatnim IP adresama za druge aplikacije"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfri privat IP-adgang for andre apps"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso facoltativo agli IP privati per altre app"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ចូលប្រើ IP ឯកជនសម្រាប់កម្មវិធីផ្សេងៗជាជម្រើស"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfri privat IP-tilgang for andre apper"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcjonalny dostęp innych aplikacji do prywatnych adresów IP"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acesso opcional a IPs privados para outros apps"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательный доступ других приложений к частным IP"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเข้าถึง IP ส่วนตัวสำหรับแอปอื่นแบบไม่บังคับ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diğer uygulamalar için isteğe bağlı özel IP erişimi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необов’язковий доступ інших програм до приватних IP"
+          }
         }
       }
     },
@@ -1650,9 +3432,75 @@
             "state": "translated",
             "value": "إعداد VPN الخاص بـ Cloud غير متاح"
           }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podešavanje Cloud VPN-a nije dostupno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN-opsætning er ikke tilgængelig"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La configurazione VPN Cloud non è disponibile"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការរៀបចំ Cloud VPN មិនអាចប្រើបាន"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN-oppsett er ikke tilgjengelig"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja Cloud VPN jest niedostępna"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A configuração do Cloud VPN não está disponível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка Cloud VPN недоступна"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่า Cloud VPN ไม่พร้อมใช้งาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VPN kurulumu kullanılamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування Cloud VPN недоступне"
+          }
         }
       }
-    } ,
+    },
     "cli.vm.help.baseCreate": {
       "extractionState": "manual",
       "localizations": {
@@ -2067,20 +3915,20 @@
       }
     },
     "cloudTree.error.invalidPreviewURL": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": {
-        "stringUnit": {
-          "state": "translated",
-          "value": "The Cloud service returned an unusable preview address. Refresh and retry."
-        }
-      },
-      "ja": {
-        "stringUnit": {
-          "state": "translated",
-          "value": "Cloud サービスから使用できないプレビューアドレスが返されました。更新して再試行してください。"
-        }
-      },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Cloud service returned an unusable preview address. Refresh and retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud サービスから使用できないプレビューアドレスが返されました。更新して再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -2123,9 +3971,23 @@
             "value": "Cloud 서비스가 유효하지 않은 미리보기 주소를 반환했습니다. 새로고침 후 다시 시도하세요."
           }
         }
-    }
-  },
-    "cli.claude-hook.notification.body.error": {"extractionState": "manual", "localizations": {"en": {"stringUnit": {"state": "translated", "value": "Claude reported an error"}}, "ja": {"stringUnit": {"state": "translated", "value": "Claude がエラーを報告しました"}},
+      }
+    },
+    "cli.claude-hook.notification.body.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude reported an error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude がエラーを報告しました"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -2167,12 +4029,24 @@
             "state": "translated",
             "value": "Claude가 오류를 보고했습니다"
           }
-        }}},
+        }
+      }
+    },
     "cli.notification.invalidPayload": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Invalid notification payload" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "通知のペイロードが無効です" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid notification payload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知のペイロードが無効です"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75405,8 +77279,18 @@
     "cli.localTmux.error.cleanupSelector": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux cleanup does not take a session selector" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux cleanup ではセッションセレクターを指定できません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux cleanup does not take a session selector"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux cleanup ではセッションセレクターを指定できません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75454,8 +77338,18 @@
     "cli.localTmux.error.clientListFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not inspect attached clients." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux は接続中のクライアントを確認できませんでした。" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not inspect attached clients."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux は接続中のクライアントを確認できませんでした。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75503,8 +77397,18 @@
     "cli.localTmux.error.clientNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux client not found for session %@: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "セッション %@ の local-tmux クライアントが見つかりません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux client not found for session %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション %@ の local-tmux クライアントが見つかりません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75552,8 +77456,18 @@
     "cli.localTmux.error.listFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not list sessions; liveness is unknown." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux はセッションを一覧表示できなかったため、生存状態を確認できません。" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not list sessions; liveness is unknown."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux はセッションを一覧表示できなかったため、生存状態を確認できません。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75601,8 +77515,18 @@
     "cli.localTmux.error.listingIncomplete": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session listing was incomplete; liveness is unknown." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のセッション一覧が不完全なため、生存状態を確認できません。" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session listing was incomplete; liveness is unknown."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux のセッション一覧が不完全なため、生存状態を確認できません。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75650,8 +77574,18 @@
     "cli.localTmux.error.closeFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux close failed" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の終了に失敗しました" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux close failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の終了に失敗しました"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75699,8 +77633,18 @@
     "cli.localTmux.error.createDirectory": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "could not create local-tmux state directory" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態ディレクトリを作成できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not create local-tmux state directory"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態ディレクトリを作成できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75748,8 +77692,18 @@
     "cli.localTmux.error.cwdInvalid": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux working directory is not an accessible directory: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の作業ディレクトリにアクセスできません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux working directory is not an accessible directory: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の作業ディレクトリにアクセスできません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75797,8 +77751,18 @@
     "cli.localTmux.error.detachOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --client/--all are only valid with detach" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --client/--all は detach でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux --client/--all are only valid with detach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の --client/--all は detach でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75846,8 +77810,18 @@
     "cli.localTmux.error.attachOrStartOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux workspace and attachment options are only valid with start or attach" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のワークスペースとアタッチ用オプションは start または attach でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux workspace and attachment options are only valid with start or attach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux のワークスペースとアタッチ用オプションは start または attach でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75895,8 +77869,18 @@
     "cli.localTmux.error.detachSelectorConflict": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux detach accepts either --client or --all, not both" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux detach では --client と --all のどちらか一方を指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux detach accepts either --client or --all, not both"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux detach では --client と --all のどちらか一方を指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75944,8 +77928,18 @@
     "cli.localTmux.error.duplicateName": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: session name was supplied more than once" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: セッション名が複数回指定されています" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: session name was supplied more than once"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: セッション名が複数回指定されています"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -75993,8 +77987,18 @@
     "cli.localTmux.error.headlessOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --headless is only valid with attach or start" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --headless は attach または start でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux --headless is only valid with attach or start"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の --headless は attach または start でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76042,8 +78046,18 @@
     "cli.localTmux.error.insecurePath": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state path is not owned by the current user or is group/world accessible: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態パスが現在のユーザー所有でないか、グループ/全ユーザーに公開されています: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux state path is not owned by the current user or is group/world accessible: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態パスが現在のユーザー所有でないか、グループ/全ユーザーに公開されています: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76091,8 +78105,18 @@
     "cli.localTmux.error.interactiveExit": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux interactive client exited with status %d" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の対話クライアントがステータス %d で終了しました" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux interactive client exited with status %d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の対話クライアントがステータス %d で終了しました"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76140,8 +78164,18 @@
     "cli.localTmux.error.interactiveStart": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not start an interactive client" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の対話クライアントを起動できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not start an interactive client"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の対話クライアントを起動できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76189,8 +78223,18 @@
     "cli.localTmux.error.existingSessionCommand": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session already exists; use attach or close it before supplying a new command" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションは既に存在します。新しいコマンドを指定する前に attach または close を使用してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session already exists; use attach or close it before supplying a new command"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションは既に存在します。新しいコマンドを指定する前に attach または close を使用してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76238,8 +78282,18 @@
     "cli.localTmux.error.existingSessionCwd": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session already exists with a different working directory; use attach or close it first" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "別の作業ディレクトリを持つ local-tmux セッションが既に存在します。先に attach または close を使用してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session already exists with a different working directory; use attach or close it first"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別の作業ディレクトリを持つ local-tmux セッションが既に存在します。先に attach または close を使用してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76287,8 +78341,18 @@
     "cli.localTmux.error.invalidFocus": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: --focus must be true or false" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: --focus は true または false で指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: --focus must be true or false"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: --focus は true または false で指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76336,8 +78400,18 @@
     "cli.localTmux.error.invalidID": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: --id must be a UUID" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: --id は UUID で指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: --id must be a UUID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: --id は UUID で指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76385,8 +78459,18 @@
     "cli.localTmux.error.invalidName": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session names must contain only letters, numbers, underscore, or dash (1–128 characters)" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のセッション名には英数字、アンダースコア、ハイフンのみ使用できます（1～128文字）" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session names must contain only letters, numbers, underscore, or dash (1–128 characters)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux のセッション名には英数字、アンダースコア、ハイフンのみ使用できます（1～128文字）"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76434,8 +78518,18 @@
     "cli.localTmux.error.invalidState": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state is invalid: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態が無効です: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux state is invalid: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態が無効です: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76483,8 +78577,18 @@
     "cli.localTmux.error.listSelector": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux list does not take a session selector" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux list ではセッションセレクターを指定できません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux list does not take a session selector"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux list ではセッションセレクターを指定できません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76532,8 +78636,18 @@
     "cli.localTmux.error.lockFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "could not lock local-tmux state: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態をロックできませんでした: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not lock local-tmux state: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態をロックできませんでした: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76581,8 +78695,18 @@
     "cli.localTmux.error.multipleClients": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session has multiple clients; pass --client <id> or --all to detach explicitly" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションに複数のクライアントがあります。明示的に切断するには --client <id> または --all を指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session has multiple clients; pass --client <id> or --all to detach explicitly"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションに複数のクライアントがあります。明示的に切断するには --client <id> または --all を指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76630,8 +78754,18 @@
     "cli.localTmux.error.newClientOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --new-client is only valid with attach" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --new-client は attach でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux --new-client is only valid with attach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の --new-client は attach でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76679,8 +78813,18 @@
     "cli.localTmux.error.noClients": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session has no attached clients: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションに接続中のクライアントがありません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session has no attached clients: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションに接続中のクライアントがありません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76728,8 +78872,18 @@
     "cli.localTmux.error.operationFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ failed (exit %d)" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ に失敗しました（終了コード %d）" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ failed (exit %d)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ に失敗しました（終了コード %d）"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76777,8 +78931,18 @@
     "cli.localTmux.error.persistState": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "could not persist %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ を保存できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not persist %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を保存できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76826,8 +78990,18 @@
     "cli.localTmux.error.pruneOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --prune is only valid with cleanup" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --prune は cleanup でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux --prune is only valid with cleanup"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の --prune は cleanup でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76875,8 +79049,18 @@
     "cli.localTmux.error.requiresApp": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ requires a running cmux app; use --headless for a direct tmux client" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ には実行中の cmux アプリが必要です。直接 tmux クライアントを使うには --headless を指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ requires a running cmux app; use --headless for a direct tmux client"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ には実行中の cmux アプリが必要です。直接 tmux クライアントを使うには --headless を指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76924,8 +79108,18 @@
     "cli.localTmux.error.requiresValue": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: %@ requires a value" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: %@ には値が必要です" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: %@ requires a value"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: %@ には値が必要です"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -76973,8 +79167,18 @@
     "cli.localTmux.error.runFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not run tmux" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で tmux を実行できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not run tmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux で tmux を実行できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77022,8 +79226,18 @@
     "cli.localTmux.error.selectorConflict": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: use either a session name or --id, not both" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: セッション名または --id のどちらか一方を指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: use either a session name or --id, not both"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: セッション名または --id のどちらか一方を指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77071,8 +79285,18 @@
     "cli.localTmux.error.selectorRequired": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux %@ requires a session name or --id\n%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux %@ にはセッション名または --id が必要です\n%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ requires a session name or --id\n%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux %@ にはセッション名または --id が必要です\n%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77120,8 +79344,18 @@
     "cli.localTmux.error.sessionIDNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session not found for id %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "指定された ID の local-tmux セッションが見つかりません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session not found for id %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指定された ID の local-tmux セッションが見つかりません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77169,8 +79403,18 @@
     "cli.localTmux.error.sessionIdentityChanged": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session identity changed; refusing to operate on replacement session: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションの識別子が変更されたため、置き換えられたセッションへの操作を拒否しました: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session identity changed; refusing to operate on replacement session: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションの識別子が変更されたため、置き換えられたセッションへの操作を拒否しました: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77218,8 +79462,18 @@
     "cli.localTmux.error.sessionIdentityUnavailable": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not verify the tmux session identity: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で tmux セッションの識別子を確認できませんでした: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not verify the tmux session identity: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux で tmux セッションの識別子を確認できませんでした: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77267,8 +79521,18 @@
     "cli.localTmux.error.sessionNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session not found: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションが見つかりません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session not found: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションが見つかりません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77316,8 +79580,18 @@
     "cli.localTmux.error.sessionNotRunning": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux session is no longer running: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux セッションは実行されていません: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux session is no longer running: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux セッションは実行されていません: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77365,8 +79639,18 @@
     "cli.localTmux.error.socketPathTooLong": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state directory is too long for a Unix socket: %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態ディレクトリが Unix ソケットには長すぎます: %@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux state directory is too long for a Unix socket: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態ディレクトリが Unix ソケットには長すぎます: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77414,8 +79698,18 @@
     "cli.localTmux.error.stateOperationFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux state could not be accessed safely" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の状態に安全にアクセスできませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux state could not be accessed safely"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の状態に安全にアクセスできませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77463,8 +79757,18 @@
     "cli.localTmux.error.surfaceNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux surface target was not found" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のサーフェス対象が見つかりません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux surface target was not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux のサーフェス対象が見つかりません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77512,8 +79816,18 @@
     "cli.localTmux.error.startID": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux start accepts a name, not --id" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux start では --id ではなく名前を指定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux start accepts a name, not --id"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux start では --id ではなく名前を指定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77561,8 +79875,18 @@
     "cli.localTmux.error.startOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux --cwd and --command are only valid with start" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の --cwd と --command は start でのみ使用できます" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux --cwd and --command are only valid with start"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の --cwd と --command は start でのみ使用できます"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77610,8 +79934,18 @@
     "cli.localTmux.error.startRequiresName": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux start requires a session name" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux start にはセッション名が必要です" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux start requires a session name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux start にはセッション名が必要です"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77659,8 +79993,18 @@
     "cli.localTmux.error.timedOut": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux command timed out" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux コマンドがタイムアウトしました" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux command timed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux コマンドがタイムアウトしました"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77708,8 +80052,18 @@
     "cli.localTmux.error.tmuxMissing": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux requires tmux. Install tmux or configure an executable tmux path" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux には tmux が必要です。tmux をインストールするか、実行可能な tmux のパスを設定してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux requires tmux. Install tmux or configure an executable tmux path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux には tmux が必要です。tmux をインストールするか、実行可能な tmux のパスを設定してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77757,8 +80111,18 @@
     "cli.localTmux.error.tmuxAliasAttachOnly": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "the tmux alias only supports attach; use local-tmux for other session operations" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "tmux エイリアスは attach のみをサポートします。他のセッション操作には local-tmux を使用してください" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "the tmux alias only supports attach; use local-tmux for other session operations"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tmux エイリアスは attach のみをサポートします。他のセッション操作には local-tmux を使用してください"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77806,8 +80170,18 @@
     "cli.localTmux.error.targetNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not resolve %@ target %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で %@ の対象 %@ を解決できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not resolve %@ target %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux で %@ の対象 %@ を解決できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77855,8 +80229,18 @@
     "cli.localTmux.error.livenessUnavailable": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not verify the existing surface; no new client was created" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux で既存サーフェスを確認できなかったため、新しいクライアントは作成されませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not verify the existing surface; no new client was created"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux で既存サーフェスを確認できなかったため、新しいクライアントは作成されませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77904,8 +80288,18 @@
     "cli.localTmux.error.workspaceNotFound": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux workspace target was not found" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux のワークスペース対象が見つかりません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux workspace target was not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux のワークスペース対象が見つかりません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -77953,8 +80347,18 @@
     "cli.localTmux.error.workspaceRequiredForTarget": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux pane or surface targets require a workspace" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux の pane または surface 対象にはワークスペースが必要です" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux pane or surface targets require a workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux の pane または surface 対象にはワークスペースが必要です"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78002,8 +80406,18 @@
     "cli.localTmux.error.unexpectedArgument": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: unexpected argument '%@'" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: 予期しない引数 '%@'" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: unexpected argument '%@'"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: 予期しない引数 '%@'"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78051,8 +80465,18 @@
     "cli.localTmux.error.unknownFlag": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux: unknown flag '%@'\n%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local-tmux: 不明なフラグ '%@'\n%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: unknown flag '%@'\n%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux: 不明なフラグ '%@'\n%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78100,8 +80524,18 @@
     "cli.localTmux.error.unknownSubcommand": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Unknown local-tmux subcommand '%@'.\n%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "不明な local-tmux サブコマンド '%@' です。\n%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown local-tmux subcommand '%@'.\n%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な local-tmux サブコマンド '%@' です。\n%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78149,8 +80583,18 @@
     "cli.localTmux.error.writeState": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "could not write %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ に書き込めませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "could not write %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に書き込めませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78198,8 +80642,18 @@
     "cli.localTmux.error.workspaceCreateFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "local-tmux could not create a workspace for %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ 用のワークスペースを local-tmux で作成できませんでした" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local-tmux could not create a workspace for %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 用のワークスペースを local-tmux で作成できませんでした"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78247,8 +80701,18 @@
     "cli.localTmux.output.attached": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "OK session=%@ surface=%@ mode=local-tmux" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "OK session=%@ surface=%@ mode=local-tmux" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK session=%@ surface=%@ mode=local-tmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK session=%@ surface=%@ mode=local-tmux"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78296,7 +80760,12 @@
     "cli.localTmux.output.closed": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "OK closed session=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK closed session=%@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -78350,7 +80819,12 @@
     "cli.localTmux.output.detached": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "OK detached session=%@ client=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK detached session=%@ client=%@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -78404,7 +80878,12 @@
     "cli.localTmux.output.detachedAll": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "OK detached all clients from session=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK detached all clients from session=%@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -78637,8 +81116,18 @@
     "cli.localTmux.output.idSuffix": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": " id=%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": " id=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " id=%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " id=%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78686,8 +81175,18 @@
     "cli.localTmux.output.noSessions": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "No local tmux sessions" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "local tmux セッションはありません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No local tmux sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "local tmux セッションはありません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78735,8 +81234,18 @@
     "cli.localTmux.output.noStale": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "No stale local tmux sessions" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "古い local tmux セッションはありません" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No stale local tmux sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い local tmux セッションはありません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -78784,8 +81293,18 @@
     "cli.localTmux.output.record": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "OK session=%@ id=%@ state=%@ socket=%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "OK session=%@ id=%@ state=%@ socket=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK session=%@ id=%@ state=%@ socket=%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK session=%@ id=%@ state=%@ socket=%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79012,8 +81531,18 @@
     "cli.localTmux.output.sessionRow": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ [%@] clients=%lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ [%@] clients=%lld"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79061,8 +81590,18 @@
     "cli.localTmux.output.status": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld socket=%@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ [%@] clients=%lld socket=%@" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ [%@] clients=%lld socket=%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ [%@] clients=%lld socket=%@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79110,8 +81649,18 @@
     "cli.localTmux.state.detached": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "detached" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "切断済み" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "detached"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断済み"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79159,8 +81708,18 @@
     "cli.localTmux.state.live": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "live" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "稼働中" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "live"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稼働中"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79208,8 +81767,18 @@
     "cli.localTmux.state.stale": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "stale" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "古い" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79257,8 +81826,18 @@
     "cli.localTmux.state.unknown": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "unknown" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "不明" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79306,8 +81885,18 @@
     "cli.localTmux.target.pane": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "pane" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ペイン" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペイン"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -79355,8 +81944,18 @@
     "cli.localTmux.target.surface": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "surface" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "サーフェス" } },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェス"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482288,7 +484887,21 @@
         }
       }
     },
-    "cloudTree.port.forwardListenerFailed": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not open a local port for the forward: %@"}},"ja":{"stringUnit":{"state":"translated","value":"cmux は転送用のローカルポートを開けませんでした: %@"}},
+    "cloudTree.port.forwardListenerFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux could not open a local port for the forward: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux は転送用のローカルポートを開けませんでした: %@"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482330,8 +484943,24 @@
             "state": "translated",
             "value": "cmux가 포트 포워딩을 위한 로컬 포트를 열 수 없습니다: %@"
           }
-        }}},
-    "cloudTree.port.forwardListenerCancelled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The local port forward was closed before it started."}},"ja":{"stringUnit":{"state":"translated","value":"ローカルポート転送は開始前に閉じられました。"}},
+        }
+      }
+    },
+    "cloudTree.port.forwardListenerCancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The local port forward was closed before it started."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルポート転送は開始前に閉じられました。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482373,8 +485002,24 @@
             "state": "translated",
             "value": "로컬 포트 포워딩이 시작되기 전에 닫혔습니다."
           }
-        }}},
-    "cloudTree.port.noPort": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"%@ has no port to open."}},"ja":{"stringUnit":{"state":"translated","value":"%@ には開くポートがありません。"}},
+        }
+      }
+    },
+    "cloudTree.port.noPort": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ has no port to open."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ には開くポートがありません。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482416,8 +485061,24 @@
             "state": "translated",
             "value": "%@에 열 수 있는 포트가 없습니다."
           }
-        }}},
-    "cloudTree.port.noPrivateAddress": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"%@ has no private network address yet; refresh the machine list and retry."}},"ja":{"stringUnit":{"state":"translated","value":"%@ にはまだプライベートネットワークアドレスがありません。マシン一覧を更新して再試行してください。"}},
+        }
+      }
+    },
+    "cloudTree.port.noPrivateAddress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ has no private network address yet; refresh the machine list and retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ にはまだプライベートネットワークアドレスがありません。マシン一覧を更新して再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482459,8 +485120,24 @@
             "state": "translated",
             "value": "%@에 아직 사설 네트워크 주소가 없습니다. 머신 목록을 새로고침한 후 다시 시도하세요."
           }
-        }}},
-    "cloudTree.error.hubUnavailable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This cmux build has no user-space WireGuard hub, so it cannot reach ports on Cloud machines."}},"ja":{"stringUnit":{"state":"translated","value":"この cmux ビルドにはユーザー空間 WireGuard ハブがないため、クラウドマシンのポートに接続できません。"}},
+        }
+      }
+    },
+    "cloudTree.error.hubUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This cmux build has no user-space WireGuard hub, so it cannot reach ports on Cloud machines."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この cmux ビルドにはユーザー空間 WireGuard ハブがないため、クラウドマシンのポートに接続できません。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482502,8 +485179,24 @@
             "state": "translated",
             "value": "이 cmux 빌드에는 사용자 공간 WireGuard 허브가 없어 Cloud 머신의 포트에 접근할 수 없습니다."
           }
-        }}},
-    "cloudTree.tunnel.connectedPinned": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. `cmux vpn down` turns it off."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。`cmux vpn down` でオフになります。"}},
+        }
+      }
+    },
+    "cloudTree.tunnel.connectedPinned": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. `cmux vpn down` turns it off."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。`cmux vpn down` でオフになります。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482545,8 +485238,24 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel이 켜져 있습니다: 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있습니다. `cmux vpn down`으로 끌 수 있습니다."
           }
-        }}},
-    "cloudTree.tunnel.connected": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. It stops on its own when idle."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。アイドル状態になると自動的に停止します。"}},
+        }
+      }
+    },
+    "cloudTree.tunnel.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Cloud Tunnel is on: every app on this Mac can reach your Cloud VM network. It stops on its own when idle."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux クラウドトンネルはオンです。この Mac のすべてのアプリがクラウド VM ネットワークに到達できます。アイドル状態になると自動的に停止します。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482588,8 +485297,24 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel이 켜져 있습니다: 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있습니다. 유휴 상태가 되면 자동으로 중지됩니다."
           }
-        }}},
-    "cloudTree.tunnel.openSystemSettings": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Open System Settings"}},"ja":{"stringUnit":{"state":"translated","value":"システム設定を開く"}},
+        }
+      }
+    },
+    "cloudTree.tunnel.openSystemSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open System Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定を開く"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482631,8 +485356,24 @@
             "state": "translated",
             "value": "시스템 설정 열기"
           }
-        }}},
-    "cloudTree.tunnel.help": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The cmux Cloud Tunnel is a macOS network extension that gives every app on this Mac a route to your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルは、この Mac のすべてのアプリにクラウド VM ネットワークへの経路を与える macOS のネットワーク機能拡張です。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"}},
+        }
+      }
+    },
+    "cloudTree.tunnel.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cmux Cloud Tunnel is a macOS network extension that gives every app on this Mac a route to your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux クラウドトンネルは、この Mac のすべてのアプリにクラウド VM ネットワークへの経路を与える macOS のネットワーク機能拡張です。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482674,8 +485415,24 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel은 이 Mac의 모든 앱에 Cloud VM 네트워크로 가는 경로를 제공하는 macOS 네트워크 확장 프로그램입니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다."
           }
-        }}},
-    "cloudTree.operation.copyPortLink": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Preparing the link…"}},"ja":{"stringUnit":{"state":"translated","value":"リンクを準備しています…"}},
+        }
+      }
+    },
+    "cloudTree.operation.copyPortLink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing the link…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクを準備しています…"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482717,8 +485474,24 @@
             "state": "translated",
             "value": "링크 준비 중…"
           }
-        }}},
-    "cloudTree.menu.copyLink": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy Link"}},"ja":{"stringUnit":{"state":"translated","value":"リンクをコピー"}},
+        }
+      }
+    },
+    "cloudTree.menu.copyLink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Link"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクをコピー"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482760,8 +485533,24 @@
             "state": "translated",
             "value": "링크 복사"
           }
-        }}},
-    "cloudTree.menu.copyPrivateURL": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy Private Address URL"}},"ja":{"stringUnit":{"state":"translated","value":"プライベートアドレスの URL をコピー"}},
+        }
+      }
+    },
+    "cloudTree.menu.copyPrivateURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Private Address URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライベートアドレスの URL をコピー"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482803,8 +485592,24 @@
             "state": "translated",
             "value": "사설 주소 URL 복사"
           }
-        }}},
-    "cli.vpn.appManaged.explain": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This installs the cmux Cloud Tunnel network extension and a macOS VPN configuration named “cmux Cloud”, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel. The first time, macOS asks you to allow the extension in System Settings › General › Login Items & Extensions."}},"ja":{"stringUnit":{"state":"translated","value":"これにより、cmux クラウドトンネルのネットワーク機能拡張と「cmux Cloud」という名前の macOS VPN 構成がインストールされ、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。初回は、macOS が「システム設定」›「一般」›「ログイン項目と機能拡張」で機能拡張の許可を求めます。"}},
+        }
+      }
+    },
+    "cli.vpn.appManaged.explain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This installs the cmux Cloud Tunnel network extension and a macOS VPN configuration named “cmux Cloud”, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel. The first time, macOS asks you to allow the extension in System Settings › General › Login Items & Extensions."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これにより、cmux クラウドトンネルのネットワーク機能拡張と「cmux Cloud」という名前の macOS VPN 構成がインストールされ、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。初回は、macOS が「システム設定」›「一般」›「ログイン項目と機能拡張」で機能拡張の許可を求めます。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482846,8 +485651,24 @@
             "state": "translated",
             "value": "이 작업은 cmux Cloud Tunnel 네트워크 확장 프로그램과 “cmux Cloud”라는 이름의 macOS VPN 구성을 설치하여, 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있도록 합니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다. 최초 실행 시, macOS가 시스템 설정 › 일반 › 로그인 항목 및 확장 프로그램에서 확장 프로그램을 허용하도록 요청합니다."
           }
-        }}},
-    "cloudTree.link.tunnelStopping": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"The cmux Cloud Tunnel is stopping…"}},"ja":{"stringUnit":{"state":"translated","value":"cmux クラウドトンネルを停止しています…"}},
+        }
+      }
+    },
+    "cloudTree.link.tunnelStopping": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cmux Cloud Tunnel is stopping…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux クラウドトンネルを停止しています…"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482889,8 +485710,24 @@
             "state": "translated",
             "value": "cmux Cloud Tunnel을 중지하는 중…"
           }
-        }}},
-    "cloudTree.error.localForwardURLUnavailable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not build a local address for this port forward."}},"ja":{"stringUnit":{"state":"translated","value":"cmux はこのポート転送用のローカルアドレスを作成できませんでした。"}},
+        }
+      }
+    },
+    "cloudTree.error.localForwardURLUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux could not build a local address for this port forward."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux はこのポート転送用のローカルアドレスを作成できませんでした。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482932,8 +485769,24 @@
             "state": "translated",
             "value": "cmux가 이 포트 포워딩을 위한 로컬 주소를 구성할 수 없습니다."
           }
-        }}},
-    "cli.vpn.appManaged.explainReconnect": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"This turns the cmux Cloud Tunnel back on, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."}},"ja":{"stringUnit":{"state":"translated","value":"これにより cmux クラウドトンネルが再びオンになり、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"}},
+        }
+      }
+    },
+    "cli.vpn.appManaged.explainReconnect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This turns the cmux Cloud Tunnel back on, so every app on this Mac can reach your Cloud VM network. cmux itself does not need it: terminals, Ports, and Desktop use the built-in user-space tunnel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これにより cmux クラウドトンネルが再びオンになり、この Mac のすべてのアプリがクラウド VM ネットワークに到達できるようになります。cmux 自体には不要です。ターミナル、ポート、デスクトップは内蔵のユーザー空間トンネルを使います。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -482975,7 +485828,9 @@
             "state": "translated",
             "value": "이 작업은 cmux Cloud Tunnel을 다시 켜서 이 Mac의 모든 앱이 Cloud VM 네트워크에 연결할 수 있도록 합니다. cmux 자체는 이것이 필요하지 않습니다: 터미널, Ports, Desktop은 내장된 사용자 공간 터널을 사용합니다."
           }
-        }}},
+        }
+      }
+    },
     "agentRestore.admission.invalid": {
       "extractionState": "manual",
       "localizations": {
@@ -492035,10 +494890,20 @@
       }
     },
     "cloudTree.displays.loading": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "Discovering displays…" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出中…" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovering displays…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスプレイを検出中…"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492081,13 +494946,23 @@
             "value": "디스플레이 감지 중…"
           }
         }
-    }
-  },
+      }
+    },
     "cloudTree.displays.failed": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "Couldn’t discover displays. Refresh to retry." } },
-      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイを検出できませんでした。更新して再試行してください。" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t discover displays. Refresh to retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスプレイを検出できませんでした。更新して再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492130,13 +495005,23 @@
             "value": "디스플레이를 감지할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-    }
-  },
+      }
+    },
     "cloudTree.displays.asleep": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "Displays unavailable while the machine sleeps" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "マシンがスリープ中はディスプレイを利用できません" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Displays unavailable while the machine sleeps"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンがスリープ中はディスプレイを利用できません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492179,13 +495064,23 @@
             "value": "머신이 절전 모드인 동안에는 디스플레이를 사용할 수 없습니다."
           }
         }
-    }
-  },
+      }
+    },
     "cloudTree.displays.unavailable": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "Display discovery unavailable. Refresh to retry." } },
-      "ja": { "stringUnit": { "state": "translated", "value": "ディスプレイ検出を利用できません。更新して再試行してください。" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display discovery unavailable. Refresh to retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスプレイ検出を利用できません。更新して再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492228,13 +495123,23 @@
             "value": "디스플레이 감지 기능을 사용할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-    }
-  },
+      }
+    },
     "cloudTree.displays.empty": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "No displays available" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "利用可能なディスプレイはありません" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No displays available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なディスプレイはありません"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492277,13 +495182,23 @@
             "value": "사용할 수 있는 디스플레이가 없습니다."
           }
         }
-    }
-  },
+      }
+    },
     "cloudTree.workspace.pending": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "New workspace" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "新しいワークスペース" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいワークスペース"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492326,13 +495241,23 @@
             "value": "새 워크스페이스"
           }
         }
-    }
-  },
+      }
+    },
     "cli.vm.open.sessionsUnavailable": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "The machine’s sessions are unavailable. Refresh and retry." } },
-      "ja": { "stringUnit": { "state": "translated", "value": "マシンのセッションを利用できません。更新して再試行してください。" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The machine’s sessions are unavailable. Refresh and retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンのセッションを利用できません。更新して再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492375,13 +495300,23 @@
             "value": "머신의 세션을 사용할 수 없습니다. 새로고침 후 다시 시도하세요."
           }
         }
-    }
-  },
+      }
+    },
     "cli.vm.tree.noDisplays": {
-    "extractionState": "manual",
-    "localizations": {
-      "en": { "stringUnit": { "state": "translated", "value": "(none available)" } },
-      "ja": { "stringUnit": { "state": "translated", "value": "（利用可能なものはありません）" } },
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(none available)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（利用可能なものはありません）"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492424,8 +495359,8 @@
             "value": "(사용 가능한 항목 없음)"
           }
         }
-    }
-  },
+      }
+    },
     "cloudTunnel.error.cloudMachinesOff": {
       "extractionState": "manual",
       "localizations": {
@@ -492603,8 +495538,146 @@
         }
       }
     },
-    "cli.coderouter.error.notFound": {"extractionState":"manual","localizations":{"ar":{"stringUnit":{"state":"translated","value":"تعذر العثور على أداة سطر الأوامر المطلوبة. ثبّت الأمر ثم أعد المحاولة."}},"bs":{"stringUnit":{"state":"translated","value":"Traženi CLI nije pronađen. Instalirajte naredbu i pokušajte ponovo."}},"da":{"stringUnit":{"state":"translated","value":"Den nødvendige CLI blev ikke fundet. Installer kommandoen, og prøv igen."}},"de":{"stringUnit":{"state":"translated","value":"Die erforderliche CLI wurde nicht gefunden. Installieren Sie den Befehl und versuchen Sie es erneut."}},"en":{"stringUnit":{"state":"translated","value":"Required CLI not found. Install the command and retry."}},"es":{"stringUnit":{"state":"translated","value":"No se encontró la CLI necesaria. Instala el comando y vuelve a intentarlo."}},"fr":{"stringUnit":{"state":"translated","value":"La CLI requise est introuvable. Installez la commande, puis réessayez."}},"it":{"stringUnit":{"state":"translated","value":"La CLI richiesta non è stata trovata. Installa il comando e riprova."}},"ja":{"stringUnit":{"state":"translated","value":"必要な CLI が見つかりません。コマンドをインストールして、もう一度お試しください。"}},"km":{"stringUnit":{"state":"translated","value":"រកមិនឃើញ CLI ដែលត្រូវការ។ សូមដំឡើងពាក្យបញ្ជា ហើយព្យាយាមម្ដងទៀត។"}},"ko":{"stringUnit":{"state":"translated","value":"필요한 CLI를 찾을 수 없습니다. 명령을 설치한 후 다시 시도하세요."}},"nb":{"stringUnit":{"state":"translated","value":"Fant ikke den nødvendige CLI-en. Installer kommandoen og prøv igjen."}},"pl":{"stringUnit":{"state":"translated","value":"Nie znaleziono wymaganej CLI. Zainstaluj polecenie i spróbuj ponownie."}},"pt-BR":{"stringUnit":{"state":"translated","value":"A CLI necessária não foi encontrada. Instale o comando e tente novamente."}},"ru":{"stringUnit":{"state":"translated","value":"Не удалось найти необходимый CLI. Установите команду и повторите попытку."}},"th":{"stringUnit":{"state":"translated","value":"ไม่พบ CLI ที่จำเป็น โปรดติดตั้งคำสั่งแล้วลองอีกครั้ง"}},"tr":{"stringUnit":{"state":"translated","value":"Gerekli CLI bulunamadı. Komutu yükleyip tekrar deneyin."}},"uk":{"stringUnit":{"state":"translated","value":"Не знайдено потрібний CLI. Установіть команду та повторіть спробу."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"未找到所需的 CLI。请安装该命令后重试。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"找不到必要的 CLI。請安裝該命令後再試一次。"}}}},
-    "featureFlags.cloudVM.description": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Shows Cloud VM entrypoints in the new-workspace dropdown and command palette."}},"ja":{"stringUnit":{"state":"translated","value":"新規ワークスペースのドロップダウンとコマンドパレットにクラウドVMのエントリーポイントを表示します。"}},
+    "cli.coderouter.error.notFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذر العثور على أداة سطر الأوامر المطلوبة. ثبّت الأمر ثم أعد المحاولة."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traženi CLI nije pronađen. Instalirajte naredbu i pokušajte ponovo."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den nødvendige CLI blev ikke fundet. Installer kommandoen, og prøv igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die erforderliche CLI wurde nicht gefunden. Installieren Sie den Befehl und versuchen Sie es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required CLI not found. Install the command and retry."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la CLI necesaria. Instala el comando y vuelve a intentarlo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La CLI requise est introuvable. Installez la commande, puis réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La CLI richiesta non è stata trovata. Installa il comando e riprova."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必要な CLI が見つかりません。コマンドをインストールして、もう一度お試しください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញ CLI ដែលត្រូវការ។ សូមដំឡើងពាក្យបញ្ជា ហើយព្យាយាមម្ដងទៀត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "필요한 CLI를 찾을 수 없습니다. 명령을 설치한 후 다시 시도하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke den nødvendige CLI-en. Installer kommandoen og prøv igjen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono wymaganej CLI. Zainstaluj polecenie i spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A CLI necessária não foi encontrada. Instale o comando e tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось найти необходимый CLI. Установите команду и повторите попытку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบ CLI ที่จำเป็น โปรดติดตั้งคำสั่งแล้วลองอีกครั้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerekli CLI bulunamadı. Komutu yükleyip tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не знайдено потрібний CLI. Установіть команду та повторіть спробу."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到所需的 CLI。请安装该命令后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到必要的 CLI。請安裝該命令後再試一次。"
+          }
+        }
+      }
+    },
+    "featureFlags.cloudVM.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows Cloud VM entrypoints in the new-workspace dropdown and command palette."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ワークスペースのドロップダウンとコマンドパレットにクラウドVMのエントリーポイントを表示します。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492646,8 +495719,24 @@
             "state": "translated",
             "value": "새 워크스페이스 드롭다운 및 명령 팔레트에 Cloud VM 진입점을 표시합니다."
           }
-        }}},
-    "featureFlags.cloudVM.title": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud VM UI"}},"ja":{"stringUnit":{"state":"translated","value":"クラウドVM UI"}},
+        }
+      }
+    },
+    "featureFlags.cloudVM.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VM UI"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドVM UI"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492689,8 +495778,24 @@
             "state": "translated",
             "value": "클라우드 VM UI"
           }
-        }}},
-    "cloud.managed.tunnelDisabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud private-network access is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"Cloud のプライベートネットワークアクセスは組織によって無効になっています。"}},
+        }
+      }
+    },
+    "cloud.managed.tunnelDisabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud private-network access is disabled by your organization."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud のプライベートネットワークアクセスは組織によって無効になっています。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492732,8 +495837,24 @@
             "state": "translated",
             "value": "조직에 의해 Cloud 사설 네트워크 접근이 비활성화되었습니다."
           }
-        }}},
-    "machines.managedPolicy.disconnectedDetail": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Cloud VM access ended because your organization disabled cmux Cloud."}},"ja":{"stringUnit":{"state":"translated","value":"組織が cmux Cloud を無効にしたため、Cloud VM へのアクセスは終了しました。"}},
+        }
+      }
+    },
+    "machines.managedPolicy.disconnectedDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud VM access ended because your organization disabled cmux Cloud."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組織が cmux Cloud を無効にしたため、Cloud VM へのアクセスは終了しました。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492775,8 +495896,24 @@
             "state": "translated",
             "value": "조직에서 cmux Cloud를 비활성화했기 때문에 Cloud VM 접근이 종료되었습니다."
           }
-        }}},
-    "managedPolicy.remoteConnections.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Remote connections are disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"リモート接続は組織によって無効になっています。"}},
+        }
+      }
+    },
+    "managedPolicy.remoteConnections.disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote connections are disabled by your organization."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモート接続は組織によって無効になっています。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492818,8 +495955,24 @@
             "state": "translated",
             "value": "조직에 의해 원격 연결이 비활성화되었습니다."
           }
-        }}},
-    "managedPolicy.fileTransfer.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"File transfer is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"ファイル転送は組織によって無効になっています。"}},
+        }
+      }
+    },
+    "managedPolicy.fileTransfer.disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File transfer is disabled by your organization."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル転送は組織によって無効になっています。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492861,8 +496014,24 @@
             "state": "translated",
             "value": "조직에 의해 파일 전송이 비활성화되었습니다."
           }
-        }}},
-    "managedPolicy.irohNetworking.disabled": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux relay networking is disabled by your organization."}},"ja":{"stringUnit":{"state":"translated","value":"cmux のリレーネットワークは組織によって無効になっています。"}},
+        }
+      }
+    },
+    "managedPolicy.irohNetworking.disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux relay networking is disabled by your organization."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux のリレーネットワークは組織によって無効になっています。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492904,8 +496073,24 @@
             "state": "translated",
             "value": "조직에 의해 cmux 릴레이 네트워킹이 비활성화되었습니다."
           }
-        }}},
-    "agentRestore.admission.unavailable.hookStoreUnreadable": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not read its saved session records for this agent, so it cannot tell whether the session is already running. Retry 'cmux restore --surface'."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントの保存済みセッション記録を読み取れなかったため、セッションがすでに実行中かどうかを cmux で判断できません。「cmux restore --surface」を再試行してください。"}},
+        }
+      }
+    },
+    "agentRestore.admission.unavailable.hookStoreUnreadable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux could not read its saved session records for this agent, so it cannot tell whether the session is already running. Retry 'cmux restore --surface'."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエージェントの保存済みセッション記録を読み取れなかったため、セッションがすでに実行中かどうかを cmux で判断できません。「cmux restore --surface」を再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492947,8 +496132,24 @@
             "state": "translated",
             "value": "cmux가 이 에이전트에 대해 저장된 세션 기록을 읽을 수 없어 세션이 이미 실행 중인지 알 수 없습니다. 'cmux restore --surface'를 다시 시도하세요."
           }
-        }}},
-    "agentRestore.admission.unavailable.timedOut": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not finish checking whether this agent session is already running before the time limit. Retry 'cmux restore --surface'."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントセッションがすでに実行中かどうかの確認が制限時間内に終わりませんでした。「cmux restore --surface」を再試行してください。"}},
+        }
+      }
+    },
+    "agentRestore.admission.unavailable.timedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux could not finish checking whether this agent session is already running before the time limit. Retry 'cmux restore --surface'."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエージェントセッションがすでに実行中かどうかの確認が制限時間内に終わりませんでした。「cmux restore --surface」を再試行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -492990,8 +496191,24 @@
             "state": "translated",
             "value": "cmux가 시간 제한 내에 이 에이전트 세션의 중복 실행 여부를 확인하지 못했습니다. 'cmux restore --surface'를 다시 시도하세요."
           }
-        }}},
-    "agentRestore.unverifiable.notice": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"cmux could not verify whether this agent session is already running, so it did not resume the session automatically. Run 'cmux restore --surface' to resume it here."}},"ja":{"stringUnit":{"state":"translated","value":"このエージェントセッションがすでに実行中かどうかを cmux で確認できなかったため、セッションを自動的に再開しませんでした。このターミナルで再開するには「cmux restore --surface」を実行してください。"}},
+        }
+      }
+    },
+    "agentRestore.unverifiable.notice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux could not verify whether this agent session is already running, so it did not resume the session automatically. Run 'cmux restore --surface' to resume it here."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエージェントセッションがすでに実行中かどうかを cmux で確認できなかったため、セッションを自動的に再開しませんでした。このターミナルで再開するには「cmux restore --surface」を実行してください。"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
@@ -493033,7 +496250,9 @@
             "state": "translated",
             "value": "cmux가 이 에이전트 세션의 중복 실행 여부를 확인할 수 없어 세션을 자동으로 재개하지 않았습니다. 여기서 재개하려면 'cmux restore --surface'를 실행하세요."
           }
-        }}}  ,
+        }
+      }
+    },
     "cli.surface.open.tabAndSide": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate+CloudVPNSetupWorkspace.swift
+++ b/Sources/AppDelegate+CloudVPNSetupWorkspace.swift
@@ -1,0 +1,48 @@
+import AppKit
+import CmuxSettings
+
+extension AppDelegate {
+    @objc func openCloudVPNSetupMenuItem(_ sender: NSMenuItem) {
+        guard let windowID = sender.representedObject as? UUID,
+              let context = mainWindowContexts.values.first(where: { $0.windowId == windowID }) else { return }
+        openCloudVPNSetupWorkspace(preferredTabManager: context.tabManager, preferredWindow: context.window)
+    }
+
+    /// Opens the optional Cloud VPN guide as a normal cmux pane. All entry
+    /// points use this method so the Machines panel and context menu behave the
+    /// same way as the iOS pairing pane.
+    @discardableResult
+    func openCloudVPNSetupWorkspace(
+        preferredTabManager: TabManager? = nil,
+        preferredWindow: NSWindow? = nil,
+        focus: Bool = true
+    ) -> Workspace? {
+        guard !ManagedDevicePolicy().isEnforced(.disableCloud) else { return nil }
+        guard let manager = preferredTabManager
+            ?? synchronizeActiveMainWindowContext(preferredWindow: preferredWindow) else { return nil }
+        if let workspace = manager.tabs.first(where: { $0.panels.values.contains { $0 is CloudVPNSetupPanel } }),
+           let panel = workspace.panels.values.first(where: { $0 is CloudVPNSetupPanel }) {
+            if focus {
+                manager.selectedTabId = workspace.id
+                workspace.focusPanel(panel.id)
+            }
+            return workspace
+        }
+        guard let workspace = manager.addWorkspaceIfActive(
+            title: String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN"),
+            select: focus,
+            eagerLoadTerminal: false,
+            autoWelcomeIfNeeded: false,
+            autoRefreshMetadata: false,
+            allowTextBoxFocusDefault: false
+        ) else { return nil }
+        guard let initialPanelID = workspace.focusedPanelId,
+        let paneID = workspace.paneId(forPanelId: initialPanelID),
+        workspace.newCloudVPNSetupSurface(inPane: paneID, coordinator: cloudTunnelCoordinator, focus: focus) != nil else {
+            manager.closeWorkspace(workspace, recordHistory: false)
+            return nil
+        }
+        _ = workspace.closePanel(initialPanelID, force: true)
+        return workspace
+    }
+}

--- a/Sources/AppDelegate+NewWorkspaceMenuRendering.swift
+++ b/Sources/AppDelegate+NewWorkspaceMenuRendering.swift
@@ -116,6 +116,17 @@ extension AppDelegate {
                     addRenderedSection([item])
                 }
             case .management(let management):
+                if CloudMachinesFeature.isEnabled {
+                    let vpnItem = NSMenuItem(
+                        title: String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…"),
+                        action: #selector(openCloudVPNSetupMenuItem(_:)),
+                        keyEquivalent: ""
+                    )
+                    vpnItem.target = self
+                    vpnItem.representedObject = context.windowId as NSUUID
+                    vpnItem.image = NSImage(systemSymbolName: "network", accessibilityDescription: nil)
+                    addRenderedSection([vpnItem])
+                }
                 var items: [NSMenuItem] = []
                 let saveItem = NSMenuItem(
                     title: String(

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -115,6 +115,7 @@ struct WorkspaceCanvasHostView: View {
         case .cloudVMLoading: return "cloud.fill"
         case .mobilePairing: return "iphone"
         case .accountSignIn: return "person.crop.circle"
+        case .cloudVPNSetup: return "network"
         }
     }
 

--- a/Sources/ClosedItemHistory+PanelTitle.swift
+++ b/Sources/ClosedItemHistory+PanelTitle.swift
@@ -45,6 +45,8 @@ extension ClosedItemHistoryStore {
             return String(localized: "mobile.pairing.window.title", defaultValue: "Tailscale Pairing")
         case .accountSignIn:
             return String(localized: "account.signIn.workspace.title", defaultValue: "Sign In")
+        case .cloudVPNSetup:
+            return String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")
         }
     }
 }

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -768,6 +768,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 items.append(item(String(localized: "cloudTree.menu.copyLink", defaultValue: "Copy Link")) { [nodeActions] in nodeActions.copyPortLink(resource.id) })
                 if let portURL {
                     items.append(item(String(localized: "cloudTree.menu.copyPrivateURL", defaultValue: "Copy Private Address URL")) { [nodeActions] in nodeActions.copyToPasteboard(portURL) })
+                    items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { [machineActions] in machineActions.setupVPN() })
                 }
             } else if let portURL {
                 items.append(item(String(localized: "cloudTree.menu.copyLink", defaultValue: "Copy Link")) { [nodeActions] in nodeActions.copyToPasteboard(portURL) })
@@ -801,6 +802,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             if let address = machine.privateAddress {
                 items.append(item(String(localized: "machines.menu.copyIPAddress", defaultValue: "Copy IP Address")) { [nodeActions] in nodeActions.copyToPasteboard(address) })
             }
+            items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { actions.setupVPN() })
             items.append(item(String(localized: "machines.menu.status", defaultValue: "Status")) { actions.runCommand(id, ["vm", "status"]) })
             // Only verbs this provider can honor: a Checkpoint that answers 502 is not a verb.
             if machine.capabilities.snapshot {

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -768,7 +768,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 items.append(item(String(localized: "cloudTree.menu.copyLink", defaultValue: "Copy Link")) { [nodeActions] in nodeActions.copyPortLink(resource.id) })
                 if let portURL {
                     items.append(item(String(localized: "cloudTree.menu.copyPrivateURL", defaultValue: "Copy Private Address URL")) { [nodeActions] in nodeActions.copyToPasteboard(portURL) })
-                    items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { [machineActions] in machineActions.setupVPN() })
+                    items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { [machineActions, window = outlineView?.window] in machineActions.setupVPN(window) })
                 }
             } else if let portURL {
                 items.append(item(String(localized: "cloudTree.menu.copyLink", defaultValue: "Copy Link")) { [nodeActions] in nodeActions.copyToPasteboard(portURL) })
@@ -802,7 +802,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             if let address = machine.privateAddress {
                 items.append(item(String(localized: "machines.menu.copyIPAddress", defaultValue: "Copy IP Address")) { [nodeActions] in nodeActions.copyToPasteboard(address) })
             }
-            items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { actions.setupVPN() })
+            items.append(item(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")) { [window = outlineView?.window] in actions.setupVPN(window) })
             items.append(item(String(localized: "machines.menu.status", defaultValue: "Status")) { actions.runCommand(id, ["vm", "status"]) })
             // Only verbs this provider can honor: a Checkpoint that answers 502 is not a verb.
             if machine.capabilities.snapshot {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -80,6 +80,29 @@ struct MachinesPanelView: View {
     @ViewBuilder
     private var authenticatedContent: some View {
         controlBar
+        Button {
+            AppDelegate.shared?.openCloudVPNSetupWorkspace()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "network")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(tunnelStatus.status?.state == .up
+                        ? String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")
+                        : String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…"))
+                        .cmuxFont(size: 12, weight: .medium)
+                    Text(String(localized: "cloud.vpn.setup.entry.subtitle", defaultValue: "Optional private IP access for other apps"))
+                        .cmuxFont(size: 11)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right").font(.system(size: 10))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("CloudVPNSetupEntryButton")
         if let banner = tunnelStatus.banner {
             MachinesTunnelBanner(banner: banner, backgroundColor: chromeBackgroundColor) {
                 SystemExtensionSettingsLink.open()
@@ -710,6 +733,7 @@ struct MachinesChromeIconButton: View {
 /// see the store. All verbs go through `CloudVMActionLauncher` so this panel,
 /// the ＋ menu, the palette, and the CLI share one mutation path.
 struct MachineRowActions {
+    let setupVPN: @MainActor () -> Void
     let openShell: @MainActor (String) -> Void
     let openDesktop: @MainActor (String) -> Void
     let runCommand: @MainActor (String, [String]) -> Void
@@ -726,6 +750,7 @@ struct MachineRowActions {
         onDidMutate: @escaping @MainActor () -> Void
     ) -> MachineRowActions {
         MachineRowActions(
+            setupVPN: { _ = AppDelegate.shared?.openCloudVPNSetupWorkspace() },
             openShell: { id in
                 onWillMutate(String(format: String(localized: "machines.operation.openShell", defaultValue: "Opening %@\u{2026}"), id))
                 if !launch(arguments: ["vm", "shell", id], onDidMutate: onDidMutate) {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -38,6 +38,7 @@ struct MachinesPanelView: View {
     /// and @AppStorage re-renders the live panel the moment it changes.
     @AppStorage(CloudTreeStyleStore.defaultsKey) private var cloudTreeStyleID: String = CloudTreeStyle.defaultStyle.id
     let chromeBackgroundColor: NSColor
+    var tabManager: TabManager? = nil
 
     private var accountFlow: HostAccountFlow? {
         AppDelegate.shared?.auth?.accountFlow
@@ -81,7 +82,7 @@ struct MachinesPanelView: View {
     private var authenticatedContent: some View {
         controlBar
         Button {
-            AppDelegate.shared?.openCloudVPNSetupWorkspace()
+            AppDelegate.shared?.openCloudVPNSetupWorkspace(preferredTabManager: tabManager)
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: "network")
@@ -733,7 +734,7 @@ struct MachinesChromeIconButton: View {
 /// see the store. All verbs go through `CloudVMActionLauncher` so this panel,
 /// the ＋ menu, the palette, and the CLI share one mutation path.
 struct MachineRowActions {
-    let setupVPN: @MainActor () -> Void
+    let setupVPN: @MainActor (NSWindow?) -> Void
     let openShell: @MainActor (String) -> Void
     let openDesktop: @MainActor (String) -> Void
     let runCommand: @MainActor (String, [String]) -> Void
@@ -750,7 +751,7 @@ struct MachineRowActions {
         onDidMutate: @escaping @MainActor () -> Void
     ) -> MachineRowActions {
         MachineRowActions(
-            setupVPN: { _ = AppDelegate.shared?.openCloudVPNSetupWorkspace() },
+            setupVPN: { window in _ = AppDelegate.shared?.openCloudVPNSetupWorkspace(preferredWindow: window) },
             openShell: { id in
                 onWillMutate(String(format: String(localized: "machines.operation.openShell", defaultValue: "Opening %@\u{2026}"), id))
                 if !launch(arguments: ["vm", "shell", id], onDidMutate: onDidMutate) {

--- a/Sources/Cloud/Tunnel/CloudTunnelStatusModel.swift
+++ b/Sources/Cloud/Tunnel/CloudTunnelStatusModel.swift
@@ -13,6 +13,10 @@ final class CloudTunnelStatusModel {
         status.flatMap(CloudTunnelBanner.init(status:))
     }
 
+    func refresh(_ coordinator: CloudTunnelCoordinator) async {
+        status = await coordinator.status()
+    }
+
     /// Follows the coordinator's state until the calling task is cancelled
     /// (the panel's `.task` ends when it leaves the screen).
     func observe(_ coordinator: CloudTunnelCoordinator?) async {

--- a/Sources/Cloud/Tunnel/CloudVPNSetupModel.swift
+++ b/Sources/Cloud/Tunnel/CloudVPNSetupModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Observation
+
+/// UI projection only. Opening the guide observes status without enrolling or
+/// activating the extension; the existing coordinator owns the connection.
+@MainActor
+@Observable
+final class CloudVPNSetupModel {
+    let tunnelStatus = CloudTunnelStatusModel()
+    private let coordinator: CloudTunnelCoordinator?
+    private(set) var isSubmitting = false
+    private(set) var errorMessage: String?
+
+    init(coordinator: CloudTunnelCoordinator?) {
+        self.coordinator = coordinator
+    }
+
+    var state: CloudTunnelState { tunnelStatus.status?.state ?? .off }
+
+    var unavailableMessage: String? {
+        guard coordinator?.backend.isNetworkExtension == true else {
+            return String(localized: "cloud.vpn.setup.unavailable", defaultValue: "This copy of cmux does not include a signed VPN extension. Use a cmux release with Cloud VPN support. Cloud terminals, Ports, and Desktop remain available without the VPN.")
+        }
+        return nil
+    }
+
+    var canConnect: Bool {
+        unavailableMessage == nil && !isSubmitting && !state.isSettling && state != .up
+    }
+
+    func observe() async {
+        guard let coordinator else { return }
+        for await _ in await coordinator.stateUpdates() {
+            await refresh()
+        }
+    }
+
+    func refresh() async {
+        guard let coordinator else { return }
+        await tunnelStatus.refresh(coordinator)
+        if state == .off, let refusal = await coordinator.recordedStartRefusal() {
+            errorMessage = refusal.error.description
+        } else if state == .starting || state == .up {
+            errorMessage = nil
+        }
+    }
+
+    func connect() async {
+        guard canConnect, let coordinator else { return }
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+        // Admission can fail before the coordinator enters starting. Keep that
+        // refusal visible instead of silently leaving the pane in its off state.
+        if let refusal = await coordinator.beginUp(pin: true) {
+            errorMessage = refusal.error.description
+        }
+        await tunnelStatus.refresh(coordinator)
+    }
+
+    func disconnect() async {
+        guard !isSubmitting, let coordinator else { return }
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+        await coordinator.requestDown()
+        await tunnelStatus.refresh(coordinator)
+    }
+}

--- a/Sources/Cloud/Tunnel/CloudVPNSetupPanel.swift
+++ b/Sources/Cloud/Tunnel/CloudVPNSetupPanel.swift
@@ -1,0 +1,26 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class CloudVPNSetupPanel: Panel {
+    let id = UUID()
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    let panelType: PanelType = .cloudVPNSetup
+
+    let model: CloudVPNSetupModel
+
+    init(coordinator: CloudTunnelCoordinator?) {
+        model = CloudVPNSetupModel(coordinator: coordinator)
+    }
+
+    var displayTitle: String {
+        String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")
+    }
+
+    var displayIcon: String? { "network" }
+
+    func focus() {}
+    func unfocus() {}
+    func close() {}
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) { _ = reason }
+}

--- a/Sources/Cloud/Tunnel/CloudVPNSetupPanelView.swift
+++ b/Sources/Cloud/Tunnel/CloudVPNSetupPanelView.swift
@@ -13,7 +13,7 @@ struct CloudVPNSetupPanelView: View {
                 explanation
                 statusCard
                 actions
-                if model.state != .up { approvalSteps }
+                if model.state != .up && model.unavailableMessage == nil { approvalSteps }
                 addressHelp
             }
             .padding(28)

--- a/Sources/Cloud/Tunnel/CloudVPNSetupPanelView.swift
+++ b/Sources/Cloud/Tunnel/CloudVPNSetupPanelView.swift
@@ -1,0 +1,161 @@
+import AppKit
+import SwiftUI
+
+struct CloudVPNSetupPanelView: View {
+    let appearance: PanelAppearance
+    let onRequestPanelFocus: () -> Void
+    let model: CloudVPNSetupModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                explanation
+                statusCard
+                actions
+                if model.state != .up { approvalSteps }
+                addressHelp
+            }
+            .padding(28)
+            .frame(maxWidth: 640, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .background(Color(nsColor: appearance.contentBackgroundColor))
+        .environment(\.colorScheme, appearance.backgroundColor.isLightColor ? .light : .dark)
+        .contentShape(Rectangle())
+        .onTapGesture { onRequestPanelFocus() }
+        .task { await model.observe() }
+        .accessibilityIdentifier("CloudVPNSetupPanel")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Label {
+                Text(String(localized: "cloud.vpn.setup.heading", defaultValue: "Use Cloud machines from any app"))
+                    .cmuxFont(.title2, weight: .semibold)
+            } icon: {
+                Image(systemName: "network")
+                    .foregroundStyle(.blue)
+            }
+            Text(String(localized: "cloud.vpn.setup.subtitle", defaultValue: "Optional access to each VM's private address and original ports, such as 10.40.0.10:3000."))
+                .cmuxFont(size: 13)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var explanation: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(String(localized: "cloud.vpn.setup.howItWorks.title", defaultValue: "How it works"))
+                .cmuxFont(size: 14, weight: .semibold)
+            Text(String(localized: "cloud.vpn.setup.howItWorks.body", defaultValue: "Connect Safari, Chrome, and other apps to your Cloud machines. Each machine keeps its private IP address and original ports. Only traffic to your Cloud network uses this encrypted connection. cmux terminals, Ports, and Desktop work without it."))
+                .cmuxFont(size: 13)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(String(localized: "cloud.vpn.setup.permission.body", defaultValue: "The VPN software is included in cmux. You do not need another app. macOS may require your password or Touch ID during approval."))
+                .cmuxFont(size: 13)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var statusCard: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text(String(localized: "cloud.vpn.setup.status.title", defaultValue: "Private network status"))
+                    .cmuxFont(size: 14, weight: .semibold)
+                Spacer()
+                statusLabel
+            }
+            if let message = model.errorMessage ?? model.unavailableMessage {
+                Text(message)
+                    .cmuxFont(size: 12)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("CloudVPNSetupError")
+            } else if let banner = model.tunnelStatus.banner {
+                Text(banner.text)
+                    .cmuxFont(size: 12)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text(String(localized: "cloud.vpn.setup.status.off", defaultValue: "Off. Your Cloud panes continue to work through cmux's built-in route."))
+                    .cmuxFont(size: 12)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(14)
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch model.state {
+        case .up:
+            Label(String(localized: "cloud.vpn.setup.connected", defaultValue: "Connected"), systemImage: "checkmark.circle.fill").foregroundStyle(.green)
+        case .starting, .awaitingApproval, .stopping:
+            Label(String(localized: "cloud.vpn.setup.waiting", defaultValue: "Waiting"), systemImage: "clock").foregroundStyle(.orange)
+        case .failed:
+            Label(String(localized: "cloud.vpn.setup.failed", defaultValue: "Needs attention"), systemImage: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+        default:
+            Label(String(localized: "cloud.vpn.setup.off", defaultValue: "Off"), systemImage: "circle").foregroundStyle(.secondary)
+        }
+    }
+
+    private var actions: some View {
+        HStack(spacing: 10) {
+            if model.state == .up || model.state.isSettling {
+                Button(model.state == .up
+                    ? String(localized: "cloud.vpn.setup.disconnect", defaultValue: "Disconnect")
+                    : String(localized: "cloud.vpn.setup.cancel", defaultValue: "Cancel")) {
+                    Task { await model.disconnect() }
+                }
+                .disabled(model.isSubmitting || model.state == .stopping)
+                .accessibilityIdentifier("CloudVPNDisconnectButton")
+            } else {
+                Button(String(localized: "cloud.vpn.setup.connect", defaultValue: "Connect Cloud VPN")) {
+                    Task { await model.connect() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!model.canConnect)
+                .accessibilityIdentifier("CloudVPNConnectButton")
+            }
+            if model.state == .awaitingApproval {
+                Button(String(localized: "cloud.vpn.setup.openSettings", defaultValue: "Open System Settings")) {
+                    SystemExtensionSettingsLink.open()
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("CloudVPNOpenSystemSettingsButton")
+            }
+            if model.isSubmitting || model.state == .starting || model.state == .stopping {
+                ProgressView().controlSize(.small)
+            }
+        }
+    }
+
+    private var approvalSteps: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(localized: "cloud.vpn.setup.steps.title", defaultValue: "First-time setup"))
+                .cmuxFont(size: 14, weight: .semibold)
+            Text(String(localized: "cloud.vpn.setup.steps.extension", defaultValue: "1. Click Connect Cloud VPN. When macOS asks, allow the cmux network extension in System Settings."))
+            Text(ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 15
+                ? String(localized: "cloud.vpn.setup.steps.settings", defaultValue: "Open General > Login Items & Extensions > Network Extensions, then enable cmux.")
+                : String(localized: "cloud.vpn.setup.steps.settingsLegacy", defaultValue: "Open Privacy & Security and allow the cmux extension."))
+                .foregroundStyle(.secondary)
+            Text(String(localized: "cloud.vpn.setup.steps.configuration", defaultValue: "2. Allow cmux to add a VPN configuration named cmux Cloud. This is a separate macOS permission."))
+            Text(String(localized: "cloud.vpn.setup.steps.return", defaultValue: "3. Return to this pane. The connection continues automatically after approval. Disconnect here when finished. Quitting cmux or signing out also disconnects it."))
+        }
+        .cmuxFont(size: 13)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var addressHelp: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "cloud.vpn.setup.address.title", defaultValue: "Private addresses"))
+                .cmuxFont(size: 14, weight: .semibold)
+            Text(String(localized: "cloud.vpn.setup.address.body", defaultValue: "Each machine has its own private IP. Two machines may both expose port 3000, for example 10.40.0.10:3000 and 10.40.0.11:3000. Right-click a Cloud port and choose Copy Private Address URL after connecting. These addresses are private, not public share links."))
+                .cmuxFont(size: 13)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/Sources/CmuxLifecycleEventPublishing.swift
+++ b/Sources/CmuxLifecycleEventPublishing.swift
@@ -235,6 +235,8 @@ extension Workspace {
             return "mobile_pairing"
         case .accountSignIn:
             return "account_sign_in"
+        case .cloudVPNSetup:
+            return "cloud_vpn_setup"
         }
     }
 }

--- a/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
+++ b/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
@@ -32,6 +32,8 @@ extension ContentView {
             return String(localized: "command.mobileConnect.subtitle", defaultValue: "Tailscale")
         case .accountSignIn:
             return String(localized: "settings.section.account", defaultValue: "Account")
+        case .cloudVPNSetup:
+            return String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")
         }
     }
     func commandPaletteSurfaceKeywords(for panelType: PanelType) -> [String] {
@@ -65,6 +67,8 @@ extension ContentView {
             return ContentView.commandPaletteMobileConnectKeywords
         case .accountSignIn:
             return ["account", "auth", "profile", "sign in"]
+        case .cloudVPNSetup:
+            return ["cloud", "vpn", "wireguard", "private", "network", "freestyle"]
         }
     }
 }

--- a/Sources/ContentView+SidebarSurfaceKind.swift
+++ b/Sources/ContentView+SidebarSurfaceKind.swift
@@ -14,7 +14,7 @@ extension VerticalTabsSidebar {
         case .rightSidebarTool:
             return .rightSidebarTool
         case .customSidebar, .simulator, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading,
-             .mobilePairing, .accountSignIn:
+             .mobilePairing, .accountSignIn, .cloudVPNSetup:
             return .unknown
         case .agentSession:
             return .agentSession

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7612,6 +7612,13 @@ struct ContentView: View {
                 when: { !$0.bool(CommandPaletteContextKeys.mobileRemoteControlManagedByPolicy) }
             )
         )
+        contributions.append(CommandPaletteCommandContribution(
+            commandId: "palette.cloudVPNSetup",
+            title: constant(String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…")),
+            subtitle: constant(String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")),
+            keywords: ["cloud", "vpn", "private", "network", "wireguard", "freestyle"],
+            when: { _ in CloudMachinesFeature.isEnabled }
+        ))
         contributions.append(contentsOf: Self.commandPaletteAuthCommandContributions() + Self.commandPaletteProCommandContributions())
         contributions.append(
             CommandPaletteCommandContribution(
@@ -8836,6 +8843,12 @@ struct ContentView: View {
                 preferredWindow: observedWindow,
                 enforceFeatureFlag: false,
                 debugSource: "palette.mobileConnect"
+            )
+        }
+        registry.register(commandId: "palette.cloudVPNSetup") {
+            _ = AppDelegate.shared?.openCloudVPNSetupWorkspace(
+                preferredTabManager: tabManager,
+                preferredWindow: observedWindow
             )
         }
         registerAuthCommandHandlers(&registry)

--- a/Sources/PaneDropContainer.swift
+++ b/Sources/PaneDropContainer.swift
@@ -219,7 +219,7 @@ extension PaneDropContainer {
             return .editor
         case .browser, .markdown, .rightSidebarTool, .customSidebar, .simulator,
              .agentSession, .project, .extensionBrowser, .workspaceTodo,
-             .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+             .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn, .cloudVPNSetup:
             return nil
         }
     }

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -19,6 +19,7 @@ public enum PanelType: String, Codable, CaseIterable, Sendable {
     case cloudVMLoading
     case mobilePairing
     case accountSignIn
+    case cloudVPNSetup
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -61,6 +62,10 @@ public enum PanelType: String, Codable, CaseIterable, Sendable {
         }
         if rawValue.lowercased() == Self.accountSignIn.rawValue.lowercased() {
             self = .accountSignIn
+            return
+        }
+        if rawValue.lowercased() == Self.cloudVPNSetup.rawValue.lowercased() {
+            self = .cloudVPNSetup
             return
         }
         throw DecodingError.dataCorruptedError(

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -229,6 +229,14 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .cloudVPNSetup:
+            if let vpnPanel = panel as? CloudVPNSetupPanel {
+                CloudVPNSetupPanelView(
+                    appearance: appearance,
+                    onRequestPanelFocus: onRequestPanelFocus,
+                    model: vpnPanel.model
+                )
+            }
         }
     }
 
@@ -246,7 +254,7 @@ struct PanelContentView: View {
     private var shouldInstallPaneDropTarget: Bool {
         guard isVisibleInUI else { return false }
         switch panel.panelType {
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn, .cloudVPNSetup:
             return true
         case .terminal, .browser:
             return false

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -510,13 +510,15 @@ struct RightSidebarPanelView: View {
                     }
             case .feed:
                 FeedPanelView(
-                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor
+                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
+                    tabManager: tabManager
                 )
             case .dock:
                 dockPanel(windowAppearance: windowAppearance)
             case .machines:
                 MachinesPanelView(
-                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor
+                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
+                    tabManager: tabManager
                 )
             case .customSidebar:
                 customSidebarPanel

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -510,8 +510,7 @@ struct RightSidebarPanelView: View {
                     }
             case .feed:
                 FeedPanelView(
-                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
-                    tabManager: tabManager
+                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor
                 )
             case .dock:
                 dockPanel(windowAppearance: windowAppearance)

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -35,7 +35,7 @@ enum GlobalSearchDocuments {
         case .markdown:
             kind = .markdown
         case .terminal, .filePreview, .rightSidebarTool, .customSidebar, .agentSession, .project,
-             .extensionBrowser, .simulator, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+             .extensionBrowser, .simulator, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn, .cloudVPNSetup:
             kind = .title
         }
 

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -43,7 +43,7 @@ extension TerminalController {
         case .accountSignIn:
             return MobileSurfaceKind(rawValue: "accountSignIn")
         case .cloudVPNSetup:
-            return MobileSurfaceKind(rawValue: "cloudVPNSetup")
+            return MobileSurfaceKind(rawValue: "cloud_vpn_setup")
         }
     }
 

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -42,6 +42,8 @@ extension TerminalController {
             return MobileSurfaceKind(rawValue: "mobilePairing")
         case .accountSignIn:
             return MobileSurfaceKind(rawValue: "accountSignIn")
+        case .cloudVPNSetup:
+            return MobileSurfaceKind(rawValue: "cloudVPNSetup")
         }
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5366,7 +5366,7 @@ class TerminalController {
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
-            "set_color", "clear_color", "mobile_connect"
+            "set_color", "clear_color", "mobile_connect", "cloud_vpn_setup"
         ]
 
         var result: V2CallResult = .err(code: "invalid_params", message: "Unknown workspace action", data: [
@@ -5375,6 +5375,23 @@ class TerminalController {
         ])
 
         v2MainSync {
+            if action == "cloud_vpn_setup" {
+                // Pane creation belongs to the main actor. The socket focus
+                // policy controls selection, just as for the mobile setup pane.
+                guard let workspace = AppDelegate.shared?.openCloudVPNSetupWorkspace(
+                    preferredTabManager: tabManager,
+                    focus: v2FocusAllowed()
+                ) else {
+                    result = .err(code: "unavailable", message: String(localized: "cloud.vpn.setup.openUnavailable", defaultValue: "Cloud VPN setup is unavailable"), data: nil)
+                    return
+                }
+                result = .ok([
+                    "action": action,
+                    "workspace_id": workspace.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id)
+                ])
+                return
+            }
             if action == "mobile_connect" {
                 let windowId = v2ResolveWindowId(tabManager: tabManager)
                 guard let workspace = AppDelegate.shared?.performMobileConnectWorkspaceAction(

--- a/Sources/Workspace+CloudVPNSetupPane.swift
+++ b/Sources/Workspace+CloudVPNSetupPane.swift
@@ -1,0 +1,42 @@
+import Bonsplit
+import Foundation
+
+extension Workspace {
+    @discardableResult
+    func newCloudVPNSetupSurface(inPane paneId: PaneID, coordinator: CloudTunnelCoordinator?, focus: Bool = true) -> CloudVPNSetupPanel? {
+        guard !isRetiredFromOwningTabManager else { return nil }
+        let panel = CloudVPNSetupPanel(coordinator: coordinator)
+        panels[panel.id] = panel
+        panelTitles[panel.id] = panel.displayTitle
+        guard let tabId = bonsplitController.createTab(
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            kind: "cloud_vpn_setup",
+            isDirty: false,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: panel.id)
+            panelTitles.removeValue(forKey: panel.id)
+            return nil
+        }
+        bindSurface(tabId, toPanelId: panel.id)
+        publishCmuxSurfaceCreated(panel.id, paneId: paneId, kind: "cloud_vpn_setup", origin: "cloud_vpn_setup_workspace", focused: focus)
+        if focus {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(tabId)
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        }
+        return panel
+    }
+
+    @discardableResult
+    func openOrFocusCloudVPNSetupSurface(inPane paneId: PaneID, coordinator: CloudTunnelCoordinator?, focus: Bool = true) -> CloudVPNSetupPanel? {
+        if let existing = panels.values.compactMap({ $0 as? CloudVPNSetupPanel }).first {
+            if focus { focusPanel(existing.id) }
+            return existing
+        }
+        return newCloudVPNSetupSurface(inPane: paneId, coordinator: coordinator, focus: focus)
+    }
+}

--- a/Sources/Workspace+LayoutCapture.swift
+++ b/Sources/Workspace+LayoutCapture.swift
@@ -152,7 +152,7 @@ extension Workspace {
                     focus: nil
                 )
             }
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn, .cloudVPNSetup:
             unsupportedSurfaceCount += 1
             definition = CmuxSurfaceDefinition(type: .terminal)
         }

--- a/Sources/Workspace+SurfaceNavigation.swift
+++ b/Sources/Workspace+SurfaceNavigation.swift
@@ -209,6 +209,8 @@ extension Workspace {
             return SurfaceKind.notifications.rawValue
         case .cloudVMLoading:
             return SurfaceKind.cloudVMLoading.rawValue
+        case .cloudVPNSetup:
+            return "cloud_vpn_setup"
         case .mobilePairing:
             return SurfaceKind.mobilePairing.rawValue
         case .accountSignIn:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -824,6 +824,8 @@ extension Workspace {
             return nil
         case .accountSignIn:
             return nil
+        case .cloudVPNSetup:
+            return nil
         }
         return SessionPanelSnapshot(
             id: panelId,
@@ -2324,6 +2326,8 @@ extension Workspace {
         case .mobilePairing:
             return nil
         case .accountSignIn:
+            return nil
+        case .cloudVPNSetup:
             return nil
         }
     }
@@ -6723,7 +6727,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         if isRemoteTmuxMirror { return false }
         if panels.values.contains(where: {
             switch $0.panelType {
-            case .cloudVMLoading, .mobilePairing, .accountSignIn:
+            case .cloudVMLoading, .mobilePairing, .accountSignIn, .cloudVPNSetup:
                 true
             default:
                 false

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */; };
 		C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */; };
 		7A0CE1000000000000000045 /* AppDelegate+CloudTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CE1000000000000000019 /* AppDelegate+CloudTunnel.swift */; };
+		456688D7D7AF1B04FD2A1151 /* AppDelegate+CloudVPNSetupWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FB4C4DFDC44DB548B76938 /* AppDelegate+CloudVPNSetupWorkspace.swift */; };
 		C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */; };
 		C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */; };
 		C0A716920000000000000002 /* AppDelegate+ComputerUseOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A716920000000000000001 /* AppDelegate+ComputerUseOnboarding.swift */; };
@@ -808,6 +809,9 @@
 		C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */; };
 		2F48EE37A14B4D76A8013B83 /* CloudVMState+SnapshotComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18D73C012B643DBADE8B7B5 /* CloudVMState+SnapshotComparison.swift */; };
 		2D7F228001C24ABD865AFD66 /* CloudVMStateSnapshotComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFB9C9E7B5D4F39873871A1 /* CloudVMStateSnapshotComparisonTests.swift */; };
+		FA180397F33FBA8B9015B562 /* CloudVPNSetupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3055A839520F46C3C7FCD198 /* CloudVPNSetupModel.swift */; };
+		142C1512A9FF7D8D6D605D13 /* CloudVPNSetupPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEE3497B1A91FBE5F449E3D /* CloudVPNSetupPanel.swift */; };
+		211BAB87353921474EF587A5 /* CloudVPNSetupPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0C7A4AFC6199BECB6E2ECD /* CloudVPNSetupPanelView.swift */; };
 		999B711473384AA9593B1936 /* CloudWireGuardHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F40FDCEAFAA24EB9A175A2 /* CloudWireGuardHub.swift */; };
 		7A0CE1000000000000000710 /* CloudWireGuardHubDialer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CE100000000000000070F /* CloudWireGuardHubDialer.swift */; };
 		05FCD63D10A4F9C56B683B5A /* CloudWireGuardHubProcessSpawner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C68DA526C0C2D39FE217B6 /* CloudWireGuardHubProcessSpawner.swift */; };
@@ -3304,6 +3308,7 @@
 		C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11323020000000000000001 /* Workspace+CloudManualMirror.swift */; };
 		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */; };
+		7806088FC566EAEFDB186931 /* Workspace+CloudVPNSetupPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5748A8176DB3678214B1436 /* Workspace+CloudVPNSetupPane.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
 		A5FB120D /* Workspace+CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB120E /* Workspace+CustomLayout.swift */; };
 		C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */; };
@@ -3806,6 +3811,7 @@
 		C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CanvasShortcutRouting.swift"; sourceTree = "<group>"; };
 		C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ClosedItemHistory.swift"; sourceTree = "<group>"; };
 		7A0CE1000000000000000019 /* AppDelegate+CloudTunnel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CloudTunnel.swift"; sourceTree = "<group>"; };
+		E9FB4C4DFDC44DB548B76938 /* AppDelegate+CloudVPNSetupWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CloudVPNSetupWorkspace.swift"; sourceTree = "<group>"; };
 		C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxNavigationDeepLinks.swift"; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
 		C0A716920000000000000001 /* AppDelegate+ComputerUseOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ComputerUseOnboarding.swift"; sourceTree = "<group>"; };
@@ -4390,6 +4396,9 @@
 		C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMMenuItemMetricsTests.swift; sourceTree = "<group>"; };
 		F18D73C012B643DBADE8B7B5 /* CloudVMState+SnapshotComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudVMState+SnapshotComparison.swift"; sourceTree = "<group>"; };
 		7EFB9C9E7B5D4F39873871A1 /* CloudVMStateSnapshotComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMStateSnapshotComparisonTests.swift; sourceTree = "<group>"; };
+		3055A839520F46C3C7FCD198 /* CloudVPNSetupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cloud/Tunnel/CloudVPNSetupModel.swift"; sourceTree = "<group>"; };
+		7AEE3497B1A91FBE5F449E3D /* CloudVPNSetupPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cloud/Tunnel/CloudVPNSetupPanel.swift"; sourceTree = "<group>"; };
+		7D0C7A4AFC6199BECB6E2ECD /* CloudVPNSetupPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cloud/Tunnel/CloudVPNSetupPanelView.swift"; sourceTree = "<group>"; };
 		D8F40FDCEAFAA24EB9A175A2 /* CloudWireGuardHub.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWireGuardHub.swift; sourceTree = "<group>"; };
 		7A0CE100000000000000070F /* CloudWireGuardHubDialer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWireGuardHubDialer.swift; sourceTree = "<group>"; };
 		20C68DA526C0C2D39FE217B6 /* CloudWireGuardHubProcessSpawner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudWireGuardHubProcessSpawner.swift; sourceTree = "<group>"; };
@@ -6771,6 +6780,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		C11323020000000000000001 /* Workspace+CloudManualMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudManualMirror.swift"; sourceTree = "<group>"; };
 		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPlacementFailure.swift"; sourceTree = "<group>"; };
+		E5748A8176DB3678214B1436 /* Workspace+CloudVPNSetupPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudVPNSetupPane.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
 		A5FB120E /* Workspace+CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomLayout.swift"; sourceTree = "<group>"; };
 		C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPane.swift"; sourceTree = "<group>"; };
@@ -9392,6 +9402,11 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D81390020000000000000002 /* DockSplitStore+ShortcutCommands.swift */,
 				DCDC1000000000000000C001 /* AppDelegate+DockSurfaceMove.swift */,
 				A5C01700000000000000000E /* AppDelegate+AccountSignInWorkspace.swift */,
+				3055A839520F46C3C7FCD198 /* CloudVPNSetupModel.swift */,
+				7D0C7A4AFC6199BECB6E2ECD /* CloudVPNSetupPanelView.swift */,
+				7AEE3497B1A91FBE5F449E3D /* CloudVPNSetupPanel.swift */,
+				E5748A8176DB3678214B1436 /* Workspace+CloudVPNSetupPane.swift */,
+				E9FB4C4DFDC44DB548B76938 /* AppDelegate+CloudVPNSetupWorkspace.swift */,
 				DCDC1000000000000000C021 /* DockScope.swift */,
 				904090409040904090409044 /* DockSplitContentView.swift */,
 				DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */,
@@ -11354,6 +11369,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */,
 				C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */,
 				7A0CE1000000000000000045 /* AppDelegate+CloudTunnel.swift in Sources */,
+				456688D7D7AF1B04FD2A1151 /* AppDelegate+CloudVPNSetupWorkspace.swift in Sources */,
 				C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */,
 				C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */,
 				C0A716920000000000000002 /* AppDelegate+ComputerUseOnboarding.swift in Sources */,
@@ -11724,6 +11740,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				7A0CE1000000000000000502 /* CloudTunnelTiming.swift in Sources */,
 				C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */,
 				2F48EE37A14B4D76A8013B83 /* CloudVMState+SnapshotComparison.swift in Sources */,
+				FA180397F33FBA8B9015B562 /* CloudVPNSetupModel.swift in Sources */,
+				142C1512A9FF7D8D6D605D13 /* CloudVPNSetupPanel.swift in Sources */,
+				211BAB87353921474EF587A5 /* CloudVPNSetupPanelView.swift in Sources */,
 				999B711473384AA9593B1936 /* CloudWireGuardHub.swift in Sources */,
 				7A0CE1000000000000000710 /* CloudWireGuardHubDialer.swift in Sources */,
 				05FCD63D10A4F9C56B683B5A /* CloudWireGuardHubProcessSpawner.swift in Sources */,
@@ -13283,6 +13302,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */,
 				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */,
+				7806088FC566EAEFDB186931 /* Workspace+CloudVPNSetupPane.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,
 				A5FB120D /* Workspace+CustomLayout.swift in Sources */,
 				C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */,

--- a/cmuxTests/CloudTreeMachineMenuTests.swift
+++ b/cmuxTests/CloudTreeMachineMenuTests.swift
@@ -45,6 +45,7 @@ struct CloudTreeMachineMenuTests {
             Self.title("cloudTree.menu.refresh", "Refresh"),
             Self.title("machines.menu.rename", "Rename\u{2026}"),
             Self.title("machines.menu.copyIPAddress", "Copy IP Address"),
+            Self.title("machines.menu.setupVPN", "Set Up cmux VPN…"),
             Self.title("machines.menu.status", "Status"),
             Self.title("machines.menu.checkpoint", "Checkpoint"),
             Self.title("machines.menu.fork", "Fork"),

--- a/cmuxTests/CloudTreeMachineMenuTests.swift
+++ b/cmuxTests/CloudTreeMachineMenuTests.swift
@@ -33,7 +33,9 @@ struct CloudTreeMachineMenuTests {
         // The container owns the outline view the coordinator only holds
         // weakly; keep it alive for the whole menu round-trip.
         let container = CloudTreeContainerView(coordinator: coordinator)
-        defer { withExtendedLifetime(container) {} }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 300, height: 400), styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        defer { window.contentView = nil; withExtendedLifetime(window) {} }
         coordinator.apply(nodes: [Self.machineNode()])
 
         let menu = try #require(coordinator.contextMenu(forRow: 0))
@@ -53,6 +55,7 @@ struct CloudTreeMachineMenuTests {
         ])
         try Self.choose(Self.title("machines.menu.setupVPN", "Set Up cmux VPN…"), in: menu)
         #expect(recorder.vpnSetupCount == 1)
+        #expect(recorder.vpnSetupWindow === window)
         // Every verb is a leaf: nothing opens a submenu of targets.
         #expect(menu.items.allSatisfy { $0.submenu == nil })
 
@@ -109,7 +112,7 @@ struct CloudTreeMachineMenuTests {
 
     private static func machineActions(recording recorder: CloudTreeMenuVerbRecorder) -> MachineRowActions {
         MachineRowActions(
-            setupVPN: { recorder.vpnSetupCount += 1 },
+            setupVPN: { window in recorder.vpnSetupCount += 1; recorder.vpnSetupWindow = window },
             openShell: { _ in },
             openDesktop: { _ in },
             runCommand: { id, verb in recorder.commands.append((id: id, verb: verb)) },
@@ -146,6 +149,7 @@ struct CloudTreeMachineMenuTests {
 @MainActor
 private final class CloudTreeMenuVerbRecorder {
     var vpnSetupCount = 0
+    weak var vpnSetupWindow: NSWindow?
     var newTerminals: [SurfaceMachineID] = []
     var commands: [(id: String, verb: [String])] = []
     var deletions: [String] = []

--- a/cmuxTests/CloudTreeMachineMenuTests.swift
+++ b/cmuxTests/CloudTreeMachineMenuTests.swift
@@ -51,6 +51,8 @@ struct CloudTreeMachineMenuTests {
             Self.title("machines.menu.fork", "Fork"),
             Self.title("machines.menu.delete", "Delete\u{2026}"),
         ])
+        try Self.choose(Self.title("machines.menu.setupVPN", "Set Up cmux VPN…"), in: menu)
+        #expect(recorder.vpnSetupCount == 1)
         // Every verb is a leaf: nothing opens a submenu of targets.
         #expect(menu.items.allSatisfy { $0.submenu == nil })
 
@@ -107,6 +109,7 @@ struct CloudTreeMachineMenuTests {
 
     private static func machineActions(recording recorder: CloudTreeMenuVerbRecorder) -> MachineRowActions {
         MachineRowActions(
+            setupVPN: { recorder.vpnSetupCount += 1 },
             openShell: { _ in },
             openDesktop: { _ in },
             runCommand: { id, verb in recorder.commands.append((id: id, verb: verb)) },
@@ -142,6 +145,7 @@ struct CloudTreeMachineMenuTests {
 /// wired to its closure and not merely titled.
 @MainActor
 private final class CloudTreeMenuVerbRecorder {
+    var vpnSetupCount = 0
     var newTerminals: [SurfaceMachineID] = []
     var commands: [(id: String, verb: [String])] = []
     var deletions: [String] = []

--- a/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
+++ b/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
@@ -261,6 +261,7 @@ struct CloudTreeNativeDragOwnershipTests {
     }
 
     private static let machineActions = MachineRowActions(
+        setupVPN: {},
         openShell: { _ in },
         openDesktop: { _ in },
         runCommand: { _, _ in },

--- a/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
+++ b/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
@@ -261,7 +261,7 @@ struct CloudTreeNativeDragOwnershipTests {
     }
 
     private static let machineActions = MachineRowActions(
-        setupVPN: {},
+        setupVPN: { _ in },
         openShell: { _ in },
         openDesktop: { _ in },
         runCommand: { _, _ in },

--- a/cmuxTests/CloudTunnelBannerTests.swift
+++ b/cmuxTests/CloudTunnelBannerTests.swift
@@ -89,7 +89,7 @@ struct CloudTunnelBannerTests {
 }
 
 @MainActor
-@Suite("Optional Cloud VPN setup", .timeLimit(.minutes(1)))
+@Suite("Optional Cloud VPN setup")
 struct CloudVPNSetupModelTests {
     private let backend = CloudTunnelBackend.networkExtension(extensionBundleIdentifier: "test.cloud.vpn")
 

--- a/cmuxTests/CloudTunnelBannerTests.swift
+++ b/cmuxTests/CloudTunnelBannerTests.swift
@@ -87,3 +87,91 @@ struct CloudTunnelBannerTests {
         return predicate()
     }
 }
+
+@MainActor
+@Suite("Optional Cloud VPN setup", .timeLimit(.minutes(1)))
+struct CloudVPNSetupModelTests {
+    private let backend = CloudTunnelBackend.networkExtension(extensionBundleIdentifier: "test.cloud.vpn")
+
+    @Test("Opening setup reads status without enrolling or requesting approval")
+    func openingIsPassive() async {
+        let controller = FakeTunnelController()
+        let enroller = FakeTunnelEnroller()
+        let coordinator = CloudTunnelCoordinator(backend: backend, controller: controller, enroller: enroller, consumers: FakeTunnelConsumers())
+        let model = CloudVPNSetupModel(coordinator: coordinator)
+        await model.refresh()
+        #expect(model.state == .off)
+        #expect(model.canConnect)
+        #expect(enroller.enrollCount == 0)
+        #expect(controller.calls.isEmpty)
+    }
+
+    @Test("Unavailable extensions cannot start setup")
+    func unsupportedBuild() async {
+        let model = CloudVPNSetupModel(coordinator: nil)
+        #expect(!model.canConnect)
+        #expect(model.unavailableMessage != nil)
+        await model.connect()
+        #expect(model.state == .off)
+    }
+
+    @Test("Admission errors stay visible without an extension prompt")
+    func admissionError() async {
+        let controller = FakeTunnelController()
+        let enroller = FakeTunnelEnroller()
+        let coordinator = CloudTunnelCoordinator(
+            backend: backend,
+            controller: controller,
+            enroller: enroller,
+            consumers: FakeTunnelConsumers(),
+            admission: CloudTunnelAdmission(knownRefusal: { .noCloudMachine }, resolvedRefusal: { .noCloudMachine })
+        )
+        let model = CloudVPNSetupModel(coordinator: coordinator)
+        await model.connect()
+        #expect(model.errorMessage == CloudTunnelError.noCloudMachine.description)
+        #expect(!model.isSubmitting)
+        #expect(controller.calls.isEmpty)
+        #expect(enroller.enrollCount == 0)
+    }
+
+    @Test("Approval completes the same connection, and Disconnect stops it")
+    func approvalThenDisconnect() async {
+        let controller = FakeTunnelController()
+        controller.holdInstallForApproval = true
+        let enroller = FakeTunnelEnroller()
+        let coordinator = CloudTunnelCoordinator(backend: backend, controller: controller, enroller: enroller, consumers: FakeTunnelConsumers())
+        let model = CloudVPNSetupModel(coordinator: coordinator)
+        await model.connect()
+        #expect(await coordinator.waitForState(timeout: .seconds(5)) { $0 == .awaitingApproval } == .awaitingApproval)
+        await model.refresh()
+        #expect(model.state == .awaitingApproval)
+        #expect(!model.canConnect)
+        await model.connect()
+        #expect(enroller.enrollCount == 1)
+        controller.approve()
+        #expect(await coordinator.waitForState(timeout: .seconds(5)) { $0 == .up } == .up)
+        await model.refresh()
+        #expect(model.state == .up)
+        #expect(await coordinator.status().isPinned)
+        await model.disconnect()
+        #expect(model.state == .off)
+        #expect(!(await coordinator.status().isPinned))
+    }
+
+    @Test("Failed connection is reported and the user can retry")
+    func failedStartCanRetry() async {
+        let controller = FakeTunnelController()
+        controller.startError = FakeTunnelController.Failure.refused
+        let coordinator = CloudTunnelCoordinator(backend: backend, controller: controller, enroller: FakeTunnelEnroller(), consumers: FakeTunnelConsumers())
+        let model = CloudVPNSetupModel(coordinator: coordinator)
+        await model.connect()
+        _ = await coordinator.waitForState(timeout: .seconds(5)) { $0.failureMessage != nil }
+        await model.refresh()
+        #expect(model.state.failureMessage != nil)
+        #expect(model.canConnect)
+        controller.startError = nil
+        await model.connect()
+        #expect(await coordinator.waitForState(timeout: .seconds(5)) { $0 == .up } == .up)
+        await model.disconnect()
+    }
+}

--- a/cmuxTests/MobileSurfaceKindMappingTests.swift
+++ b/cmuxTests/MobileSurfaceKindMappingTests.swift
@@ -24,6 +24,11 @@ import Testing
         .extensionBrowser: "extensionBrowser",
         .workspaceTodo: "todo",
         .cloudVMLoading: "cloudVMLoading",
+        .cloudVPNSetup: "cloud_vpn_setup",
+        .notifications: "notifications",
+        .simulator: "simulator",
+        .mobilePairing: "mobilePairing",
+        .accountSignIn: "accountSignIn",
     ]
 
     @Test func everyPanelTypeMapsToItsCanonicalWireKind() throws {

--- a/docs/cloud-userspace-wireguard.md
+++ b/docs/cloud-userspace-wireguard.md
@@ -69,6 +69,17 @@ back to the control plane's tokened preview URL.
 
 ## System-wide route (`cmux vpn up`)
 
+The Machines panel has an optional **Set Up cmux VPN…** entry. The same action
+is available in the workspace plus-button menu, the command palette, and the
+context menus for Cloud machines and private port URLs. Each opens the same
+native setup pane, like iPhone pairing. Opening it only reads connection status;
+**Connect Cloud VPN** explicitly starts and pins the existing tunnel coordinator.
+The pane explains extension approval and VPN configuration permission, follows
+approval automatically, reports errors, and supports cancellation and disconnect.
+It reports builds without a signed extension as unavailable without prompting.
+Automation can open it through `workspace.action {action: "cloud_vpn_setup"}`.
+
+
 `cmux vpn up` creates a separate browser peer through `POST /api/vm/tunnel`,
 saves its configuration in the Apple VPN manager, and requests activation of
 the bundled packet tunnel system extension. macOS can require one user


### PR DESCRIPTION
## Summary
- Add an optional Cloud VPN setup pane with private-address examples and macOS extension/VPN approval steps.
- Route the Machines panel entry, workspace plus-button, command palette, Cloud machine context menu, and automation action through one pane-opening path.
- Show approval, failure, retry, cancel, disconnect, and signed-extension-unavailable states without starting a tunnel when the pane opens.
- Add behavior coverage for passive opening, admission failures, approval, retry, disconnect, and menu wiring.

## Testing
- `CMUX_DEV_BACKEND_MODE=off ./scripts/reload-cloud.sh --tag vpnu` succeeded on the shared Mac fleet in 304 seconds.
- `python3 scripts/localization_catalog.py check --limit 5` passed for 6 catalogs and 9 locales.
- `./scripts/lint-pbxproj-test-wiring.sh` passed.
- Focused XCTest was attempted but the fleet was at capacity and its available test preflight had no usable GUI session.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791709565&installation_model_id=21920&pr_number=12317&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12317&signature=e05fbece197a96d39a743c23371bcce80edcabadf6adb7b4d9cfff4e67e8b5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces user-facing VPN connect/disconnect and macOS network-extension approval flows via the existing tunnel coordinator; routing is broad but logic is mostly UI and pane orchestration.
> 
> **Overview**
> Adds an **optional Cloud VPN setup** experience so users can connect cmux’s network extension and reach Cloud VM **private IPs** from apps like Safari, without changing how built-in Cloud terminals/ports work.
> 
> A new **`cloudVPNSetup` workspace pane** (`CloudVPNSetupPanel` / `CloudVPNSetupModel` / `CloudVPNSetupPanelView`) observes `CloudTunnelCoordinator`, shows status and first-time macOS approval steps, and drives **Connect / Disconnect / Cancel** (including admission errors and unsigned-extension messaging). **`AppDelegate.openCloudVPNSetupWorkspace`** centralizes opening or focusing that pane (reuses an existing workspace when present).
> 
> **Entry points** now route through that helper: Machines sidebar row, **Set Up cmux VPN…** in the new-workspace management menu (when Cloud Machines is enabled), Cloud machine/port context menus, the command palette, and a new CLI/workspace action **`cloud_vpn_setup`**. The PR also registers the panel type across canvas, history, search, lifecycle, and layout capture (VPN setup is excluded from session restore like other ephemeral setup panes).
> 
> **Localization** adds full `cloud.vpn.setup.*` strings (many locales). **Tests** cover setup model behavior (passive open, admission failure, approval, retry, disconnect) and machine menu VPN wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41895c8850b5e7a5945e73ff734039679a6b190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Cloud VPN setup pane with connection status, guidance, approval steps, and Connect, Disconnect, and Cancel actions.
  - Added access through the Machines panel, workspace menu, command palette, and Cloud machine or port context menus.
  - Added support for opening the setup pane through workspace actions.
  - Reports unavailable status when required VPN support is not present.
  - Added localized Cloud VPN interface text in multiple languages.

- **Documentation**
  - Documented Cloud VPN setup options, permissions, errors, and workspace access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->