### PR TITLE
cloud: enable beta feature by default in dev builds

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
@@ -68,13 +68,20 @@ public struct BetaFeaturesCatalogSection: SettingCatalogSection {
 
     /// Cloud Machines: the Cloud tab in the right sidebar plus every other
     /// Cloud VM surface (Settings section, palette commands), and the gate
-    /// for launch-time Cloud work (fleet polling, the Cloud tunnel). Defaults
-    /// off on every build; this toggle is the only way in.
+    /// for launch-time Cloud work (fleet polling, the Cloud tunnel). Dev
+    /// builds default on for dogfood; release builds stay opt-in. An explicit
+    /// setting still wins on either build.
     public let cloudMachines = DefaultsKey<Bool>(
         id: "cloud.beta.machines.enabled",
-        defaultValue: false,
+        defaultValue: Self.cloudMachinesDefault,
         userDefaultsKey: "cloud.beta.machines.enabled"
     )
+
+    #if DEBUG
+    private static let cloudMachinesDefault = true
+    #else
+    private static let cloudMachinesDefault = false
+    #endif
 
     /// Remote tmux: mirror a remote host's tmux sessions in the cmux sidebar
     /// over `ssh … tmux -CC` (iTerm2-style control mode). Sessions appear as

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -75,7 +75,8 @@ public struct SettingsWindowRoot: View {
     // Mirrors BetaFeaturesCatalogSection.cloudMachines so flipping the Beta
     // Features toggle shows/hides the Cloud sidebar row without reopening
     // Settings; the host folds in the remote rollout flag.
-    @AppStorage(SettingsWindowRoot.cloudMachinesBetaDefaultsKey) private var cloudMachinesBetaEnabled = false
+    @AppStorage(SettingsWindowRoot.cloudMachinesBetaDefaultsKey)
+    private var cloudMachinesBetaEnabled = BetaFeaturesCatalogSection().cloudMachines.defaultValue
     // Legacy `SettingsRootView` binds `NavigationSplitView`'s
     // `columnVisibility` so the user can collapse the sidebar via the
     // toolbar button (or the SidebarCommands menu) and have that state

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -485,7 +485,7 @@ enum RightSidebarBetaFeatureSettings {
 
     static let defaultFeedEnabled = false
     static let defaultDockEnabled = false
-    static let defaultCloudMachinesEnabled = false
+    static let defaultCloudMachinesEnabled = BetaFeaturesCatalogSection().cloudMachines.defaultValue
     static let didChangeNotification = Notification.Name("rightSidebarBetaFeatureDidChange")
 
     nonisolated static func isFeedEnabled(defaults: UserDefaults = .standard) -> Bool {

--- a/Sources/Cloud/CloudActivationPolicy.swift
+++ b/Sources/Cloud/CloudActivationPolicy.swift
@@ -55,7 +55,7 @@ struct CloudActivationPolicy: Sendable {
     /// Mac used Cloud before (an update must not strand a fleet the user
     /// already has). A Debug default alone does not start background work.
     var allowsBackgroundCloudWork: Bool {
-        (isCloudMachinesExplicitlyEnabled?() ?? isCloudMachinesEnabled()) || hasUsedCloud()
+        (isCloudMachinesEnabled() && (isCloudMachinesExplicitlyEnabled?() ?? true)) || hasUsedCloud()
     }
 
     /// The launch-time tunnel controller may read NetworkExtension preferences

--- a/Sources/Cloud/CloudActivationPolicy.swift
+++ b/Sources/Cloud/CloudActivationPolicy.swift
@@ -30,6 +30,10 @@ struct CloudActivationPolicy: Sendable {
     /// `Settings › Beta Features › Cloud Machines` is on and no managed
     /// profile disables Cloud (``CloudMachinesFeature``).
     let isCloudMachinesEnabled: @Sendable () -> Bool
+    /// Whether the user explicitly enabled Cloud Machines. Dev builds may
+    /// expose Cloud by default without starting background fleet polling.
+    /// Tests and older callers may omit this and fall back to the main gate.
+    let isCloudMachinesExplicitlyEnabled: (@Sendable () -> Bool)?
     /// This Mac has used Cloud before: the cached marker says the account had
     /// a machine, or a tunnel role was enrolled here (which only happens for a
     /// machine). Cleared by sign-out.
@@ -47,10 +51,11 @@ struct CloudActivationPolicy: Sendable {
     /// use that is about to schedule a start, never at launch or for status.
     let resolveCloudMachine: @Sendable () async -> Bool?
 
-    /// Fleet polling and links may run: the user opted in, or this Mac used
-    /// Cloud before (an update must not strand a fleet the user already has).
+    /// Fleet polling and links may run: the user explicitly opted in, or this
+    /// Mac used Cloud before (an update must not strand a fleet the user
+    /// already has). A Debug default alone does not start background work.
     var allowsBackgroundCloudWork: Bool {
-        isCloudMachinesEnabled() || hasUsedCloud()
+        (isCloudMachinesExplicitlyEnabled?() ?? isCloudMachinesEnabled()) || hasUsedCloud()
     }
 
     /// The launch-time tunnel controller may read NetworkExtension preferences
@@ -111,6 +116,9 @@ struct CloudActivationPolicy: Sendable {
         return CloudActivationPolicy(
             isCloudMachinesEnabled: {
                 CloudMachinesFeature.offMainIsEnabled(defaults: toggleDefaults)
+            },
+            isCloudMachinesExplicitlyEnabled: {
+                CloudMachinesFeature.isExplicitlyEnabled(defaults: toggleDefaults)
             },
             hasUsedCloud: {
                 machineCache.hasAnyMachine == true

--- a/Sources/Cloud/CloudActivationPolicy.swift
+++ b/Sources/Cloud/CloudActivationPolicy.swift
@@ -30,10 +30,6 @@ struct CloudActivationPolicy: Sendable {
     /// `Settings › Beta Features › Cloud Machines` is on and no managed
     /// profile disables Cloud (``CloudMachinesFeature``).
     let isCloudMachinesEnabled: @Sendable () -> Bool
-    /// Whether the user explicitly enabled Cloud Machines. Dev builds may
-    /// expose Cloud by default without starting background fleet polling.
-    /// Tests and older callers may omit this and fall back to the main gate.
-    let isCloudMachinesExplicitlyEnabled: (@Sendable () -> Bool)?
     /// This Mac has used Cloud before: the cached marker says the account had
     /// a machine, or a tunnel role was enrolled here (which only happens for a
     /// machine). Cleared by sign-out.
@@ -51,11 +47,10 @@ struct CloudActivationPolicy: Sendable {
     /// use that is about to schedule a start, never at launch or for status.
     let resolveCloudMachine: @Sendable () async -> Bool?
 
-    /// Fleet polling and links may run: the user explicitly opted in, or this
-    /// Mac used Cloud before (an update must not strand a fleet the user
-    /// already has). A Debug default alone does not start background work.
+    /// Fleet polling and links may run: Cloud is enabled, or this Mac used
+    /// Cloud before (an update must not strand a fleet the user already has).
     var allowsBackgroundCloudWork: Bool {
-        (isCloudMachinesEnabled() && (isCloudMachinesExplicitlyEnabled?() ?? true)) || hasUsedCloud()
+        isCloudMachinesEnabled() || hasUsedCloud()
     }
 
     /// The launch-time tunnel controller may read NetworkExtension preferences
@@ -116,9 +111,6 @@ struct CloudActivationPolicy: Sendable {
         return CloudActivationPolicy(
             isCloudMachinesEnabled: {
                 CloudMachinesFeature.offMainIsEnabled(defaults: toggleDefaults)
-            },
-            isCloudMachinesExplicitlyEnabled: {
-                CloudMachinesFeature.isExplicitlyEnabled(defaults: toggleDefaults)
             },
             hasUsedCloud: {
                 machineCache.hasAnyMachine == true

--- a/Sources/Cloud/CloudMachinesFeature.swift
+++ b/Sources/Cloud/CloudMachinesFeature.swift
@@ -4,10 +4,11 @@ import Foundation
 /// Whether the Cloud Machines surfaces are available: the local Beta Features
 /// opt-in (`Settings › Beta Features › Cloud Machines`, also
 /// `cloud.beta.machines.enabled` in `cmux.json`), unless a managed profile
-/// disables Cloud. Off by default on every build. Every entry point
+/// disables Cloud. Dev builds default on for dogfood; release builds default
+/// off. Every entry point
 /// (right-sidebar Cloud tab, Settings section, command palette) and every
 /// launch-time Cloud subsystem (``CloudActivationPolicy``) funnels through
-/// this gate, so the toggle is the only way in.
+/// this gate, so the toggle remains the single local override.
 enum CloudMachinesFeature {
     static var isEnabled: Bool {
         offMainIsEnabled()

--- a/Sources/Cloud/CloudMachinesFeature.swift
+++ b/Sources/Cloud/CloudMachinesFeature.swift
@@ -32,4 +32,13 @@ enum CloudMachinesFeature {
         guard defaults.object(forKey: key.userDefaultsKey) != nil else { return key.defaultValue }
         return defaults.bool(forKey: key.userDefaultsKey)
     }
+
+    /// Whether the user has stored an explicit local Cloud Machines choice.
+    /// This is separate from ``localOptIn`` so a Debug default can expose the
+    /// UI without starting background fleet polling until the user opts in.
+    nonisolated static func isExplicitlyEnabled(defaults: UserDefaults) -> Bool {
+        let key = BetaFeaturesCatalogSection().cloudMachines
+        return defaults.object(forKey: key.userDefaultsKey) != nil
+            && defaults.bool(forKey: key.userDefaultsKey)
+    }
 }

--- a/Sources/Cloud/CloudMachinesFeature.swift
+++ b/Sources/Cloud/CloudMachinesFeature.swift
@@ -32,13 +32,4 @@ enum CloudMachinesFeature {
         guard defaults.object(forKey: key.userDefaultsKey) != nil else { return key.defaultValue }
         return defaults.bool(forKey: key.userDefaultsKey)
     }
-
-    /// Whether the user has stored an explicit local Cloud Machines choice.
-    /// This is separate from ``localOptIn`` so a Debug default can expose the
-    /// UI without starting background fleet polling until the user opts in.
-    nonisolated static func isExplicitlyEnabled(defaults: UserDefaults) -> Bool {
-        let key = BetaFeaturesCatalogSection().cloudMachines
-        return defaults.object(forKey: key.userDefaultsKey) != nil
-            && defaults.bool(forKey: key.userDefaultsKey)
-    }
 }

--- a/cmuxTests/CloudActivationPolicyTests.swift
+++ b/cmuxTests/CloudActivationPolicyTests.swift
@@ -284,7 +284,7 @@ struct CloudActivationPolicyTests {
         #expect(cache.hasAnyMachine == nil)
     }
 
-    @Test("Cloud Machines is off by default, on only through the Beta Features toggle, and never on under a managed DisableCloud")
+    @Test("Cloud Machines defaults on in dev builds, remains explicitly controllable, and never bypasses managed DisableCloud")
     func cloudMachinesGateIsTheBetaToggle() throws {
         let suiteName = "cmux.cloud.feature.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -294,8 +294,13 @@ struct CloudActivationPolicyTests {
             key == ManagedDevicePolicyKey.disableCloud.rawValue ? true : nil
         })
 
-        #expect(CloudMachinesFeature.localOptIn(defaults: defaults) == false)
-        #expect(CloudMachinesFeature.isEnabled(defaults: defaults, policy: unmanaged) == false)
+        #if DEBUG
+        let expectedDefault = true
+        #else
+        let expectedDefault = false
+        #endif
+        #expect(CloudMachinesFeature.localOptIn(defaults: defaults) == expectedDefault)
+        #expect(CloudMachinesFeature.isEnabled(defaults: defaults, policy: unmanaged) == expectedDefault)
 
         defaults.set(true, forKey: RightSidebarBetaFeatureSettings.cloudMachinesEnabledKey)
         #expect(CloudMachinesFeature.isEnabled(defaults: defaults, policy: unmanaged))

--- a/cmuxTests/CloudActivationPolicyTests.swift
+++ b/cmuxTests/CloudActivationPolicyTests.swift
@@ -312,5 +312,15 @@ struct CloudActivationPolicyTests {
 
         defaults.set(false, forKey: RightSidebarBetaFeatureSettings.cloudMachinesEnabledKey)
         #expect(CloudMachinesFeature.isEnabled(defaults: defaults, policy: unmanaged) == false)
+
+        let managedBackground = CloudActivationPolicy(
+            isCloudMachinesEnabled: { false },
+            isCloudMachinesExplicitlyEnabled: { true },
+            hasUsedCloud: { false },
+            hasCloudMachine: { nil },
+            isTunnelConfigured: { false },
+            resolveCloudMachine: { nil }
+        )
+        #expect(managedBackground.allowsBackgroundCloudWork == false)
     }
 }

--- a/cmuxTests/CloudActivationPolicyTests.swift
+++ b/cmuxTests/CloudActivationPolicyTests.swift
@@ -191,7 +191,11 @@ struct CloudActivationPolicyTests {
 
         #expect(policy.allowsBackgroundCloudWork == false)
         #expect(policy.allowsLaunchTimeTunnelAdoption == false)
+        #if DEBUG
+        #expect(policy.tunnelStartRefusal() == nil)
+        #else
         #expect(policy.tunnelStartRefusal() == .cloudMachinesOff)
+        #endif
 
         harness.turnCloudMachines(on: true)
         #expect(policy.allowsBackgroundCloudWork)

--- a/cmuxTests/CloudActivationPolicyTests.swift
+++ b/cmuxTests/CloudActivationPolicyTests.swift
@@ -189,7 +189,11 @@ struct CloudActivationPolicyTests {
         defer { harness.tearDown() }
         let policy = harness.policy
 
+        #if DEBUG
+        #expect(policy.allowsBackgroundCloudWork)
+        #else
         #expect(policy.allowsBackgroundCloudWork == false)
+        #endif
         #expect(policy.allowsLaunchTimeTunnelAdoption == false)
         #if DEBUG
         #expect(policy.tunnelStartRefusal() == nil)
@@ -313,14 +317,5 @@ struct CloudActivationPolicyTests {
         defaults.set(false, forKey: RightSidebarBetaFeatureSettings.cloudMachinesEnabledKey)
         #expect(CloudMachinesFeature.isEnabled(defaults: defaults, policy: unmanaged) == false)
 
-        let managedBackground = CloudActivationPolicy(
-            isCloudMachinesEnabled: { false },
-            isCloudMachinesExplicitlyEnabled: { true },
-            hasUsedCloud: { false },
-            hasCloudMachine: { nil },
-            isTunnelConfigured: { false },
-            resolveCloudMachine: { nil }
-        )
-        #expect(managedBackground.allowsBackgroundCloudWork == false)
     }
 }

--- a/docs/cloud-userspace-wireguard.md
+++ b/docs/cloud-userspace-wireguard.md
@@ -91,8 +91,9 @@ the single decision every tunnel consumer (browser navigation, `cmux vpn up`,
 `vm.tunnel_config`, `vm.tunnel_up`) flows through:
 
 - A start is admitted only when `Settings › Beta Features › Cloud Machines` is
-  on (`cloud.beta.machines.enabled`, off by default on every build, and never
-  forced on by a managed `DisableCloud` profile) **and** the account has at
+  on (`cloud.beta.machines.enabled`, on by default in dev builds and off by
+  default in release builds, and never forced on by a managed `DisableCloud`
+  profile) **and** the account has at
   least one machine. Launch-time decisions and status answer "has a machine"
   from a cached marker written by every machine list and create
   (`cloud.machines.cachedHasAny`; cleared on sign-out, reset to unknown by a


### PR DESCRIPTION
Cloud Machines now defaults on in Debug builds, so a fresh dev build exposes Cloud without a manual Beta Features toggle. Release builds keep their existing default. Saved user settings and the managed `DisableCloud` policy still apply.

The shared settings catalog supplies the default to Settings, the sidebar, and the Cloud activation gate. Debug builds also start the existing Cloud background work when the feature is enabled. This is intentional: a separate stored opt-in would make the enabled toggle require an off/on cycle. No polling loop or interval changes.

Validation:
- 332 CmuxSettings tests passed in Debug and in Release.
- Tagged Debug build `cdf4` passed at commit `301bdc98ca471fbef82b2b86554a90ed838516ef`.
- The same runtime behavior was checked in `cdevdf`: the Cloud sidebar opened without changing the beta toggle. The direct development backend was full, so Cloud service connectivity remains unverified.
- The fresh-install Cloud activation test now expects the Debug default while preserving explicit on/off and managed-policy checks. [Focused hosted test run](https://github.com/manaflow-ai/cmux/actions/runs/34597162495) is in progress.
- Localization audit: no displayed text or translation keys changed.
