### PR TITLE
cloud: fix Freestyle VM fork via snapshot clone

### DIFF
--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -27,6 +27,8 @@ import {
   type CmuxRemoteApprovalOptions,
   type CmuxRemoteAttachOptions,
   type CmuxRemoteEndpoint,
+  type VmCapabilities,
+  vmCapabilitiesFor,
 } from "./drivers";
 import { VmOperationUnsupportedError, VmProviderOperationError } from "./errors";
 
@@ -68,6 +70,8 @@ export type VmProviderGatewayShape = {
     snapshotId: string,
   ) => Effect.Effect<void, VmProviderOperationError>;
   readonly fork?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
+  /** Driver capabilities. Optional for compatibility with older test doubles. */
+  readonly capabilities?: (provider: ProviderId) => VmCapabilities;
   readonly exec: (
     provider: ProviderId,
     vmId: string,
@@ -218,6 +222,7 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
     providerEffect(provider, "snapshot", () => getProvider(provider).snapshot(vmId, name)),
   restore: (provider, snapshotId, options) =>
     providerEffect(provider, "restore", () => getProvider(provider).restore(snapshotId, options)),
+  capabilities: (provider) => vmCapabilitiesFor(provider),
   listSnapshots: (provider, vmId) =>
     providerEffect(provider, "listSnapshots", async () => {
       const impl = getProvider(provider);

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1503,6 +1503,16 @@ function finalizeNativeForkReservation(
   );
 }
 
+/**
+ * Select native cloning only when the driver declares that capability. The
+ * gateway exposes a fork function for every provider, but unsupported drivers
+ * fail inside that function; checking its presence alone selects the wrong path.
+ */
+function providerForksNatively(providers: VmProviderGatewayShape, provider: ProviderId): boolean {
+  if (provider !== "freestyle" || providers.fork === undefined) return false;
+  return providers.capabilities?.(provider).fork ?? true;
+}
+
 export function forkVm(input: {
   readonly userId: string;
   readonly billingCustomerType: BillingCustomerType;
@@ -1544,7 +1554,7 @@ export function forkVm(input: {
     // A native fork has no way to accept the new row's edge rules. Use the
     // snapshot/create path for a model-plane machine so it receives its own
     // VM-bound credential instead of inheriting an unrouteable alias.
-    const nativeFork = !input.modelPlane && source.provider === "freestyle" && providers.fork !== undefined;
+    const nativeFork = !input.modelPlane && providerForksNatively(providers, source.provider) ? providers.fork : undefined;
     // The provider owns cloning the source. Record its initial shape and
     // reconcile the copied machine independently after the fork completes.
     const sourceHasReservation = hasVmResourceReservationMetadata(source.providerMetadata);
@@ -1625,7 +1635,7 @@ export function forkVm(input: {
       const handle = yield* measureVmEffect(
         input.timing,
         "provider_create",
-        providers.fork(source.provider, source.providerVmId ?? input.providerVmId),
+        nativeFork(source.provider, source.providerVmId ?? input.providerVmId),
       ).pipe(
         Effect.tapError((err) =>
           Effect.all([

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1766,6 +1766,7 @@ export function forkVm(input: {
       provider: source.provider,
       imageId: source.imageId,
       metadata: {
+        native: false,
         snapshotId: snapshot.id,
         forkProviderVmId: fork.providerVmId,
         idempotencyKeySet: !!input.idempotencyKey,

--- a/web/tests/vm-fork-capability.test.ts
+++ b/web/tests/vm-fork-capability.test.ts
@@ -8,9 +8,9 @@ import { VmBillingGateway, noOpVmBillingGateway } from "../services/vms/billingG
 import { VmDatabaseError, VmOperationUnsupportedError, VmProviderOperationError } from "../services/vms/errors";
 import {
   VmProviderGateway,
-  VmProviderGatewayLive,
   type VmProviderGatewayShape,
 } from "../services/vms/providerGateway";
+import { vmCapabilitiesFor } from "../services/vms/drivers";
 import { VmRepository, type VmRepositoryShape } from "../services/vms/repository";
 import { forkVm } from "../services/vms/workflows";
 
@@ -21,7 +21,7 @@ import { forkVm } from "../services/vms/workflows";
 // the snapshot-based path a few lines below was unreachable.
 describe("forkVm provider capability", () => {
   test("the live gateway reports no native fork for freestyle", () => {
-    expect(VmProviderGatewayLive.capabilities?.("freestyle").fork).toBe(false);
+    expect(vmCapabilitiesFor("freestyle").fork).toBe(false);
   });
 
   test("a provider without native fork takes the snapshot path, never the fork call", async () => {
@@ -53,8 +53,8 @@ describe("forkVm provider capability", () => {
       getStatus: () => Effect.succeed("running" as const),
       resume: () => Effect.fail(new Error("unused") as never),
       // Mirrors VmProviderGatewayLive: the function exists, the driver does not.
-      fork: (providerId: "freestyle", vmId: string) =>
-        Effect.sync(() => calls.push("fork")).pipe(
+      fork: (providerId: "freestyle", _vmId: string) =>
+        Effect.sync(() => { void _vmId; calls.push("fork"); }).pipe(
           Effect.flatMap(() =>
             Effect.fail(new VmProviderOperationError({
               provider: providerId,

--- a/web/tests/vm-fork-capability.test.ts
+++ b/web/tests/vm-fork-capability.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Cause from "effect/Cause";
+import * as Layer from "effect/Layer";
+
+import { VmBillingGateway, noOpVmBillingGateway } from "../services/vms/billingGateway";
+import { VmDatabaseError, VmOperationUnsupportedError, VmProviderOperationError } from "../services/vms/errors";
+import {
+  VmProviderGateway,
+  VmProviderGatewayLive,
+  type VmProviderGatewayShape,
+} from "../services/vms/providerGateway";
+import { VmRepository, type VmRepositoryShape } from "../services/vms/repository";
+import { forkVm } from "../services/vms/workflows";
+
+// The live gateway always defines `fork` and answers "unsupported" from inside
+// it when the driver has no native fork. forkVm used the presence of that
+// function as "the provider forks natively", so on Freestyle (snapshot and
+// create, no fork call) every fork failed with vm_operation_unsupported while
+// the snapshot-based path a few lines below was unreachable.
+describe("forkVm provider capability", () => {
+  test("the live gateway reports no native fork for freestyle", () => {
+    expect(VmProviderGatewayLive.capabilities?.("freestyle").fork).toBe(false);
+  });
+
+  test("a provider without native fork takes the snapshot path, never the fork call", async () => {
+    const source = {
+      id: "00000000-0000-4000-8000-0000000000f0",
+      userId: "user-fork-capability",
+      billingTeamId: "team-fork-capability",
+      billingPlanId: "pro",
+      provider: "freestyle" as const,
+      providerVmId: "provider-vm-fork-source",
+      imageId: "sh-source",
+      imageVersion: null,
+      status: "running" as const,
+      providerMetadata: {},
+    };
+    const repo = {
+      findUserVm: () => Effect.succeed(source),
+      findUserVmAnyStatus: () => Effect.succeed(source),
+      recordUsageEvent: () => Effect.void,
+      markProviderObservedStatus: () => Effect.succeed(true),
+      // The native path inserts the copy row before calling the provider; a
+      // typed failure here names that path when the decision is wrong.
+      beginCreate: () =>
+        Effect.fail(new VmDatabaseError({ operation: "beginCreate", cause: new Error("native fork path reached") })),
+    } as unknown as VmRepositoryShape;
+    const calls: string[] = [];
+    const provider = {
+      capabilities: () => ({ snapshot: true, restore: true, fork: false, ports: false }),
+      getStatus: () => Effect.succeed("running" as const),
+      resume: () => Effect.fail(new Error("unused") as never),
+      // Mirrors VmProviderGatewayLive: the function exists, the driver does not.
+      fork: (providerId: "freestyle", vmId: string) =>
+        Effect.sync(() => calls.push("fork")).pipe(
+          Effect.flatMap(() =>
+            Effect.fail(new VmProviderOperationError({
+              provider: providerId,
+              operation: "fork",
+              cause: new VmOperationUnsupportedError({ provider: providerId, operation: "fork" }),
+            }))
+          ),
+        ),
+      snapshot: (providerId: "freestyle") =>
+        Effect.sync(() => calls.push("snapshot")).pipe(
+          Effect.flatMap(() =>
+            Effect.fail(new VmProviderOperationError({
+              provider: providerId,
+              operation: "snapshot",
+              cause: new Error("snapshot path reached"),
+            }))
+          ),
+        ),
+      create: () => Effect.fail(new Error("unused") as never),
+      destroy: () => Effect.void,
+      exec: () => Effect.fail(new Error("unused") as never),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    } as unknown as VmProviderGatewayShape;
+    const layer = Layer.mergeAll(
+      Layer.succeed(VmRepository, repo),
+      Layer.succeed(VmProviderGateway, provider),
+      Layer.succeed(VmBillingGateway, noOpVmBillingGateway()),
+    );
+
+    const exit = await Effect.runPromiseExit(
+      forkVm({
+        userId: source.userId,
+        billingCustomerType: "team",
+        billingTeamId: source.billingTeamId,
+        teamIds: [source.billingTeamId],
+        billingPlanId: "pro",
+        maxActiveVms: 50,
+        providerVmId: source.providerVmId,
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const failure = Cause.failureOption(exit.cause);
+    expect(failure._tag).toBe("Some");
+    if (failure._tag !== "Some") return;
+    expect(`${failure.value._tag}:${(failure.value as { operation?: string }).operation}`)
+      .toBe("VmProviderOperationError:snapshot");
+    expect(calls).toEqual(["snapshot"]);
+  });
+});


### PR DESCRIPTION
## Problem
`cmux vm fork` selected the gateway's always-present `fork()` method on Freestyle, then returned `501 vm_operation_unsupported`. Freestyle has no native fork API.

## Fix
Expose driver capabilities from the provider gateway and select the native path only when the driver declares `fork: true`. Freestyle now uses the existing documented snapshot-then-create clone path.

The PR keeps the regression test in its own first commit, followed by the fix.

## Validation
- `bun test --isolate tests/vm-fork-capability.test.ts` passes.
- ESLint passes for the changed files.
- Full `bun run typecheck` reaches two existing unrelated test errors in `tests/docs-search-cache.test.ts` and `tests/vercel-ignore-build.test.ts`.
- Live Freestyle validation was completed on the prior PR's `vmfx1` stack: fork created a new VM from a fresh snapshot, exec worked, and delete worked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791717997&installation_model_id=21920&pr_number=12320&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12320&signature=b0b34edf70602146e28e2847122d7d955bcd8ddd48ac9c462287ef917d037ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fork routing in the VM workflow for Freestyle and any provider without native fork; wrong capability wiring could still pick the wrong clone path or skip billing/create semantics on the native branch.
> 
> **Overview**
> **Fixes `cmux vm fork` on Freestyle**, which was incorrectly treated as a native clone because the provider gateway always exposes a `fork` method that fails with `vm_operation_unsupported` when the driver has no real fork API.
> 
> The gateway now exposes optional **`capabilities(provider)`** (backed by `vmCapabilitiesFor`), and **`forkVm`** picks the native path only when the driver reports **`fork: true`** via `providerForksNatively`. Freestyle (`fork: false`) goes through the existing **snapshot → create** clone flow instead of calling provider fork. A regression test asserts Freestyle never hits the fork call and reaches snapshot first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ca9539838661ea447bafd5c790006f52b54297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux vm fork` on Freestyle, which previously always selected the gateway's `fork()` method and failed with `vm_operation_unsupported`. The gateway now exposes driver capabilities, and the native fork path is used only when the driver declares `fork: true`. Freestyle uses the existing snapshot-then-create clone path instead, with usage events recording which fork path was taken. A regression test locks in the capability decision.

<sup>Written for commit af7025c9f73899b4151e965f357d7ad4e8b54016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM forking behavior by respecting provider-declared capabilities.
  * Freestyle providers now correctly use the snapshot-based fallback when native forking is unsupported.
  * Prevented unsupported native fork attempts from causing VM operations to fail unnecessarily.
  * Improved reliability when providers report that native VM cloning is unavailable.

* **New Features**
  * Added capability detection for VM providers to support more accurate operation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->