### PR TITLE
Show exact Mac compatibility floors in What's New

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -81,7 +81,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 nightly: nightly,
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
-                    MobileBuildType.beta.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                     MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: stableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -43,6 +43,8 @@ struct CMUXMobileRootView: View {
     /// previews and package hosts keep the store's compiled-in fallback.
     @Environment(MobileMacCompatCenter.self) private var macCompatCenter:
         MobileMacCompatCenter?
+    @Environment(MobileWhatsNewCenter.self) private var whatsNewCenter:
+        MobileWhatsNewCenter?
     /// Set when the one-shot remote policy refresh has been started. The
     /// cached/baked policy is installed synchronously; the network refresh
     /// continues independently of auth restore and stored-Mac reconnect.
@@ -1123,10 +1125,12 @@ struct CMUXMobileRootView: View {
             return
         }
         store.applyMacCompatibilityPolicy(macCompatCenter.policy)
+        whatsNewCenter?.applyMacCompatibilityPolicy(macCompatCenter.policy)
         Task { @MainActor in
             await macCompatCenter.refresh()
             guard !Task.isCancelled else { return }
             store.applyMacCompatibilityPolicy(macCompatCenter.policy)
+            whatsNewCenter?.applyMacCompatibilityPolicy(macCompatCenter.policy)
             store.revalidateActiveMacCompatibilityPolicy()
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import CmuxMobileShell
 import CmuxMobileShellModel
 import CmuxMobileSupport
 import Foundation
@@ -61,13 +62,6 @@ struct MobileWhatsNewPage: Identifiable {
 /// (`/api/whats-new` `visibleEntryIds`) both reference it, and the
 /// unseen computation orders pages by catalog index.
 enum MobileWhatsNewCatalog {
-    /// Filled in precisely at the accompanying Mac release cut; the What's
-    /// New compat notice interpolates it. ONE value to edit at cut time.
-    static let requiredMacVersionLabel = L10n.string(
-        "mobile.connectionsUpdate.macUpdate.requiredVersion",
-        defaultValue: "the latest cmux NIGHTLY or cmux RELEASE"
-    )
-
     /// Newest first. The one-time sheet shows every visible entry newer than
     /// the acknowledgement marker.
     static var entries: [MobileWhatsNewPage] {
@@ -172,19 +166,44 @@ enum MobileWhatsNewCatalog {
     /// App Store app has no older protocol version to revert to, so it gets
     /// the update requirement only; App Review's Guideline 2.2 rejection also
     /// bars beta-lane vocabulary from its UI.
-    static func macUpdateFootnote(buildType: MobileBuildType = .current()) -> String {
-        let requirement = String(
+    static func macUpdateFootnote(
+        buildType: MobileBuildType = .current(),
+        iosVersion: String? = nil,
+        policy: MobileMacCompatPolicy = .baked
+    ) -> String {
+        let version = iosVersion
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "0"
+        let tier = policy.tier(forIOSVersion: version)
+        let requirement = tier?.buildKinds[buildType.token]
+            ?? tier.map { MobileMacCompatPolicy.Requirement(stableMinVersion: $0.stableMinVersion, nightly: $0.nightly) }
+        let stableVersion = requirement?.stableMinVersion.description
+            ?? L10n.string(
+                "mobile.macUpdate.unknownStableMinimum",
+                defaultValue: "the current supported stable version"
+            )
+        let nightlyVersion: String
+        if let nightly = requirement?.nightly {
+            nightlyVersion = "\(nightly.minBaseVersion)-nightly.\(nightly.minBuild)"
+        } else {
+            nightlyVersion = L10n.string(
+                "mobile.macUpdate.noNightlyMinimum",
+                defaultValue: "no minimum for this iOS build"
+            )
+        }
+        let requirementText = String(
             format: L10n.string(
-                "mobile.macUpdate.requiredOnMacFormat",
-                defaultValue: "Requires %@ on your Mac."
+                "mobile.macUpdate.requiredStableAndNightlyFormat",
+                defaultValue: "Requires cmux %@ or later on stable Macs. cmux NIGHTLY minimum: %@."
             ),
-            requiredMacVersionLabel
+            stableVersion,
+            nightlyVersion
         )
         guard buildType.usesInternalBuildVocabulary else {
-            return requirement
+            return requirementText
         }
         return [
-            requirement,
+            requirementText,
             L10n.string(
                 "mobile.macUpdate.revertShort",
                 defaultValue: "Not ready? Stay on (or revert to) cmux BETA 1.0.4 (20260817224846)."

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCenter.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCenter.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import CmuxMobileShell
 import CmuxMobileShellModel
 import Foundation
 import Observation
@@ -45,6 +46,10 @@ public final class MobileWhatsNewCenter {
     /// that gates web-content pages into the one-time sheet, so an offline
     /// launch skips them instead of presenting an unloadable webview.
     private(set) var lastRefreshSucceeded = false
+    /// The policy currently enforced by the shell. Root view pushes the
+    /// cached/baked policy before the first refresh and the refreshed policy
+    /// after it succeeds, keeping What's New copy in lockstep with admission.
+    private(set) var macCompatibilityPolicy: MobileMacCompatPolicy = .baked
 
     public init(
         apiBaseURL: String?,
@@ -100,6 +105,12 @@ public final class MobileWhatsNewCenter {
         }
     }
 
+    /// Keeps the What's New compatibility footnote synchronized with the
+    /// policy used by the connection store.
+    public func applyMacCompatibilityPolicy(_ policy: MobileMacCompatPolicy) {
+        macCompatibilityPolicy = policy
+    }
+
     /// Drops acknowledged announcement ids the authoritative list no longer
     /// carries. Announcements expire remotely and their ids never return, so
     /// without pruning the UserDefaults-backed set would grow without bound.
@@ -140,9 +151,19 @@ public final class MobileWhatsNewCenter {
                 buildType: buildType
             )
         }
-        guard let remoteList else { return channelAllowed }
+        let withCompatibilityCopy = channelAllowed.map { page -> MobileWhatsNewPage in
+            guard page.id == "connections.v1" else { return page }
+            var updated = page
+            updated.footnote = MobileWhatsNewCatalog.macUpdateFootnote(
+                buildType: buildType,
+                iosVersion: appVersion,
+                policy: macCompatibilityPolicy
+            )
+            return updated
+        }
+        guard let remoteList else { return withCompatibilityCopy }
         let visible = Set(remoteList.visibleEntryIds)
-        return channelAllowed.filter { visible.contains($0.id) }
+        return withCompatibilityCopy.filter { visible.contains($0.id) }
     }
 
     /// Cached announcements targeted at this app version, resolved to

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
@@ -28,7 +28,7 @@ import Testing
             iosVersion: "1.0.5"
         )
         #expect(beta.contains("0.64.23"))
-        #expect(beta.contains("no minimum for this iOS build"))
+        #expect(beta.contains("0.64.22-nightly.3345650013202"))
 
         let prod = MobileWhatsNewCatalog.macUpdateFootnote(
             buildType: .prod,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
@@ -22,6 +22,22 @@ import Testing
         #expect(team.contains("Requires"))
     }
 
+    @Test func whatsNewCompatFootnoteUsesTheBakedMacCompatFloors() {
+        let beta = MobileWhatsNewCatalog.macUpdateFootnote(
+            buildType: .beta,
+            iosVersion: "1.0.5"
+        )
+        #expect(beta.contains("0.64.23"))
+        #expect(beta.contains("no minimum for this iOS build"))
+
+        let prod = MobileWhatsNewCatalog.macUpdateFootnote(
+            buildType: .prod,
+            iosVersion: "1.0.5"
+        )
+        #expect(prod.contains("0.64.23"))
+        #expect(prod.contains("0.64.22-nightly.3345650013202"))
+    }
+
     @Test func whatsNewCarriesTheCompatNoticeAsFootnoteNotFeatureRow() {
         let page = MobileWhatsNewCatalog.connectionsUpdate
         #expect(page.footnote != nil)

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -384,11 +384,7 @@ public struct MobileAuthComposition {
         accessGroup: String?,
         legacyProjectID: String
     ) -> TokenStoreInit {
-        // Simulator artifacts built without a device provisioning profile do
-        // not have a valid keychain application-identifier entitlement. Keep
-        // simulator dogfood functional in every configuration while device
-        // Release builds continue to use the signed keychain store.
-        #if targetEnvironment(simulator)
+        #if DEBUG && targetEnvironment(simulator)
         .memory
         #else
         guard let appNamespace else {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -384,7 +384,11 @@ public struct MobileAuthComposition {
         accessGroup: String?,
         legacyProjectID: String
     ) -> TokenStoreInit {
-        #if DEBUG && targetEnvironment(simulator)
+        // Simulator artifacts built without a device provisioning profile do
+        // not have a valid keychain application-identifier entitlement. Keep
+        // simulator dogfood functional in every configuration while device
+        // Release builds continue to use the signed keychain store.
+        #if targetEnvironment(simulator)
         .memory
         #else
         guard let appNamespace else {

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -121,7 +121,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
       nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
-        beta: { stableMinVersion: "0.64.23" },
+        beta: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         internal: { stableMinVersion: "0.64.23" },
         demo: { stableMinVersion: "0.64.23" },
         prod: {


### PR DESCRIPTION
What changed
- Derive the What's New Mac compatibility footnote from the fetched mobile-mac-compat policy and installed iOS version.
- Show exact stable and nightly requirements, including the BETA no-minimum-nightly rule.
- Keep the footnote synchronized with the policy enforced by the connection store.

Validation
- Cloud Release BETA simulator build succeeded from latest main.
- Clean simulator upgrade 1.0.4 -> 1.0.5 launched successfully after install.
- Live mac-compat API reports BETA stable 0.64.23, no BETA nightly floor; machine NIGHTLY is 0.64.22-nightly.3439608067501.
- Physical install was not attempted because local signing lacks the BETA distribution profile and automatic export failed re-signing Iroh.framework.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791736682&installation_model_id=21920&pr_number=12325&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12325&signature=1ad0731c57f5605def416b51baec6b9a7005e9b32bf0b6329e534a2819461ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared mac-compat policy for BETA (nightly floor) and ties user-facing requirement text to the same policy used for admission, so copy and enforcement can diverge if refresh fails.
> 
> **Overview**
> **What's New** now builds the Mac compatibility footnote from the same **mobile-mac-compat** policy and installed iOS version as connection admission, instead of a single static “latest NIGHTLY or RELEASE” string. Copy spells out **stable** and **NIGHTLY** minimums (with fallbacks when a channel has no nightly floor), and the root view pushes cached then refreshed policy into `MobileWhatsNewCenter` so the `connections.v1` page footnote stays aligned with the store.
> 
> **Policy data** for the iOS **1.0.5** tier adds an explicit **nightly** floor for **BETA** in both the baked Swift policy and `web/data/mobile-mac-compat.ts`, matching prod-style nightly guidance. Tests assert the footnote includes the baked stable and nightly version strings for beta and prod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac81b82bfffe483321cf3d853c2eaecb79c55a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows exact stable and nightly Mac version floors in the What's New footnote instead of the generic "the latest cmux NIGHTLY or cmux RELEASE" text. The footnote derives from the mobile-mac-compat policy and installed iOS version, and BETA now carries the same nightly floor as production in both the footnote and the baked policy.

- Nightly-channel admission for BETA now enforces that same minimum, since the connection store shares the baked policy.
- Applies the cached policy immediately and the refreshed policy after a successful fetch, keeping footnote and admission in lockstep.
- Adds tests covering the baked stable and nightly floors for BETA and production builds.

<sup>Written for commit 1ac81b82bfffe483321cf3d853c2eaecb79c55a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the in-app “What’s New” information to show Mac compatibility requirements based on the current iOS version, release channel, and compatibility policy.
  - Added localized messaging for stable and nightly Mac version requirements.

- **Bug Fixes**
  - Corrected beta-channel compatibility guidance so it includes the required nightly Mac build.
  - Ensured compatibility messaging stays current after policy updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->