### PR TITLE
Warn for Macs without a verified version

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -170,6 +170,7 @@ struct MacComputerRow: View {
     /// records the build version in the durable overlay.
     private var showsListAuthWarning: Bool {
         hasVersionGateWarning
+            || MobileMacListAuthState.shared.entry(deviceID: computer.deviceId)?.isOutdated == true
             || hasUnverifiedVersionWarning
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -170,7 +170,17 @@ struct MacComputerRow: View {
     /// records the build version in the durable overlay.
     private var showsListAuthWarning: Bool {
         hasVersionGateWarning
-            || MobileMacListAuthState.shared.entry(deviceID: computer.deviceId)?.isOutdated == true
+            || hasUnverifiedVersionWarning
+    }
+
+    /// A paired Mac with no directory entry has not advertised its version in
+    /// this session. Keep the warning visible until a hello establishes that
+    /// the Mac meets the current floor.
+    private var hasUnverifiedVersionWarning: Bool {
+        guard MobileMacListAuthState.shared.hasSnapshot,
+              MobileMacListAuthState.shared.minimumSupportedMacVersion != nil
+        else { return false }
+        return MobileMacListAuthState.shared.entry(deviceID: computer.deviceId) == nil
     }
 
     /// Outdated rows carry a compact warning triangle beside the name; the
@@ -229,7 +239,7 @@ struct MacComputerRow: View {
                 requirement
             )
         }
-        guard hasVersionGateWarning else { return "" }
+        guard hasVersionGateWarning || hasUnverifiedVersionWarning else { return "" }
         return L10n.string(
             "mobile.pairing.guidance.macUpdateRequired",
             defaultValue: "Update cmux on this Mac to connect securely."


### PR DESCRIPTION
A paired stable Mac can remain absent from the directory projection after the iOS app relaunches. In that state the current floor is known, but the row has no entry and therefore showed no warning until a new connection attempt.

Treat an entry-less Mac as unverified while a policy floor and directory snapshot are available. The Computers row keeps the warning visible until the Mac advertises a compatible hello, then clears through the existing directory projection.

Validation:
- `git diff --check` passed.
- The previous merged fix has a successful fleet iOS archive and signed install.
- A new fleet rebuild is being run for this follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791740122&installation_model_id=21920&pr_number=12327&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12327&signature=e0ef470d12b7c7f8c7f30af4a5ea3e98775e2a01d0773b529e7c2a32fbb2fdd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to when the Computers list shows an existing version warning; no auth or connection logic is modified.
> 
> **Overview**
> **Extends Mac version warnings** when a paired Mac has no directory entry after relaunch but the app already has a policy floor and device-list snapshot.
> 
> `MacComputerRow` now treats that state as **unverified**: the warning triangle stays visible (and the generic “update cmux on this Mac” popover copy applies) until a hello populates the directory entry and existing outdated-entry logic can clear it. No new connection flow—only when `showsListAuthWarning` and `listAuthWarningMessage` fire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf92ec97d5507c6600561cbc38be3114de0bebb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the version warning for paired Macs with no directory entry after app relaunch, so a Mac with an unknown version is treated as unverified while a policy floor and snapshot are available. The warning and its popover text clear once the Mac advertises a compatible hello.

<sup>Written for commit bf92ec97d5507c6600561cbc38be3114de0bebb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version warning coverage for paired Mac devices that are not present in the current directory.
  - These devices now display the appropriate update-required guidance when their supported version cannot be verified.
  - This makes version requirements clearer and helps identify when a paired Mac needs to be updated before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->