### PR TITLE
Show Mac warning before directory snapshot

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -178,8 +178,7 @@ struct MacComputerRow: View {
     /// this session. Keep the warning visible until a hello establishes that
     /// the Mac meets the current floor.
     private var hasUnverifiedVersionWarning: Bool {
-        guard MobileMacListAuthState.shared.hasSnapshot,
-              MobileMacListAuthState.shared.minimumSupportedMacVersion != nil
+        guard MobileMacListAuthState.shared.minimumSupportedMacVersion != nil
         else { return false }
         return MobileMacListAuthState.shared.entry(deviceID: computer.deviceId) == nil
     }


### PR DESCRIPTION
The previous warning fix waited for `MobileMacListAuthState.hasSnapshot`. The iOS policy floor can arrive before the directory snapshot, which is the exact relaunch state shown by the report. In that window paired stable Macs had no warning despite the known minimum.

Use the policy floor as the readiness signal. A paired Mac without a directory entry remains visibly unverified until its version hello arrives, even when the directory snapshot is still pending. Existing outdated-entry and explicit gate warnings remain unchanged.

Validation: `git diff --check`; local autoreview and CI pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791747068&installation_model_id=21920&pr_number=12328&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12328&signature=0cff1f9bed38df93716257cf59dbdd245bc295d691bbbce86d9fc858f3905ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the outdated-Mac warning as soon as the policy floor is known instead of waiting for the directory snapshot, so paired Macs no longer appear verified in the window where the policy arrives before the snapshot. A paired Mac without a directory entry still stays unverified until its version hello arrives.

<sup>Written for commit 5d6d5c3b8934e27e18a85845018ec3f317599109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard change in list-row UI logic; no auth, networking, or data-path changes.
> 
> **Overview**
> **Fixes a gap where paired Macs showed no version warning right after relaunch** when the iOS policy floor was already known but the account directory snapshot had not arrived yet.
> 
> `hasUnverifiedVersionWarning` in `MacComputerRow` no longer waits on `MobileMacListAuthState.hasSnapshot`. It only requires a known `minimumSupportedMacVersion`, so a paired Mac with no directory entry still gets the warning triangle until its version hello clears it. Outdated-entry and explicit version-gate warnings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6d5c3b8934e27e18a85845018ec3f317599109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mac version warnings now appear when a Mac lacks a directory entry, even if no directory snapshot is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->