### PR TITLE
Unify Mac version compatibility gating

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -134,7 +134,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
             guard let nightly = requirement.nightly else { return nil }
             requirementDisplay = "\(nightly.minBaseVersion)-nightly.\(nightly.minBuild)"
         }
-        let result = MobileMacVersionCompatibilityEvaluator.evaluate(
+        let result = evaluateMobileMacVersionCompatibility(
             appVersion: macAppVersion,
             releaseTrack: channel == .nightly ? "nightly" : "stable",
             stableMinimum: requirement.stableMinVersion.description,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -134,7 +134,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
             guard let nightly = requirement.nightly else { return nil }
             requirementDisplay = "\(nightly.minBaseVersion)-nightly.\(nightly.minBuild)"
         }
-        let result = evaluateMobileMacVersionCompatibility(
+        let result = MobileMacVersionCompatibility(
             appVersion: macAppVersion,
             releaseTrack: channel == .nightly ? "nightly" : "stable",
             stableMinimum: requirement.stableMinVersion.description,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -134,28 +134,21 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
             guard let nightly = requirement.nightly else { return nil }
             requirementDisplay = "\(nightly.minBaseVersion)-nightly.\(nightly.minBuild)"
         }
+        let result = MobileMacVersionCompatibilityEvaluator.evaluate(
+            appVersion: macAppVersion,
+            releaseTrack: channel == .nightly ? "nightly" : "stable",
+            stableMinimum: requirement.stableMinVersion.description,
+            nightlyMinimum: requirement.nightly.map {
+                "\($0.minBaseVersion)-nightly.\($0.minBuild)"
+            }
+        )
+        guard result.isOutdated else { return nil }
         let reported = macAppVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let violation = Violation(
+        return Violation(
             channel: channel,
             macAppVersion: reported?.isEmpty == false ? reported : nil,
-            requiredVersionDisplay: requirementDisplay
+            requiredVersionDisplay: result.requiredVersionDisplay ?? requirementDisplay
         )
-        guard let reported, let stamp = MobileMacBuildVersionStamp(parsing: reported) else {
-            return violation
-        }
-        switch channel {
-        case .stable:
-            // A nightly stamp on the stable channel is a mislabeled build;
-            // fail closed rather than guessing which rule it satisfies.
-            guard stamp.nightlyBuild == nil else { return violation }
-            return stamp.base >= requirement.stableMinVersion ? nil : violation
-        case .nightly:
-            guard let nightly = requirement.nightly else { return nil }
-            guard let build = stamp.nightlyBuild else { return violation }
-            if stamp.base > nightly.minBaseVersion { return nil }
-            if stamp.base < nightly.minBaseVersion { return violation }
-            return build >= nightly.minBuild ? nil : violation
-        }
     }
 
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -14,30 +14,6 @@ private func entriesWithMinimumSupportedVersions(
     }
 }
 
-private func numericMacVersion(_ raw: String) -> [Int]? {
-    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-    let parts = core.split(separator: ".", omittingEmptySubsequences: false)
-    guard !parts.isEmpty,
-          parts.allSatisfy({ !$0.isEmpty && Int($0) != nil }) else { return nil }
-    var values = parts.map { Int($0)! }
-    while values.count < 3 { values.append(0) }
-    return values
-}
-
-private func nightlyMacVersion(_ raw: String) -> (base: [Int], build: UInt64)? {
-    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-    let marker = "-nightly."
-    guard let markerRange = core.range(of: marker),
-          let base = numericMacVersion(String(core[..<markerRange.lowerBound]))
-    else { return nil }
-    let buildText = core[markerRange.upperBound...]
-    guard !buildText.isEmpty,
-          buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
-          let build = UInt64(buildText)
-    else { return nil }
-    return (base, build)
-}
-
 /// The phone's view of the account device list (the list-auth admission
 /// authority), projected for UI.
 ///
@@ -95,37 +71,22 @@ public final class MobileMacListAuthState {
         /// reported version cannot establish compatibility, so it is treated
         /// as possibly too old until a valid hello arrives.
         public var isOutdated: Bool {
-            if isNightly {
-                guard let minimumSupportedNightlyVersion,
-                      let required = nightlyMacVersion(minimumSupportedNightlyVersion)
-                else { return false }
-                guard let appVersion,
-                      let installed = nightlyMacVersion(appVersion)
-                else { return true }
-                if installed.base != required.base {
-                    return installed.base.lexicographicallyPrecedes(required.base)
-                }
-                return installed.build < required.build
-            }
-            guard let minimumSupportedVersion,
-                  let required = numericMacVersion(minimumSupportedVersion)
-            else { return false }
-            guard let appVersion else { return true }
-            guard let installed = numericMacVersion(appVersion) else { return true }
-            return installed.lexicographicallyPrecedes(required)
+            return MobileMacVersionCompatibilityEvaluator.evaluate(
+                appVersion: appVersion,
+                releaseTrack: releaseTrack,
+                stableMinimum: minimumSupportedVersion,
+                nightlyMinimum: minimumSupportedNightlyVersion
+            ).isOutdated
         }
 
         /// The floor to show in the warning for this row's release lane.
         public var requiredVersionDisplay: String? {
-            guard isOutdated else { return nil }
-            return isNightly ? minimumSupportedNightlyVersion : minimumSupportedVersion
-        }
-
-        private var isNightly: Bool {
-            if let releaseTrack {
-                return releaseTrack.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
-            }
-            return appVersion?.contains("-nightly.") == true
+            MobileMacVersionCompatibilityEvaluator.evaluate(
+                appVersion: appVersion,
+                releaseTrack: releaseTrack,
+                stableMinimum: minimumSupportedVersion,
+                nightlyMinimum: minimumSupportedNightlyVersion
+            ).requiredVersionDisplay
         }
 
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -71,7 +71,7 @@ public final class MobileMacListAuthState {
         /// reported version cannot establish compatibility, so it is treated
         /// as possibly too old until a valid hello arrives.
         public var isOutdated: Bool {
-            return evaluateMobileMacVersionCompatibility(
+            return MobileMacVersionCompatibility(
                 appVersion: appVersion,
                 releaseTrack: releaseTrack,
                 stableMinimum: minimumSupportedVersion,
@@ -81,7 +81,7 @@ public final class MobileMacListAuthState {
 
         /// The floor to show in the warning for this row's release lane.
         public var requiredVersionDisplay: String? {
-            evaluateMobileMacVersionCompatibility(
+            MobileMacVersionCompatibility(
                 appVersion: appVersion,
                 releaseTrack: releaseTrack,
                 stableMinimum: minimumSupportedVersion,

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacListAuthState.swift
@@ -71,7 +71,7 @@ public final class MobileMacListAuthState {
         /// reported version cannot establish compatibility, so it is treated
         /// as possibly too old until a valid hello arrives.
         public var isOutdated: Bool {
-            return MobileMacVersionCompatibilityEvaluator.evaluate(
+            return evaluateMobileMacVersionCompatibility(
                 appVersion: appVersion,
                 releaseTrack: releaseTrack,
                 stableMinimum: minimumSupportedVersion,
@@ -81,7 +81,7 @@ public final class MobileMacListAuthState {
 
         /// The floor to show in the warning for this row's release lane.
         public var requiredVersionDisplay: String? {
-            MobileMacVersionCompatibilityEvaluator.evaluate(
+            evaluateMobileMacVersionCompatibility(
                 appVersion: appVersion,
                 releaseTrack: releaseTrack,
                 stableMinimum: minimumSupportedVersion,

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
@@ -3,81 +3,90 @@ import Foundation
 /// The channel-specific result of comparing a Mac's reported version with the
 /// minimum advertised to the current iOS build.
 public struct MobileMacVersionCompatibility: Equatable, Sendable {
+    /// Whether the reported version fails the selected minimum requirement.
     public let isOutdated: Bool
+    /// The selected minimum to display when the Mac is outdated.
     public let requiredVersionDisplay: String?
 
+    /// Creates the shared connection and warning result.
     public init(isOutdated: Bool, requiredVersionDisplay: String?) {
         self.isOutdated = isOutdated
         self.requiredVersionDisplay = requiredVersionDisplay
     }
 }
 
-/// Single comparison authority shared by connection admission and UI warning
-/// state. Missing or malformed Mac versions fail closed when a floor exists.
-public enum MobileMacVersionCompatibilityEvaluator {
-    public static func evaluate(
-        appVersion: String?,
-        releaseTrack: String?,
-        stableMinimum: String?,
-        nightlyMinimum: String?
-    ) -> MobileMacVersionCompatibility {
-        let nightly = releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
-            || (releaseTrack == nil && appVersion?.contains("-nightly.") == true)
-        if nightly {
-            guard let nightlyMinimum,
-                  let required = parseNightly(nightlyMinimum)
-            else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
-            guard let appVersion,
-                  let installed = parseNightly(appVersion)
-            else {
-                return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: nightlyMinimum)
-            }
-            let outdated = lexicographicallyPrecedes(installed.base, required.base)
-                || (installed.base == required.base && installed.build < required.build)
-            return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? nightlyMinimum : nil)
-        }
-        guard let stableMinimum,
-              let required = parseNumeric(stableMinimum)
+/// Compares a Mac version with the floor for its release track.
+///
+/// Connection admission and UI warning state use this same comparison. Missing
+/// or malformed Mac versions fail closed when a floor exists.
+public func evaluateMobileMacVersionCompatibility(
+    appVersion: String?,
+    releaseTrack: String?,
+    stableMinimum: String?,
+    nightlyMinimum: String?
+) -> MobileMacVersionCompatibility {
+    let nightly = releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
+        || (releaseTrack == nil && appVersion?.contains("-nightly.") == true)
+    if nightly {
+        guard let nightlyMinimum,
+              let required = parseMobileMacNightlyVersion(nightlyMinimum)
         else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
         guard let appVersion,
-              let installed = parseNumeric(appVersion),
-              !appVersion.contains("-nightly.")
+              let installed = parseMobileMacNightlyVersion(appVersion)
         else {
-            return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: stableMinimum)
+            return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: nightlyMinimum)
         }
-        let outdated = lexicographicallyPrecedes(installed, required)
-        return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? stableMinimum : nil)
+        let outdated = mobileMacVersionPrecedes(installed.base, required.base)
+            || (installed.base == required.base && installed.build < required.build)
+        return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? nightlyMinimum : nil)
     }
+    guard let stableMinimum,
+          let required = parseMobileMacNumericVersion(stableMinimum)
+    else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
+    guard let appVersion,
+          let installed = parseMobileMacNumericVersion(appVersion),
+          !appVersion.contains("-nightly.")
+    else {
+        return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: stableMinimum)
+    }
+    let outdated = mobileMacVersionPrecedes(installed, required)
+    return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? stableMinimum : nil)
+}
 
-    private static func parseNumeric(_ raw: String) -> [Int]? {
-        let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-        let parts = core.split(separator: ".", omittingEmptySubsequences: false)
-        guard !parts.isEmpty, parts.allSatisfy({ !$0.isEmpty && Int($0) != nil }) else { return nil }
-        var values = parts.map { Int($0)! }
-        while values.count < 3 { values.append(0) }
-        return values
-    }
+private func parseMobileMacNumericVersion(_ raw: String) -> [Int]? {
+    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+    let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+    guard (1 ... 3).contains(parts.count),
+          parts.allSatisfy({
+              !$0.isEmpty
+                  && $0.utf8.allSatisfy { (48 ... 57).contains($0) }
+                  && Int($0) != nil
+          })
+    else { return nil }
+    var values = parts.map { Int($0)! }
+    while values.count < 3 { values.append(0) }
+    return values
+}
 
-    private static func lexicographicallyPrecedes(_ lhs: [Int], _ rhs: [Int]) -> Bool {
-        for index in 0 ..< max(lhs.count, rhs.count) {
-            let left = index < lhs.count ? lhs[index] : 0
-            let right = index < rhs.count ? rhs[index] : 0
-            if left != right { return left < right }
-        }
-        return false
+private func mobileMacVersionPrecedes(_ lhs: [Int], _ rhs: [Int]) -> Bool {
+    for index in 0 ..< max(lhs.count, rhs.count) {
+        let left = index < lhs.count ? lhs[index] : 0
+        let right = index < rhs.count ? rhs[index] : 0
+        if left != right { return left < right }
     }
+    return false
+}
 
-    private static func parseNightly(_ raw: String) -> (base: [Int], build: UInt64)? {
-        let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
-        let marker = "-nightly."
-        guard let range = core.range(of: marker),
-              let base = parseNumeric(String(core[..<range.lowerBound]))
-        else { return nil }
-        let buildText = core[range.upperBound...]
-        guard !buildText.isEmpty,
-              buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
-              let build = UInt64(buildText)
-        else { return nil }
-        return (base, build)
-    }
+private func parseMobileMacNightlyVersion(_ raw: String) -> (base: [Int], build: UInt64)? {
+    let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+    let marker = "-nightly."
+    guard let range = core.range(of: marker),
+          let base = parseMobileMacNumericVersion(String(core[..<range.lowerBound]))
+    else { return nil }
+    let buildText = core[range.upperBound...]
+    guard !buildText.isEmpty,
+          buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
+          let build = UInt64(buildText)
+    else { return nil }
+    return (base, build)
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
@@ -8,31 +8,44 @@ public struct MobileMacVersionCompatibility: Equatable, Sendable {
     /// The selected minimum to display when the Mac is outdated.
     public let requiredVersionDisplay: String?
 
-    /// Creates the shared connection and warning result.
-    public init(isOutdated: Bool, requiredVersionDisplay: String?) {
+    /// Compares a reported Mac version with the stable or nightly floor.
+    public init(
+        appVersion: String?,
+        releaseTrack: String?,
+        stableMinimum: String?,
+        nightlyMinimum: String?
+    ) {
+        let result = mobileMacVersionCompatibility(
+            appVersion: appVersion,
+            releaseTrack: releaseTrack,
+            stableMinimum: stableMinimum,
+            nightlyMinimum: nightlyMinimum
+        )
+        isOutdated = result.isOutdated
+        requiredVersionDisplay = result.requiredVersionDisplay
+    }
+
+    fileprivate init(isOutdated: Bool, requiredVersionDisplay: String?) {
         self.isOutdated = isOutdated
         self.requiredVersionDisplay = requiredVersionDisplay
     }
 }
 
-/// Compares a Mac version with the floor for its release track.
-///
-/// Connection admission and UI warning state use this same comparison. Missing
-/// or malformed Mac versions fail closed when a floor exists.
-public func evaluateMobileMacVersionCompatibility(
+private func mobileMacVersionCompatibility(
     appVersion: String?,
     releaseTrack: String?,
     stableMinimum: String?,
     nightlyMinimum: String?
 ) -> MobileMacVersionCompatibility {
+    let normalizedAppVersion = appVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
     let nightly = releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
-        || (releaseTrack == nil && appVersion?.contains("-nightly.") == true)
+        || (releaseTrack == nil && normalizedAppVersion?.contains("-nightly.") == true)
     if nightly {
         guard let nightlyMinimum,
               let required = parseMobileMacNightlyVersion(nightlyMinimum)
         else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
-        guard let appVersion,
-              let installed = parseMobileMacNightlyVersion(appVersion)
+        guard let normalizedAppVersion,
+              let installed = parseMobileMacNightlyVersion(normalizedAppVersion)
         else {
             return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: nightlyMinimum)
         }
@@ -43,9 +56,9 @@ public func evaluateMobileMacVersionCompatibility(
     guard let stableMinimum,
           let required = parseMobileMacNumericVersion(stableMinimum)
     else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
-    guard let appVersion,
-          let installed = parseMobileMacNumericVersion(appVersion),
-          !appVersion.contains("-nightly.")
+    guard let normalizedAppVersion,
+          let installed = parseMobileMacNumericVersion(normalizedAppVersion),
+          !normalizedAppVersion.contains("-nightly.")
     else {
         return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: stableMinimum)
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileMacVersionCompatibility.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// The channel-specific result of comparing a Mac's reported version with the
+/// minimum advertised to the current iOS build.
+public struct MobileMacVersionCompatibility: Equatable, Sendable {
+    public let isOutdated: Bool
+    public let requiredVersionDisplay: String?
+
+    public init(isOutdated: Bool, requiredVersionDisplay: String?) {
+        self.isOutdated = isOutdated
+        self.requiredVersionDisplay = requiredVersionDisplay
+    }
+}
+
+/// Single comparison authority shared by connection admission and UI warning
+/// state. Missing or malformed Mac versions fail closed when a floor exists.
+public enum MobileMacVersionCompatibilityEvaluator {
+    public static func evaluate(
+        appVersion: String?,
+        releaseTrack: String?,
+        stableMinimum: String?,
+        nightlyMinimum: String?
+    ) -> MobileMacVersionCompatibility {
+        let nightly = releaseTrack?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nightly"
+            || (releaseTrack == nil && appVersion?.contains("-nightly.") == true)
+        if nightly {
+            guard let nightlyMinimum,
+                  let required = parseNightly(nightlyMinimum)
+            else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
+            guard let appVersion,
+                  let installed = parseNightly(appVersion)
+            else {
+                return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: nightlyMinimum)
+            }
+            let outdated = lexicographicallyPrecedes(installed.base, required.base)
+                || (installed.base == required.base && installed.build < required.build)
+            return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? nightlyMinimum : nil)
+        }
+        guard let stableMinimum,
+              let required = parseNumeric(stableMinimum)
+        else { return MobileMacVersionCompatibility(isOutdated: false, requiredVersionDisplay: nil) }
+        guard let appVersion,
+              let installed = parseNumeric(appVersion),
+              !appVersion.contains("-nightly.")
+        else {
+            return MobileMacVersionCompatibility(isOutdated: true, requiredVersionDisplay: stableMinimum)
+        }
+        let outdated = lexicographicallyPrecedes(installed, required)
+        return MobileMacVersionCompatibility(isOutdated: outdated, requiredVersionDisplay: outdated ? stableMinimum : nil)
+    }
+
+    private static func parseNumeric(_ raw: String) -> [Int]? {
+        let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty, parts.allSatisfy({ !$0.isEmpty && Int($0) != nil }) else { return nil }
+        var values = parts.map { Int($0)! }
+        while values.count < 3 { values.append(0) }
+        return values
+    }
+
+    private static func lexicographicallyPrecedes(_ lhs: [Int], _ rhs: [Int]) -> Bool {
+        for index in 0 ..< max(lhs.count, rhs.count) {
+            let left = index < lhs.count ? lhs[index] : 0
+            let right = index < rhs.count ? rhs[index] : 0
+            if left != right { return left < right }
+        }
+        return false
+    }
+
+    private static func parseNightly(_ raw: String) -> (base: [Int], build: UInt64)? {
+        let core = raw.split(separator: "+", maxSplits: 1).first.map(String.init) ?? raw
+        let marker = "-nightly."
+        guard let range = core.range(of: marker),
+              let base = parseNumeric(String(core[..<range.lowerBound]))
+        else { return nil }
+        let buildText = core[range.upperBound...]
+        guard !buildText.isEmpty,
+              buildText.utf8.allSatisfy({ (48 ... 57).contains($0) }),
+              let build = UInt64(buildText)
+        else { return nil }
+        return (base, build)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileMacListAuthStateTests.swift
@@ -46,6 +46,29 @@ struct MobileMacListAuthStateTests {
         #expect(malformed.isOutdated)
     }
 
+    @Test(arguments: ["999.-1.0", "999.0.0.1", "999..0", "999.a.0"])
+    func invalidVersionComponentsWarnInBothReleaseTracks(_ version: String) {
+        let stable = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: version,
+            minimumSupportedVersion: "0.64.23",
+            releaseTrack: "stable"
+        )
+        #expect(stable.isOutdated)
+
+        let nightly = MobileMacListAuthState.Entry(
+            status: "active",
+            revoked: false,
+            isFresh: true,
+            appVersion: "\(version)-nightly.100",
+            releaseTrack: "nightly",
+            minimumSupportedNightlyVersion: "0.64.22-nightly.99"
+        )
+        #expect(nightly.isOutdated)
+    }
+
     @Test
     func nightlyVersionIsNotComparedToStableFloor() {
         let current = MobileMacListAuthState.Entry(


### PR DESCRIPTION
## Problem
The connection admission path and the iOS Computers row warning used separate Mac version parsers. They could disagree about stable, nightly, or malformed versions.

## Change
- Share one evaluator between connection gating and row warning state.
- Compare stable versions numerically with trailing components treated as zero.
- Compare nightly versions by base version, then numeric nightly build.
- Treat missing or malformed Mac versions as outdated when the selected floor exists.
- Keep stable and nightly build-kind floors independent.

## Validation
- `swift test --package-path Packages/iOS/CmuxMobileShellModel --filter MobileMacListAuthStateTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileMacCompatPolicyTests`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791748780&installation_model_id=21920&pr_number=12331&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12331&signature=43a9c93d9b38e3efd8f46aefa6d279efc9e90de839f15e69c46a9e499fece234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection refusal and outdated-Mac UI warnings together; stricter parsing may flag versions that previously slipped through, but behavior is intentionally aligned across both paths.
> 
> **Overview**
> Connection admission (`MobileMacCompatPolicy.violation`) and Computers row warnings (`MobileMacListAuthState.Entry`) now share **`MobileMacVersionCompatibility`** in `CmuxMobileShellModel`, replacing duplicate stable/nightly parsers and the policy’s inline `MobileMacBuildVersionStamp` checks.
> 
> The shared evaluator picks stable vs nightly from `releaseTrack` (or a `-nightly.` suffix when track is unset), compares stable semver numerically with trailing segments zero-filled, and compares nightly by base version then build counter. **Missing, malformed, or invalid-component versions are treated as outdated** when a floor exists; stable rows with a nightly-shaped version fail the stable lane. Violations and UI copy use the evaluator’s `requiredVersionDisplay` when present.
> 
> Tests add coverage for bad version strings on both release tracks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c0a8aff002b61894baf6d473b7765c46363886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Mac version compatibility checks so connection admission and the iOS Computers row warning use the same evaluator and can no longer disagree.

- Adds `MobileMacVersionCompatibility` as the single comparison authority for both paths.
- Treats missing or malformed versions (too many, empty, or non-numeric components) and stable-channel nightly stamps as outdated when a minimum floor exists.
- Picks the nightly lane from the release track, falling back to a `-nightly.` marker when no track is set.
- Compares stable versions numerically with trailing components treated as zero.
- Compares nightly versions by base version, then numeric nightly build; stable and nightly minimum floors stay independent.

<sup>Written for commit 35c0a8aff002b61894baf6d473b7765c46363886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Mac version compatibility checks across stable and nightly release tracks.
  - Correctly identifies nightly builds using release-track information or version markers.
  - Provides clearer required-version information when an installed Mac app is outdated.
  - Handles missing or malformed version details consistently, marking versions as outdated when a minimum requirement is configured.
  - Applies the same compatibility behavior across Mac access and authentication checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->