### PR TITLE
fix: preserve Codex activity in Dock tabs

### DIFF
--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -20,6 +20,7 @@ extension DockSplitStore {
         agentRuntimeByPanelId.removeValue(forKey: panelId)
         syncAgentNeedsInputAttention(panelId: panelId, runtime: nil)
         restoredPanelTitleBoundariesByPanelId.removeValue(forKey: panelId)
+        panelCustomTitleSourcesByPanelId.removeValue(forKey: panelId)
     }
 
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
@@ -121,6 +122,14 @@ extension DockSplitStore {
     func adoptSessionRestoreState(from detached: Workspace.DetachedSurfaceTransfer) {
         invalidatedCachedTransferAgentSessionPanelIds.remove(detached.panelId)
         replacedCachedTransferAgentSessionPanelIds.remove(detached.panelId)
+        if detached.customTitle != nil {
+            panelCustomTitleSourcesByPanelId[detached.panelId] =
+                detached.customTitleSource ?? .user
+        } else {
+            panelCustomTitleSourcesByPanelId.removeValue(
+                forKey: detached.panelId
+            )
+        }
         storeRestoredPanelTitleBoundary(
             detached.restoredPanelTitleBoundary,
             panelId: detached.panelId
@@ -365,6 +374,9 @@ extension DockSplitStore {
         mutation: (inout Workspace.DetachedAgentRuntimeState) -> Void
     ) {
         guard panels[panelId] != nil else { return }
+        let previousCodexLifecycle = agentRuntimeByPanelId[panelId]?
+            .agentLifecycleStates["codex"]
+        let stableTitle = stableDockTerminalTabTitle(panelId: panelId)?.title
         var runtime = agentRuntimeByPanelId[panelId] ?? Workspace.DetachedAgentRuntimeState(
             panelId: panelId,
             statusEntries: [:],
@@ -390,6 +402,12 @@ extension DockSplitStore {
             syncAgentNeedsInputAttention(
                 panelId: panelId,
                 runtime: shouldKeep ? runtime : nil
+            )
+        }
+        if previousCodexLifecycle != runtime.agentLifecycleStates["codex"] {
+            _ = reconcileCodexTabTitlePresentation(
+                panelId: panelId,
+                fallback: stableTitle
             )
         }
     }

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -687,6 +687,12 @@ extension DockSplitStore {
             return nil
         }
         panels[panel.id] = panel
+        if snapshot.customTitle != nil {
+            panelCustomTitleSourcesByPanelId[panel.id] =
+                snapshot.effectiveCustomTitleSource ?? .user
+        } else {
+            panelCustomTitleSourcesByPanelId.removeValue(forKey: panel.id)
+        }
         let title = snapshot.customTitle ?? snapshot.title ?? panel.displayTitle
         let isAudioMuted = resolvedAudioMuted(for: panel)
         guard let tabId = bonsplitController.createTab(

--- a/Sources/DockSplitStore+ShortcutCommands.swift
+++ b/Sources/DockSplitStore+ShortcutCommands.swift
@@ -234,7 +234,10 @@ extension DockSplitStore {
             localized: "alert.renameTab.message",
             defaultValue: "Enter a custom name for this tab."
         )
-        let input = NSTextField(string: tab.title)
+        let input = NSTextField(
+            string: stableDockTerminalTabTitle(panelId: panel.id)?.title
+                ?? tab.title
+        )
         input.placeholderString = String(
             localized: "alert.renameTab.placeholder",
             defaultValue: "Tab name"
@@ -281,12 +284,21 @@ extension DockSplitStore {
         let customTitle = title?.trimmingCharacters(
             in: .whitespacesAndNewlines
         ) ?? ""
+        if customTitle.isEmpty {
+            panelCustomTitleSourcesByPanelId.removeValue(forKey: panelId)
+        } else {
+            panelCustomTitleSourcesByPanelId[panelId] = .user
+        }
         bonsplitController.updateTab(
             tabId,
             title: customTitle.isEmpty
                 ? panel.displayTitle
                 : customTitle,
             hasCustomTitle: !customTitle.isEmpty
+        )
+        _ = reconcileCodexTabTitlePresentation(
+            panelId: panelId,
+            fallback: panel.displayTitle
         )
         return true
     }

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -60,17 +60,25 @@ extension DockSplitStore {
             )
         }
 
-        let customTitle = tab.hasCustomTitle ? tab.title : nil
+        let stableTerminalTitle = panel is TerminalPanel
+            ? stableDockTerminalTabTitle(
+                panelId: panel.id,
+                transferOverride: transfer
+            )
+            : nil
+        let stableTabTitle = stableTerminalTitle?.title ?? tab.title
+        let customTitle = tab.hasCustomTitle ? stableTabTitle : nil
         let customTitleSource: Workspace.CustomTitleSource? = if let customTitle {
-            customTitle == transfer?.customTitle
-                ? transfer?.customTitleSource
-                : .user
+            panelCustomTitleSourcesByPanelId[panel.id]
+                ?? (customTitle == transfer?.customTitle
+                    ? (transfer?.customTitleSource ?? .user)
+                    : .user)
         } else {
             nil
         }
-        let cachedTitle = tab.hasCustomTitle ? panel.displayTitle : tab.title
+        let cachedTitle = tab.hasCustomTitle ? panel.displayTitle : stableTabTitle
         return (
-            title: tab.title,
+            title: stableTabTitle,
             cachedTitle: cachedTitle,
             customTitle: customTitle,
             customTitleSource: customTitleSource
@@ -494,6 +502,10 @@ extension DockSplitStore {
             focus: focus,
             reconcileReason: "dock.attachDetachedSurface"
         )
+        _ = reconcileCodexTabTitlePresentation(
+            panelId: detached.panelId,
+            fallback: detached.customTitle ?? detached.title
+        )
         if let terminalPanel = panel as? TerminalPanel {
             if let owningWorkspace =
                     terminalFontSizeOwningWorkspace {
@@ -591,6 +603,10 @@ extension DockSplitStore {
             inPane: newPane,
             focus: focus,
             reconcileReason: "dock.attachDetachedSurface.split"
+        )
+        _ = reconcileCodexTabTitlePresentation(
+            panelId: detached.panelId,
+            fallback: detached.customTitle ?? detached.title
         )
         if let terminalPanel = panel as? TerminalPanel {
             if let owningWorkspace =

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -79,6 +79,8 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
     @ObservationIgnored private let terminalTitleUpdateCoalescer:
         NotificationBurstCoalescer
     @ObservationIgnored var detachedSurfaceTransfersByPanelId: [UUID: Workspace.DetachedSurfaceTransfer] = [:]
+    @ObservationIgnored var panelCustomTitleSourcesByPanelId:
+        [UUID: Workspace.CustomTitleSource] = [:]
     /// Focused presentation of Dock panels whose agent lifecycle needs input.
     @ObservationIgnored let agentNeedsInputAttention = SurfaceAttentionModel()
     @ObservationIgnored var restoredPanelTitleBoundariesByPanelId:
@@ -1236,27 +1238,148 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         (existingTab.hasCustomTitle ? nil : metadata.title, nil)
     }
 
+    /// Returns the Codex lifecycle that controls one Dock terminal tab.
+    private func dockCodexTabLifecycle(panelId: UUID) -> CodexTabTitleLifecycle? {
+        guard let raw = agentRuntimeByPanelId[panelId]?
+            .agentLifecycleStates["codex"] else {
+            return nil
+        }
+        switch raw {
+        case .running: return .running
+        case .idle: return .idle
+        case .needsInput: return .needsInput
+        case .unknown: return .unknown
+        }
+    }
+
+    /// Resolves the stable title beneath a Dock tab's transient Codex marker.
+    ///
+    /// The undecorated Bonsplit title and its ownership remain the source of
+    /// truth so transient markers never leak into persistence or a later move
+    /// back to a workspace.
+    func stableDockTerminalTabTitle(
+        panelId: UUID,
+        fallback: String? = nil,
+        transferOverride: Workspace.DetachedSurfaceTransfer? = nil
+    ) -> (title: String, hasUserOwnedTitle: Bool)? {
+        guard panels[panelId] is TerminalPanel,
+              let tabId = surfaceId(forPanelId: panelId),
+              let existing = bonsplitController.tab(tabId) else {
+            return nil
+        }
+        let transfer = transferOverride ?? detachedSurfaceTransfersByPanelId[panelId]
+        let composer = CodexTabTitleComposer()
+        let transferredCustomTitleSource: Workspace.CustomTitleSource? =
+            transfer?.customTitle == nil
+                ? nil
+                : (transfer?.customTitleSource ?? .user)
+        let customTitleSource = panelCustomTitleSourcesByPanelId[panelId]
+            ?? transferredCustomTitleSource
+        let hasUserOwnedTitle = existing.hasCustomTitle
+            && (customTitleSource ?? .user) != .auto
+
+        if hasUserOwnedTitle {
+            return (existing.title, true)
+        }
+
+        if let fallback {
+            return (fallback, false)
+        }
+
+        if let lifecycle = dockCodexTabLifecycle(panelId: panelId) {
+            let marker = composer.presentation(
+                baseTitle: "",
+                lifecycle: lifecycle,
+                hasUserOwnedTitle: false
+            ).title
+            let hasProjectedMarker = switch lifecycle {
+            case .running:
+                existing.isLoading && !marker.isEmpty && existing.title.hasPrefix(marker)
+            case .idle:
+                !marker.isEmpty && existing.title.hasPrefix(marker)
+            case .needsInput, .unknown:
+                false
+            }
+            if hasProjectedMarker {
+                return (String(existing.title.dropFirst(marker.count)), false)
+            }
+        }
+
+        if existing.hasCustomTitle {
+            return (transfer?.customTitle ?? existing.title, false)
+        }
+
+        if restoredPanelTitleBoundariesByPanelId[panelId] != nil {
+            return (
+                transfer?.cachedTitle ?? transfer?.title ?? existing.title,
+                false
+            )
+        }
+        return (existing.title, false)
+    }
+
+    /// Projects Codex lifecycle state onto one Dock terminal tab.
+    @discardableResult
+    func reconcileCodexTabTitlePresentation(
+        panelId: UUID,
+        fallback: String? = nil
+    ) -> Bool {
+        guard let tabId = surfaceId(forPanelId: panelId),
+              let existing = bonsplitController.tab(tabId),
+              let stable = stableDockTerminalTabTitle(
+                  panelId: panelId,
+                  fallback: fallback
+              ) else {
+            return false
+        }
+        let presentation = CodexTabTitleComposer().presentation(
+            baseTitle: stable.title,
+            lifecycle: dockCodexTabLifecycle(panelId: panelId),
+            hasUserOwnedTitle: stable.hasUserOwnedTitle
+        )
+        let titleUpdate = existing.title == presentation.title
+            ? nil
+            : presentation.title
+        let loadingUpdate = existing.isLoading == presentation.isAnimating
+            ? nil
+            : presentation.isAnimating
+        guard titleUpdate != nil || loadingUpdate != nil else { return false }
+        bonsplitController.updateTab(
+            tabId,
+            title: titleUpdate,
+            isLoading: loadingUpdate
+        )
+        return true
+    }
+
     /// Keeps the live terminal model and its non-custom Bonsplit tab on one
     /// title mutation path. Callers that synchronously adopt a Ghostty title
     /// invoke this directly; the publisher remains the fallback for other
     /// terminal title writers.
     private func synchronizeTerminalTabTitle(_ terminal: TerminalPanel) {
-        guard let tabId = surfaceId(forPanelId: terminal.id),
-              let existing = bonsplitController.tab(tabId) else {
-            return
-        }
-        let resolvedTitle = terminal.displayTitle
-        guard !existing.hasCustomTitle,
-              existing.title != resolvedTitle else {
-            return
-        }
-        bonsplitController.updateTab(tabId, title: resolvedTitle)
+        let hasCustomTitle = surfaceId(forPanelId: terminal.id)
+            .flatMap { bonsplitController.tab($0) }?
+            .hasCustomTitle == true
+        _ = reconcileCodexTabTitlePresentation(
+            panelId: terminal.id,
+            fallback: hasCustomTitle ? nil : terminal.displayTitle
+        )
     }
 
     /// Applies an admitted Dock terminal title to the model and its tab in the
     /// same main-actor turn.
     func applyResolvedTerminalTitle(_ title: String, to terminal: TerminalPanel) {
         terminal.updateTitle(title)
+        let hasCustomTitle = surfaceId(forPanelId: terminal.id)
+            .flatMap { bonsplitController.tab($0) }?
+            .hasCustomTitle == true
+        if var transfer = detachedSurfaceTransfersByPanelId[terminal.id] {
+            transfer.cachedTitle = terminal.displayTitle
+            if !hasCustomTitle {
+                transfer.title = terminal.displayTitle
+            }
+            setDetachedSurfaceTransfer(transfer, forPanelID: terminal.id)
+        }
         synchronizeTerminalTabTitle(terminal)
     }
 

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -27,7 +27,7 @@ extension Workspace {
         let sessionRestoreSourceWorkspaceId: UUID?
         let panelId: UUID
         let panel: any Panel
-        let title: String
+        var title: String
         let icon: String?
         let iconImageData: Data?
         let kind: String?
@@ -39,7 +39,7 @@ extension Workspace {
         var ttyName: String?
         var ttyNameWasReportedByCurrentRuntime: Bool = false
         var ttyReportRuntimeSurfaceGeneration: UInt64? = nil
-        let cachedTitle: String?
+        var cachedTitle: String?
         let customTitle: String?
         let customTitleSource: Workspace.CustomTitleSource?
         let manuallyUnread: Bool

--- a/cmuxTests/CodexTabTitlePresentationTests.swift
+++ b/cmuxTests/CodexTabTitlePresentationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CmuxWorkspaces
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -288,7 +289,8 @@ struct CodexTabTitlePresentationTests {
             let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
             #expect(dock.attachDetachedSurface(detached, inPane: dockPane, focus: false) == panelId)
             let dockTabId = try #require(dock.surfaceId(forPanelId: panelId))
-            #expect(dock.bonsplitController.tab(dockTabId)?.title == stableTitle)
+            #expect(dock.bonsplitController.tab(dockTabId)?.title == decoratedTitle)
+            #expect(dock.bonsplitController.tab(dockTabId)?.isLoading == isRunning)
 
             let returned = try #require(dock.detachSurface(panelId: panelId))
             #expect(returned.title == stableTitle)
@@ -305,5 +307,511 @@ struct CodexTabTitlePresentationTests {
             target.clearAgentLifecycle(key: "codex", panelId: panelId)
             #expect(target.bonsplitController.tab(targetTabId)?.title == stableTitle)
         }
+    }
+
+    @Test("Codex lifecycle presentation survives a Dock round trip")
+    func lifecyclePresentationSurvivesDockRoundTrip() throws {
+        let source = Workspace()
+        let destination = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+            destination.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("some-name")
+        #expect(source.updatePanelTitle(panelId: panelId, title: "some-name"))
+        source.setAgentLifecycle(key: "codex", panelId: panelId, lifecycle: .running)
+
+        let transfer = try #require(source.detachSurface(panelId: panelId))
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(dock.attachDetachedSurface(transfer, inPane: dockPane, focus: false) == panelId)
+
+        let dockTabId = try #require(dock.surfaceId(forPanelId: panelId))
+        let dockTab = try #require(dock.bonsplitController.tab(dockTabId))
+        #expect(dockTab.title == "◐ some-name")
+        #expect(dockTab.isLoading)
+
+        let roundTripped = try #require(dock.detachSurface(panelId: panelId))
+        #expect(roundTripped.title == "some-name")
+        #expect(roundTripped.cachedTitle == "some-name")
+
+        let destinationPane = try #require(
+            destination.bonsplitController.allPaneIds.first
+        )
+        #expect(
+            destination.attachDetachedSurface(
+                roundTripped,
+                inPane: destinationPane,
+                focus: false
+            ) == panelId
+        )
+        let destinationTabId = try #require(
+            destination.surfaceIdFromPanelId(panelId)
+        )
+        let destinationTab = try #require(
+            destination.bonsplitController.tab(destinationTabId)
+        )
+        #expect(destinationTab.title == "◐ some-name")
+        #expect(destinationTab.isLoading)
+        #expect(destination.panelTitles[panelId] == "some-name")
+    }
+
+    @Test("Dock lifecycle, title, and custom-title changes share one presentation path")
+    func dockLifecycleAndTitleChangesReconcilePresentation() throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("first-name")
+        #expect(source.updatePanelTitle(panelId: panelId, title: "first-name"))
+
+        let transfer = try #require(source.detachSurface(panelId: panelId))
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(dock.attachDetachedSurface(transfer, inPane: dockPane, focus: false) == panelId)
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+
+        dock.setAgentLifecycle(key: "codex", panelId: panelId, lifecycle: .running)
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ first-name")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        dock.applyResolvedTerminalTitle("second-name", to: terminal)
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ second-name")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        #expect(dock.setDockPanelCustomTitle(panelId: panelId, title: "Pinned lane"))
+        dock.setAgentLifecycle(key: "codex", panelId: panelId, lifecycle: .idle)
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Pinned lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+
+        dock.setAgentLifecycle(key: "codex", panelId: panelId, lifecycle: .running)
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Pinned lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        #expect(dock.clearAgentLifecycle(key: "codex", panelId: panelId))
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Pinned lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+    }
+
+    @Test(
+        "Dock persistence keeps the transferred title before another terminal title arrives",
+        arguments: [false, true]
+    )
+    func dockPersistenceKeepsTransferredTitle(isRemoteTerminal: Bool) throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("runtime-title")
+        #expect(
+            source.updatePanelTitle(
+                panelId: panelId,
+                title: "Configured lane"
+            )
+        )
+        if isRemoteTerminal {
+            source.activeRemoteTerminalSurfaceIds.insert(panelId)
+        }
+
+        let transfer = try #require(source.detachSurface(panelId: panelId))
+        #expect(transfer.isRemoteTerminal == isRemoteTerminal)
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                transfer,
+                inPane: dockPane,
+                focus: false
+            ) == panelId
+        )
+
+        let roundTripped = try #require(
+            dock.detachSurface(panelId: panelId)
+        )
+        #expect(roundTripped.title == "Configured lane")
+        #expect(roundTripped.cachedTitle == "Configured lane")
+        roundTripped.panel.close()
+    }
+
+    @Test("renaming a running auto-titled Dock tab claims the stable title")
+    func dockRenameClaimsStableAutoTitle() throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        #expect(
+            source.setPanelCustomTitle(
+                panelId: panelId,
+                title: "Generated lane",
+                source: .auto
+            )
+        )
+        source.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .running
+        )
+
+        let transfer = try #require(source.detachSurface(panelId: panelId))
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                transfer,
+                inPane: dockPane,
+                focus: false
+            ) == panelId
+        )
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ Generated lane")
+        let stableTitle = try #require(
+            dock.stableDockTerminalTabTitle(panelId: panelId)?.title
+        )
+        #expect(stableTitle == "Generated lane")
+
+        #expect(
+            dock.setDockPanelCustomTitle(
+                panelId: panelId,
+                title: stableTitle
+            )
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        let roundTripped = try #require(
+            dock.detachSurface(panelId: panelId)
+        )
+        #expect(roundTripped.customTitle == "Generated lane")
+        #expect(roundTripped.customTitleSource == .user)
+        roundTripped.panel.close()
+    }
+
+    @Test("restored auto-titled Dock tabs retain lifecycle presentation")
+    func restoredDockAutoTitleKeepsProvenance() throws {
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer { dock.closeAllPanels() }
+        let snapshotPanelId = UUID()
+        let panelSnapshot = SessionPanelSnapshot(
+            id: snapshotPanelId,
+            type: .terminal,
+            title: "Generated lane",
+            customTitle: "Generated lane",
+            customTitleSource: .auto,
+            directory: "/tmp",
+            isPinned: false,
+            isManuallyUnread: false,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: SessionTerminalPanelSnapshot(
+                workingDirectory: "/tmp"
+            ),
+            browser: nil,
+            markdown: nil,
+            filePreview: nil,
+            rightSidebarTool: nil
+        )
+        let restoredPanelIds = dock.restoreSessionSnapshot(
+            SessionSplitContainerSnapshot(
+                focusedPanelId: snapshotPanelId,
+                layout: .pane(
+                    SessionPaneLayoutSnapshot(
+                        panelIds: [snapshotPanelId],
+                        selectedPanelId: snapshotPanelId
+                    )
+                ),
+                panels: [panelSnapshot]
+            )
+        )
+        let panelId = try #require(restoredPanelIds[snapshotPanelId])
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+
+        dock.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .running
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        dock.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .idle
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "✳ Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+
+        #expect(dock.clearAgentLifecycle(key: "codex", panelId: panelId))
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+
+        let persisted = try #require(
+            dock.sessionSnapshot(includeScrollback: false)
+                .panels.first { $0.id == panelId }
+        )
+        #expect(persisted.customTitle == "Generated lane")
+        #expect(persisted.customTitleSource == .auto)
+    }
+
+    @Test("transferred auto titles survive an active restore boundary")
+    func transferredDockAutoTitleSurvivesActiveRestoreBoundary() throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("Shell title")
+        #expect(
+            source.updatePanelTitle(
+                panelId: panelId,
+                title: "Shell title"
+            )
+        )
+        #expect(
+            source.setPanelCustomTitle(
+                panelId: panelId,
+                title: "Generated lane",
+                source: .auto
+            )
+        )
+
+        var transfer = try #require(source.detachSurface(panelId: panelId))
+        transfer.restoredPanelTitleBoundary = RestoredPanelTitleBoundary(
+            internallySeededInput: "resume-session\n",
+            shellState: .commandRunning
+        )
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                transfer,
+                inPane: dockPane,
+                focus: false
+            ) == panelId
+        )
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+
+        dock.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .running
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+        #expect(dock.clearAgentLifecycle(key: "codex", panelId: panelId))
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Generated lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+
+        #expect(
+            dock.stableDockTerminalTabTitle(panelId: panelId)?.title
+                == "Generated lane"
+        )
+
+        let persisted = try #require(
+            dock.sessionSnapshot(includeScrollback: false)
+                .panels.first { $0.id == panelId }
+        )
+        #expect(persisted.customTitle == "Generated lane")
+        #expect(persisted.customTitleSource == .auto)
+
+        let roundTripped = try #require(
+            dock.detachSurface(panelId: panelId)
+        )
+        #expect(roundTripped.title == "Generated lane")
+        #expect(roundTripped.cachedTitle == "Shell title")
+        #expect(roundTripped.customTitle == "Generated lane")
+        #expect(roundTripped.customTitleSource == .auto)
+        roundTripped.panel.close()
+    }
+
+    @Test("an admitted Dock title survives detach while its restore boundary remains active")
+    func admittedDockTitleSurvivesActiveRestoreBoundary() throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("Persisted lane")
+        #expect(
+            source.updatePanelTitle(
+                panelId: panelId,
+                title: "Persisted lane"
+            )
+        )
+
+        var transfer = try #require(source.detachSurface(panelId: panelId))
+        transfer.restoredPanelTitleBoundary = RestoredPanelTitleBoundary(
+            internallySeededInput: "resume-session\n",
+            shellState: .commandRunning
+        )
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                transfer,
+                inPane: dockPane,
+                focus: false
+            ) == panelId
+        )
+        #expect(
+            dock.shouldApplyRestoredPanelTitle(
+                panelId: panelId,
+                rawTitle: "Live Codex lane"
+            )
+        )
+        dock.applyResolvedTerminalTitle("Live Codex lane", to: terminal)
+
+        let roundTripped = try #require(
+            dock.detachSurface(panelId: panelId)
+        )
+        #expect(roundTripped.title == "Live Codex lane")
+        #expect(roundTripped.cachedTitle == "Live Codex lane")
+        roundTripped.panel.close()
+    }
+
+    @Test("remote Dock terminals retain Codex lifecycle presentation")
+    func remoteDockTerminalShowsLifecycle() throws {
+        let source = Workspace()
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer {
+            dock.closeAllPanels()
+            source.teardownAllPanels()
+        }
+        let panelId = try #require(source.focusedPanelId)
+        let terminal = try #require(source.panels[panelId] as? TerminalPanel)
+        terminal.updateTitle("Remote Codex")
+        #expect(
+            source.updatePanelTitle(
+                panelId: panelId,
+                title: "Remote Codex"
+            )
+        )
+        source.activeRemoteTerminalSurfaceIds.insert(panelId)
+        source.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .running
+        )
+
+        let transfer = try #require(source.detachSurface(panelId: panelId))
+        #expect(transfer.isRemoteTerminal)
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                transfer,
+                inPane: dockPane,
+                focus: false
+            ) == panelId
+        )
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+        #expect(dock.bonsplitController.tab(tabId)?.title == "◐ Remote Codex")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+    }
+
+    @Test("restored remote-titled Dock tabs retain title protection")
+    func restoredDockRemoteTitleKeepsProtection() throws {
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer { dock.closeAllPanels() }
+        let snapshotPanelId = UUID()
+        let panelSnapshot = SessionPanelSnapshot(
+            id: snapshotPanelId,
+            type: .terminal,
+            title: "Remote lane",
+            customTitle: "Remote lane",
+            customTitleSource: .user,
+            customTitleWasRemote: true,
+            directory: "/tmp",
+            isPinned: false,
+            isManuallyUnread: false,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: SessionTerminalPanelSnapshot(
+                workingDirectory: "/tmp"
+            ),
+            browser: nil,
+            markdown: nil,
+            filePreview: nil,
+            rightSidebarTool: nil
+        )
+        let restoredPanelIds = dock.restoreSessionSnapshot(
+            SessionSplitContainerSnapshot(
+                focusedPanelId: snapshotPanelId,
+                layout: .pane(
+                    SessionPaneLayoutSnapshot(
+                        panelIds: [snapshotPanelId],
+                        selectedPanelId: snapshotPanelId
+                    )
+                ),
+                panels: [panelSnapshot]
+            )
+        )
+        let panelId = try #require(restoredPanelIds[snapshotPanelId])
+        let tabId = try #require(dock.surfaceId(forPanelId: panelId))
+
+        dock.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .running
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Remote lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == true)
+
+        dock.setAgentLifecycle(
+            key: "codex",
+            panelId: panelId,
+            lifecycle: .idle
+        )
+        #expect(dock.bonsplitController.tab(tabId)?.title == "Remote lane")
+        #expect(dock.bonsplitController.tab(tabId)?.isLoading == false)
+
+        let persisted = try #require(
+            dock.sessionSnapshot(includeScrollback: false)
+                .panels.first { $0.id == panelId }
+        )
+        #expect(persisted.customTitle == "Remote lane")
+        #expect(persisted.customTitleSource == .user)
+        #expect(persisted.customTitleWasRemote == true)
     }
 }


### PR DESCRIPTION
This in-org replacement supersedes https://github.com/manaflow-ai/cmux/pull/11743.

Preserves Codex activity markers and stable title ownership for Dock tabs through transfers, restore, rename, and follow-up child activity. Includes focused lifecycle and ownership coverage.

The replacement is based on the current stacked base and contains only the feature delta, with the external-fork conflict resolved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791750116&installation_model_id=21920&pr_number=12333&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12333&signature=28fbdeae3b259f09a8b6e18b222384512fe1940a5bcd2255c98d7cc93497834b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Dock tab title resolution, persistence, and cross-container transfers for terminal/Codex panels; regressions could mis-save titles or lose activity indicators, but scope is UI/state sync rather than security-critical paths.
> 
> **Overview**
> Dock terminal tabs now **project Codex lifecycle state** (running spinner, idle prefix, etc.) onto the visible Bonsplit title while keeping a **stable underlying title** for persistence, detach/attach, and rename.
> 
> **Title ownership and reconciliation**
> - Tracks per-panel **custom title source** (`user` vs `auto`) through session restore, transfer adoption, rename, and panel teardown.
> - Adds `stableDockTerminalTabTitle` and `reconcileCodexTabTitlePresentation` so transient Codex markers are stripped when resolving transfers/snapshots and re-applied when agent runtime changes, terminal titles update, or surfaces attach to the Dock.
> - Rename uses the stable title in the dialog; clearing/setting a custom title updates provenance and re-reconciles presentation.
> 
> **Transfer and terminal sync**
> - Detach metadata resolution prefers stable tab titles for terminals; `DetachedSurfaceTransfer` **`title`/`cachedTitle` are mutable** so admitted terminal titles can refresh transfer snapshots without baking in decorations.
> - Terminal title sync paths route through reconciliation instead of copying `displayTitle` directly onto the tab.
> 
> **Tests**
> - Expands `CodexTabTitlePresentationTests` for Dock round-trips, lifecycle + rename interactions, restore boundaries, auto/user titles, and remote-titled tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e1fd6e2d66b7e86bd8d645a6222de08744fbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Codex activity markers and stable title ownership on Dock tabs through transfers, restore, rename, and lifecycle updates, so spinners and idle indicators no longer get lost or stuck.

**Dock title reconciliation**
- Tracks custom-title provenance (`user` vs `auto`) through transfers and session restore.
- Re-runs Codex title projection on lifecycle changes, rename, attach/detach, and terminal title updates.
- Renaming a running auto-titled tab keeps the running indicator on the stable title.
- Persisted snapshots record custom-title source and remote-title protection for correct restoration.

<sup>Written for commit 86e1fd6e2d66b7e86bd8d645a6222de08744fbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

