### PR TITLE
Fix cloud terminal read buffer initializer compilation

### DIFF
--- a/Sources/Cloud/CloudTuiManualIOConnection.swift
+++ b/Sources/Cloud/CloudTuiManualIOConnection.swift
@@ -40,7 +40,7 @@ final class CloudTuiManualIOConnection: @unchecked Sendable {
     private var pendingLine = Data()
     private var pendingLineSearchOffset = 0
     // This storage is queue-owned and reused for every socket read.
-    private var readBuffer = [UInt8](repeating: 0, count: Self.readChunkBytes)
+    private var readBuffer = [UInt8](repeating: 0, count: CloudTuiManualIOConnection.readChunkBytes)
     private var pendingWrites: [Data] = []
     private var pendingWriteOffset = 0
     private var pendingWriteBytes = 0


### PR DESCRIPTION
## Summary

Fix the Swift compiler error introduced by the read-buffer reuse in #12315: `covariant 'Self' type cannot be referenced from a stored property initializer`. Qualify `readChunkBytes` with `CloudTuiManualIOConnection` in the stored-property initializer. The buffer size, queue ownership, and runtime behavior are unchanged.

## Testing

- Before the fix, an exact-source transport harness fails to compile with the diagnostic above on the shared Mac fleet (macOS 26.5.1, Swift 6.2.4).
- With the fix, `swift test --filter CloudTuiManualIOConnectionTests -Xswiftc -warnings-as-errors` passes all 7 existing socket tests, including ordered burst delivery, input writes while consumption is paused, peer EOF on cancellation, large frames, and the 16 MiB line limit.
- All six production files and the test file on this branch are byte-identical to the passing remote harness. The temporary harness is outside the repository.
- `git diff --check` and `python3 scripts/swift_file_length_budget.py` pass.
- Localization audit: no user-facing strings changed.

## Demo Video

Not applicable to this compile-only correction. No app was built or launched for dogfood; verification used the remote socket harness.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791751816&installation_model_id=21920&pr_number=12336&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12336&signature=033401d6d638d9ab1bb0ead96560e9d8f1db523c035ca06f58926a922c3c3425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line compile fix with no runtime or behavioral change to cloud terminal I/O.
> 
> **Overview**
> Fixes a **Swift 6 compile failure** on `CloudTuiManualIOConnection` where the reused socket read buffer could not be sized with `Self.readChunkBytes` in a stored-property initializer (`covariant 'Self' type cannot be referenced from a stored property initializer`).
> 
> The initializer now uses **`CloudTuiManualIOConnection.readChunkBytes`** instead of `Self.readChunkBytes`. Buffer size (16 KiB), queue ownership, and socket read behavior are unchanged—this is a naming/qualification fix only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82767849a26271a901d30d64628dab822840778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Swift compiler error in `CloudTuiManualIOConnection` by qualifying `readChunkBytes` with the concrete type name in the stored property initializer. The buffer size, queue ownership, and runtime behavior are unchanged.

- Passes all 7 existing socket tests, including the 16 MiB line limit, with warnings-as-errors.

<sup>Written for commit f82767849a26271a901d30d64628dab822840778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal constant reference without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->