### PR TITLE
Fix discovery projection for Mac compatibility warnings

### DIFF
--- a/ios/cmuxPackage/Package.swift
+++ b/ios/cmuxPackage/Package.swift
@@ -111,6 +111,7 @@ let package = Package(
                 "CmuxAuthRuntime",
                 "CmuxClientConfig",
                 "CmuxIrohTransport",
+                "CmuxIrxTransport",
                 "CMUXMobileCore",
                 "CmuxMobileAnalytics",
                 "CmuxMobileBrowser",

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -480,11 +480,37 @@ public actor MobileIrxRuntimeComposition {
     /// Mirrors the lease into the @Observable UI state (Computers rows read
     /// it to badge seeded Macs).
     private func projectDeviceListForUI(_ snapshot: IrxDeviceListSnapshot) async {
+        let entries = Self.macListAuthEntries(from: snapshot)
+        await MainActor.run {
+            MobileMacListAuthState.shared.replace(
+                entriesByIdentity: entries,
+                minimumSupportedMacVersion: snapshot.minimumSupportedMacVersion
+            )
+        }
+        publishSettingsUpdate()
+    }
+
+    /// Preserves each advertised app, endpoint, binding, and generation all the
+    /// way to the state read by the Computers screen.
+    nonisolated static func macListAuthEntries(
+        from snapshot: IrxDeviceListSnapshot
+    ) -> [MobileMacListAuthState.Identity: MobileMacListAuthState.Entry] {
         let fresh = snapshot.isFresh(now: .now)
-        var byEndpoint: [String: MobileMacListAuthState.Entry] = [:]
-        var byPairing: [String: MobileMacListAuthState.Entry] = [:]
+        var entries: [MobileMacListAuthState.Identity: MobileMacListAuthState.Entry] = [:]
         for (endpointIDHex, entry) in snapshot.entries {
-            let projected = MobileMacListAuthState.Entry(
+            let pairingID = entry.deviceID.map {
+                MobilePairedMac.pairingID(
+                    macDeviceID: $0,
+                    instanceTag: entry.tag ?? (entry.releaseTrack == "nightly" ? "nightly" : "default")
+                )
+            }
+            let identity = MobileMacListAuthState.Identity(
+                pairingID: pairingID,
+                endpointIDHex: endpointIDHex,
+                bindingID: entry.bindingID,
+                identityGeneration: entry.identityGeneration
+            )
+            entries[identity] = MobileMacListAuthState.Entry(
                 status: entry.status,
                 revoked: entry.revoked,
                 isFresh: fresh,
@@ -492,23 +518,8 @@ public actor MobileIrxRuntimeComposition {
                 minimumSupportedVersion: snapshot.minimumSupportedMacVersion,
                 releaseTrack: entry.releaseTrack
             )
-            byEndpoint[endpointIDHex] = projected
-            if let deviceID = entry.deviceID {
-                let pairingID = MobilePairedMac.pairingID(
-                    macDeviceID: deviceID,
-                    instanceTag: entry.tag ?? (entry.releaseTrack == "nightly" ? "nightly" : "default")
-                )
-                byPairing[MobileMacListAuthState.identityKey(pairingID: pairingID, endpointIDHex: endpointIDHex)] = projected
-            }
         }
-        await MainActor.run {
-            MobileMacListAuthState.shared.replace(
-                entriesByEndpointID: byEndpoint,
-                entriesByIdentityKey: byPairing,
-                minimumSupportedMacVersion: snapshot.minimumSupportedMacVersion
-            )
-        }
-        publishSettingsUpdate()
+        return entries
     }
 
     /// UI/programmatic lookup: the peer's list-auth stance right now.

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrxCompatibilityProjectionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrxCompatibilityProjectionTests.swift
@@ -1,0 +1,66 @@
+import CMUXMobileCore
+import CmuxIrxTransport
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import cmuxFeature
+
+@MainActor
+@Suite
+struct MobileIrxCompatibilityProjectionTests {
+    @Test(arguments: [false, true])
+    func directoryProjectionKeepsStableAndNightlySeparate(reverseOrder: Bool) throws {
+        let records = [
+            ("stable-peer", IrxDeviceListEntry(
+                deviceID: "physical-mac", status: "active", revoked: false,
+                appVersion: "0.64.22", releaseTrack: "stable",
+                bindingID: "stable-binding", tag: "default", identityGeneration: 2
+            )),
+            ("nightly-peer", IrxDeviceListEntry(
+                deviceID: "physical-mac", status: "active", revoked: false,
+                appVersion: "0.64.22-nightly.3439608067501", releaseTrack: "nightly",
+                bindingID: "nightly-binding", tag: "nightly", identityGeneration: 3
+            )),
+        ]
+        let snapshot = snapshot(entries: Dictionary(uniqueKeysWithValues: reverseOrder ? records.reversed() : records))
+        let entries = MobileIrxRuntimeComposition.macListAuthEntries(from: snapshot)
+        let state = MobileMacListAuthState()
+        state.applyPolicyMinimumSupportedMacVersions(stable: "0.64.23", nightly: nil)
+        state.replace(entriesByIdentity: entries)
+
+        #expect(entries.count == 2)
+        #expect(entries.keys.contains(.init(
+            pairingID: "physical-mac\u{1F}default", endpointIDHex: "stable-peer",
+            bindingID: "stable-binding", identityGeneration: 2
+        )))
+        #expect(entries.keys.contains(.init(
+            pairingID: "physical-mac\u{1F}nightly", endpointIDHex: "nightly-peer",
+            bindingID: "nightly-binding", identityGeneration: 3
+        )))
+        let stable = state.compatibilityEntry(pairingID: "physical-mac\u{1F}default")
+        let nightly = state.compatibilityEntry(pairingID: "physical-mac\u{1F}nightly")
+        #expect(stable.appVersion == "0.64.22")
+        #expect(stable.isOutdated)
+        #expect(stable.requiredVersionDisplay == "0.64.23")
+        #expect(nightly.appVersion == "0.64.22-nightly.3439608067501")
+        #expect(!nightly.isOutdated)
+    }
+
+    @Test
+    func missingStableRecordCannotBorrowNightlyCompatibility() {
+        let snapshot = snapshot(entries: ["nightly-peer": .init(
+            deviceID: "physical-mac", status: "active", revoked: false,
+            appVersion: "0.64.22-nightly.3439608067501", releaseTrack: "nightly"
+        )])
+        let state = MobileMacListAuthState()
+        state.applyPolicyMinimumSupportedMacVersions(stable: "0.64.23", nightly: nil)
+        state.replace(entriesByIdentity: MobileIrxRuntimeComposition.macListAuthEntries(from: snapshot))
+        #expect(state.compatibilityEntry(pairingID: "physical-mac\u{1F}default").isOutdated)
+        #expect(!state.compatibilityEntry(pairingID: "physical-mac\u{1F}nightly").isOutdated)
+    }
+
+    private func snapshot(entries: [String: IrxDeviceListEntry]) -> IrxDeviceListSnapshot {
+        .init(entries: entries, rev: 1, issuedAt: .now, ttlSeconds: 300,
+              receivedAtWall: .now, receivedAtMonotonic: .now)
+    }
+}


### PR DESCRIPTION
The merged compatibility fix was not present in the installed INTERNAL build, and its app-level discovery adapter still called the removed projection API. This repair routes directory records through the complete app, endpoint, binding, and generation identity and adds a behavior test covering Stable and Nightly sharing one physical Mac in either directory order.

Validation: the phone was confirmed on pre-fix build 20260911212247; live API cache matched the server policy. Package-level tests had passed before the app-target integration was exercised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791755569&installation_model_id=21920&pr_number=12344&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12344&signature=e14e0d5c606e7f98ecc414ed809ce5ffbc9d74d65849c0d2aad6c3ec3fdcbbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how device-list facts map into UI compatibility state; wrong projection could mis-badge Macs or show incorrect upgrade prompts, but does not alter dial-gate enforcement or auth.
> 
> **Overview**
> Repairs **Mac compatibility / discovery projection** on the IRX path so the Computers screen gets directory rows keyed by full **identity** (pairing, endpoint, binding, generation) instead of the removed dual-map `replace` API.
> 
> `projectDeviceListForUI` now builds entries via **`macListAuthEntries(from:)`** and calls **`MobileMacListAuthState.shared.replace(entriesByIdentity:)`**, so stable and nightly installs on the same physical Mac stay distinct and nightly metadata cannot satisfy stable compatibility checks.
> 
> Adds **`MobileIrxCompatibilityProjectionTests`** (including directory order permutations) and wires **`CmuxIrxTransport`** into **`cmuxFeatureTests`** so the projection compiles and runs in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf452fe213881409dd3684d3b59de96ed95e24c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device authorization state handling by keeping separate release-track identities for the same physical device.
  - Device compatibility checks now correctly account for binding and identity-generation details.
  - Stable and nightly device entries no longer affect each other’s compatibility status.
  - Missing stable-release records are correctly reported as outdated instead of inheriting compatibility from a nightly entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->