### PR TITLE
agent-chat: preserve Windows PATH entries

### DIFF
--- a/agent-chat/package.json
+++ b/agent-chat/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "bun server.ts",
     "build": "bun run build.ts",
-    "check": "bun x tsc --noEmit && bun test/claude-environment.test.ts && bun test/model-label.test.ts && bun test/model-picker-loading.test.ts && bun test/activity.test.ts && bun test/keymap.test.ts && bun test/options-store.test.ts && bun test/options-ui.test.ts && bun test/turns.test.ts && bun test/selection-css.test.ts && bun test/highlight.test.ts"
+    "check": "bun x tsc --noEmit && bun test/path-environment.test.ts && bun test/claude-environment.test.ts && bun test/model-label.test.ts && bun test/model-picker-loading.test.ts && bun test/activity.test.ts && bun test/keymap.test.ts && bun test/options-store.test.ts && bun test/options-ui.test.ts && bun test/turns.test.ts && bun test/selection-css.test.ts && bun test/highlight.test.ts"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",

--- a/agent-chat/path-environment.ts
+++ b/agent-chat/path-environment.ts
@@ -1,0 +1,9 @@
+/** Supplement minimal launchd environments without changing Windows search paths. */
+export function initializeAgentPath(env: Record<string, string | undefined>, platform: NodeJS.Platform): void {
+  // Windows uses semicolons and may spell the variable "Path". Leave it intact.
+  if (platform === "win32") return;
+  const home = env.HOME ?? "";
+  const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
+  const cur = (env.PATH ?? "").split(":");
+  env.PATH = [...extra.filter((p) => !cur.includes(p)), ...cur].join(":");
+}

--- a/agent-chat/path-environment.ts
+++ b/agent-chat/path-environment.ts
@@ -4,6 +4,6 @@ export function initializeAgentPath(env: Record<string, string | undefined>, pla
   if (platform === "win32") return;
   const home = env.HOME ?? "";
   const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
-  const cur = (env.PATH ?? "").split(":");
+  const cur = env.PATH ? env.PATH.split(":") : [];
   env.PATH = [...extra.filter((p) => !cur.includes(p)), ...cur].join(":");
 }

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -107,7 +107,10 @@ export async function writeStateFileForTest(path: string, port: number) {
 }
 
 // Under launchd the PATH is minimal; make sure the agent CLIs resolve.
-{
+// launchd is macOS-only and these are POSIX paths joined with ":", so skip the
+// block on Windows, where ";" separates PATH entries and a ":"-joined prefix
+// would fuse all four additions onto the first real entry and hide it.
+if (process.platform !== "win32") {
   const home = process.env.HOME ?? "";
   const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
   const cur = (process.env.PATH ?? "").split(":");

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -1,3 +1,4 @@
+import { initializeAgentPath } from "./path-environment";
 import type {
   Adapter,
   AgentEvent,
@@ -106,16 +107,7 @@ export async function writeStateFileForTest(path: string, port: number) {
   await writeStateFilePath(path, port);
 }
 
-// Under launchd the PATH is minimal; make sure the agent CLIs resolve.
-// launchd is macOS-only and these are POSIX paths joined with ":", so skip the
-// block on Windows, where ";" separates PATH entries and a ":"-joined prefix
-// would fuse all four additions onto the first real entry and hide it.
-if (process.platform !== "win32") {
-  const home = process.env.HOME ?? "";
-  const extra = [`${home}/.local/bin`, `${home}/.bun/bin`, "/opt/homebrew/bin", "/usr/local/bin"];
-  const cur = (process.env.PATH ?? "").split(":");
-  process.env.PATH = [...extra.filter((p) => !cur.includes(p)), ...cur].join(":");
-}
+initializeAgentPath(process.env, process.platform);
 const ROOT = import.meta.dir;
 const DEFAULT_CWD = `${ROOT}/scratch`;
 const ICON_ROOT = resolve(ROOT, "../Assets.xcassets/AgentIcons");

--- a/agent-chat/test/path-environment.test.ts
+++ b/agent-chat/test/path-environment.test.ts
@@ -23,3 +23,11 @@ for (const platform of ["darwin", "linux"] as const) {
   deepStrictEqual(env, once);
 }
 console.log("PATH environment assertions passed");
+
+for (const platform of ["darwin", "linux"] as const) {
+  for (const inherited of [{ HOME: "/home/test" }, { HOME: "/home/test", PATH: "" }]) {
+    const env: Record<string, string> = { ...inherited };
+    initializeAgentPath(env, platform);
+    strictEqual(env.PATH, "/home/test/.local/bin:/home/test/.bun/bin:/opt/homebrew/bin:/usr/local/bin");
+  }
+}

--- a/agent-chat/test/path-environment.test.ts
+++ b/agent-chat/test/path-environment.test.ts
@@ -1,0 +1,25 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { initializeAgentPath } from "../path-environment";
+
+// Preserve the first search entry, spelling of Path, and even an absent PATH.
+for (const inherited of [
+  { PATH: "C:\\Python314\\Scripts\\;C:\\Windows\\System32", USERPROFILE: "C:\\Users\\test" },
+  { Path: "C:\\Tools;C:\\Windows\\System32" },
+  { PATH: "" },
+  {},
+]) {
+  const env = { ...inherited };
+  initializeAgentPath(env, "win32");
+  deepStrictEqual(env, inherited);
+}
+
+for (const platform of ["darwin", "linux"] as const) {
+  const env = { HOME: "/home/test", PATH: "/usr/bin:/usr/local/bin:/bin", KEEP: "value" };
+  initializeAgentPath(env, platform);
+  strictEqual(env.PATH, "/home/test/.local/bin:/home/test/.bun/bin:/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin");
+  strictEqual(env.KEEP, "value");
+  const once = { ...env };
+  initializeAgentPath(env, platform);
+  deepStrictEqual(env, once);
+}
+console.log("PATH environment assertions passed");


### PR DESCRIPTION
## Summary
Follow-up to #12206, crediting @Somuuuu007. Preserve inherited Windows PATH entries while prepending agent CLI directories on POSIX systems. Empty or missing POSIX PATH values are treated as having no inherited entries, preventing an empty PATH element from enabling current-directory executable lookup.

## Testing
- `bun run check` (Linux)
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py`

## Demo video
Not applicable: this is a server-side environment fix.

## Review trigger
Please review the platform-specific PATH initialization and regression coverage.

## Checklist
- [x] Tests run on Linux
- [x] Builds were not run (Linux-only override)
- [x] No Swift/macOS, xcodebuild, reload, cloud-build, or dogfood commands were run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk startup environment tweak with platform-specific guards and dedicated regression tests; no auth or data-path changes.
> 
> **Overview**
> Moves agent-chat **PATH** bootstrapping out of `server.ts` into `initializeAgentPath` in `path-environment.ts`, called at server startup with `process.env` and `process.platform`.
> 
> On **Windows**, the function is a no-op so inherited `PATH`/`Path` (including empty or missing) is left unchanged. On **POSIX**, it still prepends `~/.local/bin`, `~/.bun/bin`, Homebrew, and `/usr/local/bin` ahead of existing entries, but **empty or absent `PATH` is treated as no inherited segments** so the result does not start with a stray `:` that could affect executable lookup. Adds `path-environment.test.ts` and wires it into the `check` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87aef4da78075de54742e20d5917879092532c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved agent CLI discovery on macOS and Linux by automatically including common user and system binary locations in the search path.
  - Preserved existing environment settings and prevented duplicate search-path entries.
  - Windows environments remain unchanged.
  - Added a fallback search path when no usable path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->