### PR TITLE
docs: make tmux permission diagnostics reproducible

### DIFF
--- a/docs/local-tmux.md
+++ b/docs/local-tmux.md
@@ -95,6 +95,98 @@ GUI/API operations still use cmux's authenticated control socket. Headless
 operations are limited by the operating-system user; do not share the state
 directory or socket with another Unix user.
 
+## Diagnosing protected-folder access errors
+
+If a shell in tmux reports `Operation not permitted` while reading a file in
+`~/Documents` or another protected folder, record the failure before restarting
+cmux, replacing the tmux server, or changing permissions. A live server and a
+successful attach do not establish that its child processes can read that file.
+
+First identify the affected server. Inside the affected tmux pane, run:
+
+```sh
+tmux display-message -p 'socket=#{socket_path} server_pid=#{pid} server_version=#{version}'
+tmux -V
+```
+
+`server_version` comes from the running server; `tmux -V` describes the client
+binary currently on `PATH`. They can differ after a package upgrade. Record the
+server PID and start time as well as the cmux and macOS versions. On macOS,
+substitute the reported server PID in these read-only commands:
+
+```sh
+ps -p <server-pid> -o pid=,ppid=,lstart=,command=
+lsof -a -p <server-pid> -d txt
+```
+
+The `txt` entries show mapped executable and code files.
+If the mapped executable path has been replaced or removed, record that too; it
+is a possible confounding factor, not proof of the permission failure's cause.
+
+Outside the pane, use `tmux -S <socket-path>` to query the same server, or
+`tmux -L <socket-name>` for an explicitly named server. A plain `tmux ls`
+does not list every server. For the cmux local-tmux profile,
+`cmux local-tmux list --json` includes `socket_path`; external tmux launchers
+may use a different socket.
+Do not infer that a session died from a query against another socket.
+
+Compare the original failing operation in the affected pane, a direct cmux
+shell outside tmux, and a direct shell in the other terminal app. Use the same
+absolute path and record which app hosts each shell. For a directory-listing
+failure, run this POSIX-shell snippet in each context, replacing the example
+path with the affected directory:
+
+```sh
+diagnostic_dir="$HOME/Documents/path/to/affected-directory"
+date -u '+%Y-%m-%dT%H:%M:%SZ'
+/bin/ls -a "$diagnostic_dir" > /dev/null
+diagnostic_status=$?
+printf 'directory listing exit=%s\n' "$diagnostic_status"
+```
+
+Standard output is discarded to avoid printing directory entries; standard
+error remains visible so the exact error can be recorded. If the original
+failure used a relative path such as `ls .`, also record the working directory
+and repeat that exact command: a fresh lookup by absolute path may behave
+differently from access through an existing working directory.
+
+For a file-read failure, choose one harmless, existing regular file and use
+this additional check in the same shell contexts:
+
+```sh
+diagnostic_file="$HOME/Documents/path/to/harmless-file"
+date -u '+%Y-%m-%dT%H:%M:%SZ'
+cat "$diagnostic_file" > /dev/null
+diagnostic_status=$?
+printf 'file read exit=%s\n' "$diagnostic_status"
+```
+
+A successful file read does not establish that listing its directory works.
+Record each command, time, exact error, and exit status without including
+private contents. If a separate server succeeds, also record its version and
+launch context: that result alone does not isolate server age, TCC state, or
+cmux as the cause. If a later retry succeeds without intervention, report the
+failure as currently non-reproducible rather than permanently fixed.
+
+When reporting the problem, include:
+
+- Whether the session uses `cmux local-tmux` or an external launcher.
+- The tested app build/revision and whether newer relevant changes were tested;
+  a marketing version alone may not distinguish a release from a development
+  build.
+- The affected server's version/start time and how its socket was selected.
+- The failing operation and the results for the same path in each shell context.
+- Any available permission-denial record at the failure time, with private
+  paths and unrelated process details removed.
+
+`EPERM` is not specific to TCC, and a daemon's parent PID alone does not identify
+its responsible application. `Operation not permitted` (EPERM) and
+`Permission denied` (EACCES) are different errors; record the exact wording or
+errno rather than treating them as interchangeable. See
+[Apple's guidance](https://developer.apple.com/forums/thread/678819).
+The related [report](https://github.com/manaflow-ai/cmux/issues/2866) is an
+investigation, not evidence that every similar failure has the same cause.
+
 ## Limitations
 
 - This slice requires a local `tmux` executable (or `CMUX_LOCAL_TMUX_BIN`).


### PR DESCRIPTION
Follow-up to #12219, incorporating and crediting @haung921209. Improves diagnostics by comparing exact operations across shell contexts and documenting server inspection.\n\nValidation: git diff --check; Linux shell and isolated tmux checks; python3 scripts/swift_file_length_budget.py. Builds were not run per Linux-only constraints. Localization audit: Markdown only; no catalogs changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758024&installation_model_id=21920&pr_number=12350&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12350&signature=7c9c9efa2482cf10dd07619a9010001564225e5eacf5006252af2efd02d95a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime, API, or security behavior changes.
> 
> **Overview**
> Adds a **Diagnosing protected-folder access errors** section to `docs/local-tmux.md` for macOS-style `Operation not permitted` failures in tmux (e.g. under `~/Documents`).
> 
> The guide tells users to capture evidence before restarting cmux or tmux, inspect the running server (`tmux display-message`, `ps`, `lsof`), query the correct socket (`-S`, `cmux local-tmux list --json`), and compare the same absolute-path operations across tmux, cmux, and another terminal using copy-paste POSIX snippets for directory listing and file read. It also lists what to include in bug reports, distinguishes EPERM from EACCES, and links Apple guidance and issue #2866 as an investigation reference—not a single root cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0002c27ec2cfc1745fdffa13a2404030a86c7630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a documented procedure for diagnosing `Operation not permitted` errors in tmux panes, so failures are recorded before any restart or permission change. The new section covers identifying the server, comparing the exact failing command across shell contexts, and reporting the right data without including private contents.

<sup>Written for commit 0002c27ec2cfc1745fdffa13a2404030a86c7630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

