### PR TITLE
build(setup): preflight Metal before setup mutations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@
   Homebrew's `rustup` formula works too, but it is keg-only and no longer ships `rustup-init`, so
   add `$(brew --prefix rustup)/bin` to `PATH` and run `rustup default stable` yourself.
 - On Xcode 26 the Metal compiler is a separately downloaded component, and the build fails
-  without it:
+  without it. Select the intended full Xcode installation first (`DEVELOPER_DIR`, if
+  exported, overrides `xcode-select`), then install the component:
 
   ```bash
   xcodebuild -downloadComponent MetalToolchain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@
 - macOS 14+
 - Xcode 26 (the pinned toolchain); Xcode 16.2 on Intel Macs running macOS 14 also builds the macOS app (best effort)
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
+- [Rust](https://rustup.rs) (install via `brew install rustup && rustup-init`) — `scripts/setup.sh`
+  requires `rustup`, and the app build compiles the bundled `cmux-cua` engine with `cargo`
+- On Xcode 26, the Metal toolchain is a separate download and the build fails without it:
+  ```bash
+  xcodebuild -downloadComponent MetalToolchain
+  ```
 
 ## Getting Started
 
@@ -21,7 +27,9 @@
 
    This will:
    - Initialize git submodules (ghostty, homebrew-cmux)
-   - Build the GhosttyKit.xcframework from source
+   - Install the pinned Rust toolchain
+   - Fetch a checksum-pinned prebuilt GhosttyKit.xcframework, falling back to building it
+     from source with Zig (force the source build with `CMUX_GHOSTTYKIT_NO_PREBUILT=1`)
    - Create the necessary symlinks
 
 3. Build the debug app:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,19 @@
 - macOS 14+
 - Xcode 26 (the pinned toolchain); Xcode 16.2 on Intel Macs running macOS 14 also builds the macOS app (best effort)
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
-- [Rust](https://rustup.rs) (install via `brew install rustup && rustup-init`) — `scripts/setup.sh`
-  requires `rustup`, and the app build compiles the bundled `cmux-cua` engine with `cargo`
-- On Xcode 26, the Metal toolchain is a separate download and the build fails without it:
+- [Rust](https://rustup.rs) — `scripts/setup.sh` requires `rustup`, and every app build compiles
+  the bundled `cmux-cua` engine with `cargo`. The official installer puts both in `~/.cargo/bin`,
+  which is where `setup.sh` looks:
+
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+  Homebrew's `rustup` formula works too, but it is keg-only and no longer ships `rustup-init`, so
+  add `$(brew --prefix rustup)/bin` to `PATH` and run `rustup default stable` yourself.
+- On Xcode 26 the Metal compiler is a separately downloaded component, and the build fails
+  without it:
+
   ```bash
   xcodebuild -downloadComponent MetalToolchain
   ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,6 +51,18 @@ if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     exit 1
 fi
 
+# Xcode 26 ships the Metal compiler as a separately downloaded component rather
+# than inside Xcode.app. Without it the app target fails partway through the
+# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
+# the Swift modules have already compiled. Fail here instead, where the fix is
+# one command. Older Xcode bundles metal, so this check simply passes there.
+echo "==> Checking for the Metal toolchain..."
+if ! xcrun metal --version &> /dev/null; then
+    echo "Error: the Metal toolchain is not installed."
+    echo "Install via: xcodebuild -downloadComponent MetalToolchain"
+    exit 1
+fi
+
 # The Cloud tunnel system extension embeds wireguard-go, built by
 # scripts/build-wireguard-go.sh. Release builds require Go; a Debug build
 # without it gets a stub engine (the extension cannot load in a Debug build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,7 +47,9 @@ rustup run "$DIFF_RUST_TOOLCHAIN" rustc --version
 echo "==> Checking for cargo (bundled cmux-cua)..."
 if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     echo "Error: a working Rust toolchain (cargo) is required to build the bundled cmux-cua."
-    echo "Install via rustup: https://rustup.rs (or \`brew install rustup && rustup-init\`)"
+    echo "Install via rustup: https://rustup.rs"
+    echo "(Homebrew's rustup is keg-only and ships no rustup-init: add"
+    echo " \"\$(brew --prefix rustup)/bin\" to PATH, then run \`rustup default stable\`.)"
     exit 1
 fi
 
@@ -56,10 +58,16 @@ fi
 # build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
 # the Swift modules have already compiled. Fail here instead, where the fix is
 # one command. Older Xcode bundles metal, so this check simply passes there.
+# The Command Line Tools do not ship metal at all, so the message names both
+# causes rather than assuming the component is merely missing.
 echo "==> Checking for the Metal toolchain..."
 if ! xcrun metal --version &> /dev/null; then
-    echo "Error: the Metal toolchain is not installed."
-    echo "Install via: xcodebuild -downloadComponent MetalToolchain"
+    echo "Error: the Metal compiler is not available."
+    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
+    echo "If that is a full Xcode, install the toolchain component:"
+    echo "    xcodebuild -downloadComponent MetalToolchain"
+    echo "If it is the Command Line Tools, select Xcode first:"
+    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,6 +6,26 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_DIR"
 
+# Xcode 26 ships the Metal compiler as a separately downloaded component rather
+# than inside Xcode.app. Without it the app target fails partway through the
+# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
+# the Swift modules have already compiled. Fail here instead, where the fix is
+# one command. Older Xcode bundles metal, so this check simply passes there.
+# The Command Line Tools do not ship metal at all, so the message names both
+# causes rather than assuming the component is merely missing.
+echo "==> Checking for the Metal toolchain..."
+if ! xcrun metal --version &> /dev/null; then
+    echo "Error: the Metal compiler is not available."
+    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
+    echo "For Xcode 26 or later, install the toolchain component:"
+    echo "    xcodebuild -downloadComponent MetalToolchain"
+    echo "If it is the Command Line Tools, select Xcode first:"
+    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
+    echo "If DEVELOPER_DIR is exported, unset it or point it to the intended Xcode;"
+    echo "it overrides the system selection."
+    exit 1
+fi
+
 echo "==> Initializing submodules..."
 git submodule update --init --recursive
 
@@ -50,24 +70,6 @@ if ! command -v cargo &> /dev/null || ! cargo --version &> /dev/null; then
     echo "Install via rustup: https://rustup.rs"
     echo "(Homebrew's rustup is keg-only and ships no rustup-init: add"
     echo " \"\$(brew --prefix rustup)/bin\" to PATH, then run \`rustup default stable\`.)"
-    exit 1
-fi
-
-# Xcode 26 ships the Metal compiler as a separately downloaded component rather
-# than inside Xcode.app. Without it the app target fails partway through the
-# build ("cannot execute tool 'metal' due to missing Metal Toolchain"), after
-# the Swift modules have already compiled. Fail here instead, where the fix is
-# one command. Older Xcode bundles metal, so this check simply passes there.
-# The Command Line Tools do not ship metal at all, so the message names both
-# causes rather than assuming the component is merely missing.
-echo "==> Checking for the Metal toolchain..."
-if ! xcrun metal --version &> /dev/null; then
-    echo "Error: the Metal compiler is not available."
-    echo "Active developer directory: $(xcode-select -p 2>/dev/null || echo 'unset')"
-    echo "If that is a full Xcode, install the toolchain component:"
-    echo "    xcodebuild -downloadComponent MetalToolchain"
-    echo "If it is the Command Line Tools, select Xcode first:"
-    echo "    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 


### PR DESCRIPTION
Contributor setup can fail late because Metal and Rust prerequisites are missing. This follow-up to #12107 carries forward SangHun Lee (@nrhys2005)'s prerequisite documentation, corrected Homebrew rustup guidance, and Metal probe, preserving both original commits and authorship.

The Metal probe now runs before submodule initialization and Rust installation. Its recovery instructions explain that an exported DEVELOPER_DIR overrides the system selection, and limit component-download guidance to Xcode 26+. The existing xcode-select diagnostic is retained: the review finding claiming it ignores DEVELOPER_DIR was withdrawn. Current main's Xcode 26 / Intel Xcode 16.2 guidance is preserved.

Validation performed on Linux:
- `bash -n scripts/setup.sh` passed.
- `git diff --check` passed.
- `python3 scripts/swift_file_length_budget.py` passed (0 changed Swift files).
- Executed setup.sh with isolated stubs for xcrun, xcode-select, and git: available Metal reaches the submodule sentinel; missing Metal exits 1 before mutations for default Xcode, Command Line Tools, and a custom path containing spaces. The sentinel stops execution before real setup or builds.
- Localization audit covered CONTRIBUTING.md and developer-only shell diagnostics. They remain English-only; no app/web catalog strings changed.

Builds were not run. No compilation, xcodebuild, reload, local/remote/cloud builds, app launches, or dogfood was performed. Stub checks establish shell control flow only; actual Apple toolchain behavior and end-to-end macOS setup remain unverified for this follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758041&installation_model_id=21920&pr_number=12352&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12352&signature=a0c5157134d40190544f2f4ef16c3d6b579b4b8a4d100c9b2e11ca562de52352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only setup script and documentation changes; no app runtime, auth, or production build pipeline behavior is altered.
> 
> **Overview**
> **Setup now fails fast on a missing Metal compiler** before submodules, Rust installs, or other setup side effects. `scripts/setup.sh` runs `xcrun metal --version` up front and prints targeted recovery steps (MetalToolchain download on Xcode 26+, switching off Command Line Tools, and `DEVELOPER_DIR` overriding `xcode-select`).
> 
> **Contributor docs and Rust/cargo errors are tightened** in `CONTRIBUTING.md` and `setup.sh`: Rust/rustup and Xcode 26 Metal prerequisites are documented; setup steps now mention the pinned Rust toolchain and checksum-pinned GhosttyKit with a source-build override; Homebrew `rustup` guidance replaces the outdated `rustup-init` hint when `cargo` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76050fdfa768a8a85e6b451854350b1c361c212b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries forward the Metal toolchain preflight and prerequisite documentation from #12107 so setup fails early with clear recovery steps instead of failing during builds.

- Checks for the Metal compiler via `xcrun metal` before any submodule init or Rust install.
- Recovery messages explain both the missing MetalToolchain component on Xcode 26+ and Command Line Tools lacking Metal, and note that exported `DEVELOPER_DIR` overrides `xcode-select`.
- Adds Rust and Metal prerequisites to `CONTRIBUTING.md`, including corrected Homebrew `rustup` guidance (keg-only, no `rustup-init`).
- Updates the GhosttyKit build note to mention the checksum-pinned prebuilt framework with a source-build fallback (force with `CMUX_GHOSTTYKIT_NO_PREBUILT=1`).

<sup>Written for commit b686b385935bc8546be7f9d517742ff5a8dca79e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor setup instructions with Rust toolchain requirements and Metal compiler setup guidance.
  - Documented downloading a prebuilt GhosttyKit framework, with an option to build it from source.

- **Bug Fixes**
  - Added clearer setup validation and remediation messages for missing Metal and Rust tooling.
  - Improved guidance for configuring PATH when Rust is installed through Homebrew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->