### PR TITLE
Fix correctness issues in Read Aloud follow-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1761,6 +1761,7 @@ jobs:
             CmuxMobileTerminalKit
             CmuxMobileWorkspace
             CmuxNotifications
+            CmuxReadAloud
             CmuxSettings
             CmuxSettingsUI
             CmuxTerminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to cmux are documented here.
 
+## [Unreleased]
+
+### Added
+- Read selected terminal text aloud with MiniMax streaming speech, a Stop Speaking action, and native voice, speed, and API-key settings.
+
 ## [0.64.22] - 2026-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to cmux are documented here.
 
-## [Unreleased]
-
-### Added
-- Read selected terminal text aloud with MiniMax streaming speech, a Stop Speaking action, and native voice, speed, and API-key settings.
-
 ## [0.64.22] - 2026-08-03
 
 ### Fixed

--- a/Packages/macOS/CmuxReadAloud/Package.swift
+++ b/Packages/macOS/CmuxReadAloud/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CmuxReadAloud",
+    defaultLocalization: "en",
+    platforms: [.macOS(.v14)],
+    products: [.library(name: "CmuxReadAloud", targets: ["CmuxReadAloud"])],
+    targets: [
+        .target(name: "CmuxReadAloud", resources: [.process("Resources")]),
+        .testTarget(name: "CmuxReadAloudTests", dependencies: ["CmuxReadAloud"]),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
@@ -1,0 +1,179 @@
+import AVFoundation
+import Foundation
+
+/// Plays streamed mono 32 kHz signed 16-bit little-endian PCM through local audio output.
+///
+/// The coordinator owns playback sessions. At most 400 ms of decoded audio is
+/// scheduled ahead, plus the current incoming chunk and one incomplete sample.
+@MainActor
+public final class PCMReadAloudPlayer {
+    private let engine = AVAudioEngine()
+    private let node = AVAudioPlayerNode()
+    private let format = AVAudioFormat(standardFormatWithSampleRate: 32_000, channels: 1)
+    private var graphConnected = false
+    private var generation: UUID?
+    private var incompleteSample: UInt8?
+    private var scheduledBuffers: Set<UUID> = []
+    private var playbackWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    // Mutated only on MainActor; deinit reads the opaque token after actor access
+    // has ceased. NotificationCenter permits removal from any thread.
+    private nonisolated(unsafe) var configurationObserver: (any NSObjectProtocol)?
+
+    /// Creates an idle player without starting audio output.
+    public init() {}
+
+    deinit {
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+        }
+    }
+
+    func begin(
+        generation: UUID,
+        onFailure: @escaping @MainActor @Sendable (ReadAloudPlaybackError) -> Void
+    ) {
+        stop()
+        self.generation = generation
+        configurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange, object: engine, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard self?.generation == generation else { return }
+                onFailure(.outputUnavailable)
+            }
+        }
+    }
+
+    func append(_ data: Data, generation: UUID) async throws {
+        try checkActive(generation)
+        var offset = 0
+        while offset < data.count {
+            while scheduledBuffers.count >= 4 {
+                try await waitForPlayback(generation: generation)
+            }
+            try checkActive(generation)
+            let availableBytes = data.count - offset + (incompleteSample == nil ? 0 : 1)
+            let frameCount = min(3_200, availableBytes / 2)
+            if frameCount == 0 {
+                incompleteSample = data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in bytes[offset] }
+                return
+            }
+            guard let format,
+                  let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount)),
+                  let samples = buffer.floatChannelData?[0] else {
+                throw ReadAloudPlaybackError.outputUnavailable
+            }
+            buffer.frameLength = AVAudioFrameCount(frameCount)
+            // AVAudioPlayerNode consumes Float32; decode LE explicitly, without alignment assumptions.
+            data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+                var frame = 0
+                if let low = incompleteSample {
+                    samples[0] = sample(low: low, high: bytes[offset])
+                    incompleteSample = nil
+                    offset += 1
+                    frame = 1
+                }
+                while frame < frameCount {
+                    samples[frame] = sample(low: bytes[offset], high: bytes[offset + 1])
+                    offset += 2
+                    frame += 1
+                }
+            }
+            try startEngine(format: format)
+            let bufferID = UUID()
+            scheduledBuffers.insert(bufferID)
+            // AVFoundation invokes this legacy callback off-actor. Only Sendable IDs
+            // and the main-actor player cross the seam; no audio objects cross it.
+            let completion: @Sendable (AVAudioPlayerNodeCompletionCallbackType) -> Void = { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.played(bufferID, generation: generation)
+                }
+            }
+            node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack, completionHandler: completion)
+            if !node.isPlaying {
+                node.play()
+            }
+        }
+    }
+
+    func finish(generation: UUID) async throws {
+        try checkActive(generation)
+        guard incompleteSample == nil else {
+            throw ReadAloudPlaybackError.incompleteSample
+        }
+        while !scheduledBuffers.isEmpty {
+            try await waitForPlayback(generation: generation)
+        }
+        try checkActive(generation)
+    }
+
+    func stop() {
+        generation = nil
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+            self.configurationObserver = nil
+        }
+        incompleteSample = nil
+        scheduledBuffers.removeAll(keepingCapacity: true)
+        node.stop()
+        engine.stop()
+        resumeWaiters(throwing: CancellationError())
+    }
+
+    private func startEngine(format: AVAudioFormat) throws {
+        if !graphConnected {
+            engine.attach(node)
+            engine.connect(node, to: engine.mainMixerNode, format: format)
+            graphConnected = true
+        }
+        if !engine.isRunning {
+            do {
+                try engine.start()
+            } catch {
+                // Do not expose system error details through the parent alert.
+                throw ReadAloudPlaybackError.outputUnavailable
+            }
+        }
+    }
+
+    private func sample(low: UInt8, high: UInt8) -> Float {
+        Float(Int16(bitPattern: UInt16(low) | (UInt16(high) << 8))) / 32_768
+    }
+
+    private func checkActive(_ generation: UUID) throws {
+        try Task.checkCancellation()
+        guard self.generation == generation else { throw CancellationError() }
+    }
+
+    private func waitForPlayback(generation: UUID) async throws {
+        try await withTaskCancellationHandler {
+            try checkActive(generation)
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                playbackWaiters[UUID()] = continuation
+            }
+            try checkActive(generation)
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                guard let self, self.generation == generation else { return }
+                self.stop()
+            }
+        }
+    }
+
+    private func played(_ bufferID: UUID, generation: UUID) {
+        guard self.generation == generation, scheduledBuffers.remove(bufferID) != nil else { return }
+        resumeWaiters()
+    }
+
+    private func resumeWaiters(throwing error: (any Error)? = nil) {
+        let waiters = playbackWaiters
+        playbackWaiters.removeAll(keepingCapacity: true)
+        for waiter in waiters.values {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
@@ -11,6 +11,7 @@ public final class PCMReadAloudPlayer {
     private let node = AVAudioPlayerNode()
     private let format = AVAudioFormat(standardFormatWithSampleRate: 32_000, channels: 1)
     private var graphConnected = false
+    private var nodeAttached = false
     private var generation: UUID?
     private var incompleteSample: UInt8?
     private var scheduledBuffers: Set<UUID> = []
@@ -124,8 +125,11 @@ public final class PCMReadAloudPlayer {
     }
 
     private func startEngine(format: AVAudioFormat) throws {
-        if !graphConnected {
+        if !nodeAttached {
             engine.attach(node)
+            nodeAttached = true
+        }
+        if !graphConnected {
             engine.connect(node, to: engine.mainMixerNode, format: format)
             graphConnected = true
         }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/PCMReadAloudPlayer.swift
@@ -38,7 +38,10 @@ public final class PCMReadAloudPlayer {
             forName: .AVAudioEngineConfigurationChange, object: engine, queue: nil
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard self?.generation == generation else { return }
+                guard let self, self.generation == generation else { return }
+                self.node.stop()
+                self.engine.stop()
+                self.graphConnected = false
                 onFailure(.outputUnavailable)
             }
         }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudCoordinator.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudCoordinator.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Observation
+
+/// Owns one selected-text speech operation, including loading, streaming, and playback.
+///
+/// Route every Read Aloud and Stop action through the same coordinator. Replacing
+/// a read cancels its caller immediately and prevents late audio from that read.
+///
+/// ```swift
+/// let coordinator = ReadAloudCoordinator(
+///     synthesizer: synthesizer, preferences: preferences, player: PCMReadAloudPlayer()
+/// )
+/// try await coordinator.read(selectedText)
+/// ```
+@MainActor
+@Observable
+public final class ReadAloudCoordinator {
+    /// Whether the current read is loading, synthesizing, or still playing queued audio.
+    public private(set) var isSpeaking = false
+
+    @ObservationIgnored private let synthesizer: any ReadAloudSynthesizing
+    @ObservationIgnored private let player: PCMReadAloudPlayer
+    @ObservationIgnored private let authorization: @Sendable () async throws -> (ReadAloudConfiguration, String)
+    @ObservationIgnored private var generation: UUID?
+    @ObservationIgnored private var operation: Task<Void, Never>?
+    @ObservationIgnored private var completion: CheckedContinuation<Void, any Error>?
+
+    /// Creates the shared speech coordinator using explicit service dependencies.
+    /// - Parameters:
+    ///   - synthesizer: The streaming speech provider, honoring sink backpressure and cancellation.
+    ///   - preferences: The configuration, consent, and Keychain credential repository.
+    ///   - player: The local PCM output owned exclusively by this coordinator.
+    public init(
+        synthesizer: any ReadAloudSynthesizing,
+        preferences: ReadAloudPreferences,
+        player: PCMReadAloudPlayer
+    ) {
+        self.synthesizer = synthesizer
+        self.player = player
+        self.authorization = {
+            guard await preferences.consentGranted() else {
+                throw ReadAloudCoordinatorError.configurationRequired
+            }
+            try Task.checkCancellation()
+            guard let key = try await preferences.apiKey(),
+                  !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ReadAloudCoordinatorError.configurationRequired
+            }
+            try Task.checkCancellation()
+            let configuration = await preferences.configuration()
+            try Task.checkCancellation()
+            return (configuration, key)
+        }
+    }
+
+    /// Injects authorization suspension points for isolated cancellation tests without Keychain access.
+    init(
+        synthesizer: any ReadAloudSynthesizing,
+        player: PCMReadAloudPlayer,
+        authorization: @escaping @Sendable () async throws -> (ReadAloudConfiguration, String)
+    ) {
+        self.synthesizer = synthesizer
+        self.player = player
+        self.authorization = authorization
+    }
+
+    /// Replaces any active read and waits until all generated audio has played.
+    ///
+    /// Empty or whitespace-only text cancels an older read without contacting the
+    /// provider. Cancelling the calling task has the same effect as ``stop()``.
+    /// - Parameter text: The selected text, passed to the provider without truncation.
+    /// - Throws: ``ReadAloudCoordinatorError/configurationRequired`` when credentials
+    ///   or consent are absent; `CancellationError` on stop, replacement, or caller
+    ///   cancellation; otherwise the provider or local playback error.
+    public func read(_ text: String) async throws {
+        try Task.checkCancellation()
+        stop()
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let generation = UUID()
+        self.generation = generation
+        isSpeaking = true
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                completion = continuation
+                if Task.isCancelled {
+                    stop(generation: generation)
+                    return
+                }
+                operation = Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        try await self.performRead(text, generation: generation)
+                        self.complete(generation: generation, result: .success(()))
+                    } catch {
+                        let error = Task.isCancelled ? CancellationError() : error
+                        self.complete(generation: generation, result: .failure(error))
+                    }
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.stop(generation: generation)
+            }
+        }
+        try Task.checkCancellation()
+    }
+
+    /// Immediately cancels loading, network synthesis, and all queued audio.
+    ///
+    /// Pending read and playback waits resume with `CancellationError`. This does
+    /// not depend on whether terminal text remains selected.
+    public func stop() {
+        generation = nil
+        operation?.cancel()
+        operation = nil
+        player.stop()
+        isSpeaking = false
+        let completion = self.completion
+        self.completion = nil
+        completion?.resume(throwing: CancellationError())
+    }
+
+    private func performRead(_ text: String, generation: UUID) async throws {
+        try checkActive(generation)
+        let (configuration, key) = try await authorization()
+        try checkActive(generation)
+        player.begin(generation: generation) { [weak self] error in
+            guard let self, self.generation == generation else { return }
+            self.operation?.cancel()
+            self.complete(generation: generation, result: .failure(error))
+        }
+        let player = self.player
+        try await synthesizer.synthesize(text: text, configuration: configuration, apiKey: key) { data in
+            try await player.append(data, generation: generation)
+        }
+        try checkActive(generation)
+        try await player.finish(generation: generation)
+        try checkActive(generation)
+    }
+
+    private func checkActive(_ generation: UUID) throws {
+        try Task.checkCancellation()
+        guard self.generation == generation else { throw CancellationError() }
+    }
+
+    private func stop(generation: UUID) {
+        guard self.generation == generation else { return }
+        stop()
+    }
+
+    private func complete(generation: UUID, result: Result<Void, any Error>) {
+        guard self.generation == generation else { return }
+        self.generation = nil
+        operation = nil
+        player.stop()
+        isSpeaking = false
+        let completion = self.completion
+        self.completion = nil
+        completion?.resume(with: result)
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudCoordinatorError.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudCoordinatorError.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Recoverable setup errors that let the app present Read Aloud settings.
+public enum ReadAloudCoordinatorError: LocalizedError {
+    /// Read Aloud needs a nonempty API key and consent to send selected text to MiniMax.
+    case configurationRequired
+
+    /// A localized description safe to present without credentials or selected text.
+    public var errorDescription: String? {
+        String(
+            localized: "readAloud.playback.configurationRequired",
+            defaultValue: "Open Read Aloud settings to add your MiniMax API key and allow selected text to be sent to MiniMax.",
+            table: "ReadAloudPlayback",
+            bundle: .module
+        )
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudPlaybackError.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Playback/ReadAloudPlaybackError.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Safe descriptions for local audio failures, without underlying device details.
+enum ReadAloudPlaybackError: LocalizedError {
+    case outputUnavailable
+    case incompleteSample
+
+    var errorDescription: String? {
+        switch self {
+        case .outputUnavailable:
+            String(
+                localized: "readAloud.playback.outputUnavailable",
+                defaultValue: "Audio output is unavailable. Check your sound output device and try again.",
+                table: "ReadAloudPlayback",
+                bundle: .module
+            )
+        case .incompleteSample:
+            String(
+                localized: "readAloud.playback.incompleteSample",
+                defaultValue: "The speech service returned incomplete audio. Please try again.",
+                table: "ReadAloudPlayback",
+                bundle: .module
+            )
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Non-secret preferences for reading selected text through MiniMax.
+public struct ReadAloudConfiguration: Codable, Equatable, Sendable {
+    /// MiniMax speech model identifier.
+    public var model: String
+    /// MiniMax system or custom voice identifier.
+    public var voiceID: String
+    /// Synthesis speed, from 0.5 to 2.0.
+    public var speed: Double
+
+    /// Creates speech preferences without reading global settings.
+    /// - Parameters:
+    ///   - model: The requested MiniMax speech model.
+    ///   - voiceID: The requested MiniMax voice.
+    ///   - speed: The requested synthesis speed.
+    public init(
+        model: String = "speech-2.8-turbo",
+        voiceID: String = "English_expressive_narrator",
+        speed: Double = 1.0
+    ) {
+        self.model = model
+        self.voiceID = voiceID
+        self.speed = speed
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
@@ -1,26 +1,28 @@
 import Foundation
 
-/// Non-secret preferences for reading selected text through MiniMax.
+/// Validated runtime preferences for reading selected text through MiniMax.
 public struct ReadAloudConfiguration: Codable, Equatable, Sendable {
-    /// MiniMax speech model identifier.
     public var model: String
-    /// MiniMax system or custom voice identifier.
     public var voiceID: String
-    /// Synthesis speed, from 0.5 to 2.0.
     public var speed: Double
 
-    /// Creates speech preferences without reading global settings.
-    /// - Parameters:
-    ///   - model: The requested MiniMax speech model.
-    ///   - voiceID: The requested MiniMax voice.
-    ///   - speed: The requested synthesis speed.
-    public init(
-        model: String = "speech-2.8-turbo",
-        voiceID: String = "English_expressive_narrator",
-        speed: Double = 1.0
-    ) {
-        self.model = model
-        self.voiceID = voiceID
-        self.speed = speed
+    public init(model: String = "speech-2.8-turbo", voiceID: String = "English_expressive_narrator", speed: Double = 1.0) {
+        self.model = model; self.voiceID = voiceID; self.speed = speed
     }
+
+    /// Validates the complete runtime snapshot against the supported provider contract.
+    public func validate() throws {
+        guard model == "speech-2.8-turbo" || model == "speech-2.8-hd" else { throw ConfigurationError.unsupportedModel }
+        guard !voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !voiceID.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else { throw ConfigurationError.invalidVoice }
+        guard speed.isFinite, (0.5...2.0).contains(speed) else { throw ConfigurationError.invalidSpeed }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(model: try c.decode(String.self, forKey: .model), voiceID: try c.decode(String.self, forKey: .voiceID), speed: try c.decode(Double.self, forKey: .speed))
+        try validate()
+    }
+
+    public enum ConfigurationError: Error, Equatable { case unsupportedModel, invalidVoice, invalidSpeed }
 }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
@@ -39,7 +39,7 @@ public struct ReadAloudConfiguration: Codable, Equatable, Sendable {
             throw ReadAloudPreferencesError.invalidSpeed
         }
         self.model = model
-        self.voiceID = voiceID
+        self.voiceID = voiceID.trimmingCharacters(in: .whitespacesAndNewlines)
         self.speed = speed
     }
 

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudConfiguration.swift
@@ -1,28 +1,57 @@
 import Foundation
 
-/// Validated runtime preferences for reading selected text through MiniMax.
+/// An immutable, validated snapshot shared by persistence and speech synthesis.
 public struct ReadAloudConfiguration: Codable, Equatable, Sendable {
-    public var model: String
-    public var voiceID: String
-    public var speed: Double
-
-    public init(model: String = "speech-2.8-turbo", voiceID: String = "English_expressive_narrator", speed: Double = 1.0) {
-        self.model = model; self.voiceID = voiceID; self.speed = speed
+    /// Models supported by both the settings interface and speech transport.
+    public enum Model: String, Codable, CaseIterable, Sendable {
+        /// Lower-latency speech synthesis.
+        case turbo = "speech-2.8-turbo"
+        /// Higher-quality speech synthesis.
+        case hd = "speech-2.8-hd"
     }
 
-    /// Validates the complete runtime snapshot against the supported provider contract.
-    public func validate() throws {
-        guard model == "speech-2.8-turbo" || model == "speech-2.8-hd" else { throw ConfigurationError.unsupportedModel }
+    /// Supported MiniMax speech model.
+    public let model: Model
+    /// Nonempty voice identifier containing no control characters.
+    public let voiceID: String
+    /// Finite synthesis speed from 0.5 through 2.0.
+    public let speed: Double
+
+    /// Creates the supported default configuration without reading stored preferences.
+    public init() {
+        model = .turbo
+        voiceID = "English_expressive_narrator"
+        speed = 1.0
+    }
+
+    /// Validates editable settings before they become runtime preferences.
+    /// - Parameters:
+    ///   - model: The supported provider model; defaults to Turbo.
+    ///   - voiceID: A nonempty voice identifier without control characters.
+    ///   - speed: A finite synthesis speed from 0.5 through 2.0; defaults to 1.
+    /// - Throws: A localized settings error if the voice or speed is invalid.
+    public init(model: Model = .turbo, voiceID: String, speed: Double = 1.0) throws {
         guard !voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !voiceID.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else { throw ConfigurationError.invalidVoice }
-        guard speed.isFinite, (0.5...2.0).contains(speed) else { throw ConfigurationError.invalidSpeed }
+              !voiceID.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
+            throw ReadAloudPreferencesError.emptyVoice
+        }
+        guard speed.isFinite, (0.5...2.0).contains(speed) else {
+            throw ReadAloudPreferencesError.invalidSpeed
+        }
+        self.model = model
+        self.voiceID = voiceID
+        self.speed = speed
     }
 
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.init(model: try c.decode(String.self, forKey: .model), voiceID: try c.decode(String.self, forKey: .voiceID), speed: try c.decode(Double.self, forKey: .speed))
-        try validate()
+    /// Decodes existing string-based preferences through the same validation as settings.
+    /// - Parameter decoder: The persisted configuration decoder.
+    /// - Throws: A decoding or validation error for unsupported stored values.
+    public init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            model: values.decode(Model.self, forKey: .model),
+            voiceID: values.decode(String.self, forKey: .voiceID),
+            speed: values.decode(Double.self, forKey: .speed)
+        )
     }
-
-    public enum ConfigurationError: Error, Equatable { case unsupportedModel, invalidVoice, invalidSpeed }
 }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudSynthesizing.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/ReadAloudSynthesizing.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Synthesizes selected text into mono 32 kHz signed 16-bit little-endian PCM.
+public protocol ReadAloudSynthesizing: Sendable {
+    /// Streams audio, awaiting consumption before reading the next audio chunk.
+    ///
+    /// The sink is a backpressure boundary, not a completion callback. Cancellation
+    /// must stop the underlying request. No text, key, or audio is persisted.
+    /// - Parameters:
+    ///   - text: The selected text, without silent truncation.
+    ///   - configuration: Model, voice, and speed preferences.
+    ///   - apiKey: The caller-provided MiniMax credential.
+    ///   - audioSink: Consumes a chunk before synthesis continues reading.
+    /// - Throws: Cancellation, transport, provider, or consumption errors.
+    func synthesize(
+        text: String,
+        configuration: ReadAloudConfiguration,
+        apiKey: String,
+        audioSink: @escaping @Sendable (Data) async throws -> Void
+    ) async throws
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudPlayback.xcstrings
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudPlayback.xcstrings
@@ -1,0 +1,381 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "readAloud.playback.configurationRequired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Read Aloud settings to add your MiniMax API key and allow selected text to be sent to MiniMax."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定を開き、MiniMax API キーを追加して、選択したテキストの MiniMax への送信を許可してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح إعدادات القراءة بصوت عالٍ لإضافة مفتاح API الخاص بك لخدمة MiniMax والسماح بإرسال النص المحدد إلى MiniMax."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvorite postavke čitanja naglas da dodate svoj MiniMax API ključ i dozvolite slanje odabranog teksta usluzi MiniMax."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn indstillingerne for Læs op for at tilføje din MiniMax-API-nøgle og tillade, at markeret tekst sendes til MiniMax."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen Sie die Einstellungen für „Vorlesen“, um Ihren MiniMax-API-Schlüssel hinzuzufügen und das Senden von ausgewähltem Text an MiniMax zu erlauben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre los ajustes de Leer en voz alta para añadir tu clave de API de MiniMax y permitir que se envíe el texto seleccionado a MiniMax."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez les réglages de lecture à voix haute pour ajouter votre clé API MiniMax et autoriser l’envoi du texte sélectionné à MiniMax."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri le impostazioni di Leggi ad alta voce per aggiungere la tua chiave API MiniMax e consentire l'invio del testo selezionato a MiniMax."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើកការកំណត់អានឮៗ ដើម្បីបន្ថែមសោ API របស់ MiniMax របស់អ្នក និងអនុញ្ញាតឱ្យផ្ញើអត្ថបទដែលបានជ្រើសរើសទៅ MiniMax។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기 설정을 열어 MiniMax API 키를 추가하고 선택한 텍스트를 MiniMax로 전송하도록 허용하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne innstillingene for Les høyt for å legge til MiniMax API-nøkkelen din og tillate at markert tekst sendes til MiniMax."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz ustawienia funkcji Czytaj na głos, aby dodać klucz API MiniMax i zezwolić na wysyłanie zaznaczonego tekstu do MiniMax."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra os ajustes de Ler em voz alta para adicionar sua chave de API da MiniMax e permitir o envio do texto selecionado à MiniMax."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте настройки чтения вслух, чтобы добавить API-ключ MiniMax и разрешить отправку выделенного текста в MiniMax."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่าการอ่านออกเสียงเพื่อเพิ่มคีย์ API ของ MiniMax และอนุญาตให้ส่งข้อความที่เลือกไปยัง MiniMax"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax API anahtarınızı eklemek ve seçili metnin MiniMax’e gönderilmesine izin vermek için Sesli Oku ayarlarını açın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте налаштування «Читати вголос», щоб додати свій API-ключ MiniMax і дозволити надсилання вибраного тексту до MiniMax."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请打开朗读设置，添加你的 MiniMax API 密钥，并允许将所选文本发送至 MiniMax。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請開啟「朗讀」設定，加入您的 MiniMax API 金鑰，並允許將所選文字傳送至 MiniMax。"
+          }
+        }
+      }
+    },
+    "readAloud.playback.incompleteSample": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The speech service returned incomplete audio. Please try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声サービスから不完全な音声が返されました。もう一度お試しください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أعادت خدمة تحويل النص إلى كلام صوتًا غير مكتمل. يُرجى المحاولة مجددًا."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usluga za govor vratila je nepotpun audio. Pokušajte ponovo."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taletjenesten returnerede ufuldstændig lyd. Prøv igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Sprachausgabedienst hat unvollständige Audiodaten zurückgegeben. Bitte versuchen Sie es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El servicio de síntesis de voz ha devuelto un audio incompleto. Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le service de synthèse vocale a renvoyé un contenu audio incomplet. Veuillez réessayer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il servizio di sintesi vocale ha restituito un audio incompleto. Riprova."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "សេវាសំឡេងអានបានត្រឡប់សំឡេងមិនពេញលេញ។ សូមព្យាយាមម្ដងទៀត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 서비스에서 불완전한 오디오를 반환했습니다. 다시 시도하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taletjenesten returnerte ufullstendig lyd. Prøv igjen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usługa generowania mowy zwróciła niekompletne dane audio. Spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O serviço de fala retornou um áudio incompleto. Tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Служба синтеза речи вернула неполные аудиоданные. Повторите попытку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บริการเสียงพูดส่งข้อมูลเสียงกลับมาไม่ครบถ้วน โปรดลองอีกครั้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma hizmeti eksik ses döndürdü. Lütfen tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Служба синтезу мовлення повернула неповне аудіо. Спробуйте ще раз."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音服务返回了不完整的音频。请重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音服務傳回的音訊不完整。請再試一次。"
+          }
+        }
+      }
+    },
+    "readAloud.playback.outputUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio output is unavailable. Check your sound output device and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声を出力できません。サウンドの出力装置を確認して、もう一度お試しください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخراج الصوت غير متاح. تحقّق من جهاز إخراج الصوت وحاول مجددًا."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio izlaz nije dostupan. Provjerite uređaj za izlaz zvuka i pokušajte ponovo."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lydoutput er ikke tilgængeligt. Kontrollér din lydoutputenhed, og prøv igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audioausgabe ist nicht verfügbar. Überprüfen Sie Ihr Audioausgabegerät und versuchen Sie es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La salida de audio no está disponible. Comprueba el dispositivo de salida de sonido e inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sortie audio est indisponible. Vérifiez votre périphérique de sortie audio et réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'uscita audio non è disponibile. Controlla il dispositivo di uscita audio e riprova."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចបញ្ចេញសំឡេងបានទេ។ សូមពិនិត្យឧបករណ៍បញ្ចេញសំឡេងរបស់អ្នក ហើយព្យាយាមម្ដងទៀត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 출력을 사용할 수 없습니다. 사운드 출력 장치를 확인하고 다시 시도하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lydutgang er utilgjengelig. Kontroller lydutgangsenheten og prøv igjen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyjście audio jest niedostępne. Sprawdź urządzenie wyjściowe dźwięku i spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A saída de áudio está indisponível. Verifique seu dispositivo de saída de som e tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аудиовыход недоступен. Проверьте устройство вывода звука и повторите попытку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถส่งเสียงออกได้ ตรวจสอบอุปกรณ์ส่งเสียงออกของคุณแล้วลองอีกครั้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses çıkışı kullanılamıyor. Ses çıkış aygıtınızı kontrol edip tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виведення аудіо недоступне. Перевірте пристрій виведення звуку та спробуйте ще раз."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频输出不可用。请检查声音输出设备后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音訊輸出無法使用。請檢查您的聲音輸出裝置，然後再試一次。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
@@ -1,0 +1,4506 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "القراءة بصوت عالٍ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čitanje naglas"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Læs op"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlesen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leer en voz alta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire à voix haute"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggi ad alta voce"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "អានឮៗ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les høyt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czytaj na głos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ler em voz alta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтение вслух"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Читати вголос"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗读"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗讀"
+          }
+        }
+      }
+    },
+    "section.speech": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الكلام"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Govor"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tale"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachausgabe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Síntesis de voz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synthèse vocale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sintesi vocale"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "សំឡេងអាន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tale"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mowa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fala"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Речь"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เสียงพูด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мовлення"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音"
+          }
+        }
+      }
+    },
+    "section.key": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax Credential"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 認証情報"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بيانات اعتماد MiniMax"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax pristupni podaci"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax-legitimationsoplysninger"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax-Zugangsdaten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credencial de MiniMax"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifiant MiniMax"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credenziale MiniMax"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ព័ត៌មានសម្ងាត់ MiniMax"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 인증 정보"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax-legitimasjon"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dane uwierzytelniające MiniMax"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credencial da MiniMax"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Учётные данные MiniMax"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อมูลรับรอง MiniMax"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax Kimlik Bilgisi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Облікові дані MiniMax"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 凭据"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 憑證"
+          }
+        }
+      }
+    },
+    "section.privacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Processing Consent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウド処理への同意"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الموافقة على المعالجة السحابية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pristanak na obradu u oblaku"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Samtykke til behandling i skyen"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einwilligung zur Cloud-Verarbeitung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consentimiento para el procesamiento en la nube"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consentement au traitement dans le cloud"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenso all'elaborazione nel cloud"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការយល់ព្រមឱ្យដំណើរការលើក្លោដ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 처리 동의"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Samtykke til behandling i skyen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgoda na przetwarzanie w chmurze"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consentimento para processamento na nuvem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Согласие на облачную обработку"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความยินยอมให้ประมวลผลบนคลาวด์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bulutta İşleme Onayı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Згода на обробку в хмарі"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云端处理授权"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雲端處理同意"
+          }
+        }
+      }
+    },
+    "model.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデル"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النموذج"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modello"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ម៉ូដែល"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модель"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โมเดล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модель"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
+        }
+      }
+    },
+    "model.turbo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo（speech-2.8-turbo）"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo (speech-2.8-turbo)"
+          }
+        }
+      }
+    },
+    "model.hd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD（speech-2.8-hd）"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HD (speech-2.8-hd)"
+          }
+        }
+      }
+    },
+    "voice.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声 ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف الصوت"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID glasa"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stemme-id"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimmen-ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de voz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifiant de voix"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID voce"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID សំឡេង"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 ID"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stemme-ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identyfikator głosu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID da voz"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идентификатор голоса"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID เสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Kimliği"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ідентифікатор голосу"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音色 ID"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聲音 ID"
+          }
+        }
+      }
+    },
+    "voice.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use a MiniMax voice ID, such as English_expressive_narrator, or your custom voice ID."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English_expressive_narrator などの MiniMax 音声 ID、またはカスタム音声 ID を入力してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدم معرّف صوت من MiniMax، مثل English_expressive_narrator، أو معرّف صوتك المخصص."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koristite MiniMax ID glasa, kao što je English_expressive_narrator, ili ID svog prilagođenog glasa."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brug et MiniMax-stemme-id, f.eks. English_expressive_narrator, eller dit eget tilpassede stemme-id."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie eine MiniMax-Stimmen-ID, etwa English_expressive_narrator, oder Ihre benutzerdefinierte Stimmen-ID."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa un ID de voz de MiniMax, como English_expressive_narrator, o el ID de tu voz personalizada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez un identifiant de voix MiniMax, tel que English_expressive_narrator, ou votre identifiant de voix personnalisé."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa un ID voce MiniMax, ad esempio English_expressive_narrator, oppure l'ID della tua voce personalizzata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ប្រើ ID សំឡេងរបស់ MiniMax ដូចជា English_expressive_narrator ឬ ID សំឡេងផ្ទាល់ខ្លួនរបស់អ្នក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English_expressive_narrator 등의 MiniMax 음성 ID 또는 사용자 지정 음성 ID를 사용하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bruk en MiniMax-stemme-ID, som English_expressive_narrator, eller din egendefinerte stemme-ID."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj identyfikatora głosu MiniMax, takiego jak English_expressive_narrator, lub identyfikatora własnego głosu."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use um ID de voz da MiniMax, como English_expressive_narrator, ou o ID da sua voz personalizada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используйте идентификатор голоса MiniMax, например English_expressive_narrator, или идентификатор собственного голоса."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้ ID เสียงของ MiniMax เช่น English_expressive_narrator หรือ ID เสียงที่คุณกำหนดเอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English_expressive_narrator gibi bir MiniMax ses kimliği veya özel ses kimliğinizi kullanın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Використовуйте ідентифікатор голосу MiniMax, наприклад English_expressive_narrator, або ідентифікатор власного голосу."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 MiniMax 音色 ID（例如 English_expressive_narrator），或你的自定义音色 ID。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請使用 MiniMax 聲音 ID，例如 English_expressive_narrator，或您的自訂聲音 ID。"
+          }
+        }
+      }
+    },
+    "speed.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السرعة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brzina"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hastighed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitesse"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocità"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ល្បឿន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "속도"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hastighet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szybkość"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidade"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความเร็ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hız"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Швидкість"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语速"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度"
+          }
+        }
+      }
+    },
+    "speed.value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 倍"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@×"
+          }
+        }
+      }
+    },
+    "status.unsaved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsaved speech settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声設定に未保存の変更があります"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعدادات الكلام غير محفوظة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nesačuvane postavke govora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taleindstillinger er ikke gemt"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht gespeicherte Sprachausgabeeinstellungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de síntesis de voz sin guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages de synthèse vocale non enregistrés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni di sintesi vocale non salvate"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការកំណត់សំឡេងអានមិនទាន់បានរក្សាទុក"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장되지 않은 음성 설정"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ulagrede taleinnstillinger"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niezapisane ustawienia mowy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de fala não salvos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки речи не сохранены"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่ได้บันทึกการตั้งค่าเสียงพูด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydedilmemiş konuşma ayarları"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Незбережені налаштування мовлення"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音设置尚未保存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音設定尚未儲存"
+          }
+        }
+      }
+    },
+    "status.working": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating Read Aloud settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定を更新中"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ تحديث إعدادات القراءة بصوت عالٍ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ažuriranje postavki čitanja naglas"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opdaterer indstillingerne for Læs op"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen für „Vorlesen“ werden aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando los ajustes de Leer en voz alta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour des réglages de lecture à voix haute"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento delle impostazioni di Leggi ad alta voce"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "កំពុងធ្វើបច្ចុប្បន្នភាពការកំណត់អានឮៗ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기 설정 업데이트 중"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppdaterer innstillingene for Les høyt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizowanie ustawień funkcji Czytaj na głos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizando os ajustes de Ler em voz alta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление настроек чтения вслух"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังอัปเดตการตั้งค่าการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku ayarları güncelleniyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновлення налаштувань «Читати вголос»"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新朗读设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新朗讀設定"
+          }
+        }
+      }
+    },
+    "status.settingsSaved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech settings saved."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声設定を保存しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم حفظ إعدادات الكلام."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke govora su sačuvane."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taleindstillingerne er gemt."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachausgabeeinstellungen gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de síntesis de voz guardados."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages de synthèse vocale enregistrés."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni di sintesi vocale salvate."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានរក្សាទុកការកំណត់សំឡេងអាន។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 설정이 저장되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taleinnstillingene er lagret."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia mowy zostały zapisane."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de fala salvos."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки речи сохранены."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกการตั้งค่าเสียงพูดแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma ayarları kaydedildi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування мовлення збережено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音设置已保存。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音設定已儲存。"
+          }
+        }
+      }
+    },
+    "status.keySaved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key saved in Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーをキーチェーンに保存しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم حفظ مفتاح API في سلسلة المفاتيح."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API ključ je sačuvan u privjesku ključeva (Keychain)."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-nøglen er gemt i nøgleringen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel im Schlüsselbund gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clave de API guardada en el llavero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé API enregistrée dans le trousseau."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiave API salvata nel Portachiavi."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានរក្សាទុកសោ API ក្នុង Keychain។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키가 키체인에 저장되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-nøkkelen er lagret i nøkkelringen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klucz API został zapisany w pęku kluczy."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave de API salva nas Chaves."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ сохранён в Связке ключей."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกคีย์ API ในพวงกุญแจแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API anahtarı Anahtar Zinciri’ne kaydedildi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ збережено у В’язці ключів."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥已保存到钥匙串。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 金鑰已儲存至鑰匙圈。"
+          }
+        }
+      }
+    },
+    "status.keyRemoved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key removed from Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーをキーチェーンから削除しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمت إزالة مفتاح API من سلسلة المفاتيح."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API ključ je uklonjen iz privjeska ključeva (Keychain)."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-nøglen er fjernet fra nøgleringen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel aus dem Schlüsselbund entfernt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clave de API eliminada del llavero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé API supprimée du trousseau."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiave API rimossa dal Portachiavi."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានដកសោ API ចេញពី Keychain។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키가 키체인에서 제거되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-nøkkelen er fjernet fra nøkkelringen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klucz API został usunięty z pęku kluczy."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave de API removida das Chaves."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ удалён из Связки ключей."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "นำคีย์ API ออกจากพวงกุญแจแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API anahtarı Anahtar Zinciri’nden kaldırıldı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ видалено з В’язки ключів."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥已从钥匙串中移除。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 金鑰已從鑰匙圈移除。"
+          }
+        }
+      }
+    },
+    "action.reload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を再読み込み"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تحميل الإعدادات"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponovo učitaj postavke"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genindlæs indstillinger"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen neu laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a cargar los ajustes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recharger les réglages"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricarica impostazioni"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្ទុកការកំណត់ឡើងវិញ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 다시 불러오기"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last inn innstillingene på nytt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wczytaj ustawienia ponownie"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recarregar ajustes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезагрузить настройки"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหลดการตั้งค่าใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayarları Yeniden Yükle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезавантажити налаштування"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新载入设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新載入設定"
+          }
+        }
+      }
+    },
+    "action.saveSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Speech Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声設定を保存"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ إعدادات الكلام"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sačuvaj postavke govora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gem taleindstillinger"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachausgabeeinstellungen sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar ajustes de síntesis de voz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer les réglages de synthèse vocale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva impostazioni di sintesi vocale"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រក្សាទុកការកំណត់សំឡេងអាន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 설정 저장"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagre taleinnstillinger"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz ustawienia mowy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar ajustes de fala"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить настройки речи"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกการตั้งค่าเสียงพูด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma Ayarlarını Kaydet"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберегти налаштування мовлення"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存语音设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存語音設定"
+          }
+        }
+      }
+    },
+    "action.removeKey": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove API Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーを削除"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة مفتاح API"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukloni API ključ"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern API-nøgle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar clave de API"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer la clé API"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi chiave API"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ដកសោ API ចេញ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키 제거"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern API-nøkkel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń klucz API"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover chave de API"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить API-ключ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "นำคีย์ API ออก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Anahtarını Kaldır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити API-ключ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 API 密钥"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 API 金鑰"
+          }
+        }
+      }
+    },
+    "action.saveKey": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save API Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーを保存"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ مفتاح API"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sačuvaj API ključ"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gem API-nøgle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar clave de API"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer la clé API"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva chiave API"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រក្សាទុកសោ API"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키 저장"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagre API-nøkkel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz klucz API"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar chave de API"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить API-ключ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกคีย์ API"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Anahtarını Kaydet"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберегти API-ключ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存 API 密钥"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存 API 金鑰"
+          }
+        }
+      }
+    },
+    "key.entry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New MiniMax API Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい MiniMax API キー"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفتاح API جديد لخدمة MiniMax"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novi MiniMax API ključ"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ny MiniMax-API-nøgle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer MiniMax-API-Schlüssel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva clave de API de MiniMax"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle clé API MiniMax"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chiave API MiniMax"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "សោ API ថ្មីរបស់ MiniMax"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 MiniMax API 키"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ny MiniMax API-nøkkel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy klucz API MiniMax"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova chave de API da MiniMax"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый API-ключ MiniMax"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คีย์ API ของ MiniMax ใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni MiniMax API Anahtarı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новий API-ключ MiniMax"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新的 MiniMax API 密钥"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新的 MiniMax API 金鑰"
+          }
+        }
+      }
+    },
+    "key.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored only in this Mac’s Keychain. Saved keys are never displayed here. Enter a new key to replace the saved key."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac のキーチェーンにのみ保存されます。保存済みのキーがここに表示されることはありません。置き換えるには新しいキーを入力してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يُخزَّن فقط في سلسلة المفاتيح على جهاز Mac هذا. لا تُعرض المفاتيح المحفوظة هنا أبدًا. أدخل مفتاحًا جديدًا لاستبدال المفتاح المحفوظ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čuva se samo u privjesku ključeva (Keychain) na ovom Macu. Sačuvani ključevi se ovdje nikada ne prikazuju. Unesite novi ključ da zamijenite sačuvani ključ."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemmes kun i nøgleringen på denne Mac. Gemte nøgler vises aldrig her. Indtast en ny nøgle for at erstatte den gemte nøgle."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird nur im Schlüsselbund dieses Mac gespeichert. Gespeicherte Schlüssel werden hier niemals angezeigt. Geben Sie einen neuen Schlüssel ein, um den gespeicherten Schlüssel zu ersetzen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se almacena únicamente en el llavero de este Mac. Las claves guardadas nunca se muestran aquí. Introduce una nueva clave para sustituir la guardada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockée uniquement dans le trousseau de ce Mac. Les clés enregistrées ne sont jamais affichées ici. Saisissez une nouvelle clé pour remplacer la clé enregistrée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memorizzata solo nel Portachiavi di questo Mac. Le chiavi salvate non vengono mai visualizzate qui. Inserisci una nuova chiave per sostituire quella salvata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រក្សាទុកតែក្នុង Keychain របស់ Mac នេះប៉ុណ្ណោះ។ សោដែលបានរក្សាទុកនឹងមិនត្រូវបានបង្ហាញនៅទីនេះឡើយ។ បញ្ចូលសោថ្មីដើម្បីជំនួសសោដែលបានរក្សាទុក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 Mac의 키체인에만 저장됩니다. 저장된 키는 여기에 절대 표시되지 않습니다. 저장된 키를 교체하려면 새 키를 입력하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagres kun i nøkkelringen på denne Macen. Lagrede nøkler vises aldri her. Skriv inn en ny nøkkel for å erstatte den lagrede nøkkelen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przechowywany wyłącznie w pęku kluczy tego Maca. Zapisane klucze nigdy nie są tutaj wyświetlane. Wprowadź nowy klucz, aby zastąpić zapisany klucz."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Armazenada apenas nas Chaves deste Mac. As chaves salvas nunca são exibidas aqui. Insira uma nova chave para substituir a chave salva."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранится только в Связке ключей этого Mac. Сохранённые ключи здесь никогда не отображаются. Введите новый ключ, чтобы заменить сохранённый."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จัดเก็บไว้ในพวงกุญแจของ Mac เครื่องนี้เท่านั้น คีย์ที่บันทึกไว้จะไม่แสดงที่นี่ ป้อนคีย์ใหม่เพื่อแทนที่คีย์ที่บันทึกไว้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yalnızca bu Mac’in Anahtar Zinciri’nde saklanır. Kaydedilmiş anahtarlar burada asla gösterilmez. Kaydedilmiş anahtarı değiştirmek için yeni bir anahtar girin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберігається лише у В’язці ключів цього Mac. Збережені ключі тут ніколи не відображаються. Введіть новий ключ, щоб замінити збережений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅存储在这台 Mac 的钥匙串中。已保存的密钥绝不会在此处显示。输入新密钥可替换已保存的密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅儲存在此 Mac 的鑰匙圈中。已儲存的金鑰絕不會顯示於此處。輸入新金鑰即可取代已儲存的金鑰。"
+          }
+        }
+      }
+    },
+    "key.saved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An API key is saved in Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーはキーチェーンに保存されています。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يوجد مفتاح API محفوظ في سلسلة المفاتيح."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API ključ je sačuvan u privjesku ključeva (Keychain)."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der er gemt en API-nøgle i nøgleringen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein API-Schlüssel ist im Schlüsselbund gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay una clave de API guardada en el llavero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une clé API est enregistrée dans le trousseau."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una chiave API è salvata nel Portachiavi."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មានសោ API មួយបានរក្សាទុកក្នុង Keychain។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키가 키체인에 저장되어 있습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En API-nøkkel er lagret i nøkkelringen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klucz API jest zapisany w pęku kluczy."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Há uma chave de API salva nas Chaves."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ сохранён в Связке ключей."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มีคีย์ API บันทึกไว้ในพวงกุญแจ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anahtar Zinciri’nde bir API anahtarı kayıtlı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ збережено у В’язці ключів."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钥匙串中已保存 API 密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鑰匙圈中已儲存 API 金鑰。"
+          }
+        }
+      }
+    },
+    "key.missing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No API key is saved."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API キーは保存されていません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يوجد مفتاح API محفوظ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nijedan API ključ nije sačuvan."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der er ikke gemt nogen API-nøgle."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es ist kein API-Schlüssel gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna clave de API guardada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune clé API n’est enregistrée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna chiave API salvata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនមានសោ API ដែលបានរក្សាទុកទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 API 키가 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen API-nøkkel er lagret."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak zapisanego klucza API."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma chave de API está salva."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-ключ не сохранён."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีคีย์ API ที่บันทึกไว้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıtlı API anahtarı yok."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає збереженого API-ключа."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未保存 API 密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未儲存 API 金鑰。"
+          }
+        }
+      }
+    },
+    "key.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved API key status is not yet available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済みの API キーの状態はまだ確認できていません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالة مفتاح API المحفوظ غير متاحة بعد."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status sačuvanog API ključa još nije dostupan."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status for den gemte API-nøgle er endnu ikke tilgængelig."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Status des gespeicherten API-Schlüssels ist noch nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado de la clave de API guardada aún no está disponible."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’état de la clé API enregistrée n’est pas encore disponible."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stato della chiave API salvata non è ancora disponibile."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនទាន់មានព័ត៌មានអំពីស្ថានភាពសោ API ដែលបានរក្សាទុកទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 API 키의 상태를 아직 확인할 수 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status for lagret API-nøkkel er ikke tilgjengelig ennå."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status zapisanego klucza API nie jest jeszcze dostępny."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O status da chave de API salva ainda não está disponível."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус сохранённого API-ключа пока недоступен."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่สามารถตรวจสอบสถานะของคีย์ API ที่บันทึกไว้ได้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydedilmiş API anahtarının durumu henüz bilinmiyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стан збереженого API-ключа поки що недоступний."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂时无法获取已保存 API 密钥的状态。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前尚無法取得已儲存 API 金鑰的狀態。"
+          }
+        }
+      }
+    },
+    "consent.disclosure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud sends only the terminal text you select to MiniMax to generate speech. MiniMax bills usage to your account. cmux streams the audio without saving selected text or audio to a disk cache."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げでは、ターミナルで選択したテキストのみを MiniMax に送信して音声を生成します。MiniMax の利用料金はお使いのアカウントに請求されます。cmux は音声をストリーミング再生し、選択したテキストや音声をディスクキャッシュに保存しません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترسل ميزة القراءة بصوت عالٍ نص الطرفية الذي تحدده فقط إلى MiniMax لتوليد الكلام. تُحمِّل MiniMax تكاليف الاستخدام على حسابك. يبث cmux الصوت دون حفظ النص المحدد أو الصوت في ذاكرة تخزين مؤقت على القرص."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čitanje naglas šalje usluzi MiniMax samo tekst koji odaberete u terminalu radi generisanja govora. MiniMax naplaćuje korištenje na vašem računu. cmux prenosi audio putem streaminga bez čuvanja odabranog teksta ili audija u predmemoriji na disku."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Læs op sender kun den terminaltekst, du markerer, til MiniMax for at generere tale. MiniMax fakturerer forbruget på din konto. cmux streamer lyden uden at gemme markeret tekst eller lyd i en diskcache."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„Vorlesen“ sendet ausschließlich den von Ihnen ausgewählten Terminaltext an MiniMax, um eine Sprachausgabe zu erzeugen. MiniMax rechnet die Nutzung über Ihr Konto ab. cmux streamt die Audiodaten, ohne den ausgewählten Text oder die Audiodaten in einem Festplattencache zu speichern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leer en voz alta envía a MiniMax únicamente el texto del terminal que selecciones para generar la voz. MiniMax factura el uso a tu cuenta. cmux transmite el audio sin guardar el texto seleccionado ni el audio en una caché de disco."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La lecture à voix haute envoie uniquement le texte du terminal que vous sélectionnez à MiniMax pour générer la synthèse vocale. MiniMax facture l’utilisation à votre compte. cmux diffuse l’audio en streaming sans enregistrer le texte sélectionné ni l’audio dans un cache sur disque."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggi ad alta voce invia a MiniMax solo il testo del terminale che selezioni per generare l'audio vocale. MiniMax addebita i costi di utilizzo al tuo account. cmux riproduce l'audio in streaming senza salvare il testo selezionato o l'audio in una cache su disco."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មុខងារអានឮៗផ្ញើតែអត្ថបទក្នុងស្ថានីយដែលអ្នកជ្រើសរើសទៅ MiniMax ដើម្បីបង្កើតសំឡេង។ MiniMax គិតថ្លៃការប្រើប្រាស់លើគណនីរបស់អ្នក។ cmux ផ្សាយសំឡេងដោយមិនរក្សាទុកអត្ថបទដែលបានជ្រើសរើស ឬសំឡេងទៅក្នុងឃ្លាំងសម្ងាត់លើថាសទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기는 음성을 생성하기 위해 사용자가 선택한 터미널 텍스트만 MiniMax로 전송합니다. MiniMax는 사용 요금을 사용자 계정에 청구합니다. cmux는 선택한 텍스트나 오디오를 디스크 캐시에 저장하지 않고 오디오를 스트리밍합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les høyt sender kun terminalteksten du markerer til MiniMax for å generere tale. MiniMax belaster kontoen din for bruken. cmux strømmer lyden uten å lagre markert tekst eller lyd i en hurtigbuffer på disk."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funkcja Czytaj na głos wysyła do MiniMax wyłącznie zaznaczony przez Ciebie tekst z terminala, aby wygenerować mowę. MiniMax obciąża Twoje konto opłatami za użycie. cmux strumieniuje dźwięk bez zapisywania zaznaczonego tekstu ani dźwięku w pamięci podręcznej na dysku."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ler em voz alta envia à MiniMax apenas o texto do terminal que você seleciona para gerar fala. A MiniMax cobra o uso na sua conta. O cmux reproduz o áudio por streaming sem salvar o texto selecionado nem o áudio em um cache em disco."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функция чтения вслух отправляет в MiniMax только выделенный вами текст терминала для синтеза речи. MiniMax взимает плату за использование с вашей учётной записи. cmux передаёт аудио потоком, не сохраняя выделенный текст или аудио в дисковом кэше."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การอ่านออกเสียงจะส่งเฉพาะข้อความในเทอร์มินัลที่คุณเลือกไปยัง MiniMax เพื่อสร้างเสียงพูด MiniMax จะเรียกเก็บค่าบริการตามการใช้งานจากบัญชีของคุณ cmux จะสตรีมเสียงโดยไม่บันทึกข้อความที่เลือกหรือเสียงลงในแคชบนดิสก์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku, konuşma oluşturmak için yalnızca seçtiğiniz terminal metnini MiniMax’e gönderir. MiniMax, kullanım ücretini hesabınıza yansıtır. cmux, seçili metni veya sesi disk önbelleğine kaydetmeden sesi akış yoluyla oynatır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функція «Читати вголос» надсилає до MiniMax лише вибраний вами текст термінала для синтезу мовлення. MiniMax стягує плату за використання з вашого облікового запису. cmux відтворює аудіо потоково, не зберігаючи вибраний текст або аудіо в дисковому кеші."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗读仅将你在终端中选中的文本发送至 MiniMax 以生成语音。MiniMax 会向你的账户收取使用费用。cmux 以流式方式传输音频，不会将所选文本或音频保存到磁盘缓存。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「朗讀」僅會將您在終端機中選取的文字傳送至 MiniMax，以產生語音。MiniMax 會將使用費用計入您的帳號。cmux 以串流方式播放音訊，不會將所選文字或音訊儲存至磁碟快取。"
+          }
+        }
+      }
+    },
+    "consent.allow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow sending selected text to MiniMax"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したテキストの MiniMax への送信を許可する"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السماح بإرسال النص المحدد إلى MiniMax"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dozvoli slanje odabranog teksta usluzi MiniMax"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillad, at markeret tekst sendes til MiniMax"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Senden von ausgewähltem Text an MiniMax erlauben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir el envío del texto seleccionado a MiniMax"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser l’envoi du texte sélectionné à MiniMax"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti l'invio del testo selezionato a MiniMax"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "អនុញ្ញាតឱ្យផ្ញើអត្ថបទដែលបានជ្រើសរើសទៅ MiniMax"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 텍스트를 MiniMax로 전송하도록 허용"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillat at markert tekst sendes til MiniMax"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zezwalaj na wysyłanie zaznaczonego tekstu do MiniMax"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir o envio do texto selecionado à MiniMax"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить отправку выделенного текста в MiniMax"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อนุญาตให้ส่งข้อความที่เลือกไปยัง MiniMax"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçili metnin MiniMax’e gönderilmesine izin ver"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволити надсилання вибраного тексту до MiniMax"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许将所选文本发送至 MiniMax"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許將所選文字傳送至 MiniMax"
+          }
+        }
+      }
+    },
+    "consent.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Read Aloud remains unavailable until you opt in and save an API key. Turn this off to prevent future requests."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同意は任意です。同意して API キーを保存するまで読み上げは利用できません。オフにすると、以降のリクエストは送信されません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختياري. تظل القراءة بصوت عالٍ غير متاحة حتى توافق وتحفظ مفتاح API. عطّل هذا الخيار لمنع الطلبات المستقبلية."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neobavezno. Čitanje naglas ostaje nedostupno dok ne date pristanak i sačuvate API ključ. Isključite ovu opciju da spriječite buduće zahtjeve."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfrit. Læs op er ikke tilgængelig, før du giver samtykke og gemmer en API-nøgle. Slå dette fra for at forhindre fremtidige anmodninger."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. „Vorlesen“ ist erst verfügbar, wenn Sie einwilligen und einen API-Schlüssel speichern. Deaktivieren Sie diese Option, um zukünftige Anfragen zu verhindern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Leer en voz alta no estará disponible hasta que des tu consentimiento y guardes una clave de API. Desactiva esta opción para impedir futuras solicitudes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facultatif. La lecture à voix haute reste indisponible tant que vous n’avez pas donné votre consentement et enregistré une clé API. Désactivez cette option pour empêcher toute nouvelle requête."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facoltativo. Leggi ad alta voce rimane non disponibile finché non dai il consenso e salvi una chiave API. Disattiva questa opzione per impedire richieste future."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ជាជម្រើស។ មុខងារអានឮៗនៅតែមិនអាចប្រើបាន រហូតដល់អ្នកយល់ព្រម និងរក្សាទុកសោ API។ បិទជម្រើសនេះដើម្បីទប់ស្កាត់សំណើនាពេលអនាគត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 사항입니다. 전송에 동의하고 API 키를 저장하기 전까지는 소리 내어 읽기를 사용할 수 없습니다. 이후 요청을 차단하려면 이 옵션을 끄세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valgfritt. Les høyt er utilgjengelig frem til du gir samtykke og lagrer en API-nøkkel. Slå av dette for å forhindre fremtidige forespørsler."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcjonalne. Funkcja Czytaj na głos pozostaje niedostępna, dopóki nie wyrazisz zgody i nie zapiszesz klucza API. Wyłącz tę opcję, aby zapobiec wysyłaniu kolejnych żądań."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Ler em voz alta permanece indisponível até que você dê seu consentimento e salve uma chave de API. Desative esta opção para impedir solicitações futuras."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательно. Чтение вслух недоступно, пока вы не дадите согласие и не сохраните API-ключ. Отключите этот параметр, чтобы предотвратить дальнейшие запросы."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่บังคับ การอ่านออกเสียงจะยังใช้งานไม่ได้จนกว่าคุณจะให้ความยินยอมและบันทึกคีย์ API ปิดตัวเลือกนี้เพื่อป้องกันการส่งคำขอในอนาคต"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İsteğe bağlıdır. İzin verip bir API anahtarı kaydedene kadar Sesli Oku kullanılamaz. Gelecekteki istekleri engellemek için bu seçeneği kapatın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необов’язково. Функція «Читати вголос» залишатиметься недоступною, доки ви не надасте згоду та не збережете API-ключ. Вимкніть цей параметр, щоб запобігти подальшим запитам."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选。在你同意并保存 API 密钥之前，朗读功能不可用。关闭此选项可阻止后续请求。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此為選用項目。在您同意並儲存 API 金鑰之前，將無法使用「朗讀」。關閉此選項即可阻止後續請求。"
+          }
+        }
+      }
+    },
+    "error.unsupportedModel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the Turbo or HD speech-2.8 model."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "speech-2.8 の Turbo または HD モデルを選択してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر نموذج speech-2.8 بإصدار Turbo أو HD."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odaberite model govora speech-2.8 Turbo ili HD."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vælg speech-2.8-modellen Turbo eller HD."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie das Modell speech-2.8 in der Variante Turbo oder HD."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige el modelo speech-2.8 Turbo o HD."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez le modèle speech-2.8 Turbo ou HD."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli il modello speech-2.8 Turbo o HD."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ជ្រើសរើសម៉ូដែល speech-2.8 ប្រភេទ Turbo ឬ HD។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo 또는 HD speech-2.8 모델을 선택하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velg talemodellen speech-2.8 i Turbo- eller HD-versjon."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz model speech-2.8 w wersji Turbo lub HD."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha o modelo speech-2.8 Turbo ou HD."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите модель синтеза речи speech-2.8 Turbo или HD."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลือกโมเดล speech-2.8 แบบ Turbo หรือ HD"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turbo veya HD speech-2.8 modelini seçin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть модель speech-2.8 Turbo або HD."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择 Turbo 或 HD speech-2.8 模型。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇 Turbo 或 HD 的 speech-2.8 模型。"
+          }
+        }
+      }
+    },
+    "error.emptyVoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a MiniMax voice ID."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 音声 ID を入力してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل معرّف صوت من MiniMax."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unesite MiniMax ID glasa."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indtast et MiniMax-stemme-id."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie eine MiniMax-Stimmen-ID ein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce un ID de voz de MiniMax."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez un identifiant de voix MiniMax."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci un ID voce MiniMax."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បញ្ចូល ID សំឡេងរបស់ MiniMax។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 음성 ID를 입력하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn en MiniMax-stemme-ID."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wprowadź identyfikator głosu MiniMax."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira um ID de voz da MiniMax."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите идентификатор голоса MiniMax."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้อน ID เสียงของ MiniMax"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir MiniMax ses kimliği girin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть ідентифікатор голосу MiniMax."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入 MiniMax 音色 ID。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請輸入 MiniMax 聲音 ID。"
+          }
+        }
+      }
+    },
+    "error.invalidSpeed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech speed must be a finite number from 0.5 to 2."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ速度には 0.5 から 2 の有限の数値を指定してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يجب أن تكون سرعة الكلام عددًا منتهيًا بين 0.5 و2."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brzina govora mora biti konačan broj od 0,5 do 2."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talehastigheden skal være et endeligt tal fra 0,5 til 2."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Sprechgeschwindigkeit muss eine endliche Zahl zwischen 0,5 und 2 sein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La velocidad de lectura debe ser un número finito entre 0,5 y 2."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La vitesse de synthèse vocale doit être un nombre fini compris entre 0,5 et 2."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La velocità di lettura deve essere un numero finito compreso tra 0,5 e 2."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ល្បឿនអានត្រូវតែជាចំនួនមានកំណត់ចាប់ពី 0.5 ដល់ 2។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 속도는 0.5에서 2 사이의 유한한 숫자여야 합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talehastigheten må være et endelig tall fra 0,5 til 2."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szybkość mowy musi być skończoną liczbą od 0,5 do 2."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A velocidade da fala deve ser um número finito entre 0,5 e 2."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость речи должна быть конечным числом от 0,5 до 2."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความเร็วเสียงพูดต้องเป็นตัวเลขที่มีค่าจำกัดตั้งแต่ 0.5 ถึง 2"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma hızı, 0,5 ile 2 arasında sonlu bir sayı olmalıdır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Швидкість мовлення має бути скінченним числом від 0.5 до 2."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语速必须为 0.5 到 2 之间的有限数值。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音速度必須為介於 0.5 到 2 之間的有限數值。"
+          }
+        }
+      }
+    },
+    "error.emptyCredential": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a MiniMax API key before saving."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存する前に MiniMax API キーを入力してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل مفتاح API لخدمة MiniMax قبل الحفظ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unesite MiniMax API ključ prije čuvanja."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indtast en MiniMax-API-nøgle, før du gemmer."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie vor dem Speichern einen MiniMax-API-Schlüssel ein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce una clave de API de MiniMax antes de guardar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez une clé API MiniMax avant d’enregistrer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci una chiave API MiniMax prima di salvare."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បញ្ចូលសោ API របស់ MiniMax មុនពេលរក្សាទុក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장하기 전에 MiniMax API 키를 입력하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn en MiniMax API-nøkkel før du lagrer."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przed zapisaniem wprowadź klucz API MiniMax."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira uma chave de API da MiniMax antes de salvar."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перед сохранением введите API-ключ MiniMax."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้อนคีย์ API ของ MiniMax ก่อนบันทึก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydetmeden önce bir MiniMax API anahtarı girin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть API-ключ MiniMax перед збереженням."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请先输入 MiniMax API 密钥再保存。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請先輸入 MiniMax API 金鑰再儲存。"
+          }
+        }
+      }
+    },
+    "error.invalidCredential": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The saved API key cannot be read. Replace or remove it in Read Aloud settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済みの API キーを読み取れません。読み上げ設定で置き換えるか削除してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّرت قراءة مفتاح API المحفوظ. استبدله أو أزله في إعدادات القراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sačuvani API ključ nije moguće pročitati. Zamijenite ga ili uklonite u postavkama čitanja naglas."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den gemte API-nøgle kan ikke læses. Erstat eller fjern den i indstillingerne for Læs op."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der gespeicherte API-Schlüssel kann nicht gelesen werden. Ersetzen oder entfernen Sie ihn in den Einstellungen für „Vorlesen“."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede leer la clave de API guardada. Sustitúyela o elimínala en los ajustes de Leer en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La clé API enregistrée ne peut pas être lue. Remplacez-la ou supprimez-la dans les réglages de lecture à voix haute."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile leggere la chiave API salvata. Sostituiscila o rimuovila nelle impostazioni di Leggi ad alta voce."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចអានសោ API ដែលបានរក្សាទុកបានទេ។ សូមជំនួស ឬដកវាចេញក្នុងការកំណត់អានឮៗ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 API 키를 읽을 수 없습니다. 소리 내어 읽기 설정에서 키를 교체하거나 제거하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den lagrede API-nøkkelen kan ikke leses. Erstatt eller fjern den i innstillingene for Les høyt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można odczytać zapisanego klucza API. Zastąp go lub usuń w ustawieniach funkcji Czytaj na głos."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível ler a chave de API salva. Substitua ou remova a chave nos ajustes de Ler em voz alta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось прочитать сохранённый API-ключ. Замените или удалите его в настройках чтения вслух."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถอ่านคีย์ API ที่บันทึกไว้ได้ แทนที่หรือนำคีย์ออกในการตั้งค่าการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydedilmiş API anahtarı okunamıyor. Sesli Oku ayarlarında anahtarı değiştirin veya kaldırın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося прочитати збережений API-ключ. Замініть або видаліть його в налаштуваннях «Читати вголос»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取已保存的 API 密钥。请在朗读设置中替换或移除该密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法讀取已儲存的 API 金鑰。請在「朗讀」設定中取代或移除金鑰。"
+          }
+        }
+      }
+    },
+    "error.invalidService": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app has not configured a Keychain service for Read Aloud."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリで読み上げ用のキーチェーンサービスが設定されていません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يهيّئ التطبيق خدمة سلسلة المفاتيح للقراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacija nije podesila uslugu privjeska ključeva (Keychain) za čitanje naglas."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appen har ikke konfigureret en nøgleringstjeneste til Læs op."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die App hat keinen Schlüsselbunddienst für „Vorlesen“ konfiguriert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La app no ha configurado un servicio del llavero para Leer en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’application n’a pas configuré de service de trousseau pour la lecture à voix haute."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'app non ha configurato un servizio Portachiavi per Leggi ad alta voce."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "កម្មវិធីមិនទាន់បានកំណត់រចនាសម្ព័ន្ធសេវា Keychain សម្រាប់មុខងារអានឮៗទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱에 소리 내어 읽기용 키체인 서비스가 구성되어 있지 않습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appen har ikke konfigurert en nøkkelringtjeneste for Les høyt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacja nie skonfigurowała usługi pęku kluczy dla funkcji Czytaj na głos."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O app não configurou um serviço das Chaves para Ler em voz alta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В приложении не настроена служба Связки ключей для чтения вслух."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แอปยังไม่ได้กำหนดค่าบริการพวงกุญแจสำหรับการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama, Sesli Oku için bir Anahtar Zinciri hizmeti yapılandırmamış."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма не налаштувала службу В’язки ключів для функції «Читати вголос»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用尚未为朗读配置钥匙串服务。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App 尚未為「朗讀」設定鑰匙圈服務。"
+          }
+        }
+      }
+    },
+    "error.keychain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychain could not complete the operation (status %d). Your requested change was not confirmed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーチェーンの操作を完了できませんでした（ステータス %d）。変更は確認されていません。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر على سلسلة المفاتيح إكمال العملية (الحالة %d). لم يتم تأكيد التغيير الذي طلبته."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privjesak ključeva (Keychain) nije mogao dovršiti radnju (status %d). Tražena izmjena nije potvrđena."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nøgleringen kunne ikke fuldføre handlingen (status %d). Den ønskede ændring blev ikke bekræftet."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schlüsselbund konnte den Vorgang nicht abschließen (Status %d). Ihre angeforderte Änderung wurde nicht bestätigt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El llavero no ha podido completar la operación (estado %d). No se ha confirmado el cambio solicitado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le trousseau n’a pas pu terminer l’opération (statut %d). La modification demandée n’a pas été confirmée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il Portachiavi non ha potuto completare l'operazione (stato %d). La modifica richiesta non è stata confermata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychain មិនអាចបញ្ចប់ប្រតិបត្តិការបានទេ (ស្ថានភាព %d)។ ការផ្លាស់ប្ដូរដែលអ្នកបានស្នើមិនត្រូវបានបញ្ជាក់ទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키체인에서 작업을 완료하지 못했습니다(상태 %d). 요청한 변경 사항이 적용되었는지 확인되지 않았습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nøkkelringen kunne ikke fullføre operasjonen (status %d). Den forespurte endringen ble ikke bekreftet."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pęk kluczy nie mógł ukończyć operacji (status %d). Żądana zmiana nie została potwierdzona."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As Chaves não conseguiram concluir a operação (status %d). A alteração solicitada não foi confirmada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Связке ключей не удалось завершить операцию (статус %d). Запрошенное изменение не подтверждено."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พวงกุญแจไม่สามารถดำเนินการให้เสร็จสมบูรณ์ได้ (สถานะ %d) การเปลี่ยนแปลงที่คุณร้องขอยังไม่ได้รับการยืนยัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anahtar Zinciri işlemi tamamlayamadı (durum %d). İstediğiniz değişiklik doğrulanamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В’язці ключів не вдалося завершити операцію (статус %d). Запитану вами зміну не підтверджено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钥匙串无法完成操作（状态 %d）。你请求的更改尚未确认。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鑰匙圈無法完成操作（狀態 %d）。無法確認您要求的變更是否已完成。"
+          }
+        }
+      }
+    },
+    "error.persistence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud settings could not be saved. Your change was not confirmed. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定を保存できませんでした。変更は確認されていません。もう一度お試しください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر حفظ إعدادات القراءة بصوت عالٍ. لم يتم تأكيد التغيير. حاول مجددًا."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke čitanja naglas nije moguće sačuvati. Vaša izmjena nije potvrđena. Pokušajte ponovo."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillingerne for Læs op kunne ikke gemmes. Din ændring blev ikke bekræftet. Prøv igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Einstellungen für „Vorlesen“ konnten nicht gespeichert werden. Ihre Änderung wurde nicht bestätigt. Versuchen Sie es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se han podido guardar los ajustes de Leer en voz alta. No se ha confirmado el cambio. Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les réglages de lecture à voix haute n’ont pas pu être enregistrés. Votre modification n’a pas été confirmée. Réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile salvare le impostazioni di Leggi ad alta voce. La modifica non è stata confermata. Riprova."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចរក្សាទុកការកំណត់អានឮៗបានទេ។ ការផ្លាស់ប្ដូររបស់អ្នកមិនត្រូវបានបញ្ជាក់ទេ។ សូមព្យាយាមម្ដងទៀត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기 설정을 저장하지 못했습니다. 변경 사항이 적용되었는지 확인되지 않았습니다. 다시 시도하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillingene for Les høyt kunne ikke lagres. Endringen din ble ikke bekreftet. Prøv igjen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się zapisać ustawień funkcji Czytaj na głos. Zmiana nie została potwierdzona. Spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível salvar os ajustes de Ler em voz alta. Sua alteração não foi confirmada. Tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось сохранить настройки чтения вслух. Ваше изменение не подтверждено. Повторите попытку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถบันทึกการตั้งค่าการอ่านออกเสียงได้ การเปลี่ยนแปลงของคุณยังไม่ได้รับการยืนยัน ลองอีกครั้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku ayarları kaydedilemedi. Değişikliğiniz doğrulanamadı. Tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося зберегти налаштування «Читати вголос». Вашу зміну не підтверджено. Спробуйте ще раз."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存朗读设置。你的更改尚未确认。请重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法儲存朗讀設定。無法確認您的變更是否已完成。請再試一次。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
@@ -4269,7 +4269,7 @@
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تعذّر على سلسلة المفاتيح إكمال العملية (الحالة %d). لم يتم تأكيد التغيير الذي طلبته."
+            "value": "تعذّر على سلسلة المفاتيح إكمال العملية (الحالة ). لم يتم تأكيد التغيير الذي طلبته."
           }
         },
         "bs": {
@@ -4287,7 +4287,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Schlüsselbund konnte den Vorgang nicht abschließen (Status %d). Ihre angeforderte Änderung wurde nicht bestätigt."
+            "value": "Der Schlüsselbund konnte den Vorgang nicht abschließen (Status ). Ihre angeforderte Änderung wurde nicht bestätigt."
           }
         },
         "es": {
@@ -4311,7 +4311,7 @@
         "km": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keychain មិនអាចបញ្ចប់ប្រតិបត្តិការបានទេ (ស្ថានភាព %d)។ ការផ្លាស់ប្ដូរដែលអ្នកបានស្នើមិនត្រូវបានបញ្ជាក់ទេ។"
+            "value": "Keychain មិនអាចបញ្ចប់ប្រតិបត្តិការបានទេ (ស្ថានភាព )។ ការផ្លាស់ប្ដូរដែលអ្នកបានស្នើមិនត្រូវបានបញ្ជាក់ទេ។"
           }
         },
         "ko": {
@@ -4371,7 +4371,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "鑰匙圈無法完成操作（狀態 %d）。無法確認您要求的變更是否已完成。"
+            "value": "鑰匙圈無法完成操作（狀態 ）。無法確認您要求的變更是否已完成。"
           }
         }
       }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings
@@ -4257,13 +4257,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keychain could not complete the operation (status %d). Your requested change was not confirmed."
+            "value": "Keychain could not complete the operation. Your requested change was not confirmed."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "キーチェーンの操作を完了できませんでした（ステータス %d）。変更は確認されていません。"
+            "value": "キーチェーンの操作を完了できませんでした。変更は確認されていません。"
           }
         },
         "ar": {
@@ -4275,13 +4275,13 @@
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Privjesak ključeva (Keychain) nije mogao dovršiti radnju (status %d). Tražena izmjena nije potvrđena."
+            "value": "Privjesak ključeva (Keychain) nije mogao dovršiti radnju. Tražena izmjena nije potvrđena."
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nøgleringen kunne ikke fuldføre handlingen (status %d). Den ønskede ændring blev ikke bekræftet."
+            "value": "Nøgleringen kunne ikke fuldføre handlingen. Den ønskede ændring blev ikke bekræftet."
           }
         },
         "de": {
@@ -4293,19 +4293,19 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El llavero no ha podido completar la operación (estado %d). No se ha confirmado el cambio solicitado."
+            "value": "El llavero no ha podido completar la operación . No se ha confirmado el cambio solicitado."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Le trousseau n’a pas pu terminer l’opération (statut %d). La modification demandée n’a pas été confirmée."
+            "value": "Le trousseau n’a pas pu terminer l’opération . La modification demandée n’a pas été confirmée."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Il Portachiavi non ha potuto completare l'operazione (stato %d). La modifica richiesta non è stata confermata."
+            "value": "Il Portachiavi non ha potuto completare l'operazione. La modifica richiesta non è stata confermata."
           }
         },
         "km": {
@@ -4317,55 +4317,55 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "키체인에서 작업을 완료하지 못했습니다(상태 %d). 요청한 변경 사항이 적용되었는지 확인되지 않았습니다."
+            "value": "키체인에서 작업을 완료하지 못했습니다. 요청한 변경 사항이 적용되었는지 확인되지 않았습니다."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nøkkelringen kunne ikke fullføre operasjonen (status %d). Den forespurte endringen ble ikke bekreftet."
+            "value": "Nøkkelringen kunne ikke fullføre operasjonen. Den forespurte endringen ble ikke bekreftet."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pęk kluczy nie mógł ukończyć operacji (status %d). Żądana zmiana nie została potwierdzona."
+            "value": "Pęk kluczy nie mógł ukończyć operacji. Żądana zmiana nie została potwierdzona."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "As Chaves não conseguiram concluir a operação (status %d). A alteração solicitada não foi confirmada."
+            "value": "As Chaves não conseguiram concluir a operação. A alteração solicitada não foi confirmada."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Связке ключей не удалось завершить операцию (статус %d). Запрошенное изменение не подтверждено."
+            "value": "Связке ключей не удалось завершить операцию . Запрошенное изменение не подтверждено."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "พวงกุญแจไม่สามารถดำเนินการให้เสร็จสมบูรณ์ได้ (สถานะ %d) การเปลี่ยนแปลงที่คุณร้องขอยังไม่ได้รับการยืนยัน"
+            "value": "พวงกุญแจไม่สามารถดำเนินการให้เสร็จสมบูรณ์ได้  การเปลี่ยนแปลงที่คุณร้องขอยังไม่ได้รับการยืนยัน"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Anahtar Zinciri işlemi tamamlayamadı (durum %d). İstediğiniz değişiklik doğrulanamadı."
+            "value": "Anahtar Zinciri işlemi tamamlayamadı . İstediğiniz değişiklik doğrulanamadı."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "В’язці ключів не вдалося завершити операцію (статус %d). Запитану вами зміну не підтверджено."
+            "value": "В’язці ключів не вдалося завершити операцію . Запитану вами зміну не підтверджено."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "钥匙串无法完成操作（状态 %d）。你请求的更改尚未确认。"
+            "value": "钥匙串无法完成操作。你请求的更改尚未确认。"
           }
         },
         "zh-Hant": {

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudTransport.xcstrings
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudTransport.xcstrings
@@ -1,0 +1,1256 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "readAloud.transport.invalidConfiguration": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a supported speech model, a voice, and a speed between 0.5 and 2."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応している音声モデルと音声を選択し、速度を0.5〜2の範囲に設定してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر نموذجًا مدعومًا لتحويل النص إلى كلام، وصوتًا، وسرعة بين 0.5 و2."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odaberite podržani model govora, glas i brzinu između 0,5 i 2."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vælg en understøttet talemodel, en stemme og en hastighed mellem 0,5 og 2."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie ein unterstütztes Sprachausgabemodell, eine Stimme und eine Geschwindigkeit zwischen 0,5 und 2."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un modelo de síntesis de voz compatible, una voz y una velocidad entre 0,5 y 2."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un modèle de synthèse vocale pris en charge, une voix et une vitesse comprise entre 0,5 et 2."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli un modello di sintesi vocale supportato, una voce e una velocità compresa tra 0,5 e 2."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ជ្រើសរើសម៉ូដែលសំឡេងដែលគាំទ្រ សំឡេង និងល្បឿនចន្លោះពី 0.5 ដល់ 2។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원되는 음성 모델과 음성을 선택하고 속도를 0.5에서 2 사이로 설정하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velg en støttet talemodell, en stemme og en hastighet mellom 0,5 og 2."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz obsługiwany model mowy, głos i szybkość od 0,5 do 2."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha um modelo de fala compatível, uma voz e uma velocidade entre 0,5 e 2."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите поддерживаемую модель синтеза речи, голос и скорость от 0,5 до 2."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลือกโมเดลเสียงพูดที่รองรับ เสียง และความเร็วระหว่าง 0.5 ถึง 2"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desteklenen bir konuşma modeli, bir ses ve 0,5 ile 2 arasında bir hız seçin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть підтримувану модель синтезу мовлення, голос і швидкість від 0.5 до 2."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择受支持的语音模型、音色以及 0.5 到 2 之间的语速。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇支援的語音模型、聲音，以及介於 0.5 到 2 之間的速度。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.invalidCredential": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a valid MiniMax API key without spaces or line breaks in Read Aloud settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定で、空白や改行を含まない有効なMiniMax APIキーを入力してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل مفتاح API صالحًا لخدمة MiniMax دون مسافات أو فواصل أسطر في إعدادات القراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unesite važeći MiniMax API ključ bez razmaka ili prijeloma reda u postavkama čitanja naglas."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indtast en gyldig MiniMax-API-nøgle uden mellemrum eller linjeskift i indstillingerne for Læs op."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie in den Einstellungen für „Vorlesen“ einen gültigen MiniMax-API-Schlüssel ohne Leerzeichen oder Zeilenumbrüche ein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce una clave de API de MiniMax válida, sin espacios ni saltos de línea, en los ajustes de Leer en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez une clé API MiniMax valide, sans espaces ni sauts de ligne, dans les réglages de lecture à voix haute."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci una chiave API MiniMax valida, senza spazi o interruzioni di riga, nelle impostazioni di Leggi ad alta voce."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បញ្ចូលសោ API របស់ MiniMax ដែលមានសុពលភាព ដោយគ្មានដកឃ្លា ឬការចុះបន្ទាត់ ក្នុងការកំណត់អានឮៗ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 내어 읽기 설정에서 공백이나 줄바꿈이 없는 유효한 MiniMax API 키를 입력하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn en gyldig MiniMax API-nøkkel uten mellomrom eller linjeskift i innstillingene for Les høyt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wprowadź prawidłowy klucz API MiniMax bez spacji i znaków końca wiersza w ustawieniach funkcji Czytaj na głos."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira uma chave de API da MiniMax válida, sem espaços nem quebras de linha, nos ajustes de Ler em voz alta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите действительный API-ключ MiniMax без пробелов и переносов строк в настройках чтения вслух."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้อนคีย์ API ของ MiniMax ที่ถูกต้องโดยไม่มีช่องว่างหรือการขึ้นบรรทัดใหม่ในการตั้งค่าการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku ayarlarında boşluk veya satır sonu içermeyen geçerli bir MiniMax API anahtarı girin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть дійсний API-ключ MiniMax без пробілів і розривів рядків у налаштуваннях «Читати вголос»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在朗读设置中输入有效的 MiniMax API 密钥，不能包含空格或换行符。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請在「朗讀」設定中輸入有效的 MiniMax API 金鑰，且不得包含空格或換行字元。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.authentication": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax could not authenticate this request. Check the API key in Read Aloud settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxでこのリクエストを認証できませんでした。読み上げ設定のAPIキーを確認してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر على MiniMax مصادقة هذا الطلب. تحقّق من مفتاح API في إعدادات القراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nije mogao autentificirati ovaj zahtjev. Provjerite API ključ u postavkama čitanja naglas."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax kunne ikke godkende denne anmodning. Kontrollér API-nøglen i indstillingerne for Læs op."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax konnte diese Anfrage nicht authentifizieren. Überprüfen Sie den API-Schlüssel in den Einstellungen für „Vorlesen“."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax no ha podido autenticar esta solicitud. Comprueba la clave de API en los ajustes de Leer en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax n’a pas pu authentifier cette requête. Vérifiez la clé API dans les réglages de lecture à voix haute."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax non ha potuto autenticare questa richiesta. Controlla la chiave API nelle impostazioni di Leggi ad alta voce."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax មិនអាចផ្ទៀងផ្ទាត់ភាពត្រឹមត្រូវនៃសំណើនេះបានទេ។ សូមពិនិត្យសោ API ក្នុងការកំណត់អានឮៗ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에서 이 요청을 인증하지 못했습니다. 소리 내어 읽기 설정에서 API 키를 확인하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax kunne ikke autentisere denne forespørselen. Kontroller API-nøkkelen i innstillingene for Les høyt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nie mógł uwierzytelnić tego żądania. Sprawdź klucz API w ustawieniach funkcji Czytaj na głos."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A MiniMax não conseguiu autenticar esta solicitação. Verifique a chave de API nos ajustes de Ler em voz alta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не удалось аутентифицировать этот запрос. Проверьте API-ключ в настройках чтения вслух."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ไม่สามารถยืนยันตัวตนสำหรับคำขอนี้ได้ ตรวจสอบคีย์ API ในการตั้งค่าการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax bu isteğin kimliğini doğrulayamadı. Sesli Oku ayarlarındaki API anahtarını kontrol edin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не вдалося автентифікувати цей запит. Перевірте API-ключ у налаштуваннях «Читати вголос»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 无法验证此请求。请检查朗读设置中的 API 密钥。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 無法驗證此請求。請檢查「朗讀」設定中的 API 金鑰。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.rateLimited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax's speech request limit was reached. Try again later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxの音声リクエストの上限に達しました。しばらくしてから再度お試しください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم بلوغ الحد الأقصى لطلبات تحويل النص إلى كلام لدى MiniMax. حاول مجددًا لاحقًا."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostignuto je MiniMax ograničenje broja zahtjeva za govor. Pokušajte ponovo kasnije."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grænsen for taleanmodninger til MiniMax er nået. Prøv igen senere."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Limit für Sprachausgabeanfragen bei MiniMax wurde erreicht. Versuchen Sie es später erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se ha alcanzado el límite de solicitudes de síntesis de voz de MiniMax. Inténtalo de nuevo más tarde."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La limite de requêtes de synthèse vocale de MiniMax a été atteinte. Réessayez plus tard."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È stato raggiunto il limite di richieste di sintesi vocale di MiniMax. Riprova più tardi."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានឈានដល់កម្រិតកំណត់សំណើបង្កើតសំឡេងរបស់ MiniMax។ សូមព្យាយាមម្ដងទៀតនៅពេលក្រោយ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax의 음성 요청 한도에 도달했습니다. 나중에 다시 시도하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grensen for taleforespørsler hos MiniMax er nådd. Prøv igjen senere."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osiągnięto limit żądań generowania mowy w MiniMax. Spróbuj ponownie później."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O limite de solicitações de fala da MiniMax foi atingido. Tente novamente mais tarde."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Достигнут лимит запросов на синтез речи MiniMax. Повторите попытку позже."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ถึงขีดจำกัดคำขอสร้างเสียงพูดของ MiniMax แล้ว ลองอีกครั้งในภายหลัง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax konuşma isteği sınırına ulaşıldı. Daha sonra tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Досягнуто ліміту запитів на синтез мовлення MiniMax. Спробуйте пізніше."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已达到 MiniMax 的语音请求上限。请稍后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已達 MiniMax 的語音請求上限。請稍後再試。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.providerRejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax could not generate speech. Check your account, voice, and selected text."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxで音声を生成できませんでした。アカウント、音声、選択したテキストを確認してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر على MiniMax توليد الكلام. تحقّق من حسابك والصوت والنص المحدد."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nije mogao generisati govor. Provjerite svoj račun, glas i odabrani tekst."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax kunne ikke generere tale. Kontrollér din konto, stemmen og den markerede tekst."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax konnte keine Sprachausgabe erzeugen. Überprüfen Sie Ihr Konto, die Stimme und den ausgewählten Text."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax no ha podido generar la voz. Comprueba tu cuenta, la voz y el texto seleccionado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax n’a pas pu générer la synthèse vocale. Vérifiez votre compte, la voix et le texte sélectionné."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax non ha potuto generare l'audio vocale. Controlla il tuo account, la voce e il testo selezionato."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax មិនអាចបង្កើតសំឡេងបានទេ។ សូមពិនិត្យគណនី សំឡេង និងអត្ថបទដែលអ្នកបានជ្រើសរើស។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에서 음성을 생성하지 못했습니다. 계정, 음성 및 선택한 텍스트를 확인하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax kunne ikke generere tale. Kontroller kontoen din, stemmen og den markerte teksten."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nie mógł wygenerować mowy. Sprawdź swoje konto, głos i zaznaczony tekst."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A MiniMax não conseguiu gerar a fala. Verifique sua conta, a voz e o texto selecionado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не удалось синтезировать речь. Проверьте свою учётную запись, голос и выделенный текст."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ไม่สามารถสร้างเสียงพูดได้ ตรวจสอบบัญชี เสียง และข้อความที่คุณเลือก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax konuşma oluşturamadı. Hesabınızı, sesi ve seçili metni kontrol edin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не вдалося синтезувати мовлення. Перевірте свій обліковий запис, голос і вибраний текст."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 无法生成语音。请检查你的账户、音色和所选文本。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 無法產生語音。請檢查您的帳號、聲音及所選文字。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The connection to MiniMax failed. Check your network connection."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxへの接続に失敗しました。ネットワーク接続を確認してください。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل الاتصال بخدمة MiniMax. تحقّق من اتصالك بالشبكة."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povezivanje s uslugom MiniMax nije uspjelo. Provjerite mrežnu vezu."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbindelsen til MiniMax mislykkedes. Kontrollér din netværksforbindelse."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Verbindung zu MiniMax ist fehlgeschlagen. Überprüfen Sie Ihre Netzwerkverbindung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se ha podido conectar con MiniMax. Comprueba tu conexión de red."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion à MiniMax a échoué. Vérifiez votre connexion réseau."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connessione a MiniMax non è riuscita. Controlla la connessione di rete."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការតភ្ជាប់ទៅ MiniMax បានបរាជ័យ។ សូមពិនិត្យការតភ្ជាប់បណ្ដាញរបស់អ្នក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에 연결하지 못했습니다. 네트워크 연결을 확인하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilkoblingen til MiniMax mislyktes. Kontroller nettverkstilkoblingen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się połączyć z MiniMax. Sprawdź połączenie sieciowe."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A conexão com a MiniMax falhou. Verifique sua conexão de rede."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось подключиться к MiniMax. Проверьте подключение к сети."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อกับ MiniMax ไม่สำเร็จ ตรวจสอบการเชื่อมต่อเครือข่ายของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax bağlantısı başarısız oldu. Ağ bağlantınızı kontrol edin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося підключитися до MiniMax. Перевірте підключення до мережі."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 MiniMax 失败。请检查网络连接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法連線至 MiniMax。請檢查您的網路連線。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.invalidResponse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returned an invalid audio response. Read Aloud has stopped."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxから無効な音声応答が返されました。読み上げを停止しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أعادت MiniMax استجابة صوتية غير صالحة. توقفت القراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax je vratio nevažeći audio odgovor. Čitanje naglas je zaustavljeno."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerede et ugyldigt lydsvar. Oplæsningen er stoppet."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax hat eine ungültige Audioantwort zurückgegeben. Das Vorlesen wurde beendet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ha devuelto una respuesta de audio no válida. Se ha detenido la lectura en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax a renvoyé une réponse audio non valide. La lecture à voix haute s’est arrêtée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ha restituito una risposta audio non valida. La lettura ad alta voce è stata interrotta."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax បានត្រឡប់ការឆ្លើយតបជាសំឡេងដែលមិនត្រឹមត្រូវ។ ការអានឮៗបានឈប់ហើយ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에서 유효하지 않은 오디오 응답을 반환했습니다. 소리 내어 읽기가 중지되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerte et ugyldig lydsvar. Les høyt har stoppet."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax zwrócił nieprawidłową odpowiedź audio. Czytanie na głos zostało zatrzymane."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A MiniMax retornou uma resposta de áudio inválida. A leitura em voz alta foi interrompida."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax вернул некорректный аудиоответ. Чтение вслух остановлено."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ส่งข้อมูลเสียงตอบกลับที่ไม่ถูกต้อง การอ่านออกเสียงหยุดแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax geçersiz bir ses yanıtı döndürdü. Sesli okuma durduruldu."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax повернув некоректну аудіовідповідь. Читання вголос зупинено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 返回了无效的音频响应。朗读已停止。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 傳回了無效的音訊回應。朗讀已停止。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.responseTooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returned an audio message larger than the streaming safety limit. Read Aloud has stopped."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMaxからストリーミングの安全上限を超える音声メッセージが返されました。読み上げを停止しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أعادت MiniMax رسالة صوتية يتجاوز حجمها حد الأمان للبث. توقفت القراءة بصوت عالٍ."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax je vratio audio poruku veću od sigurnosnog ograničenja za streaming. Čitanje naglas je zaustavljeno."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerede en lydbesked, der overstiger sikkerhedsgrænsen for streaming. Oplæsningen er stoppet."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax hat eine Audionachricht zurückgegeben, die das Sicherheitslimit für Streaming überschreitet. Das Vorlesen wurde beendet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ha devuelto un mensaje de audio que supera el límite de seguridad de la transmisión. Se ha detenido la lectura en voz alta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax a renvoyé un message audio dont la taille dépasse la limite de sécurité du streaming. La lecture à voix haute s’est arrêtée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ha restituito un messaggio audio che supera il limite di sicurezza per lo streaming. La lettura ad alta voce è stata interrotta."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax បានត្រឡប់សារជាសំឡេងដែលមានទំហំធំជាងកម្រិតសុវត្ថិភាពនៃការផ្សាយផ្ទាល់។ ការអានឮៗបានឈប់ហើយ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에서 스트리밍 안전 한도를 초과하는 크기의 오디오 메시지를 반환했습니다. 소리 내어 읽기가 중지되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerte en lydmelding som overskrider sikkerhetsgrensen for strømming. Les høyt har stoppet."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax zwrócił wiadomość audio przekraczającą limit bezpieczeństwa strumieniowania. Czytanie na głos zostało zatrzymane."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A MiniMax retornou uma mensagem de áudio maior que o limite de segurança do streaming. A leitura em voz alta foi interrompida."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax вернул аудиосообщение, размер которого превышает безопасный лимит для потоковой передачи. Чтение вслух остановлено."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ส่งข้อมูลเสียงกลับมาซึ่งมีขนาดเกินขีดจำกัดความปลอดภัยในการสตรีม การอ่านออกเสียงหยุดแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax, akış güvenlik sınırından daha büyük bir ses iletisi döndürdü. Sesli okuma durduruldu."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax повернув аудіоповідомлення, розмір якого перевищує безпечний ліміт потокового передавання. Читання вголос зупинено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 返回的音频消息超出了流式传输的安全大小限制。朗读已停止。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 傳回的音訊訊息大小超過串流安全上限。朗讀已停止。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.truncatedStream": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The MiniMax audio stream ended before speech was complete."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げが完了する前にMiniMaxの音声ストリームが終了しました。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتهى البث الصوتي من MiniMax قبل اكتمال الكلام."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax audio tok završio je prije nego što je govor dovršen."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lydstrømmen fra MiniMax sluttede, før talen var færdig."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der MiniMax-Audiostream wurde beendet, bevor die Sprachausgabe vollständig war."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La transmisión de audio de MiniMax ha terminado antes de que se completara la lectura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le flux audio de MiniMax s’est interrompu avant la fin de la synthèse vocale."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il flusso audio di MiniMax è terminato prima che la lettura fosse completata."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការផ្សាយសំឡេងពី MiniMax បានបញ្ចប់មុនពេលអានចប់។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성이 완료되기 전에 MiniMax 오디오 스트림이 종료되었습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lydstrømmen fra MiniMax ble avsluttet før talen var ferdig."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strumień audio MiniMax zakończył się przed ukończeniem wypowiedzi."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O streaming de áudio da MiniMax terminou antes de a fala ser concluída."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аудиопоток MiniMax завершился до окончания речи."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สตรีมเสียงของ MiniMax สิ้นสุดลงก่อนที่เสียงพูดจะครบถ้วน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ses akışı, konuşma tamamlanmadan sona erdi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аудіопотік MiniMax завершився до закінчення мовлення."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 音频流在语音完成前就已结束。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 音訊串流在語音完成前便已結束。"
+          }
+        }
+      }
+    },
+    "readAloud.transport.noAudio": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax did not return any playable speech for the selected text."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したテキストに対して、MiniMaxから再生可能な音声が返されませんでした。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم تُعِد MiniMax أي كلام قابل للتشغيل للنص المحدد."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nije vratio govor koji se može reproducirati za odabrani tekst."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerede ingen tale, der kunne afspilles, for den markerede tekst."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax hat keine abspielbare Sprachausgabe für den ausgewählten Text zurückgegeben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax no ha devuelto ningún audio de voz reproducible para el texto seleccionado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax n’a renvoyé aucun contenu vocal lisible pour le texte sélectionné."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax non ha restituito alcun audio vocale riproducibile per il testo selezionato."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax មិនបានត្រឡប់សំឡេងដែលអាចចាក់បានសម្រាប់អត្ថបទដែលបានជ្រើសរើសទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax에서 선택한 텍스트에 대해 재생 가능한 음성을 반환하지 않았습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax returnerte ingen avspillbar tale for den markerte teksten."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax nie zwrócił dla zaznaczonego tekstu żadnej mowy, którą można odtworzyć."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A MiniMax não retornou nenhum áudio de fala reproduzível para o texto selecionado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не вернул аудиоданных, пригодных для воспроизведения речи по выделенному тексту."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax ไม่ได้ส่งเสียงพูดที่เล่นได้กลับมาสำหรับข้อความที่เลือก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax, seçili metin için oynatılabilir bir konuşma döndürmedi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax не повернув придатного для відтворення мовлення для вибраного тексту."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 未针对所选文本返回任何可播放的语音。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MiniMax 未針對所選文字傳回任何可播放的語音。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Security
+
+/// Persists non-secret speech preferences and a service-scoped MiniMax Keychain credential.
+///
+/// Inject a dedicated defaults suite and Keychain service for isolated environments.
+/// The saved credential is never stored in defaults or synchronized through iCloud.
+///
+/// ```swift
+/// let preferences = ReadAloudPreferences(
+///     defaults: appDefaults,
+///     keychainService: "com.example.cmux.read-aloud"
+/// )
+/// try await preferences.save(configuration: ReadAloudConfiguration())
+/// ```
+public actor ReadAloudPreferences {
+    private let defaults: UserDefaults
+    private let keychainService: String
+    private let configurationKey = "readAloud.configuration"
+    private let consentKey = "readAloud.cloudConsent"
+
+    /// Creates a preferences store without reading the saved credential.
+    /// - Parameters:
+    ///   - defaults: The caller-owned store for configuration and consent only.
+    ///   - keychainService: A nonempty service identifier scoped to the calling app or test.
+    public init(defaults: UserDefaults, keychainService: String) {
+        self.defaults = defaults
+        self.keychainService = keychainService
+    }
+
+    /// Returns saved speech preferences, or defaults if the saved representation is invalid.
+    /// - Returns: A supported configuration with a nonempty voice and speed from 0.5 through 2.
+    public func configuration() -> ReadAloudConfiguration {
+        guard let data = defaults.data(forKey: configurationKey),
+              let configuration = try? JSONDecoder().decode(ReadAloudConfiguration.self, from: data),
+              (try? validate(configuration)) != nil else {
+            return ReadAloudConfiguration()
+        }
+        return configuration
+    }
+
+    /// Saves validated non-secret speech preferences without altering consent or the credential.
+    /// - Parameter configuration: Turbo or HD speech-2.8 settings with a nonempty voice and finite speed in 0.5...2.
+    /// - Throws: A localized validation error or a configuration encoding error.
+    public func save(configuration: ReadAloudConfiguration) throws {
+        try validate(configuration)
+        let data = try JSONEncoder().encode(configuration)
+        defaults.set(data, forKey: configurationKey)
+    }
+
+    /// Reads the MiniMax credential for a synthesis request, never for display in settings.
+    /// - Returns: The saved key, or `nil` only when no item exists.
+    /// - Throws: A localized error retaining the Keychain status, or an invalid-credential error.
+    public func apiKey() throws -> String? {
+        var query = try credentialQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else { throw ReadAloudPreferencesError.keychain(status) }
+        guard let data = result as? Data,
+              let key = String(data: data, encoding: .utf8),
+              !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ReadAloudPreferencesError.invalidCredential
+        }
+        return key
+    }
+
+    /// Stores a new or replacement MiniMax key without deleting the existing key first.
+    /// - Parameter key: A nonempty key; surrounding whitespace and newlines are removed.
+    /// - Throws: A localized validation or Keychain error; an unsuccessful update leaves the old item intact.
+    public func saveAPIKey(_ key: String) throws {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { throw ReadAloudPreferencesError.emptyCredential }
+        let query = try credentialQuery()
+        let data = Data(trimmedKey.utf8)
+        let status = SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        )
+        if status == errSecSuccess { return }
+        guard status == errSecItemNotFound else { throw ReadAloudPreferencesError.keychain(status) }
+        var insert = query
+        insert[kSecValueData as String] = data
+        insert[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let insertStatus = SecItemAdd(insert as CFDictionary, nil)
+        guard insertStatus == errSecSuccess else { throw ReadAloudPreferencesError.keychain(insertStatus) }
+    }
+
+    /// Explicitly removes the service-scoped credential; a missing item is already removed.
+    /// - Throws: A localized error if the Keychain refuses the removal.
+    public func removeAPIKey() throws {
+        let query = try credentialQuery()
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw ReadAloudPreferencesError.keychain(status)
+        }
+    }
+
+    /// Returns whether the user explicitly opted in to sending selected text to MiniMax.
+    /// - Returns: `false` until consent has been recorded in the injected defaults store.
+    public func consentGranted() -> Bool {
+        defaults.bool(forKey: consentKey)
+    }
+
+    /// Records an explicit user consent choice independently of credential and speech settings.
+    /// - Parameter granted: Whether sending selected text to MiniMax is allowed.
+    public func setConsentGranted(_ granted: Bool) {
+        defaults.set(granted, forKey: consentKey)
+    }
+
+    /// Queries item existence without retrieving credential data into settings state.
+    func hasAPIKey() throws -> Bool {
+        var query = try credentialQuery()
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        if status == errSecItemNotFound { return false }
+        guard status == errSecSuccess else { throw ReadAloudPreferencesError.keychain(status) }
+        return true
+    }
+
+    private func credentialQuery() throws -> [String: Any] {
+        guard !keychainService.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ReadAloudPreferencesError.invalidService
+        }
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "minimax-api-key",
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrSynchronizable as String: false,
+        ]
+    }
+
+    private func validate(_ configuration: ReadAloudConfiguration) throws {
+        guard configuration.model == "speech-2.8-turbo" || configuration.model == "speech-2.8-hd" else {
+            throw ReadAloudPreferencesError.unsupportedModel
+        }
+        guard !configuration.voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ReadAloudPreferencesError.emptyVoice
+        }
+        guard configuration.speed.isFinite, (0.5...2.0).contains(configuration.speed) else {
+            throw ReadAloudPreferencesError.invalidSpeed
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
@@ -32,8 +32,7 @@ public actor ReadAloudPreferences {
     /// - Returns: A supported configuration with a nonempty voice and speed from 0.5 through 2.
     public func configuration() -> ReadAloudConfiguration {
         guard let data = defaults.data(forKey: configurationKey),
-              let configuration = try? JSONDecoder().decode(ReadAloudConfiguration.self, from: data),
-              (try? validate(configuration)) != nil else {
+              let configuration = try? JSONDecoder().decode(ReadAloudConfiguration.self, from: data) else {
             return ReadAloudConfiguration()
         }
         return configuration
@@ -43,7 +42,6 @@ public actor ReadAloudPreferences {
     /// - Parameter configuration: Turbo or HD speech-2.8 settings with a nonempty voice and finite speed in 0.5...2.
     /// - Throws: A localized validation error or a configuration encoding error.
     public func save(configuration: ReadAloudConfiguration) throws {
-        try configuration.validate()
         let data = try JSONEncoder().encode(configuration)
         defaults.set(data, forKey: configurationKey)
     }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferences.swift
@@ -43,7 +43,7 @@ public actor ReadAloudPreferences {
     /// - Parameter configuration: Turbo or HD speech-2.8 settings with a nonempty voice and finite speed in 0.5...2.
     /// - Throws: A localized validation error or a configuration encoding error.
     public func save(configuration: ReadAloudConfiguration) throws {
-        try validate(configuration)
+        try configuration.validate()
         let data = try JSONEncoder().encode(configuration)
         defaults.set(data, forKey: configurationKey)
     }
@@ -133,15 +133,4 @@ public actor ReadAloudPreferences {
         ]
     }
 
-    private func validate(_ configuration: ReadAloudConfiguration) throws {
-        guard configuration.model == "speech-2.8-turbo" || configuration.model == "speech-2.8-hd" else {
-            throw ReadAloudPreferencesError.unsupportedModel
-        }
-        guard !configuration.voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw ReadAloudPreferencesError.emptyVoice
-        }
-        guard configuration.speed.isFinite, (0.5...2.0).contains(configuration.speed) else {
-            throw ReadAloudPreferencesError.invalidSpeed
-        }
-    }
 }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferencesError.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferencesError.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Security
+
+/// Settings failures contain no submitted credential, voice identifier, or selected text.
+enum ReadAloudPreferencesError: LocalizedError {
+    case unsupportedModel
+    case emptyVoice
+    case invalidSpeed
+    case emptyCredential
+    case invalidCredential
+    case invalidService
+    case keychain(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedModel:
+            String(localized: "error.unsupportedModel", defaultValue: "Choose the Turbo or HD speech-2.8 model.", table: "ReadAloudSettings", bundle: .module)
+        case .emptyVoice:
+            String(localized: "error.emptyVoice", defaultValue: "Enter a MiniMax voice ID.", table: "ReadAloudSettings", bundle: .module)
+        case .invalidSpeed:
+            String(localized: "error.invalidSpeed", defaultValue: "Speech speed must be a finite number from 0.5 to 2.", table: "ReadAloudSettings", bundle: .module)
+        case .emptyCredential:
+            String(localized: "error.emptyCredential", defaultValue: "Enter a MiniMax API key before saving.", table: "ReadAloudSettings", bundle: .module)
+        case .invalidCredential:
+            String(localized: "error.invalidCredential", defaultValue: "The saved API key cannot be read. Replace or remove it in Read Aloud settings.", table: "ReadAloudSettings", bundle: .module)
+        case .invalidService:
+            String(localized: "error.invalidService", defaultValue: "The app has not configured a Keychain service for Read Aloud.", table: "ReadAloudSettings", bundle: .module)
+        case .keychain(let status):
+            String(localized: "error.keychain", defaultValue: "Keychain could not complete the operation (status \(status)). Your requested change was not confirmed.", table: "ReadAloudSettings", bundle: .module)
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferencesError.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudPreferencesError.swift
@@ -25,8 +25,8 @@ enum ReadAloudPreferencesError: LocalizedError {
             String(localized: "error.invalidCredential", defaultValue: "The saved API key cannot be read. Replace or remove it in Read Aloud settings.", table: "ReadAloudSettings", bundle: .module)
         case .invalidService:
             String(localized: "error.invalidService", defaultValue: "The app has not configured a Keychain service for Read Aloud.", table: "ReadAloudSettings", bundle: .module)
-        case .keychain(let status):
-            String(localized: "error.keychain", defaultValue: "Keychain could not complete the operation (status \(status)). Your requested change was not confirmed.", table: "ReadAloudSettings", bundle: .module)
+        case .keychain:
+            String(localized: "error.keychain", defaultValue: "Keychain could not complete the operation. Your requested change was not confirmed. Try again.", table: "ReadAloudSettings", bundle: .module)
         }
     }
 }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Observation
+
+/// Owns editable Read Aloud settings and reports the outcome of each persistence action.
+///
+/// Construct once at the app composition root and pass it to ``ReadAloudSettingsView``.
+/// Speech settings remain drafts until saved; consent and credential state change only
+/// after the preferences actor completes the corresponding operation.
+@MainActor
+@Observable
+public final class ReadAloudSettingsModel {
+    var configuration = ReadAloudConfiguration()
+    var apiKeyDraft = ""
+    private(set) var consentGranted = false
+    private(set) var hasSavedAPIKey: Bool?
+    private(set) var isBusy = false
+    private(set) var isLoaded = false
+    private(set) var errorMessage: String?
+    private(set) var statusMessage: String?
+    private var savedConfiguration = ReadAloudConfiguration()
+    private let preferences: ReadAloudPreferences
+
+    /// Creates settings state without reading the Keychain or automatically granting consent.
+    /// - Parameter preferences: The same preferences actor used by the Read Aloud coordinator.
+    public init(preferences: ReadAloudPreferences) {
+        self.preferences = preferences
+    }
+
+    var hasUnsavedConfiguration: Bool {
+        configuration != savedConfiguration
+    }
+
+    var canSaveAPIKey: Bool {
+        !apiKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    enum Action {
+        case load
+        case saveConfiguration
+        case saveAPIKey
+        case removeAPIKey
+        case setConsent(Bool)
+    }
+
+    /// Serializes every settings persistence action and exposes only confirmed results.
+    func perform(_ action: Action) async {
+        guard !isBusy else { return }
+        isBusy = true
+        errorMessage = nil
+        statusMessage = nil
+        defer { isBusy = false }
+
+        do {
+            switch action {
+            case .load:
+                configuration = await preferences.configuration()
+                savedConfiguration = configuration
+                consentGranted = await preferences.consentGranted()
+                isLoaded = true
+                hasSavedAPIKey = nil
+                hasSavedAPIKey = try await preferences.hasAPIKey()
+            case .saveConfiguration:
+                let requested = configuration
+                try await preferences.save(configuration: requested)
+                savedConfiguration = requested
+                statusMessage = String(localized: "status.settingsSaved", defaultValue: "Speech settings saved.", table: "ReadAloudSettings", bundle: .module)
+            case .saveAPIKey:
+                try await preferences.saveAPIKey(apiKeyDraft)
+                apiKeyDraft = ""
+                hasSavedAPIKey = true
+                statusMessage = String(localized: "status.keySaved", defaultValue: "API key saved in Keychain.", table: "ReadAloudSettings", bundle: .module)
+            case .removeAPIKey:
+                try await preferences.removeAPIKey()
+                apiKeyDraft = ""
+                hasSavedAPIKey = false
+                statusMessage = String(localized: "status.keyRemoved", defaultValue: "API key removed from Keychain.", table: "ReadAloudSettings", bundle: .module)
+            case .setConsent(let granted):
+                await preferences.setConsentGranted(granted)
+                consentGranted = await preferences.consentGranted()
+            }
+        } catch let error as ReadAloudPreferencesError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = String(localized: "error.persistence", defaultValue: "Read Aloud settings could not be saved. Your change was not confirmed. Try again.", table: "ReadAloudSettings", bundle: .module)
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
@@ -9,7 +9,9 @@ import Observation
 @MainActor
 @Observable
 public final class ReadAloudSettingsModel {
-    var configuration = ReadAloudConfiguration()
+    var selectedModel = ReadAloudConfiguration().model
+    var voiceID = ReadAloudConfiguration().voiceID
+    var speed = ReadAloudConfiguration().speed
     var apiKeyDraft = ""
     private(set) var consentGranted = false
     private(set) var hasSavedAPIKey: Bool?
@@ -27,7 +29,9 @@ public final class ReadAloudSettingsModel {
     }
 
     var hasUnsavedConfiguration: Bool {
-        configuration != savedConfiguration
+        selectedModel != savedConfiguration.model
+            || voiceID != savedConfiguration.voiceID
+            || speed != savedConfiguration.speed
     }
 
     var canSaveAPIKey: Bool {
@@ -53,14 +57,16 @@ public final class ReadAloudSettingsModel {
         do {
             switch action {
             case .load:
-                configuration = await preferences.configuration()
-                savedConfiguration = configuration
+                savedConfiguration = await preferences.configuration()
+                selectedModel = savedConfiguration.model
+                voiceID = savedConfiguration.voiceID
+                speed = savedConfiguration.speed
                 consentGranted = await preferences.consentGranted()
                 isLoaded = true
                 hasSavedAPIKey = nil
                 hasSavedAPIKey = try await preferences.hasAPIKey()
             case .saveConfiguration:
-                let requested = configuration
+                let requested = try ReadAloudConfiguration(model: selectedModel, voiceID: voiceID, speed: speed)
                 try await preferences.save(configuration: requested)
                 savedConfiguration = requested
                 statusMessage = String(localized: "status.settingsSaved", defaultValue: "Speech settings saved.", table: "ReadAloudSettings", bundle: .module)

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsModel.swift
@@ -30,7 +30,7 @@ public final class ReadAloudSettingsModel {
 
     var hasUnsavedConfiguration: Bool {
         selectedModel != savedConfiguration.model
-            || voiceID != savedConfiguration.voiceID
+            || voiceID.trimmingCharacters(in: .whitespacesAndNewlines) != savedConfiguration.voiceID
             || speed != savedConfiguration.speed
     }
 

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsView.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+/// Presents native speech preferences, Keychain credential entry, and explicit cloud consent.
+///
+/// The view loads through its injected model when presented. It never reads a saved key
+/// into the secure entry field and discards any unsaved key entry when dismissed.
+@MainActor
+public struct ReadAloudSettingsView: View {
+    @Bindable private var model: ReadAloudSettingsModel
+
+    /// Creates a settings surface backed by the app-owned Read Aloud settings model.
+    /// - Parameter model: The observable state sharing preferences with the speech coordinator.
+    public init(model: ReadAloudSettingsModel) {
+        self.model = model
+    }
+
+    /// The native settings controls and visible persistence results.
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(String(localized: "title", defaultValue: "Read Aloud", table: "ReadAloudSettings", bundle: .module))
+                    .font(.title2.bold())
+
+                speechSettings
+                credentialSettings
+                consentSettings
+
+                if let message = model.errorMessage {
+                    Text(message)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                        .accessibilityIdentifier("ReadAloudSettingsError")
+                }
+                if let message = model.statusMessage {
+                    Text(message)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("ReadAloudSettingsStatus")
+                }
+                HStack {
+                    if model.isBusy {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityLabel(String(localized: "status.working", defaultValue: "Updating Read Aloud settings", table: "ReadAloudSettings", bundle: .module))
+                    }
+                    Spacer()
+                    Button(String(localized: "action.reload", defaultValue: "Reload Settings", table: "ReadAloudSettings", bundle: .module)) {
+                        Task { await model.perform(.load) }
+                    }
+                    .disabled(model.isBusy)
+                }
+            }
+            .padding(20)
+        }
+        .frame(minWidth: 480, idealWidth: 560, minHeight: 620)
+        .task { await model.perform(.load) }
+        .onDisappear { model.apiKeyDraft = "" }
+    }
+
+    private var speechSettings: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker(String(localized: "model.label", defaultValue: "Model", table: "ReadAloudSettings", bundle: .module), selection: $model.configuration.model) {
+                    Text(String(localized: "model.turbo", defaultValue: "Turbo (speech-2.8-turbo)", table: "ReadAloudSettings", bundle: .module))
+                        .tag("speech-2.8-turbo")
+                    Text(String(localized: "model.hd", defaultValue: "HD (speech-2.8-hd)", table: "ReadAloudSettings", bundle: .module))
+                        .tag("speech-2.8-hd")
+                }
+                .accessibilityIdentifier("ReadAloudModel")
+
+                TextField(String(localized: "voice.label", defaultValue: "Voice ID", table: "ReadAloudSettings", bundle: .module), text: $model.configuration.voiceID)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .accessibilityIdentifier("ReadAloudVoiceID")
+                Text(String(localized: "voice.help", defaultValue: "Use a MiniMax voice ID, such as English_expressive_narrator, or your custom voice ID.", table: "ReadAloudSettings", bundle: .module))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Slider(value: $model.configuration.speed, in: 0.5...2, step: 0.1) {
+                        Text(String(localized: "speed.label", defaultValue: "Speed", table: "ReadAloudSettings", bundle: .module))
+                    }
+                    .accessibilityIdentifier("ReadAloudSpeed")
+                    Text(String(localized: "speed.value", defaultValue: "\(model.configuration.speed.formatted(.number.precision(.fractionLength(1))))×", table: "ReadAloudSettings", bundle: .module))
+                        .monospacedDigit()
+                        .frame(minWidth: 44, alignment: .trailing)
+                }
+                HStack {
+                    if model.hasUnsavedConfiguration {
+                        Text(String(localized: "status.unsaved", defaultValue: "Unsaved speech settings", table: "ReadAloudSettings", bundle: .module))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button(String(localized: "action.saveSettings", defaultValue: "Save Speech Settings", table: "ReadAloudSettings", bundle: .module)) {
+                        Task { await model.perform(.saveConfiguration) }
+                    }
+                    .disabled(!model.hasUnsavedConfiguration)
+                    .accessibilityIdentifier("ReadAloudSaveSettings")
+                }
+            }
+            .padding(8)
+            .disabled(model.isBusy || !model.isLoaded)
+        } label: {
+            Text(String(localized: "section.speech", defaultValue: "Speech", table: "ReadAloudSettings", bundle: .module))
+        }
+    }
+
+    private var credentialSettings: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(credentialStatus)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("ReadAloudKeyStatus")
+                SecureField(String(localized: "key.entry", defaultValue: "New MiniMax API Key", table: "ReadAloudSettings", bundle: .module), text: $model.apiKeyDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .accessibilityIdentifier("ReadAloudAPIKey")
+                Text(String(localized: "key.help", defaultValue: "Stored only in this Mac’s Keychain. Saved keys are never displayed here. Enter a new key to replace the saved key.", table: "ReadAloudSettings", bundle: .module))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack {
+                    Button(String(localized: "action.removeKey", defaultValue: "Remove API Key", table: "ReadAloudSettings", bundle: .module), role: .destructive) {
+                        Task { await model.perform(.removeAPIKey) }
+                    }
+                    .disabled(model.hasSavedAPIKey == false)
+                    .accessibilityIdentifier("ReadAloudRemoveKey")
+                    Spacer()
+                    Button(String(localized: "action.saveKey", defaultValue: "Save API Key", table: "ReadAloudSettings", bundle: .module)) {
+                        Task { await model.perform(.saveAPIKey) }
+                    }
+                    .disabled(!model.canSaveAPIKey)
+                    .accessibilityIdentifier("ReadAloudSaveKey")
+                }
+            }
+            .padding(8)
+            .disabled(model.isBusy || !model.isLoaded)
+        } label: {
+            Text(String(localized: "section.key", defaultValue: "MiniMax Credential", table: "ReadAloudSettings", bundle: .module))
+        }
+    }
+
+    private var consentSettings: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: "consent.disclosure", defaultValue: "Read Aloud sends only the terminal text you select to MiniMax to generate speech. MiniMax bills usage to your account. cmux streams the audio without saving selected text or audio to a disk cache.", table: "ReadAloudSettings", bundle: .module))
+                Toggle(String(localized: "consent.allow", defaultValue: "Allow sending selected text to MiniMax", table: "ReadAloudSettings", bundle: .module), isOn: Binding(
+                    get: { model.consentGranted },
+                    set: { granted in Task { await model.perform(.setConsent(granted)) } }
+                ))
+                .accessibilityIdentifier("ReadAloudConsent")
+                Text(String(localized: "consent.help", defaultValue: "Optional. Read Aloud remains unavailable until you opt in and save an API key. Turn this off to prevent future requests.", table: "ReadAloudSettings", bundle: .module))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(8)
+            .disabled(model.isBusy || !model.isLoaded)
+        } label: {
+            Text(String(localized: "section.privacy", defaultValue: "Cloud Processing Consent", table: "ReadAloudSettings", bundle: .module))
+        }
+    }
+
+    private var credentialStatus: String {
+        switch model.hasSavedAPIKey {
+        case true?:
+            String(localized: "key.saved", defaultValue: "An API key is saved in Keychain.", table: "ReadAloudSettings", bundle: .module)
+        case false?:
+            String(localized: "key.missing", defaultValue: "No API key is saved.", table: "ReadAloudSettings", bundle: .module)
+        case nil:
+            String(localized: "key.unknown", defaultValue: "Saved API key status is not yet available.", table: "ReadAloudSettings", bundle: .module)
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsView.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Settings/ReadAloudSettingsView.swift
@@ -59,15 +59,15 @@ public struct ReadAloudSettingsView: View {
     private var speechSettings: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 12) {
-                Picker(String(localized: "model.label", defaultValue: "Model", table: "ReadAloudSettings", bundle: .module), selection: $model.configuration.model) {
+                Picker(String(localized: "model.label", defaultValue: "Model", table: "ReadAloudSettings", bundle: .module), selection: $model.selectedModel) {
                     Text(String(localized: "model.turbo", defaultValue: "Turbo (speech-2.8-turbo)", table: "ReadAloudSettings", bundle: .module))
-                        .tag("speech-2.8-turbo")
+                        .tag(ReadAloudConfiguration.Model.turbo)
                     Text(String(localized: "model.hd", defaultValue: "HD (speech-2.8-hd)", table: "ReadAloudSettings", bundle: .module))
-                        .tag("speech-2.8-hd")
+                        .tag(ReadAloudConfiguration.Model.hd)
                 }
                 .accessibilityIdentifier("ReadAloudModel")
 
-                TextField(String(localized: "voice.label", defaultValue: "Voice ID", table: "ReadAloudSettings", bundle: .module), text: $model.configuration.voiceID)
+                TextField(String(localized: "voice.label", defaultValue: "Voice ID", table: "ReadAloudSettings", bundle: .module), text: $model.voiceID)
                     .textFieldStyle(.roundedBorder)
                     .autocorrectionDisabled()
                     .accessibilityIdentifier("ReadAloudVoiceID")
@@ -76,11 +76,11 @@ public struct ReadAloudSettingsView: View {
                     .foregroundStyle(.secondary)
 
                 HStack {
-                    Slider(value: $model.configuration.speed, in: 0.5...2, step: 0.1) {
+                    Slider(value: $model.speed, in: 0.5...2, step: 0.1) {
                         Text(String(localized: "speed.label", defaultValue: "Speed", table: "ReadAloudSettings", bundle: .module))
                     }
                     .accessibilityIdentifier("ReadAloudSpeed")
-                    Text(String(localized: "speed.value", defaultValue: "\(model.configuration.speed.formatted(.number.precision(.fractionLength(1))))×", table: "ReadAloudSettings", bundle: .module))
+                    Text(String(localized: "speed.value", defaultValue: "\(model.speed.formatted(.number.precision(.fractionLength(1))))×", table: "ReadAloudSettings", bundle: .module))
                         .monospacedDigit()
                         .frame(minWidth: 44, alignment: .trailing)
                 }

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxAudioParser.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxAudioParser.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Validates provider events and emits only non-aggregated, sample-aligned PCM.
+struct MiniMaxAudioParser: Sendable {
+    private(set) var isComplete = false
+    private var receivedAudio = false
+    private var pendingSampleByte: UInt8?
+    private let decoder = JSONDecoder()
+
+    mutating func consume(_ event: Data) throws -> Data? {
+        if event.isEmpty { return nil }
+        if event == Data("[DONE]".utf8) {
+            try finish()
+            return nil
+        }
+        let envelope: Envelope
+        do {
+            envelope = try decoder.decode(Envelope.self, from: event)
+        } catch {
+            throw ReadAloudTransportError.invalidResponse
+        }
+        if envelope.base_resp.status_code != 0 {
+            throw ReadAloudTransportError.provider(code: envelope.base_resp.status_code)
+        }
+        if let info = envelope.extra_info {
+            guard (info.audio_sample_rate == nil || info.audio_sample_rate == 32_000),
+                  (info.audio_channel == nil || info.audio_channel == 1),
+                  (info.audio_format == nil || info.audio_format == "pcm") else {
+                throw ReadAloudTransportError.invalidResponse
+            }
+        }
+        guard let payload = envelope.data else { return nil }
+        guard !isComplete else { throw ReadAloudTransportError.invalidResponse }
+        switch payload.status {
+        case 1:
+            guard let hex = payload.audio, !hex.isEmpty else { return nil }
+            var audio = try decodeHex(hex)
+            if let pendingSampleByte { audio.insert(pendingSampleByte, at: 0) }
+            pendingSampleByte = nil
+            if !audio.count.isMultiple(of: 2) { pendingSampleByte = audio.removeLast() }
+            guard !audio.isEmpty else { return nil }
+            receivedAudio = true
+            return audio
+        case 2:
+            // The documented status-2 audio is an aggregate, not another delta.
+            // Request exclusion as well, but never replay an aggregate if returned.
+            if let hex = payload.audio { try validateHex(hex) }
+            guard pendingSampleByte == nil else {
+                throw ReadAloudTransportError.truncatedStream
+            }
+            isComplete = true
+            return nil
+        default:
+            throw ReadAloudTransportError.invalidResponse
+        }
+    }
+
+    func finish() throws {
+        guard isComplete, pendingSampleByte == nil else {
+            throw ReadAloudTransportError.truncatedStream
+        }
+        guard receivedAudio else { throw ReadAloudTransportError.noAudio }
+    }
+
+    private func decodeHex(_ hex: String) throws -> Data {
+        guard hex.utf8.count.isMultiple(of: 2) else {
+            throw ReadAloudTransportError.invalidResponse
+        }
+        var result = Data(capacity: hex.utf8.count / 2 + 1)
+        var iterator = hex.utf8.makeIterator()
+        while let high = iterator.next() {
+            guard let low = iterator.next(), let upper = nibble(high), let lower = nibble(low) else {
+                throw ReadAloudTransportError.invalidResponse
+            }
+            result.append((upper << 4) | lower)
+        }
+        return result
+    }
+
+    private func validateHex(_ hex: String) throws {
+        guard hex.utf8.count.isMultiple(of: 2), hex.utf8.allSatisfy({ nibble($0) != nil }) else {
+            throw ReadAloudTransportError.invalidResponse
+        }
+    }
+
+    private func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39: byte - 0x30
+        case 0x41...0x46: byte - 0x41 + 10
+        case 0x61...0x66: byte - 0x61 + 10
+        default: nil
+        }
+    }
+
+    private struct Envelope: Decodable {
+        let data: Payload?
+        let base_resp: BaseResponse
+        let extra_info: AudioInfo?
+    }
+
+    private struct Payload: Decodable {
+        let audio: String?
+        let status: Int
+    }
+
+    private struct BaseResponse: Decodable {
+        let status_code: Int
+    }
+
+    private struct AudioInfo: Decodable {
+        let audio_sample_rate: Int?
+        let audio_channel: Int?
+        let audio_format: String?
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Streams MiniMax speech as mono 32 kHz signed 16-bit little-endian PCM.
+///
+/// Each invocation owns its requests. Cancelling the calling task stops its
+/// network transfer; a sink failure stops that request without retrying.
+///
+/// ```swift
+/// let client = MiniMaxSpeechClient(session: URLSession(configuration: .ephemeral))
+/// try await client.synthesize(
+///     text: selection, configuration: configuration, apiKey: key, audioSink: consumePCM
+/// )
+/// ```
+public actor MiniMaxSpeechClient: ReadAloudSynthesizing {
+    private let session: URLSession
+
+    /// Creates a client using an injected session without assuming ownership of it.
+    ///
+    /// - Parameter session: A session configured for ephemeral storage, with no
+    ///   persistent URL cache or credential storage. The client never invalidates it.
+    public init(session: URLSession) {
+        self.session = session
+    }
+
+    /// Reads the full selection through sequential, bounded provider requests.
+    ///
+    /// Empty or whitespace-only selections return without making a request.
+    /// Paragraph and sentence boundaries are preferred when splitting long text;
+    /// no text is silently truncated. The sink receives complete PCM samples and
+    /// is awaited before reading more network bytes. It must cooperate with task
+    /// cancellation; network cancellation does not depend on sink cooperation.
+    /// - Parameters:
+    ///   - text: Selected text to transmit to MiniMax.
+    ///   - configuration: A supported MiniMax model, nonempty voice ID, and speed in 0.5...2.
+    ///   - apiKey: A nonempty ASCII bearer credential without whitespace or controls.
+    ///   - audioSink: A backpressured consumer, called sequentially with PCM data.
+    /// - Throws: Cancellation, safe localized transport errors, or the sink's error.
+    public func synthesize(
+        text: String,
+        configuration: ReadAloudConfiguration,
+        apiKey: String,
+        audioSink: @escaping @Sendable (Data) async throws -> Void
+    ) async throws {
+        try Task.checkCancellation()
+        guard text.contains(where: { !$0.isWhitespace }) else { return }
+        try validate(configuration: configuration, apiKey: apiKey)
+        var chunks = ReadAloudTextChunks(text: text)
+        while let chunk = try chunks.next() {
+            // Whitespace remains in the lossless partition, but cannot produce speech alone.
+            guard chunk.contains(where: { !$0.isWhitespace }) else { continue }
+            let request = try request(text: chunk, configuration: configuration, apiKey: apiKey)
+            try await stream(request: request, audioSink: audioSink)
+        }
+    }
+
+    private func stream(
+        request: URLRequest,
+        audioSink: @escaping @Sendable (Data) async throws -> Void
+    ) async throws {
+        let bytes: URLSession.AsyncBytes
+        let response: URLResponse
+        do {
+            // Foundation's async API propagates cancellation while awaiting headers,
+            // before the underlying task is available through AsyncBytes.
+            (bytes, response) = try await session.bytes(for: request, delegate: ReadAloudRequestDelegate())
+        } catch {
+            throw transportError(error)
+        }
+        let networkTask = bytes.task
+        defer { networkTask.cancel() }
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            guard let http = response as? HTTPURLResponse else {
+                throw ReadAloudTransportError.invalidResponse
+            }
+            guard http.statusCode == 200 else {
+                throw ReadAloudTransportError.http(status: http.statusCode)
+            }
+            let contentType = http.value(forHTTPHeaderField: "Content-Type")?
+                .split(separator: ";", maxSplits: 1).first?
+                .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            var iterator = bytes.makeAsyncIterator()
+            guard contentType == "text/event-stream" else {
+                // MiniMax can return a JSON error with HTTP 200. Bound that error
+                // document; never buffer a successful audio response as a fallback.
+                guard contentType == "application/json" else {
+                    throw ReadAloudTransportError.invalidResponse
+                }
+                var document = Data()
+                while let byte = try await nextByte(&iterator) {
+                    guard document.count < 64 * 1_024 else {
+                        throw ReadAloudTransportError.responseTooLarge
+                    }
+                    document.append(byte)
+                }
+                var parser = MiniMaxAudioParser()
+                _ = try parser.consume(document)
+                throw ReadAloudTransportError.invalidResponse
+            }
+            var frames = ReadAloudSSEParser()
+            var audio = MiniMaxAudioParser()
+            while let byte = try await nextByte(&iterator) {
+                if let event = try frames.consume(byte) {
+                    if let pcm = try audio.consume(event) {
+                        try Task.checkCancellation()
+                        try await audioSink(pcm)
+                        try Task.checkCancellation()
+                    }
+                    if audio.isComplete {
+                        try audio.finish()
+                        return
+                    }
+                }
+            }
+            try frames.finish()
+            try audio.finish()
+        } onCancel: {
+            networkTask.cancel()
+        }
+    }
+
+    private func nextByte(_ iterator: inout URLSession.AsyncBytes.Iterator) async throws -> UInt8? {
+        try Task.checkCancellation()
+        do {
+            return try await iterator.next()
+        } catch {
+            throw transportError(error)
+        }
+    }
+
+    private func transportError(_ error: any Error) -> any Error {
+        if Task.isCancelled || error is CancellationError || (error as? URLError)?.code == .cancelled {
+            return CancellationError()
+        }
+        return ReadAloudTransportError.network
+    }
+
+    private func validate(configuration: ReadAloudConfiguration, apiKey: String) throws {
+        switch configuration.model {
+        case "speech-2.8-turbo", "speech-2.8-hd", "speech-2.6-turbo", "speech-2.6-hd",
+             "speech-02-turbo", "speech-02-hd", "speech-01-turbo", "speech-01-hd":
+            break
+        default:
+            throw ReadAloudTransportError.invalidConfiguration
+        }
+        guard configuration.speed.isFinite, (0.5...2).contains(configuration.speed),
+              !configuration.voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !configuration.voiceID.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
+            throw ReadAloudTransportError.invalidConfiguration
+        }
+        guard !apiKey.isEmpty, apiKey.utf8.allSatisfy({ (0x21...0x7E).contains($0) }) else {
+            throw ReadAloudTransportError.invalidCredential
+        }
+    }
+
+    private func request(text: String, configuration: ReadAloudConfiguration, apiKey: String) throws -> URLRequest {
+        guard let endpoint = URL(string: "https://api.minimax.io/v1/t2a_v2") else {
+            throw ReadAloudTransportError.invalidResponse
+        }
+        var request = URLRequest(url: endpoint, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
+        request.httpMethod = "POST"
+        request.httpShouldHandleCookies = false
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: [
+                "model": configuration.model,
+                "text": text,
+                "stream": true,
+                "stream_options": ["exclude_aggregated_audio": true],
+                "output_format": "hex",
+                "voice_setting": ["voice_id": configuration.voiceID, "speed": configuration.speed, "vol": 1, "pitch": 0],
+                "audio_setting": ["format": "pcm", "sample_rate": 32_000, "channel": 1],
+            ])
+        } catch {
+            throw ReadAloudTransportError.invalidConfiguration
+        }
+        return request
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
@@ -43,7 +43,8 @@ public actor MiniMaxSpeechClient: ReadAloudSynthesizing {
     ) async throws {
         try Task.checkCancellation()
         guard text.contains(where: { !$0.isWhitespace }) else { return }
-        try validate(configuration: configuration, apiKey: apiKey)
+        try configuration.validate()
+        guard !apiKey.isEmpty, apiKey.utf8.allSatisfy({ (0x21...0x7E).contains($0) }) else { throw ReadAloudTransportError.invalidCredential }
         var chunks = ReadAloudTextChunks(text: text)
         while let chunk = try chunks.next() {
             // Whitespace remains in the lossless partition, but cannot produce speech alone.
@@ -135,23 +136,6 @@ public actor MiniMaxSpeechClient: ReadAloudSynthesizing {
         return ReadAloudTransportError.network
     }
 
-    private func validate(configuration: ReadAloudConfiguration, apiKey: String) throws {
-        switch configuration.model {
-        case "speech-2.8-turbo", "speech-2.8-hd", "speech-2.6-turbo", "speech-2.6-hd",
-             "speech-02-turbo", "speech-02-hd", "speech-01-turbo", "speech-01-hd":
-            break
-        default:
-            throw ReadAloudTransportError.invalidConfiguration
-        }
-        guard configuration.speed.isFinite, (0.5...2).contains(configuration.speed),
-              !configuration.voiceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !configuration.voiceID.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
-            throw ReadAloudTransportError.invalidConfiguration
-        }
-        guard !apiKey.isEmpty, apiKey.utf8.allSatisfy({ (0x21...0x7E).contains($0) }) else {
-            throw ReadAloudTransportError.invalidCredential
-        }
-    }
 
     private func request(text: String, configuration: ReadAloudConfiguration, apiKey: String) throws -> URLRequest {
         guard let endpoint = URL(string: "https://api.minimax.io/v1/t2a_v2") else {

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/MiniMaxSpeechClient.swift
@@ -43,7 +43,6 @@ public actor MiniMaxSpeechClient: ReadAloudSynthesizing {
     ) async throws {
         try Task.checkCancellation()
         guard text.contains(where: { !$0.isWhitespace }) else { return }
-        try configuration.validate()
         guard !apiKey.isEmpty, apiKey.utf8.allSatisfy({ (0x21...0x7E).contains($0) }) else { throw ReadAloudTransportError.invalidCredential }
         var chunks = ReadAloudTextChunks(text: text)
         while let chunk = try chunks.next() {
@@ -150,7 +149,7 @@ public actor MiniMaxSpeechClient: ReadAloudSynthesizing {
         request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: [
-                "model": configuration.model,
+                "model": configuration.model.rawValue,
                 "text": text,
                 "stream": true,
                 "stream_options": ["exclude_aggregated_audio": true],

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudRequestDelegate.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudRequestDelegate.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Prevents redirecting selected text or caching provider responses.
+final class ReadAloudRequestDelegate: NSObject, URLSessionDataDelegate, Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        willCacheResponse proposedResponse: CachedURLResponse,
+        completionHandler: @escaping @Sendable (CachedURLResponse?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudSSEParser.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudSSEParser.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Frames SSE at byte boundaries, retaining at most one bounded event.
+struct ReadAloudSSEParser: Sendable {
+    private let maximumFrameBytes: Int
+    private var frameBytes = 0
+    private var line: [UInt8] = []
+    private var data = Data()
+    private var hasData = false
+    private var skipLF = false
+    private var isFirstLine = true
+
+    init(maximumFrameBytes: Int = 2 * 1_024 * 1_024) {
+        self.maximumFrameBytes = maximumFrameBytes
+    }
+
+    mutating func consume(_ byte: UInt8) throws -> Data? {
+        if skipLF {
+            skipLF = false
+            if byte == 0x0A { return nil }
+        }
+        frameBytes += 1
+        guard frameBytes <= maximumFrameBytes else {
+            throw ReadAloudTransportError.responseTooLarge
+        }
+        if byte == 0x0D || byte == 0x0A {
+            skipLF = byte == 0x0D
+            return try finishLine()
+        }
+        line.append(byte)
+        return nil
+    }
+
+    func finish() throws {
+        // SSE dispatch requires a blank line. Never accept a cut-off JSON event.
+        guard line.isEmpty, !hasData else {
+            throw ReadAloudTransportError.truncatedStream
+        }
+    }
+
+    private mutating func finishLine() throws -> Data? {
+        defer { line.removeAll(keepingCapacity: true) }
+        if isFirstLine {
+            isFirstLine = false
+            if line.starts(with: [0xEF, 0xBB, 0xBF]) { line.removeFirst(3) }
+        }
+        guard String(bytes: line, encoding: .utf8) != nil else {
+            throw ReadAloudTransportError.invalidResponse
+        }
+        if line.isEmpty {
+            frameBytes = 0
+            guard hasData else { return nil }
+            let event = data
+            data = Data()
+            hasData = false
+            return event
+        }
+        guard line.first != 0x3A else { return nil }
+        let colon = line.firstIndex(of: 0x3A) ?? line.endIndex
+        guard line[..<colon].elementsEqual([0x64, 0x61, 0x74, 0x61]) else {
+            return nil
+        }
+        var valueStart = colon == line.endIndex ? colon : colon + 1
+        if valueStart < line.endIndex, line[valueStart] == 0x20 { valueStart += 1 }
+        if hasData { data.append(0x0A) }
+        data.append(contentsOf: line[valueStart...])
+        hasData = true
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudTextChunks.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudTextChunks.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Lazily partitions text without trimming, preferring natural speech boundaries.
+struct ReadAloudTextChunks: Sendable {
+    private let text: String
+    private var position: String.Index
+    private let maximumUTF16Count: Int
+
+    init(text: String, maximumUTF16Count: Int = 9_999) {
+        precondition(maximumUTF16Count >= 2)
+        self.text = text
+        self.position = text.startIndex
+        self.maximumUTF16Count = maximumUTF16Count
+    }
+
+    mutating func next() throws -> String? {
+        let remaining = text[position...]
+        try Task.checkCancellation()
+        guard position < text.endIndex else { return nil }
+        let start = position
+        var end = start
+        var units = 0
+        var paragraph: String.Index?
+        var sentence: String.Index?
+        var whitespace: String.Index?
+
+        while end < text.endIndex {
+            try Task.checkCancellation()
+            let character = remaining[end]
+            let count = character.unicodeScalars.reduce(0) { $0 + ($1.value > 0xFFFF ? 2 : 1) }
+            guard units + count <= maximumUTF16Count else { break }
+            units += count
+            end = remaining.index(after: end)
+            if character.isNewline {
+                paragraph = end
+            } else if ".!?。！？".contains(character) {
+                sentence = end
+            } else if character.isWhitespace {
+                whitespace = end
+            }
+        }
+
+        if end == text.endIndex {
+            position = end
+        } else if end > start {
+            position = paragraph ?? sentence ?? whitespace ?? end
+        } else {
+            // A single extended grapheme can exceed the provider limit. Split only
+            // at scalar boundaries in that exceptional case, never inside UTF-16 pairs.
+            var scalarEnd = start
+            for scalar in text[start...].unicodeScalars {
+                try Task.checkCancellation()
+                let count = scalar.value > 0xFFFF ? 2 : 1
+                guard units + count <= maximumUTF16Count else { break }
+                units += count
+                scalarEnd = text.unicodeScalars.index(after: scalarEnd)
+            }
+            position = scalarEnd
+        }
+        return String(text[start..<position])
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudTransportError.swift
+++ b/Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Transport/ReadAloudTransportError.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Fixed messages deliberately exclude provider response bodies and credentials.
+enum ReadAloudTransportError: Error, LocalizedError, Equatable, Sendable {
+    case invalidConfiguration
+    case invalidCredential
+    case authentication
+    case rateLimited
+    case providerRejected
+    case network
+    case invalidResponse
+    case responseTooLarge
+    case truncatedStream
+    case noAudio
+
+    static func provider(code: Int) -> Self {
+        switch code {
+        case 1004: .authentication
+        case 1002, 1039: .rateLimited
+        default: .providerRejected
+        }
+    }
+
+    static func http(status: Int) -> Self {
+        switch status {
+        case 401, 403: .authentication
+        case 429: .rateLimited
+        default: .providerRejected
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration:
+            String(localized: "readAloud.transport.invalidConfiguration", defaultValue: "Choose a supported speech model, a voice, and a speed between 0.5 and 2.", table: "ReadAloudTransport", bundle: .module)
+        case .invalidCredential:
+            String(localized: "readAloud.transport.invalidCredential", defaultValue: "Enter a valid MiniMax API key without spaces or line breaks in Read Aloud settings.", table: "ReadAloudTransport", bundle: .module)
+        case .authentication:
+            String(localized: "readAloud.transport.authentication", defaultValue: "MiniMax could not authenticate this request. Check the API key in Read Aloud settings.", table: "ReadAloudTransport", bundle: .module)
+        case .rateLimited:
+            String(localized: "readAloud.transport.rateLimited", defaultValue: "MiniMax's speech request limit was reached. Try again later.", table: "ReadAloudTransport", bundle: .module)
+        case .providerRejected:
+            String(localized: "readAloud.transport.providerRejected", defaultValue: "MiniMax could not generate speech. Check your account, voice, and selected text.", table: "ReadAloudTransport", bundle: .module)
+        case .network:
+            String(localized: "readAloud.transport.network", defaultValue: "The connection to MiniMax failed. Check your network connection.", table: "ReadAloudTransport", bundle: .module)
+        case .invalidResponse:
+            String(localized: "readAloud.transport.invalidResponse", defaultValue: "MiniMax returned an invalid audio response. Read Aloud has stopped.", table: "ReadAloudTransport", bundle: .module)
+        case .responseTooLarge:
+            String(localized: "readAloud.transport.responseTooLarge", defaultValue: "MiniMax returned an audio message larger than the streaming safety limit. Read Aloud has stopped.", table: "ReadAloudTransport", bundle: .module)
+        case .truncatedStream:
+            String(localized: "readAloud.transport.truncatedStream", defaultValue: "The MiniMax audio stream ended before speech was complete.", table: "ReadAloudTransport", bundle: .module)
+        case .noAudio:
+            String(localized: "readAloud.transport.noAudio", defaultValue: "MiniMax did not return any playable speech for the selected text.", table: "ReadAloudTransport", bundle: .module)
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ControlledReadAloudSynthesizer.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ControlledReadAloudSynthesizer.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import CmuxReadAloud
+
+/// Sends late audio only when the test releases a simulated suspended request.
+actor ControlledReadAloudSynthesizer: ReadAloudSynthesizing {
+    enum Outcome: Equatable, Sendable {
+        case completed(String)
+        case cancelled(String)
+        case failed(String)
+    }
+
+    enum Failure: Error {
+        case unexpectedRequest
+    }
+
+    nonisolated let outcomes: AsyncStream<Outcome>
+    private let outcomeContinuation: AsyncStream<Outcome>.Continuation
+    private let requests: [String: ReadAloudTestGate<Data?>]
+    private(set) var requestedTexts: [String] = []
+
+    init(requests: [String: ReadAloudTestGate<Data?>]) {
+        self.requests = requests
+        (outcomes, outcomeContinuation) = AsyncStream<Outcome>.makeStream()
+    }
+
+    func synthesize(
+        text: String,
+        configuration: ReadAloudConfiguration,
+        apiKey: String,
+        audioSink: @escaping @Sendable (Data) async throws -> Void
+    ) async throws {
+        requestedTexts.append(text)
+        guard let request = requests[text] else { throw Failure.unexpectedRequest }
+        let audio = await request.wait()
+        do {
+            if let audio {
+                // Model an escaped provider callback without the cancelled task's
+                // flag, so rejection must come from the playback generation fence.
+                try await Task.detached { try await audioSink(audio) }.value
+            }
+            outcomeContinuation.yield(.completed(text))
+        } catch is CancellationError {
+            outcomeContinuation.yield(.cancelled(text))
+            throw CancellationError()
+        } catch {
+            outcomeContinuation.yield(.failed(text))
+            throw error
+        }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ReadAloudCoordinatorTests.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ReadAloudCoordinatorTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import CmuxReadAloud
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct ReadAloudCoordinatorTests {
+    enum CancellationMethod: Sendable {
+        case stop
+        case cancelCaller
+    }
+
+    @Test(arguments: [CancellationMethod.stop, .cancelCaller])
+    func cancellationReleasesCallerBeforeAuthorizationReturns(_ method: CancellationMethod) async {
+        let authorization = ReadAloudTestGate<Void>()
+        let synthesizer = ControlledReadAloudSynthesizer(requests: [:])
+        let coordinator = ReadAloudCoordinator(synthesizer: synthesizer, player: PCMReadAloudPlayer()) {
+            await authorization.wait()
+            return (ReadAloudConfiguration(), "test-only-key")
+        }
+        let read = Task { try await coordinator.read("selected text") }
+        await authorization.waitUntilEntered()
+        #expect(coordinator.isSpeaking)
+        switch method {
+        case .stop: coordinator.stop()
+        case .cancelCaller: read.cancel()
+        }
+        // This must finish while authorization is still suspended, not after its release.
+        await #expect(throws: CancellationError.self) { try await read.value }
+        #expect(!coordinator.isSpeaking)
+        #expect(await synthesizer.requestedTexts.isEmpty)
+        await authorization.release(())
+    }
+
+    @Test
+    func replacementRejectsLateAudioWithoutStoppingNewRead() async throws {
+        let first = ReadAloudTestGate<Data?>()
+        let second = ReadAloudTestGate<Data?>()
+        let synthesizer = ControlledReadAloudSynthesizer(requests: ["first": first, "second": second])
+        var outcomes = synthesizer.outcomes.makeAsyncIterator()
+        let coordinator = ReadAloudCoordinator(synthesizer: synthesizer, player: PCMReadAloudPlayer()) {
+            (ReadAloudConfiguration(), "test-only-key")
+        }
+        let oldRead = Task { try await coordinator.read("first") }
+        await first.waitUntilEntered()
+        let newRead = Task { try await coordinator.read("second") }
+        await second.waitUntilEntered()
+        await #expect(throws: CancellationError.self) { try await oldRead.value }
+        // One byte never opens audio hardware, but an unfenced sink would retain
+        // it as a partial sample and incorrectly report successful consumption.
+        await first.release(Data([0x7f]))
+        #expect(await outcomes.next() == .cancelled("first"))
+        #expect(coordinator.isSpeaking)
+        await second.release(nil)
+        try await newRead.value
+        #expect(!coordinator.isSpeaking)
+    }
+
+    @Test
+    func emptySelectionStopsExistingReadWithoutAnotherRequest() async throws {
+        let first = ReadAloudTestGate<Data?>()
+        let synthesizer = ControlledReadAloudSynthesizer(requests: ["first": first])
+        let coordinator = ReadAloudCoordinator(synthesizer: synthesizer, player: PCMReadAloudPlayer()) {
+            (ReadAloudConfiguration(), "test-only-key")
+        }
+        let oldRead = Task { try await coordinator.read("first") }
+        await first.waitUntilEntered()
+        try await coordinator.read(" \n\t")
+        await #expect(throws: CancellationError.self) { try await oldRead.value }
+        #expect(!coordinator.isSpeaking)
+        #expect(await synthesizer.requestedTexts == ["first"])
+        await first.release(nil)
+    }
+
+    @Test
+    func alreadyCancelledCallerCannotInterruptActiveRead() async throws {
+        let active = ReadAloudTestGate<Data?>()
+        let delayedStart = ReadAloudTestGate<Void>()
+        let synthesizer = ControlledReadAloudSynthesizer(requests: ["active": active])
+        let coordinator = ReadAloudCoordinator(synthesizer: synthesizer, player: PCMReadAloudPlayer()) {
+            (ReadAloudConfiguration(), "test-only-key")
+        }
+        let activeRead = Task { try await coordinator.read("active") }
+        await active.waitUntilEntered()
+        let cancelledRead = Task {
+            await delayedStart.wait()
+            try await coordinator.read("cancelled")
+        }
+        await delayedStart.waitUntilEntered()
+        cancelledRead.cancel()
+        await delayedStart.release(())
+        await #expect(throws: CancellationError.self) { try await cancelledRead.value }
+        #expect(coordinator.isSpeaking)
+        #expect(await synthesizer.requestedTexts == ["active"])
+        await active.release(nil)
+        try await activeRead.value
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ReadAloudTestGate.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Playback/ReadAloudTestGate.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A one-use suspension point that deliberately ignores cancellation until released.
+actor ReadAloudTestGate<Value: Sendable> {
+    private var entered = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var continuation: CheckedContinuation<Value, Never>?
+
+    func wait() async -> Value {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            entered = true
+            let waiters = entryWaiters
+            entryWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+        }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func release(_ value: Value) {
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(returning: value)
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Settings/ReadAloudConfigurationTests.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Settings/ReadAloudConfigurationTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import CmuxReadAloud
+
+@Suite struct ReadAloudConfigurationTests {
+    @Test(arguments: [
+        #"{"model":"unknown","voiceID":"voice","speed":1}"#,
+        #"{"model":"speech-2.6-turbo","voiceID":"voice","speed":1}"#,
+        #"{"model":"speech-2.8-turbo","voiceID":"","speed":1}"#,
+        #"{"model":"speech-2.8-turbo","voiceID":"  ","speed":1}"#,
+        #"{"model":"speech-2.8-turbo","voiceID":"voice\nID","speed":1}"#,
+        #"{"model":"speech-2.8-turbo","voiceID":"voice\u0000ID","speed":1}"#,
+        #"{"model":"speech-2.8-turbo","voiceID":"voice","speed":0.49}"#,
+        #"{"model":"speech-2.8-hd","voiceID":"voice","speed":2.01}"#
+    ])
+    func rejectsInvalidPersistedConfiguration(_ json: String) {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(ReadAloudConfiguration.self, from: Data(json.utf8))
+        }
+    }
+
+    @Test(arguments: ["speech-2.8-turbo", "speech-2.8-hd"], [0.5, 1.0, 2.0])
+    func supportedConfigurationRoundTrips(model: String, speed: Double) throws {
+        let json = try JSONSerialization.data(withJSONObject: [
+            "model": model, "voiceID": "custom_voice", "speed": speed
+        ])
+        let configuration = try JSONDecoder().decode(ReadAloudConfiguration.self, from: json)
+        let encoded = try JSONEncoder().encode(configuration)
+        #expect(try JSONDecoder().decode(ReadAloudConfiguration.self, from: encoded) == configuration)
+        let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(object["model"] as? String == model)
+        #expect(object["voiceID"] as? String == "custom_voice")
+        #expect(object["speed"] as? Double == speed)
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/MiniMaxAudioParserTests.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/MiniMaxAudioParserTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import CmuxReadAloud
+
+struct MiniMaxAudioParserTests {
+    @Test func emitsIncrementallyWithoutReplayingFinalAggregate() throws {
+        var parser = MiniMaxAudioParser()
+        #expect(try parser.consume(event(audio: "01000200", status: 1)) == Data([1, 0, 2, 0]))
+        #expect(!parser.isComplete)
+        #expect(try parser.consume(event(audio: "0300", status: 1)) == Data([3, 0]))
+        #expect(try parser.consume(event(audio: "010002000300", status: 2)) == nil)
+        try parser.finish()
+    }
+
+    @Test func nullDataDoesNotCompleteStreamAndSplitSamplesRemainLossless() throws {
+        var parser = MiniMaxAudioParser()
+        #expect(try parser.consume(Data(#"{"data":null,"base_resp":{"status_code":0}}"#.utf8)) == nil)
+        #expect(try parser.consume(event(audio: "aB", status: 1)) == nil)
+        #expect(try parser.consume(event(audio: "cD0102ff", status: 1)) == Data([0xAB, 0xCD, 1, 2]))
+        #expect(try parser.consume(event(audio: "80", status: 1)) == Data([0xFF, 0x80]))
+        _ = try parser.consume(event(audio: nil, status: 2))
+        try parser.finish()
+    }
+
+    @Test func providerErrorInsideSuccessHTTPBodyIsSanitized() throws {
+        var parser = MiniMaxAudioParser()
+        let body = Data(#"{"data":null,"base_resp":{"status_code":1004,"status_msg":"selected text and secret credential"}}"#.utf8)
+        #expect(throws: ReadAloudTransportError.authentication) { _ = try parser.consume(body) }
+        _ = try parser.consume(event(audio: "0000", status: 1))
+        #expect(throws: ReadAloudTransportError.authentication) { _ = try parser.consume(body) }
+    }
+
+    @Test(arguments: ["0", "0g", "é0", "00 0"])
+    func rejectsMalformedHex(hex: String) throws {
+        var parser = MiniMaxAudioParser()
+        #expect(throws: ReadAloudTransportError.invalidResponse) {
+            _ = try parser.consume(event(audio: hex, status: 1))
+        }
+    }
+
+    @Test func prematureEOFAndDanglingSampleAreFailures() throws {
+        var parser = MiniMaxAudioParser()
+        _ = try parser.consume(event(audio: "0000", status: 1))
+        #expect(throws: ReadAloudTransportError.truncatedStream) { try parser.finish() }
+        _ = try parser.consume(event(audio: "ff", status: 1))
+        #expect(throws: ReadAloudTransportError.truncatedStream) {
+            _ = try parser.consume(event(audio: nil, status: 2))
+        }
+    }
+
+    @Test func completionWithoutDeltaAudioIsNotSuccess() throws {
+        var parser = MiniMaxAudioParser()
+        _ = try parser.consume(event(audio: "0000", status: 2))
+        #expect(throws: ReadAloudTransportError.noAudio) { try parser.finish() }
+    }
+
+    @Test func missingFinalStatusCannotBeReplacedByDoneSentinel() throws {
+        var parser = MiniMaxAudioParser()
+        _ = try parser.consume(event(audio: "0000", status: 1))
+        #expect(throws: ReadAloudTransportError.truncatedStream) {
+            _ = try parser.consume(Data("[DONE]".utf8))
+        }
+    }
+
+    @Test func mismatchedAudioFormatIsRejectedBeforePlayback() throws {
+        var parser = MiniMaxAudioParser()
+        let event = Data(#"{"data":{"status":1,"audio":"0000"},"extra_info":{"audio_format":"mp3"},"base_resp":{"status_code":0}}"#.utf8)
+        #expect(throws: ReadAloudTransportError.invalidResponse) { _ = try parser.consume(event) }
+    }
+
+    private func event(audio: String?, status: Int) -> Data {
+        let encodedAudio = audio.map { "\"\($0)\"" } ?? "null"
+        return Data("{\"data\":{\"audio\":\(encodedAudio),\"status\":\(status)},\"base_resp\":{\"status_code\":0}}".utf8)
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/ReadAloudSSEParserTests.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/ReadAloudSSEParserTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import CmuxReadAloud
+
+struct ReadAloudSSEParserTests {
+    @Test func fragmentedCRLFMultilineAndBOM() throws {
+        let wire = "\u{FEFF}: keepalive\r\nevent: message\r\ndata: {\r\ndata: \"text\":\"日本語😀\"}\r\n\r\n: next\r\rdata: second\n\n"
+        var parser = ReadAloudSSEParser()
+        var events: [Data] = []
+        // Every byte is a separate feed, including UTF-8 code points and CRLF pairs.
+        for byte in wire.utf8 {
+            if let event = try parser.consume(byte) { events.append(event) }
+        }
+        try parser.finish()
+        #expect(events == [Data("{\n\"text\":\"日本語😀\"}".utf8), Data("second".utf8)])
+    }
+
+    @Test func eventIsNotDeliveredBeforeBlankLine() throws {
+        var parser = ReadAloudSSEParser()
+        for byte in "data: {}\n".utf8 {
+            #expect(try parser.consume(byte) == nil)
+        }
+        #expect(throws: ReadAloudTransportError.truncatedStream) { try parser.finish() }
+        #expect(try parser.consume(0x0A) == Data("{}".utf8))
+        try parser.finish()
+    }
+
+    @Test func multilineAndIgnoredFieldsShareFrameLimit() throws {
+        var parser = ReadAloudSSEParser(maximumFrameBytes: 24)
+        for byte in "data: 1234\ndata: 5678\n".utf8 { _ = try parser.consume(byte) }
+        #expect(throws: ReadAloudTransportError.responseTooLarge) {
+            for byte in ": comment without a boundary".utf8 { _ = try parser.consume(byte) }
+        }
+    }
+
+    @Test func invalidUTF8IsNotSilentlyReplaced() throws {
+        var parser = ReadAloudSSEParser()
+        for byte in Array("data: ".utf8) + [0xC3, 0x28] { _ = try parser.consume(byte) }
+        #expect(throws: ReadAloudTransportError.invalidResponse) { _ = try parser.consume(0x0A) }
+    }
+}

--- a/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/ReadAloudTextChunksTests.swift
+++ b/Packages/macOS/CmuxReadAloud/Tests/CmuxReadAloudTests/Transport/ReadAloudTextChunksTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import CmuxReadAloud
+
+struct ReadAloudTextChunksTests {
+    @Test func prefersParagraphThenSentenceWithoutDroppingWhitespace() throws {
+        var paragraphs = ReadAloudTextChunks(text: "One.\nTwo. tail", maximumUTF16Count: 10)
+        #expect(try paragraphs.next() == "One.\n")
+        #expect(try paragraphs.next() == "Two. tail")
+        #expect(try paragraphs.next() == nil)
+        var sentences = ReadAloudTextChunks(text: "One. Two. Three.", maximumUTF16Count: 10)
+        #expect(try sentences.next() == "One. Two.")
+        #expect(try sentences.next() == " Three.")
+        #expect(try sentences.next() == nil)
+    }
+
+    @Test func unbrokenUnicodePreservesGraphemesAndEveryScalar() throws {
+        let text = String(repeating: "👨‍👩‍👧‍👦e\u{301}日本語😀", count: 9)
+        let pieces = try partition(text, maximumUTF16Count: 16)
+        #expect(pieces.joined().unicodeScalars.elementsEqual(text.unicodeScalars))
+        #expect(pieces.allSatisfy { $0.utf16.count <= 16 })
+        #expect(pieces.flatMap(Array.init) == Array(text))
+    }
+
+    @Test func giantCombiningGraphemeFallsBackLosslessly() throws {
+        let text = "a" + String(repeating: "\u{301}", count: 30) + "😀end"
+        let pieces = try partition(text, maximumUTF16Count: 8)
+        #expect(pieces.joined().unicodeScalars.elementsEqual(text.unicodeScalars))
+        #expect(pieces.allSatisfy { !$0.isEmpty && $0.utf16.count <= 8 })
+    }
+
+    @Test func providerBoundaryIsStrictlyBelowTenThousand() throws {
+        let text = String(repeating: "😀", count: 5_000)
+        var chunks = ReadAloudTextChunks(text: text)
+        let first = try #require(try chunks.next())
+        let second = try #require(try chunks.next())
+        #expect(first.utf16.count == 9_998)
+        #expect(second == "😀")
+        #expect(first + second == text)
+        #expect(try chunks.next() == nil)
+    }
+
+    @Test func whitespacePartitionIsNotSilentlyTrimmed() throws {
+        let text = " \t\n\r\n   "
+        #expect(try partition(text, maximumUTF16Count: 4).joined() == text)
+        var empty = ReadAloudTextChunks(text: "")
+        #expect(try empty.next() == nil)
+    }
+
+    private func partition(_ text: String, maximumUTF16Count: Int) throws -> [String] {
+        var chunks = ReadAloudTextChunks(text: text, maximumUTF16Count: maximumUTF16Count)
+        var result: [String] = []
+        while let chunk = try chunks.next() { result.append(chunk) }
+        return result
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,881 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "readAloud.settingsTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعدادات القراءة بصوت عالٍ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke čitanja naglas"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger for oplæsning"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorleseeinstellungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de lectura en voz alta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages de lecture à voix haute"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni di lettura ad alta voce"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការកំណត់ការអានឮៗ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽어주기 설정"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger for opplesing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia czytania na głos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de Leitura em Voz Alta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки чтения вслух"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่าการอ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Okuma Ayarları"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Параметри читання вголос"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗读设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗讀設定"
+          }
+        }
+      }
+    },
+    "readAloud.errorTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذرت القراءة بصوت عالٍ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čitanje naglas nije moguće"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan ikke læse op"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlesen nicht möglich"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to Read Aloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede leer en voz alta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture à voix haute impossible"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile leggere ad alta voce"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げできません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចអានឮៗបានទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽어줄 수 없음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan ikke lese høyt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można czytać na głos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não Foi Possível Ler em Voz Alta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось прочитать вслух"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถอ่านออกเสียงได้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Okunamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося прочитати вголос"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法朗读"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法朗讀"
+          }
+        }
+      }
+    },
+    "readAloud.errorMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل تشغيل الكلام. تحقق من اتصالك وإعدادات القراءة بصوت عالٍ، ثم حاول مرة أخرى."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprodukcija govora nije uspjela. Provjerite vezu i postavke čitanja naglas, pa pokušajte ponovo."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afspilning af tale mislykkedes. Kontrollér din forbindelse og indstillingerne for oplæsning, og prøv igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Sprachausgabe ist fehlgeschlagen. Überprüfe deine Verbindung und die Vorleseeinstellungen und versuche es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech playback failed. Check your connection and Read Aloud settings, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reproducción de voz ha fallado. Comprueba tu conexión y los ajustes de lectura en voz alta y vuelve a intentarlo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La lecture vocale a échoué. Vérifiez votre connexion et les réglages de lecture à voix haute, puis réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La riproduzione vocale non è riuscita. Controlla la connessione e le impostazioni di lettura ad alta voce, quindi riprova."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声の再生に失敗しました。接続と読み上げ設定を確認してから、もう一度お試しください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការចាក់សំឡេងនិយាយបានបរាជ័យ។ សូមពិនិត្យការតភ្ជាប់ និងការកំណត់ការអានឮៗ រួចព្យាយាមម្ដងទៀត។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 재생에 실패했습니다. 연결 및 읽어주기 설정을 확인한 후 다시 시도하십시오."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avspilling av tale mislyktes. Kontroller tilkoblingen og innstillingene for opplesing, og prøv igjen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzanie mowy nie powiodło się. Sprawdź połączenie i ustawienia czytania na głos, a następnie spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A reprodução de fala falhou. Verifique sua conexão e os ajustes de Leitura em Voz Alta e tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось воспроизвести речь. Проверьте подключение и настройки чтения вслух, затем повторите попытку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเล่นเสียงพูดล้มเหลว ตรวจสอบการเชื่อมต่อและการตั้งค่าการอ่านออกเสียง แล้วลองอีกครั้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşma oynatılamadı. Bağlantınızı ve Sesli Okuma ayarlarını kontrol edip yeniden deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося відтворити мовлення. Перевірте з’єднання та параметри читання вголос, а потім спробуйте ще раз."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音播放失败。请检查连接和朗读设置，然后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音播放失敗。請檢查連線和朗讀設定，然後再試一次。"
+          }
+        }
+      }
+    },
+    "readAloud.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موافق"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U redu"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "យល់ព្រម"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОК"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตกลง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamam"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.readAloud": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قراءة بصوت عالٍ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Čitaj naglas"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Læs op"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlesen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leer en voz alta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire à voix haute"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggi ad alta voce"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "អានឮៗ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽어주기"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les høyt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czytaj na głos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ler em Voz Alta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прочитать вслух"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อ่านออกเสียง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Oku"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прочитати вголос"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗读"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗讀"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.stopSpeaking": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف الكلام"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaustavi govor"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop oplæsning"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachausgabe stoppen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Speaking"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener lectura"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter la lecture"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompi lettura"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げを停止"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បញ្ឈប់ការនិយាយ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "말하기 중단"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopp opplesing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przestań mówić"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parar de Falar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остановить чтение"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "หยุดพูด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konuşmayı Durdur"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зупинити читання"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止朗读"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止朗讀"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.readAloudSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعدادات القراءة بصوت عالٍ…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke čitanja naglas…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger for oplæsning…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorleseeinstellungen…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read Aloud Settings…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de lectura en voz alta…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages de lecture à voix haute…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni di lettura ad alta voce…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ設定…"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការកំណត់ការអានឮៗ…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽어주기 설정…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger for opplesing…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia czytania na głos…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de Leitura em Voz Alta…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки чтения вслух…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่าการอ่านออกเสียง…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Okuma Ayarları…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Параметри читання вголос…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗读设置…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朗讀設定…"
+          }
+        }
+      }
+    },
   "cloudTree.error.invalidPreviewURL": {
     "extractionState": "manual",
     "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -549,6 +549,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// Owns the About Titlebar Debug subsystem (CmuxAppKitSupportUI); composition-root
     /// owned and created lazily so the window-decoration seam can point back at `self`.
     lazy var debugWindowsCoordinator = CmuxDebugWindowsCoordinator(decorator: self)
+    /// Owns selected-text speech across terminal windows and during app teardown.
+    lazy var readAloudPresentation = ReadAloudPresentation()
     /// About Titlebar Debug options store, applied by the About/Acknowledgments windows.
     var aboutTitlebarDebugStore: AboutTitlebarDebugStore { debugWindowsCoordinator.aboutTitlebarStore }
     /// Coordinates remote tmux (`ssh … tmux -CC`) mirroring; composition-root owned.
@@ -2396,6 +2398,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sentryStopMemoryContextRefresh()
         // Plain quit detaches local ssh clients; explicit close already killed marked sessions.
         remoteTmuxController.detachAll()
+        readAloudPresentation.stop()
         // Best-effort presence goodbye; unclean exits are covered by the
         // service's missed-heartbeat timeout.
         PresenceHeartbeatClient.shared.appWillTerminate()

--- a/Sources/GhosttyNSView+ReadAloud.swift
+++ b/Sources/GhosttyNSView+ReadAloud.swift
@@ -1,0 +1,46 @@
+import AppKit
+import GhosttyKit
+
+extension GhosttyNSView {
+    func addReadAloudMenuItems(to menu: NSMenu, surface: ghostty_surface_t) {
+        guard let presentation = AppDelegate.shared?.readAloudPresentation else { return }
+        if let text = readSelectionSnapshot(surface: surface)?.string,
+           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let item = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.readAloud", defaultValue: "Read Aloud"),
+                action: #selector(readSelectedTextAloud(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            // Preserve precisely the explicit selection at menu-open, without using the clipboard.
+            item.representedObject = text
+        }
+        if presentation.isSpeaking {
+            let item = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.stopSpeaking", defaultValue: "Stop Speaking"),
+                action: #selector(stopReadingAloud(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+        }
+        let settings = menu.addItem(
+            withTitle: String(localized: "terminalContextMenu.readAloudSettings", defaultValue: "Read Aloud Settings…"),
+            action: #selector(showReadAloudSettings(_:)),
+            keyEquivalent: ""
+        )
+        settings.target = self
+    }
+
+    @objc private func readSelectedTextAloud(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        AppDelegate.shared?.readAloudPresentation.read(text)
+    }
+
+    @objc private func stopReadingAloud(_ sender: Any?) {
+        AppDelegate.shared?.readAloudPresentation.stop()
+    }
+
+    @objc private func showReadAloudSettings(_ sender: Any?) {
+        AppDelegate.shared?.readAloudPresentation.showSettings()
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8792,6 +8792,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             item.target = self
             addTranslateSelectionMenuItem(to: menu, surface: surface)
         }
+        addReadAloudMenuItems(to: menu, surface: surface)
         let pasteItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.paste", defaultValue: "Paste"),
             action: #selector(paste(_:)),

--- a/Sources/ReadAloudPresentation.swift
+++ b/Sources/ReadAloudPresentation.swift
@@ -1,0 +1,90 @@
+import AppKit
+import CmuxReadAloud
+import SwiftUI
+
+/// App-owned speech lifetime, settings window, and error presentation.
+@MainActor
+final class ReadAloudPresentation {
+    private let preferences: ReadAloudPreferences
+    private let coordinator: ReadAloudCoordinator
+    private var settingsWindowController: NSWindowController?
+    private var readTask: Task<Void, Never>?
+    private var generation: UInt64 = 0
+
+    var isSpeaking: Bool { coordinator.isSpeaking }
+
+    init() {
+        let preferences = ReadAloudPreferences(
+            defaults: .standard,
+            keychainService: "\(Bundle.main.bundleIdentifier ?? "com.cmuxterm.app").read-aloud"
+        )
+        self.preferences = preferences
+        coordinator = ReadAloudCoordinator(
+            synthesizer: MiniMaxSpeechClient(session: URLSession(configuration: .ephemeral)),
+            preferences: preferences,
+            player: PCMReadAloudPlayer()
+        )
+    }
+
+    func read(_ text: String) {
+        stop()
+        let operation = generation
+        readTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await coordinator.read(text)
+            } catch is CancellationError {
+                // Stop and replacement are deliberate, not user-facing failures.
+            } catch {
+                guard generation == operation else { return }
+                if let error = error as? ReadAloudCoordinatorError,
+                   case .configurationRequired = error {
+                    showSettings()
+                } else {
+                    showError(error)
+                }
+            }
+            if generation == operation { readTask = nil }
+        }
+    }
+
+    func stop() {
+        generation &+= 1
+        readTask?.cancel()
+        readTask = nil
+        coordinator.stop()
+    }
+
+    func showSettings() {
+        if let settingsWindowController {
+            settingsWindowController.showWindow(nil)
+            settingsWindowController.window?.makeKeyAndOrderFront(nil)
+            return
+        }
+        let model = ReadAloudSettingsModel(preferences: preferences)
+        let content = NSHostingController(rootView: ReadAloudSettingsView(model: model))
+        let window = NSWindow(contentViewController: content)
+        window.title = String(localized: "readAloud.settingsTitle", defaultValue: "Read Aloud Settings")
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.center()
+        let controller = NSWindowController(window: window)
+        settingsWindowController = controller
+        controller.showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func showError(_ error: any Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "readAloud.errorTitle", defaultValue: "Unable to Read Aloud")
+        alert.informativeText = (error as? any LocalizedError)?.errorDescription
+            ?? String(localized: "readAloud.errorMessage", defaultValue: "Speech playback failed. Check your connection and Read Aloud settings, then try again.")
+        alert.addButton(withTitle: String(localized: "readAloud.dismiss", defaultValue: "OK"))
+        if let window = NSApp.keyWindow {
+            alert.beginSheetModal(for: window)
+        } else {
+            alert.runModal()
+        }
+    }
+}

--- a/Sources/ReadAloudPresentation.swift
+++ b/Sources/ReadAloudPresentation.swift
@@ -64,6 +64,7 @@ final class ReadAloudPresentation {
         let model = ReadAloudSettingsModel(preferences: preferences)
         let content = NSHostingController(rootView: ReadAloudSettingsView(model: model))
         let window = NSWindow(contentViewController: content)
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.readAloudSettings")
         window.title = String(localized: "readAloud.settingsTitle", defaultValue: "Read Aloud Settings")
         window.styleMask = [.titled, .closable, .miniaturizable]
         window.isReleasedWhenClosed = false

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1619,6 +1619,7 @@ private struct MainWindowBootstrapView: View {
 
 private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.settings",
+    "cmux.readAloudSettings",
     "cmux.about",
     "cmux.licenses",
     "cmux.browser-popup",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1041,6 +1041,7 @@
 		F0C0A1000000000000000003 /* CmuxPhonePush in Frameworks */ = {isa = PBXBuildFile; productRef = F0C0A1000000000000000002 /* CmuxPhonePush */; };
 		F0C0A1000000000000000004 /* CmuxPhonePush in Frameworks */ = {isa = PBXBuildFile; productRef = F0C0A1000000000000000002 /* CmuxPhonePush */; };
 		A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */ = {isa = PBXBuildFile; productRef = A5C0DE0000000000000000A2 /* CMUXProjectModel */; };
+		B750A3000000000000000002 /* CmuxReadAloud in Frameworks */ = {isa = PBXBuildFile; productRef = B750A3000000000000000003 /* CmuxReadAloud */; };
 		CC0DE10000000000000000A3 /* CmuxRemoteDaemon in Frameworks */ = {isa = PBXBuildFile; productRef = CC0DE10000000000000000A2 /* CmuxRemoteDaemon */; };
 		CC0DE30000000000000000A3 /* CmuxRemoteSession in Frameworks */ = {isa = PBXBuildFile; productRef = CC0DE30000000000000000A2 /* CmuxRemoteSession */; };
 		CC0DE20000000000000000A3 /* CmuxRemoteWorkspace in Frameworks */ = {isa = PBXBuildFile; productRef = CC0DE20000000000000000A2 /* CmuxRemoteWorkspace */; };
@@ -1544,6 +1545,7 @@
 		D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */; };
 		D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */; };
 		C7261F030000000000000001 /* GhosttyNSView+PointerFocusActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */; };
+		B750A2000000000000000001 /* GhosttyNSView+ReadAloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = B750A2000000000000000002 /* GhosttyNSView+ReadAloud.swift */; };
 		265FFB2D782433ED46B87F32 /* GhosttyNSView+RemoteReconnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */; };
 		C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */; };
 		EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */; };
@@ -2086,6 +2088,7 @@
 		A64610010000000000000001 /* QuitConfirmationAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64610010000000000000002 /* QuitConfirmationAlertPresenter.swift */; };
 		A64610020000000000000001 /* QuitConfirmationAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64610020000000000000002 /* QuitConfirmationAlertPresenterTests.swift */; };
 		A500RG01 /* ReactGrab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500RG00 /* ReactGrab.swift */; };
+		B750A1000000000000000001 /* ReadAloudPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B750A1000000000000000002 /* ReadAloudPresentation.swift */; };
 		966600019666000196660001 /* RecoverableMainWindowLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966600029666000296660002 /* RecoverableMainWindowLifecycleTests.swift */; };
 		9666B0019666B0019666B001 /* RecoverableMainWindowRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9666B0029666B0029666B002 /* RecoverableMainWindowRoute.swift */; };
 		C8349011C8349011C8349011 /* RecoverableMainWindowRouteOwnerRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8349012C8349012C8349012 /* RecoverableMainWindowRouteOwnerRegistration.swift */; };
@@ -4939,6 +4942,7 @@
 		D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+IMEComposition.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+PointerFocusActivation.swift"; sourceTree = "<group>"; };
+		B750A2000000000000000002 /* GhosttyNSView+ReadAloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+ReadAloud.swift"; sourceTree = "<group>"; };
 		47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+RemoteReconnect.swift"; sourceTree = "<group>"; };
 		C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+SelectionTranslation.swift"; sourceTree = "<group>"; };
 		EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+TerminalCustomUpload.swift"; sourceTree = "<group>"; };
@@ -5472,6 +5476,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A64610010000000000000002 /* QuitConfirmationAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationAlertPresenter.swift; sourceTree = "<group>"; };
 		A64610020000000000000002 /* QuitConfirmationAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationAlertPresenterTests.swift; sourceTree = "<group>"; };
 		A500RG00 /* ReactGrab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ReactGrab.swift; sourceTree = "<group>"; };
+		B750A1000000000000000002 /* ReadAloudPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAloudPresentation.swift; sourceTree = "<group>"; };
 		966600029666000296660002 /* RecoverableMainWindowLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverableMainWindowLifecycleTests.swift; sourceTree = "<group>"; };
 		9666B0029666B0029666B002 /* RecoverableMainWindowRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverableMainWindowRoute.swift; sourceTree = "<group>"; };
 		C8349012C8349012C8349012 /* RecoverableMainWindowRouteOwnerRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverableMainWindowRouteOwnerRegistration.swift; sourceTree = "<group>"; };
@@ -6816,6 +6821,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				E3B7A30000000000000000F3 /* CmuxPanes in Frameworks */,
 				F0C0A1000000000000000003 /* CmuxPhonePush in Frameworks */,
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
+				B750A3000000000000000002 /* CmuxReadAloud in Frameworks */,
 				CC0DE10000000000000000A3 /* CmuxRemoteDaemon in Frameworks */,
 				CC0DE30000000000000000A3 /* CmuxRemoteSession in Frameworks */,
 				CC0DE20000000000000000A3 /* CmuxRemoteWorkspace in Frameworks */,
@@ -8116,6 +8122,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */,
 				47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */,
 				C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */,
+				B750A1000000000000000002 /* ReadAloudPresentation.swift */,
+				B750A2000000000000000002 /* GhosttyNSView+ReadAloud.swift */,
 				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
 				D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
 				D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */,
@@ -10421,6 +10429,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				CD0CFE5200000000CD0CFE52 /* CmuxSettings */,
 				CFF12E0000000000000000A2 /* CmuxTestSupport */,
 				CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */,
+				B750A3000000000000000003 /* CmuxReadAloud */,
 				CDFEED0200000000CDFEED02 /* CmuxUpdater */,
 				CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */,
 				CF00F00000000000000000A2 /* CmuxFoundation */,
@@ -10655,6 +10664,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				CD0CFE5100000000CD0CFE51 /* XCLocalSwiftPackageReference "CmuxSettings" */,
 				CFF12E0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTestSupport" */,
 				CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */,
+				B750A3000000000000000001 /* XCLocalSwiftPackageReference "CmuxReadAloud" */,
 				CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */,
 				CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */,
 				CF00F00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFoundation" */,
@@ -11774,6 +11784,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */,
 				D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */,
 				C7261F030000000000000001 /* GhosttyNSView+PointerFocusActivation.swift in Sources */,
+				B750A2000000000000000001 /* GhosttyNSView+ReadAloud.swift in Sources */,
 				265FFB2D782433ED46B87F32 /* GhosttyNSView+RemoteReconnect.swift in Sources */,
 				C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */,
 				EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */,
@@ -12142,6 +12153,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE86520000000000000115 /* QuickLookPreviewView.swift in Sources */,
 					A64610010000000000000001 /* QuitConfirmationAlertPresenter.swift in Sources */,
 				A500RG01 /* ReactGrab.swift in Sources */,
+				B750A1000000000000000001 /* ReadAloudPresentation.swift in Sources */,
 				9666B0019666B0019666B001 /* RecoverableMainWindowRoute.swift in Sources */,
 				C8349011C8349011C8349011 /* RecoverableMainWindowRouteOwnerRegistration.swift in Sources */,
 				9666F3019666F3019666F301 /* RecoverableMainWindowRoutePayload.swift in Sources */,
@@ -14883,6 +14895,10 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxSettingsUI;
 		};
+		B750A3000000000000000001 /* XCLocalSwiftPackageReference "CmuxReadAloud" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/macOS/CmuxReadAloud;
+		};
 		CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxUpdater;
@@ -15173,6 +15189,11 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			isa = XCSwiftPackageProductDependency;
 			package = CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */;
 			productName = CmuxSettingsUI;
+		};
+		B750A3000000000000000003 /* CmuxReadAloud */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B750A3000000000000000001 /* XCLocalSwiftPackageReference "CmuxReadAloud" */;
+			productName = CmuxReadAloud;
 		};
 		CDFEED0200000000CDFEED02 /* CmuxUpdater */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -184,6 +184,9 @@
          location = "group:CMUXProjectModel">
       </FileRef>
       <FileRef
+         location = "group:CmuxReadAloud">
+      </FileRef>
+      <FileRef
          location = "group:CmuxRemoteDaemon">
       </FileRef>
       <FileRef


### PR DESCRIPTION
## Summary

Follow-up to [#12225](https://github.com/manaflow-ai/cmux/pull/12225), crediting @asymetryk. This change centralizes validated Read Aloud runtime configuration, keeps editable settings as drafts, removes provider validation drift, sanitizes Keychain errors, registers the settings window for standard close-shortcut routing, and removes the untranslated changelog entry.

## Validation

- `git diff --check`
- `python3 -m json.tool Packages/macOS/CmuxReadAloud/Sources/CmuxReadAloud/Resources/ReadAloudSettings.xcstrings`
- `python3 scripts/lint_auxiliary_window_close_shortcuts.py` (passed)
- `python3 scripts/check-package-resolved-policy.py` (passed)
- `python3 scripts/check-workspace-package-groups.py --check` (passed)
- Swift file length review: changed/new files remain below 500 lines; the referenced `.github/swift-file-length-budget.tsv` is absent in this clone/current main, so the budget script could not be applied against that file.
- Localization audit: updated all localized `error.keychain` values to remove the OSStatus placeholder; removed the untranslated root changelog entry.

Builds and Swift tests were not run. This was performed on Linux per instruction; no Swift compilation, xcodebuild, reload, cloud build, remote build, app launch, or dogfood command was executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-selected terminal text, third-party MiniMax synthesis, and Keychain-stored API keys; playback concurrency is complex but largely isolated in the new package.
> 
> **Overview**
> Adds the **`CmuxReadAloud`** macOS package to CI and introduces the shared runtime for terminal Read Aloud: a validated **`ReadAloudConfiguration`** snapshot (MiniMax turbo/HD model, voice ID, speed), a **`ReadAloudSynthesizing`** streaming contract, and a **`ReadAloudCoordinator`** that gates reads on consent plus Keychain API key, cancels/replaces in-flight work by generation, and pipes PCM chunks into local playback.
> 
> **`PCMReadAloudPlayer`** decodes mono 32 kHz PCM with bounded scheduling (~400 ms ahead), handles partial samples and audio-route changes, and surfaces user-safe playback errors without leaking device details. New **`ReadAloudPlayback`** and **`ReadAloudSettings`** string catalogs cover settings UI copy, cloud-processing consent, and sanitized Keychain/persistence failure messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d5280acf607810d736033ef25e6b9f9c13c57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Read Aloud for terminal selections, streaming selected text through MiniMax speech synthesis in a new `CmuxReadAloud` package. Tests are included, but no macOS build or test run was executed.

**New Features**
- Read Aloud and Stop Speaking context menu items in terminal views.
- Streaming MiniMax client with SSE framing, audio parsing, and PCM playback.
- Read Aloud settings window with model, voice, speed, API key, and consent.

**Bug Fixes**
- Runtime configuration is a single validated snapshot, removing provider validation drift.
- Settings edits stay as drafts until saved.
- Settings window is registered for standard close-shortcut routing.
- Playback recovers the audio graph after configuration failures, and voice IDs are normalized before persistence and synthesis.
- Keychain error messages no longer expose OSStatus placeholders.

<sup>Written for commit 4f1569a19a85db36e1c67e14fad6e596d659207d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Read Aloud for selected terminal text with streamed speech playback.
  * Added context-menu actions to read selected text, stop speaking, and open Read Aloud settings.
  * Added settings for speech model, voice, speed, API key, and cloud-consent preferences.
  * Added automatic cancellation when starting a new reading or stopping playback.
* **Localization**
  * Added translated Read Aloud labels, controls, and error messages across supported languages.
* **Reliability**
  * Added handling for unavailable audio output, network issues, invalid responses, and incomplete speech data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->