### PR TITLE
Follow up #12192: fix grouped Move to Bottom ordering

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19140,7 +19140,7 @@ struct CMUXCLI {
               pin | unpin
               rename | clear-name
               set-description | clear-description
-              move-up | move-down | move-top
+              move-up | move-down | move-top | move-bottom
               close-others | close-above | close-below
               mark-read | mark-unread
               set-color | clear-color

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator+BoundaryMoves.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator+BoundaryMoves.swift
@@ -1,0 +1,136 @@
+public import Foundation
+
+extension WorkspaceReorderCoordinator {
+    // MARK: - Move to top
+
+    /// Moves one workspace to the top of its pin tier.
+    public func moveTabToTop(_ tabId: UUID) {
+        moveTabsToTop([tabId])
+    }
+
+    /// Moves the given workspaces to the top of their pin tiers, preserving
+    /// their relative order (group members hoist behind their anchors).
+    public func moveTabsToTop(_ tabIds: Set<UUID>) {
+        guard !tabIds.isEmpty else { return }
+        let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
+        guard !selectedTabs.isEmpty else { return }
+        let previousOrder = model.tabs.map(\.id)
+
+        if !model.workspaceGroups.isEmpty {
+            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
+            let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
+            let selectedTopLevelIdSet = Set(selectedTopLevelIds)
+            let pinnedTopLevelIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
+            let desiredTopLevelIds =
+                selectedTopLevelIds.filter { pinnedTopLevelIds.contains($0) } +
+                topLevelIds.filter { pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
+                selectedTopLevelIds.filter { !pinnedTopLevelIds.contains($0) } +
+                topLevelIds.filter { !pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) }
+            model.normalizeWorkspaceGroupRunsPreservingOrder(desiredTopLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: desiredTopLevelIds)
+        } else {
+            let remainingTabs = model.tabs.filter { !tabIds.contains($0.id) }
+            let selectedPinned = selectedTabs.filter { $0.isPinned }
+            let selectedUnpinned = selectedTabs.filter { !$0.isPinned }
+            let remainingPinned = remainingTabs.filter { $0.isPinned }
+            let remainingUnpinned = remainingTabs.filter { !$0.isPinned }
+            model.tabs = selectedPinned + remainingPinned + selectedUnpinned + remainingUnpinned
+        }
+        if model.tabs.map(\.id) != previousOrder {
+            host?.workspaceOrderDidChange(movedWorkspaceIds: selectedTabs.map(\.id))
+        }
+    }
+
+    /// Moves a workspace to the top of the unpinned tier for a notification
+    /// bump; no-ops for pinned rows or rows already at the boundary.
+    public func moveTabToTopForNotification(_ tabId: UUID) {
+        guard let tab = model.tabs.first(where: { $0.id == tabId }) else { return }
+        let previousOrder = model.tabs.map(\.id)
+
+        if !model.workspaceGroups.isEmpty {
+            guard let topLevelId = model.topLevelWorkspaceIds(for: [tab]).first else { return }
+            let pinnedTopLevelIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
+            guard !pinnedTopLevelIds.contains(topLevelId) else { return }
+            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: [tabId])
+            var desiredTopLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            guard let fromIndex = desiredTopLevelIds.firstIndex(of: topLevelId) else { return }
+            let pinnedCount = desiredTopLevelIds.reduce(into: 0) { count, id in
+                if pinnedTopLevelIds.contains(id) {
+                    count += 1
+                }
+            }
+            if fromIndex != pinnedCount {
+                let movedId = desiredTopLevelIds.remove(at: fromIndex)
+                desiredTopLevelIds.insert(movedId, at: min(pinnedCount, desiredTopLevelIds.count))
+            }
+            model.normalizeWorkspaceGroupRunsPreservingOrder(desiredTopLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: desiredTopLevelIds)
+        } else {
+            guard let index = model.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+            let pinnedCount = model.tabs.filter { $0.isPinned }.count
+            guard index != pinnedCount else { return }
+            let tab = model.tabs[index]
+            guard !tab.isPinned else { return }
+            model.tabs.remove(at: index)
+            model.tabs.insert(tab, at: pinnedCount)
+        }
+        if model.tabs.map(\.id) != previousOrder {
+            host?.workspaceOrderDidChange(movedWorkspaceIds: [tabId])
+        }
+    }
+
+    /// Moves one workspace to the bottom of its tier and its group member run.
+    public func moveTabToBottom(_ tabId: UUID) {
+        moveTabsToBottom([tabId])
+    }
+
+    /// Whether moving this selection changes member or top-level row order.
+    /// This reads the same plan as the mutation without publishing model changes.
+    public func canMoveTabsToBottom(_ tabIds: Set<UUID>) -> Bool {
+        bottomMovePlan(tabIds) != nil
+    }
+
+    /// Moves selected workspaces to the bottom, preserving selection order,
+    /// group anchors, group membership, and top-level pin tiers.
+    public func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        guard let plan = bottomMovePlan(tabIds) else { return }
+        model.tabs = plan.tabs
+        if let topLevelIds = plan.topLevelIds {
+            model.normalizeWorkspaceGroupRunsPreservingOrder(topLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: topLevelIds)
+        }
+        host?.workspaceOrderDidChange(movedWorkspaceIds: plan.movedIds)
+    }
+
+    /// Plans both member and header movement, including durable empty group rows.
+    private func bottomMovePlan(_ tabIds: Set<UUID>) -> (tabs: [Tab], topLevelIds: [UUID]?, movedIds: [UUID])? {
+        guard !tabIds.isEmpty else { return nil }
+        let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
+        guard !selectedTabs.isEmpty else { return nil }
+        let movedIds = selectedTabs.map(\.id)
+        if !model.workspaceGroups.isEmpty {
+            let reordered = model.workspaceGroupMembersReordered(workspaceIds: movedIds, toBottom: true)
+            let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            let selectedIds = Set(model.topLevelWorkspaceIds(for: selectedTabs))
+            let pinnedIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
+            let desiredIds = bottomTierOrder(topLevelIds, selectedIds: selectedIds, pinnedIds: pinnedIds)
+            guard desiredIds != topLevelIds || reordered.map(\.id) != model.tabs.map(\.id) else { return nil }
+            return (reordered, desiredIds, movedIds)
+        }
+        let currentIds = model.tabs.map(\.id)
+        let pinnedIds = Set(model.tabs.filter(\.isPinned).map(\.id))
+        let desiredIds = bottomTierOrder(currentIds, selectedIds: tabIds, pinnedIds: pinnedIds)
+        guard desiredIds != currentIds else { return nil }
+        let tabsById = Dictionary(uniqueKeysWithValues: model.tabs.map { ($0.id, $0) })
+        return (desiredIds.compactMap { tabsById[$0] }, nil, movedIds)
+    }
+
+    /// Stable partition within each pin tier; selected rows form its suffix.
+    private func bottomTierOrder(_ ids: [UUID], selectedIds: Set<UUID>, pinnedIds: Set<UUID>) -> [UUID] {
+        ids.filter { pinnedIds.contains($0) && !selectedIds.contains($0) } +
+            ids.filter { pinnedIds.contains($0) && selectedIds.contains($0) } +
+            ids.filter { !pinnedIds.contains($0) && !selectedIds.contains($0) } +
+            ids.filter { !pinnedIds.contains($0) && selectedIds.contains($0) }
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -101,6 +101,47 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
         }
     }
 
+    // MARK: - Move to bottom
+
+    /// Moves one workspace to the bottom of its pin tier.
+    public func moveTabToBottom(_ tabId: UUID) {
+        moveTabsToBottom([tabId])
+    }
+
+    /// Moves the given workspaces to the bottom of their pin tiers, preserving
+    /// their relative order (group members trail behind their anchors).
+    public func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        guard !tabIds.isEmpty else { return }
+        let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
+        guard !selectedTabs.isEmpty else { return }
+        let previousOrder = model.tabs.map(\.id)
+
+        if !model.workspaceGroups.isEmpty {
+            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
+            let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
+            let selectedTopLevelIdSet = Set(selectedTopLevelIds)
+            let pinnedTopLevelIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
+            let desiredTopLevelIds =
+                topLevelIds.filter { pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
+                selectedTopLevelIds.filter { pinnedTopLevelIds.contains($0) } +
+                topLevelIds.filter { !pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
+                selectedTopLevelIds.filter { !pinnedTopLevelIds.contains($0) }
+            model.normalizeWorkspaceGroupRunsPreservingOrder(desiredTopLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: desiredTopLevelIds)
+        } else {
+            let remainingTabs = model.tabs.filter { !tabIds.contains($0.id) }
+            let selectedPinned = selectedTabs.filter { $0.isPinned }
+            let selectedUnpinned = selectedTabs.filter { !$0.isPinned }
+            let remainingPinned = remainingTabs.filter { $0.isPinned }
+            let remainingUnpinned = remainingTabs.filter { !$0.isPinned }
+            model.tabs = remainingPinned + selectedPinned + remainingUnpinned + selectedUnpinned
+        }
+        if model.tabs.map(\.id) != previousOrder {
+            host?.workspaceOrderDidChange(movedWorkspaceIds: selectedTabs.map(\.id))
+        }
+    }
+
     // MARK: - Single reorder
 
     /// Reorders one workspace to the clamped target index; drag operations

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -117,7 +117,6 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
         let previousOrder = model.tabs.map(\.id)
 
         if !model.workspaceGroups.isEmpty {
-            model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
             let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
             let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
             let selectedTopLevelIdSet = Set(selectedTopLevelIds)

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
@@ -198,6 +198,11 @@ extension WorkspacesModel {
     /// Hoist promoted (non-anchor) members to the front of their group's
     /// member run, right after the anchor, preserving each group's position.
     func moveWorkspaceGroupMembersAfterAnchors(workspaceIds: [UUID]) {
+        tabs = workspaceGroupMembersReordered(workspaceIds: workspaceIds, toBottom: false)
+    }
+
+    /// Computes member order without mutating the model; anchors always stay first.
+    func workspaceGroupMembersReordered(workspaceIds: [UUID], toBottom: Bool) -> [Tab] {
         let groupsById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
         let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
         var promotedIdsByGroupId: [UUID: [UUID]] = [:]
@@ -210,12 +215,8 @@ extension WorkspacesModel {
             }
             promotedIdsByGroupId[groupId, default: []].append(workspaceId)
         }
-        guard !promotedIdsByGroupId.isEmpty else { return }
+        guard !promotedIdsByGroupId.isEmpty else { return tabs }
 
-        var tabsByGroupId: [UUID: [Tab]] = [:]
-        for tab in tabs {
-            if let groupId = tab.groupId { tabsByGroupId[groupId, default: []].append(tab) }
-        }
         var tabsByGroupId: [UUID: [Tab]] = [:]
         for tab in tabs {
             if let groupId = tab.groupId { tabsByGroupId[groupId, default: []].append(tab) }
@@ -237,9 +238,11 @@ extension WorkspacesModel {
             let remainingMembers = orderedMembers.filter {
                 $0.id != group.anchorWorkspaceId && !promotedIdSet.contains($0.id)
             }
-            replacementMembersByGroupId[groupId] = [anchor] + promotedMembers + remainingMembers
+            replacementMembersByGroupId[groupId] = toBottom
+                ? [anchor] + remainingMembers + promotedMembers
+                : [anchor] + promotedMembers + remainingMembers
         }
-        guard !replacementMembersByGroupId.isEmpty else { return }
+        guard !replacementMembersByGroupId.isEmpty else { return tabs }
 
         var emittedGroupIds = Set<UUID>()
         var reordered: [Tab] = []
@@ -254,7 +257,7 @@ extension WorkspacesModel {
                 reordered.append(tab)
             }
         }
-        tabs = reordered
+        return reordered
     }
 
     /// Applies the detach-path lifecycle for groups anchored by a removed

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+GroupInvariants.swift
@@ -212,11 +212,19 @@ extension WorkspacesModel {
         }
         guard !promotedIdsByGroupId.isEmpty else { return }
 
+        var tabsByGroupId: [UUID: [Tab]] = [:]
+        for tab in tabs {
+            if let groupId = tab.groupId { tabsByGroupId[groupId, default: []].append(tab) }
+        }
+        var tabsByGroupId: [UUID: [Tab]] = [:]
+        for tab in tabs {
+            if let groupId = tab.groupId { tabsByGroupId[groupId, default: []].append(tab) }
+        }
         var replacementMembersByGroupId: [UUID: [Tab]] = [:]
         for (groupId, promotedIds) in promotedIdsByGroupId {
             guard let group = groupsById[groupId] else { continue }
             let orderedMembers = anchorFirst(
-                tabs.filter { $0.groupId == groupId },
+                tabsByGroupId[groupId] ?? [],
                 anchorId: group.anchorWorkspaceId
             )
             guard let anchor = orderedMembers.first(where: { $0.id == group.anchorWorkspaceId }) else { continue }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests+BottomMoves.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests+BottomMoves.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import CmuxWorkspaces
+
+extension WorkspaceCoordinatorTests {
+    @Test
+    func moveTabsToBottomKeepsPinnedTierAboveUnpinned() {
+        let (model, host, _, reorder) = makeWorld()
+        let pinnedA = CoordinatorStubTab(isPinned: true)
+        let pinnedB = CoordinatorStubTab(isPinned: true)
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [pinnedA, pinnedB, plain1, plain2]
+        reorder.moveTabsToBottom([plain1.id, pinnedA.id])
+        // Each selection sinks to the end of its own tier; tiers stay separated.
+        #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
+        #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
+            == [pinnedA.id, plain1.id].sorted(by: { $0.uuidString < $1.uuidString }))
+    }
+
+    @Test
+    func moveTabToBottomSinksSingleRowWithinItsTier() {
+        let (model, _, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        let plain3 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2, plain3]
+        reorder.moveTabToBottom(plain1.id)
+        #expect(model.tabs.map(\.id) == [plain2.id, plain3.id, plain1.id])
+    }
+
+    @Test
+    func moveTabToBottomOnLastRowPublishesNoOrderChange() {
+        let (model, host, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2]
+        let before = host.orderChanges.count
+        reorder.moveTabToBottom(plain2.id)
+        #expect(model.tabs.map(\.id) == [plain1.id, plain2.id])
+        #expect(host.orderChanges.count == before)
+    }
+
+    @Test
+    func moveToBottomSinksGroupedChildrenAndKeepsAnchorFirst() throws {
+        let (model, host, groups, reorder) = makeWorld()
+        let first = CoordinatorStubTab()
+        let middle = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        let outside = CoordinatorStubTab()
+        model.tabs = [first, middle, last, outside]
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "G", childWorkspaceIds: [first.id, middle.id, last.id]
+        ))
+        let anchorId = try #require(model.workspaceGroups.first { $0.id == groupId }?.anchorWorkspaceId)
+
+        reorder.moveTabsToBottom([first.id, middle.id])
+
+        #expect(model.tabs.map(\.id) == [outside.id, anchorId, last.id, first.id, middle.id])
+        #expect([first, middle, last].allSatisfy { $0.groupId == groupId })
+        let changes = host.orderChanges.count
+        reorder.moveTabsToBottom([first.id, middle.id])
+        #expect(host.orderChanges.count == changes)
+
+        reorder.moveTabToTop(middle.id)
+        #expect(model.tabs.map(\.id) == [anchorId, middle.id, last.id, first.id, outside.id])
+    }
+
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -142,6 +142,44 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func moveTabsToBottomKeepsPinnedTierAboveUnpinned() {
+        let (model, host, _, reorder) = makeWorld()
+        let pinnedA = CoordinatorStubTab(isPinned: true)
+        let pinnedB = CoordinatorStubTab(isPinned: true)
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [pinnedA, pinnedB, plain1, plain2]
+        reorder.moveTabsToBottom([plain1.id, pinnedA.id])
+        // Each selection sinks to the end of its own tier; tiers stay separated.
+        #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
+        #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
+            == [pinnedA.id, plain1.id].sorted(by: { $0.uuidString < $1.uuidString }))
+    }
+
+    @Test
+    func moveTabToBottomSinksSingleRowWithinItsTier() {
+        let (model, _, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        let plain3 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2, plain3]
+        reorder.moveTabToBottom(plain1.id)
+        #expect(model.tabs.map(\.id) == [plain2.id, plain3.id, plain1.id])
+    }
+
+    @Test
+    func moveTabToBottomOnLastRowPublishesNoOrderChange() {
+        let (model, host, _, reorder) = makeWorld()
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [plain1, plain2]
+        let before = host.orderChanges.count
+        reorder.moveTabToBottom(plain2.id)
+        #expect(model.tabs.map(\.id) == [plain1.id, plain2.id])
+        #expect(host.orderChanges.count == before)
+    }
+
+    @Test
     func reorderWorkspaceClampsUnpinnedAbovePinnedBoundary() {
         let (model, host, _, reorder) = makeWorld()
         _ = host

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -110,7 +110,7 @@ final class StubGroupHost: WorkspaceGroupHosting {
 
 @MainActor
 struct WorkspaceCoordinatorTests {
-    private func makeWorld() -> (
+    func makeWorld() -> (
         model: WorkspacesModel<CoordinatorStubTab>,
         host: StubGroupHost,
         groups: WorkspaceGroupCoordinator<CoordinatorStubTab>,
@@ -139,69 +139,6 @@ struct WorkspaceCoordinatorTests {
         #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
         #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
             == [pinnedB.id, plain2.id].sorted(by: { $0.uuidString < $1.uuidString }))
-    }
-
-    @Test
-    func moveTabsToBottomKeepsPinnedTierAboveUnpinned() {
-        let (model, host, _, reorder) = makeWorld()
-        let pinnedA = CoordinatorStubTab(isPinned: true)
-        let pinnedB = CoordinatorStubTab(isPinned: true)
-        let plain1 = CoordinatorStubTab()
-        let plain2 = CoordinatorStubTab()
-        model.tabs = [pinnedA, pinnedB, plain1, plain2]
-        reorder.moveTabsToBottom([plain1.id, pinnedA.id])
-        // Each selection sinks to the end of its own tier; tiers stay separated.
-        #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
-        #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
-            == [pinnedA.id, plain1.id].sorted(by: { $0.uuidString < $1.uuidString }))
-    }
-
-    @Test
-    func moveTabToBottomSinksSingleRowWithinItsTier() {
-        let (model, _, _, reorder) = makeWorld()
-        let plain1 = CoordinatorStubTab()
-        let plain2 = CoordinatorStubTab()
-        let plain3 = CoordinatorStubTab()
-        model.tabs = [plain1, plain2, plain3]
-        reorder.moveTabToBottom(plain1.id)
-        #expect(model.tabs.map(\.id) == [plain2.id, plain3.id, plain1.id])
-    }
-
-    @Test
-    func moveTabToBottomOnLastRowPublishesNoOrderChange() {
-        let (model, host, _, reorder) = makeWorld()
-        let plain1 = CoordinatorStubTab()
-        let plain2 = CoordinatorStubTab()
-        model.tabs = [plain1, plain2]
-        let before = host.orderChanges.count
-        reorder.moveTabToBottom(plain2.id)
-        #expect(model.tabs.map(\.id) == [plain1.id, plain2.id])
-        #expect(host.orderChanges.count == before)
-    }
-
-    @Test
-    func moveToBottomSinksGroupedChildrenAndKeepsAnchorFirst() throws {
-        let (model, host, groups, reorder) = makeWorld()
-        let first = CoordinatorStubTab()
-        let middle = CoordinatorStubTab()
-        let last = CoordinatorStubTab()
-        let outside = CoordinatorStubTab()
-        model.tabs = [first, middle, last, outside]
-        let groupId = try #require(groups.createWorkspaceGroup(
-            name: "G", childWorkspaceIds: [first.id, middle.id, last.id]
-        ))
-        let anchorId = try #require(model.workspaceGroups.first { $0.id == groupId }?.anchorWorkspaceId)
-
-        reorder.moveTabsToBottom([first.id, middle.id])
-
-        #expect(model.tabs.map(\.id) == [outside.id, anchorId, last.id, first.id, middle.id])
-        #expect([first, middle, last].allSatisfy { $0.groupId == groupId })
-        let changes = host.orderChanges.count
-        reorder.moveTabsToBottom([first.id, middle.id])
-        #expect(host.orderChanges.count == changes)
-
-        reorder.moveTabToTop(middle.id)
-        #expect(model.tabs.map(\.id) == [anchorId, middle.id, last.id, first.id, outside.id])
     }
 
     @Test

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -180,6 +180,31 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func moveToBottomSinksGroupedChildrenAndKeepsAnchorFirst() throws {
+        let (model, host, groups, reorder) = makeWorld()
+        let first = CoordinatorStubTab()
+        let middle = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        let outside = CoordinatorStubTab()
+        model.tabs = [first, middle, last, outside]
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "G", childWorkspaceIds: [first.id, middle.id, last.id]
+        ))
+        let anchorId = try #require(model.workspaceGroups.first { $0.id == groupId }?.anchorWorkspaceId)
+
+        reorder.moveTabsToBottom([first.id, middle.id])
+
+        #expect(model.tabs.map(\.id) == [outside.id, anchorId, last.id, first.id, middle.id])
+        #expect([first, middle, last].allSatisfy { $0.groupId == groupId })
+        let changes = host.orderChanges.count
+        reorder.moveTabsToBottom([first.id, middle.id])
+        #expect(host.orderChanges.count == changes)
+
+        reorder.moveTabToTop(middle.id)
+        #expect(model.tabs.map(\.id) == [anchorId, middle.id, last.id, first.id, outside.id])
+    }
+
+    @Test
     func reorderWorkspaceClampsUnpinnedAbovePinnedBoundary() {
         let (model, host, _, reorder) = makeWorld()
         _ = host

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -94511,7 +94511,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nach unten bewegen"
+            "value": "Ganz nach unten verschieben"
           }
         },
         "en": {
@@ -94571,7 +94571,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Переместить вниз"
+            "value": "Переместить в конец"
           }
         },
         "th": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -94487,6 +94487,125 @@
         }
       }
     },
+    "contextMenu.moveToBottom": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقل إلى الأسفل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomjeri na dno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flyt til bunden"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten bewegen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Bottom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover al final"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer en bas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta in fondo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一番下に移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "맨 아래로 이동"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flytt til bunnen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś na dół"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para o Final"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить вниз"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ย้ายไปด้านล่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En Alta Taşı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемістити в кінець"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移到底部"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移至最下方"
+          }
+        }
+      }
+    },
     "contextMenu.moveToTop": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -94544,6 +94544,12 @@
             "value": "一番下に移動"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្លាស់ទីទៅបាតបញ្ជី"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7818,6 +7818,16 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.moveWorkspaceToBottom",
+                title: constant(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")),
+                subtitle: workspaceSubtitle,
+                keywords: ["workspace", "move", "bottom", "reorder"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceHasBelow) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.closeOtherWorkspaces",
                 title: constant(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")),
                 subtitle: workspaceSubtitle,
@@ -8927,6 +8937,14 @@ struct ContentView: View {
                 return
             }
             tabManager.moveTabsToTop([workspace.id])
+            tabManager.selectWorkspace(workspace)
+        }
+        registry.register(commandId: "palette.moveWorkspaceToBottom") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            tabManager.moveTabsToBottom([workspace.id])
             tabManager.selectWorkspace(workspace)
         }
         WorkspaceTodoPaletteCommands.registerHandlers(in: &registry, tabManager: tabManager)
@@ -15027,6 +15045,10 @@ struct VerticalTabsSidebar: View, Equatable {
             },
             moveTargetsToTop: { targetIds in
                 tabManager.moveTabsToTop(Set(targetIds))
+                syncWorkspaceRowSelectionAfterMutation()
+            },
+            moveTargetsToBottom: { targetIds in
+                tabManager.moveTabsToBottom(Set(targetIds))
                 syncWorkspaceRowSelectionAfterMutation()
             },
             currentWindowMoveTargets: {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -648,6 +648,14 @@ struct SidebarWorkspaceRowMenuBuilder {
             tabManager.moveTabsToTop(Set(commands.contextMenuWorkspaceIds))
             commands.syncSelectionAfterMutation()
         })
+        menu.addItem(item(
+            String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom"),
+            enabled: !targetIds.isEmpty
+        ) { [weak tabManager, commands] in
+            guard let tabManager else { return }
+            tabManager.moveTabsToBottom(Set(commands.contextMenuWorkspaceIds))
+            commands.syncSelectionAfterMutation()
+        })
 
         let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
         let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []

--- a/Sources/SidebarWorkspaceRowActions.swift
+++ b/Sources/SidebarWorkspaceRowActions.swift
@@ -17,6 +17,7 @@ struct SidebarWorkspaceRowActions {
     let closeWorkspace: () -> Void
     let moveBy: (Int) -> Void
     let moveTargetsToTop: ([UUID]) -> Void
+    let moveTargetsToBottom: ([UUID]) -> Void
     /// Resolves volatile app-window topology when the deferred menu is presented.
     let currentWindowMoveTargets: () -> [SidebarWorkspaceWindowMoveTarget]
     let moveTargetsToWindow: ([UUID], UUID) -> Void

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -221,6 +221,11 @@ extension TabItemView {
         }
         .disabled(targetIds.isEmpty)
 
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            actions.moveTargetsToBottom(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
+
         Menu(moveMenuTitle) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
                 actions.moveTargetsToNewWindow(targetIds)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1931,6 +1931,14 @@ class TabManager: ObservableObject {
         workspaceReordering.moveTabToTopForNotification(tabId)
     }
 
+    func moveTabToBottom(_ tabId: UUID) {
+        workspaceReordering.moveTabToBottom(tabId)
+    }
+
+    func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        workspaceReordering.moveTabsToBottom(tabIds)
+    }
+
     @discardableResult
     func reorderWorkspace(tabId: UUID, toIndex targetIndex: Int, isDragOperation: Bool = false) -> Bool {
         workspaceReordering.reorderWorkspace(tabId: tabId, toIndex: targetIndex, isDragOperation: isDragOperation)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5289,7 +5289,7 @@ class TerminalController {
         let supportedActions = [
             "pin", "unpin", "rename", "clear_name",
             "set_description", "clear_description",
-            "move_up", "move_down", "move_top",
+            "move_up", "move_down", "move_top", "move_bottom",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
             "set_color", "clear_color", "mobile_connect"
@@ -5416,6 +5416,10 @@ class TerminalController {
 
             case "move_top":
                 tabManager.moveTabToTop(workspace.id)
+                finish(["index": v2OrNull(tabManager.tabs.firstIndex(where: { $0.id == workspace.id }))])
+
+            case "move_bottom":
+                tabManager.moveTabToBottom(workspace.id)
                 finish(["index": v2OrNull(tabManager.tabs.firstIndex(where: { $0.id == workspace.id }))])
 
             case "close_others":

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1380,6 +1380,12 @@ struct cmuxApp: App {
         manager.selectWorkspace(workspace)
     }
 
+    private func moveSelectedWorkspaceToBottom(in manager: TabManager) {
+        guard let workspace = manager.selectedWorkspace else { return }
+        manager.moveTabsToBottom([workspace.id])
+        manager.selectWorkspace(workspace)
+    }
+
     private func moveSelectedWorkspace(in manager: TabManager, toWindow windowId: UUID) {
         guard let workspace = manager.selectedWorkspace else { return }
         _ = AppDelegate.shared?.moveWorkspaceToWindow(workspaceId: workspace.id, windowId: windowId, focus: true)
@@ -1482,6 +1488,11 @@ struct cmuxApp: App {
             moveSelectedWorkspaceToTop(in: manager)
         }
         .disabled(workspace == nil || workspaceIndex == 0)
+
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            moveSelectedWorkspaceToBottom(in: manager)
+        }
+        .disabled(workspace == nil || workspaceIndex == manager.tabs.count - 1)
 
         Menu(String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {

--- a/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
+++ b/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
@@ -145,6 +145,7 @@ struct SidebarWorkspaceContextMenuWindowTargetsTests {
             closeWorkspace: {},
             moveBy: { _ in },
             moveTargetsToTop: { _ in },
+            moveTargetsToBottom: { _ in },
             currentWindowMoveTargets: currentWindowMoveTargets,
             moveTargetsToWindow: { _, _ in },
             moveTargetsToNewWindow: { _ in },

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -370,7 +370,7 @@ Workspace and tab action names:
 
 | Command | Actions |
 | --- | --- |
-| `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
+| `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `move-bottom`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
 | `tab-action` | `rename`, `clear-name`, `close-left`, `close-right`, `close-others`, `new-terminal-right`, `new-browser-right`, `reload`, `duplicate`, `pin`, `unpin`, `mark-unread` |
 
 ### Workspace environment variables

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -165,7 +165,7 @@ Rules of the runtime:
   items are ordinary Button/Menu/Divider nodes, so labels and actions can be
   live bindings (`Button(() => w().pinned ? "Unpin" : "Pin", ...)`). Useful
   verbs: `workspace.action` (pin/unpin, mark_read/mark_unread,
-  move_up/move_down/move_top, close_others, set/clear color and description),
+  move_up/move_down/move_top/move_bottom, close_others, set/clear color and description),
   `workspace.close`, `workspace.move_to_window`, `workspace.group.action`
   (pin/unpin/ungroup/delete), `workspace.group.collapse` / `.expand`.
 - Actions: `cmux(method, params)`, `openURL(url)`, `log(message)` anywhere in

--- a/skills/cmux/references/windows-workspaces.md
+++ b/skills/cmux/references/windows-workspaces.md
@@ -32,4 +32,4 @@ cmux workspace-action --action pin
 cmux workspace-action --action clear-color
 ```
 
-Other actions: `unpin`, `clear-name`, `clear-description`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`, `close-others`/`close-above`/`close-below`. Named colors: Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua, Blue, Navy, Indigo, Purple, Magenta, Rose, Brown, Charcoal. `set-color` tints a single workspace (stored as workspace state); the `workspaceColors` block in `cmux.json` defines the shared palette and selection/badge colors, not per-workspace assignments.
+Other actions: `unpin`, `clear-name`, `clear-description`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`/`move-bottom`, `close-others`/`close-above`/`close-below`. Named colors: Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua, Blue, Navy, Indigo, Purple, Magenta, Rose, Brown, Charcoal. `set-color` tints a single workspace (stored as workspace state); the `workspaceColors` block in `cmux.json` defines the shared palette and selection/badge colors, not per-workspace assignments.


### PR DESCRIPTION
Follow-up to #12192, crediting @Rajkumar2002-Rk.

Fixes concrete review issues:
- Grouped Move to Bottom now keeps anchors first and sinks selected members within their group instead of hoisting them.
- Group member lookup is indexed in one pass to avoid quadratic scans.
- Adds grouped ordering/no-op regression coverage.
- Adds the missing Khmer localization.

Linux-only checks run: `git diff --check` and `python3 -m json.tool Resources/Localizable.xcstrings`. `python3 scripts/swift_file_length_budget.py` was also run and reports pre-existing/source-PR budget overruns in touched files; no budgets were changed. Swift/macOS builds, Swift compilation, xcodebuild, reload, cloud builds, and dogfood were not run per task constraints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace tab ordering with workspace groups and pin tiers across UI and automation APIs; incorrect logic could scramble sidebar order but does not touch auth or data persistence.
> 
> **Overview**
> Adds **Move to Bottom** as a workspace reorder action alongside the existing move-to-top flow, wired through sidebar/SwiftUI and AppKit context menus, the command palette, `TabManager`, and `workspace-action` / `move_bottom` (CLI + socket docs).
> 
> The follow-up fixes **grouped** bottom moves: `workspaceGroupMembersReordered(..., toBottom:)` now sinks selected non-anchor members to the end of their group run (anchor stays first), and bottom moves use a **`bottomMovePlan`** that combines member reordering with per–pin-tier top-level ordering. Boundary move-to-top/bottom logic is consolidated in `WorkspaceReorderCoordinator+BoundaryMoves.swift`, with **`canMoveTabsToBottom`** for no-op detection. New coordinator tests cover pin tiers, already-at-bottom no-ops, and grouped children. **`contextMenu.moveToBottom`** localization is added (including Khmer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb29caa84a70a5c8eacb9353361ffa9931a25cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Move to Bottom for grouped workspaces so each group's anchor stays first and selected members sink to the end of their run. Previously, grouped bottom moves could break anchor-first ordering.

- Group member reordering is now a pure function, and lookup uses a per-group tab dictionary instead of filtering the full tab list per group.
- Move to Bottom publishes no order change when the planned order matches the current order.
- Adds regression tests for grouped and ungrouped bottom moves, plus Khmer localization for the menu entry.

<sup>Written for commit deb29caa84a70a5c8eacb9353361ffa9931a25cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Move to Bottom” for workspaces in context menus, the command palette, and terminal actions.
  - Supports moving individual or multiple workspaces while preserving pinned sections and workspace groups.
  - Added localized text and CLI/sidebar action support for `move-bottom`.

- **Bug Fixes**
  - Prevents unnecessary reorder updates when a workspace is already at the bottom.

- **Documentation**
  - Updated workspace action references to include `move-bottom`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->