### PR TITLE
Raise inherited file descriptor limits with an injectable startup controller

### DIFF
--- a/Packages/macOS/CmuxFoundation/README.md
+++ b/Packages/macOS/CmuxFoundation/README.md
@@ -115,17 +115,21 @@ pair, and `writeLimit` returns whether the requested pair was accepted:
 
 ```swift
 import Darwin
+import Testing
+import CmuxFoundation
 
-var limits = rlimit()
-limits.rlim_cur = 256
-limits.rlim_max = 10_240
-let controller = FileDescriptorLimitController(
-    readLimit: { limits },
-    writeLimit: { limits = $0; return true }
-)
-controller.raiseSoftLimitIfNeeded()
-#expect(limits.rlim_cur == 10_240)
-#expect(limits.rlim_max == 10_240)
+@Test func raisesSoftLimitWithinHardLimit() {
+    var limits = rlimit()
+    limits.rlim_cur = 256
+    limits.rlim_max = 10_240
+    let controller = FileDescriptorLimitController(
+        readLimit: { limits },
+        writeLimit: { limits = $0; return true }
+    )
+    controller.raiseSoftLimitIfNeeded()
+    #expect(limits.rlim_cur == 10_240)
+    #expect(limits.rlim_max == 10_240)
+}
 ```
 
 The Codex editor takes fixture strings, so its install/reinstall/uninstall behavior is

--- a/Packages/macOS/CmuxFoundation/README.md
+++ b/Packages/macOS/CmuxFoundation/README.md
@@ -32,6 +32,8 @@ so call sites read naturally (`value.javaScriptStringLiteral`, not `f(value)`).
   lifecycle-bound repeating main-actor action.
 - `MainActorTaskStore` — keyed replaceable task ownership that keeps task
   handles out of captured SwiftUI value snapshots.
+- `FileDescriptorLimitController` — a synchronous startup policy that raises
+  inherited descriptor limits before workers and terminal children start.
 
 ## Usage
 
@@ -105,6 +107,25 @@ import CmuxFoundation
 @Test func plainStringIsQuoted() {
     #expect("hello".javaScriptStringLiteral == "\"hello\"")
 }
+```
+
+File-descriptor tests inject both resource-limit operations so they never mutate
+the test runner's process-wide limit. `readLimit` supplies the current soft/hard
+pair, and `writeLimit` returns whether the requested pair was accepted:
+
+```swift
+import Darwin
+
+var limits = rlimit()
+limits.rlim_cur = 256
+limits.rlim_max = 10_240
+let controller = FileDescriptorLimitController(
+    readLimit: { limits },
+    writeLimit: { limits = $0; return true }
+)
+controller.raiseSoftLimitIfNeeded()
+#expect(limits.rlim_cur == 10_240)
+#expect(limits.rlim_max == 10_240)
 ```
 
 The Codex editor takes fixture strings, so its install/reinstall/uninstall behavior is

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Process/FileDescriptorLimitController.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Process/FileDescriptorLimitController.swift
@@ -1,0 +1,69 @@
+public import Darwin
+
+/// Raises the process file-descriptor soft limit before child processes inherit it.
+///
+/// GUI apps can inherit launchd's low `RLIMIT_NOFILE` soft limit. Construct this
+/// controller at process entry and call it before worker routing or child creation.
+/// The preferred value is 65,536, with 10,240 and 8,192 fallbacks for Darwin
+/// configurations that reject the larger requests. The hard limit is preserved.
+///
+/// ```swift
+/// FileDescriptorLimitController().raiseSoftLimitIfNeeded()
+/// ```
+public struct FileDescriptorLimitController {
+    private let softLimitTargets: [rlim_t]
+    private let readLimit: () -> rlimit?
+    private let writeLimit: (rlimit) -> Bool
+
+    /// Creates a controller with an ordered limit policy and resource-limit operations.
+    ///
+    /// Construction performs no system calls. Inject both operations to exercise
+    /// the policy without changing the process-wide limits in a test host.
+    ///
+    /// - Parameters:
+    ///   - preferredSoftLimit: The first target, defaulting to 65,536 descriptors.
+    ///   - fallbackSoftLimits: Targets tried after rejected writes, defaulting to
+    ///     10,240 and 8,192 for compatibility with lower Darwin ceilings.
+    ///   - readLimit: Reads the current pair, or returns `nil` on failure.
+    ///     Defaults to `getrlimit(RLIMIT_NOFILE, ...)`.
+    ///   - writeLimit: Applies a pair and reports success. Defaults to
+    ///     `setrlimit(RLIMIT_NOFILE, ...)`; failed writes must leave the pair unchanged.
+    public init(
+        preferredSoftLimit: rlim_t = 65_536,
+        fallbackSoftLimits: [rlim_t] = [10_240, 8_192],
+        readLimit: @escaping () -> rlimit? = {
+            var limit = rlimit()
+            guard Darwin.getrlimit(RLIMIT_NOFILE, &limit) == 0 else { return nil }
+            return limit
+        },
+        writeLimit: @escaping (rlimit) -> Bool = { limit in
+            var updated = limit
+            return Darwin.setrlimit(RLIMIT_NOFILE, &updated) == 0
+        }
+    ) {
+        self.softLimitTargets = [preferredSoftLimit] + fallbackSoftLimits
+        self.readLimit = readLimit
+        self.writeLimit = writeLimit
+    }
+
+    /// Best-effort raises the soft limit without lowering it or changing the hard limit.
+    ///
+    /// Read failures leave the limit alone; write failures advance to the next
+    /// eligible target. An already-sufficient or unlimited soft limit is unchanged.
+    /// Run synchronously before concurrent startup so another writer cannot change
+    /// the process-wide limits between the read and write.
+    public func raiseSoftLimitIfNeeded() {
+        guard let limit = readLimit() else { return }
+
+        for target in softLimitTargets {
+            // Darwin's unlimited sentinel exceeds the finite startup targets,
+            // so this also preserves unlimited soft and hard limits.
+            let newSoftLimit = min(target, limit.rlim_max)
+            guard newSoftLimit > limit.rlim_cur else { continue }
+
+            var updated = limit
+            updated.rlim_cur = newSoftLimit
+            if writeLimit(updated) { return }
+        }
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitControllerTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitControllerTests.swift
@@ -1,0 +1,162 @@
+import Darwin
+import Testing
+
+import CmuxFoundation
+
+@Suite("File descriptor limit controller")
+struct FileDescriptorLimitControllerTests {
+    /// Darwin's `RLIM_INFINITY` macro is not imported into Swift.
+    private let unlimited = rlim_t(Int64.max)
+
+    @Test("Raises low inherited limits", arguments: [rlim_t(256), 8_192])
+    func raisesLowInheritedLimits(soft: rlim_t) {
+        let system = FileDescriptorLimitSystemStub(soft: soft, hard: unlimited)
+        let controller = FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        )
+
+        controller.raiseSoftLimitIfNeeded()
+
+        #expect(system.limits?.rlim_cur == 65_536)
+        #expect(system.limits?.rlim_max == unlimited)
+        #expect(system.attemptedLimits.count == 1)
+    }
+
+    @Test("Never lowers sufficient or unlimited limits", arguments: [rlim_t(65_536), 100_000, rlim_t(Int64.max)])
+    func leavesSufficientLimitsAlone(soft: rlim_t) {
+        let system = FileDescriptorLimitSystemStub(soft: soft, hard: unlimited)
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.isEmpty)
+        #expect(system.limits?.rlim_cur == soft)
+    }
+
+    @Test("Clamps to finite hard limits", arguments: [rlim_t(512), 8_192, 10_240])
+    func respectsFiniteHardLimits(hard: rlim_t) {
+        let system = FileDescriptorLimitSystemStub(soft: 256, hard: hard)
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.limits?.rlim_cur == hard)
+        #expect(system.limits?.rlim_max == hard)
+        #expect(system.attemptedLimits.count == 1)
+    }
+
+    @Test("Does not change an exhausted hard limit", arguments: [rlim_t(0), 256, 8_192])
+    func leavesExhaustedHardLimitsAlone(hard: rlim_t) {
+        let system = FileDescriptorLimitSystemStub(soft: hard, hard: hard)
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.isEmpty)
+    }
+
+    @Test("Stops at the first accepted target", arguments: [
+        (rlim_t(65_536), [rlim_t(65_536)]),
+        (rlim_t(10_240), [rlim_t(65_536), 10_240]),
+        (rlim_t(8_192), [rlim_t(65_536), 10_240, 8_192])
+    ])
+    func retriesRejectedTargets(maximumAccepted: rlim_t, expectedAttempts: [rlim_t]) {
+        let system = FileDescriptorLimitSystemStub(
+            soft: 256,
+            hard: unlimited,
+            maximumAcceptedSoftLimit: maximumAccepted
+        )
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.map(\.rlim_cur) == expectedAttempts)
+        #expect(system.attemptedLimits.allSatisfy { $0.rlim_max == unlimited })
+        #expect(system.limits?.rlim_cur == maximumAccepted)
+    }
+
+    @Test("Ignores a failed limits read")
+    func ignoresReadFailure() {
+        let system = FileDescriptorLimitSystemStub(soft: nil)
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.readCount == 1)
+        #expect(system.attemptedLimits.isEmpty)
+    }
+
+    @Test("Leaves the original pair intact when all writes fail")
+    func ignoresWriteFailures() {
+        let system = FileDescriptorLimitSystemStub(
+            soft: 256,
+            hard: unlimited,
+            maximumAcceptedSoftLimit: nil
+        )
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.map(\.rlim_cur) == [65_536, 10_240, 8_192])
+        #expect(system.attemptedLimits.allSatisfy { $0.rlim_max == unlimited })
+        #expect(system.limits?.rlim_cur == 256)
+        #expect(system.limits?.rlim_max == unlimited)
+    }
+
+    @Test("Rejected raises never fall back below the inherited soft limit")
+    func skipsLowerFallbacks() {
+        let system = FileDescriptorLimitSystemStub(
+            soft: 20_000,
+            hard: unlimited,
+            maximumAcceptedSoftLimit: nil
+        )
+        FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.map(\.rlim_cur) == [65_536])
+        #expect(system.limits?.rlim_cur == 20_000)
+    }
+
+    @Test("Uses injected limit configuration")
+    func usesConfiguredTargets() {
+        let system = FileDescriptorLimitSystemStub(
+            soft: 256,
+            hard: unlimited,
+            maximumAcceptedSoftLimit: 15_000
+        )
+        FileDescriptorLimitController(
+            preferredSoftLimit: 20_000,
+            fallbackSoftLimits: [15_000],
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        ).raiseSoftLimitIfNeeded()
+
+        #expect(system.attemptedLimits.map(\.rlim_cur) == [20_000, 15_000])
+        #expect(system.limits?.rlim_cur == 15_000)
+    }
+
+    @Test("A repeated invocation reads the raised limit without rewriting it")
+    func doesNotRewriteSufficientLimit() {
+        let system = FileDescriptorLimitSystemStub(soft: 256, hard: unlimited)
+        let controller = FileDescriptorLimitController(
+            readLimit: system.readLimit,
+            writeLimit: system.writeLimit
+        )
+
+        controller.raiseSoftLimitIfNeeded()
+        controller.raiseSoftLimitIfNeeded()
+
+        #expect(system.readCount == 2)
+        #expect(system.attemptedLimits.count == 1)
+        #expect(system.limits?.rlim_cur == 65_536)
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitControllerTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitControllerTests.swift
@@ -8,6 +8,7 @@ struct FileDescriptorLimitControllerTests {
     /// Darwin's `RLIM_INFINITY` macro is not imported into Swift.
     private let unlimited = rlim_t(Int64.max)
 
+    /// Verifies that low inherited limits are raised to the preferred target.
     @Test("Raises low inherited limits", arguments: [rlim_t(256), 8_192])
     func raisesLowInheritedLimits(soft: rlim_t) {
         let system = FileDescriptorLimitSystemStub(soft: soft, hard: unlimited)
@@ -23,6 +24,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.attemptedLimits.count == 1)
     }
 
+    /// Verifies that sufficient and unlimited soft limits are left untouched.
     @Test("Never lowers sufficient or unlimited limits", arguments: [rlim_t(65_536), 100_000, rlim_t(Int64.max)])
     func leavesSufficientLimitsAlone(soft: rlim_t) {
         let system = FileDescriptorLimitSystemStub(soft: soft, hard: unlimited)
@@ -35,6 +37,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.limits?.rlim_cur == soft)
     }
 
+    /// Verifies that a finite hard limit caps the requested soft limit.
     @Test("Clamps to finite hard limits", arguments: [rlim_t(512), 8_192, 10_240])
     func respectsFiniteHardLimits(hard: rlim_t) {
         let system = FileDescriptorLimitSystemStub(soft: 256, hard: hard)
@@ -48,6 +51,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.attemptedLimits.count == 1)
     }
 
+    /// Verifies that a soft limit already at its hard ceiling is unchanged.
     @Test("Does not change an exhausted hard limit", arguments: [rlim_t(0), 256, 8_192])
     func leavesExhaustedHardLimitsAlone(hard: rlim_t) {
         let system = FileDescriptorLimitSystemStub(soft: hard, hard: hard)
@@ -59,6 +63,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.attemptedLimits.isEmpty)
     }
 
+    /// Verifies that rejected targets are retried in configured order.
     @Test("Stops at the first accepted target", arguments: [
         (rlim_t(65_536), [rlim_t(65_536)]),
         (rlim_t(10_240), [rlim_t(65_536), 10_240]),
@@ -80,6 +85,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.limits?.rlim_cur == maximumAccepted)
     }
 
+    /// Verifies that a failed resource-limit read does not attempt a write.
     @Test("Ignores a failed limits read")
     func ignoresReadFailure() {
         let system = FileDescriptorLimitSystemStub(soft: nil)
@@ -92,6 +98,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.attemptedLimits.isEmpty)
     }
 
+    /// Verifies that failed writes do not mutate the supplied limits snapshot.
     @Test("Leaves the original pair intact when all writes fail")
     func ignoresWriteFailures() {
         let system = FileDescriptorLimitSystemStub(
@@ -110,6 +117,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.limits?.rlim_max == unlimited)
     }
 
+    /// Verifies that fallback targets below the inherited soft limit are skipped.
     @Test("Rejected raises never fall back below the inherited soft limit")
     func skipsLowerFallbacks() {
         let system = FileDescriptorLimitSystemStub(
@@ -126,6 +134,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.limits?.rlim_cur == 20_000)
     }
 
+    /// Verifies that callers can provide a custom preferred and fallback policy.
     @Test("Uses injected limit configuration")
     func usesConfiguredTargets() {
         let system = FileDescriptorLimitSystemStub(
@@ -144,6 +153,7 @@ struct FileDescriptorLimitControllerTests {
         #expect(system.limits?.rlim_cur == 15_000)
     }
 
+    /// Verifies that a second invocation is idempotent after a successful raise.
     @Test("A repeated invocation reads the raised limit without rewriting it")
     func doesNotRewriteSufficientLimit() {
         let system = FileDescriptorLimitSystemStub(soft: 256, hard: unlimited)

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitSystemStub.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitSystemStub.swift
@@ -1,0 +1,40 @@
+import Darwin
+
+/// An in-memory resource-limit system confined to one synchronous test invocation.
+final class FileDescriptorLimitSystemStub {
+    var limits: rlimit?
+    private let maximumAcceptedSoftLimit: rlim_t?
+    private(set) var readCount = 0
+    private(set) var attemptedLimits: [rlimit] = []
+
+    init(
+        soft: rlim_t?,
+        hard: rlim_t = rlim_t(Int64.max),
+        maximumAcceptedSoftLimit: rlim_t? = rlim_t(Int64.max)
+    ) {
+        if let soft {
+            var limits = rlimit()
+            limits.rlim_cur = soft
+            limits.rlim_max = hard
+            self.limits = limits
+        } else {
+            self.limits = nil
+        }
+        self.maximumAcceptedSoftLimit = maximumAcceptedSoftLimit
+    }
+
+    func readLimit() -> rlimit? {
+        readCount += 1
+        return limits
+    }
+
+    func writeLimit(_ limit: rlimit) -> Bool {
+        attemptedLimits.append(limit)
+        guard let maximumAcceptedSoftLimit,
+              limit.rlim_cur <= maximumAcceptedSoftLimit else {
+            return false
+        }
+        limits = limit
+        return true
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitSystemStub.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/FileDescriptorLimitSystemStub.swift
@@ -7,6 +7,7 @@ final class FileDescriptorLimitSystemStub {
     private(set) var readCount = 0
     private(set) var attemptedLimits: [rlimit] = []
 
+    /// Creates a stub with an optional initial limit pair and an acceptance ceiling.
     init(
         soft: rlim_t?,
         hard: rlim_t = rlim_t(Int64.max),
@@ -23,11 +24,13 @@ final class FileDescriptorLimitSystemStub {
         self.maximumAcceptedSoftLimit = maximumAcceptedSoftLimit
     }
 
+    /// Returns the current in-memory limit pair.
     func readLimit() -> rlimit? {
         readCount += 1
         return limits
     }
 
+    /// Records a proposed pair and accepts it when it is within the configured ceiling.
     func writeLimit(_ limit: rlimit) -> Bool {
         attemptedLimits.append(limit)
         guard let maximumAcceptedSoftLimit,

--- a/Sources/CmuxMain.swift
+++ b/Sources/CmuxMain.swift
@@ -16,6 +16,7 @@ import SwiftUI
 ///   AppKit/SwiftUI setup.
 @main
 enum CmuxMain {
+    /// Raises inherited descriptor limits before receipt writing or worker routing.
     static func main() {
         FileDescriptorLimitController().raiseSoftLimitIfNeeded()
         AppHostProcessReceipt.writeIfRequired()

--- a/Sources/CmuxMain.swift
+++ b/Sources/CmuxMain.swift
@@ -1,0 +1,34 @@
+import Bonsplit
+import CmuxFoundation
+import Foundation
+import SwiftUI
+
+/// The process entry point. When the binary is launched with a worker flag
+/// (the app re-executes its own binary so a crash or hang in paste preparation,
+/// the Simulator, interpreter, or renderer kills only the worker process), run
+/// that worker instead of the app:
+/// - the paste worker resolves providers and prepares images before any app or
+///   SwiftUI startup;
+/// - the Simulator worker owns private frameworks and remote display state;
+/// - the render worker hosts its own faceless AppKit session and shares the
+///   rendered layer tree with the host;
+/// - the interpreter worker (stage-1 fallback path) runs before any
+///   AppKit/SwiftUI setup.
+@main
+enum CmuxMain {
+    static func main() {
+        FileDescriptorLimitController().raiseSoftLimitIfNeeded()
+        AppHostProcessReceipt.writeIfRequired()
+#if DEBUG
+        // Bonsplit's `dlog` and the app's `cmuxDebugLog` resolve the same
+        // debug log file. Route bonsplit through the shared writer so the
+        // file has exactly one serialized append path (single O_APPEND
+        // handle, monotonic #<seq> line prefixes); with two independent
+        // appenders, concurrent lines interleaved and landed out of order.
+        Bonsplit.DebugEventLog.setExternalSink { cmuxDebugLog($0) }
+#endif
+        CmuxWorkerEntrypoint(arguments: CommandLine.arguments).runIfRequested()
+        SurfaceResumeApprovalStore.preloadSigningSecret()
+        cmuxApp.main()
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -15,35 +15,6 @@ import Bonsplit
 import UniformTypeIdentifiers
 import CmuxTerminal
 
-/// The process entry point. When the binary is launched with a worker flag
-/// (the app re-executes its own binary so a crash or hang in paste preparation,
-/// the Simulator, interpreter, or renderer kills only the worker process), run
-/// that worker instead of the app:
-/// - the paste worker resolves providers and prepares images before any app or
-///   SwiftUI startup;
-/// - the Simulator worker owns private frameworks and remote display state;
-/// - the render worker hosts its own faceless AppKit session and shares the
-///   rendered layer tree with the host;
-/// - the interpreter worker (stage-1 fallback path) runs before any
-///   AppKit/SwiftUI setup.
-@main
-enum CmuxMain {
-    static func main() {
-        AppHostProcessReceipt.writeIfRequired()
-#if DEBUG
-        // Bonsplit's `dlog` and the app's `cmuxDebugLog` resolve the same
-        // debug log file. Route bonsplit through the shared writer so the
-        // file has exactly one serialized append path (single O_APPEND
-        // handle, monotonic #<seq> line prefixes); with two independent
-        // appenders, concurrent lines interleaved and landed out of order.
-        Bonsplit.DebugEventLog.setExternalSink { cmuxDebugLog($0) }
-#endif
-        CmuxWorkerEntrypoint(arguments: CommandLine.arguments).runIfRequested()
-        SurfaceResumeApprovalStore.preloadSigningSecret()
-        cmuxApp.main()
-    }
-}
-
 struct cmuxApp: App {
     /// Dependency container for the new settings packages. Constructed
     /// once at app launch and injected into the SwiftUI environment via

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1056,6 +1056,7 @@
 		1A0B0C0D0E0F101112132113 /* CmuxIrxTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132112 /* CmuxIrxTransport */; };
 		1A0B0C0D0E0F101112132114 /* CmuxIrxTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 1A0B0C0D0E0F101112132112 /* CmuxIrxTransport */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
+		C12289000000000000000001 /* CmuxMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12289000000000000000002 /* CmuxMain.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
 		D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */; };
 		D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */; };
@@ -4604,6 +4605,7 @@
 		A11C00040000000000000002 /* CmuxHostedSystemSymbolImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxHostedSystemSymbolImageTests.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
+		C12289000000000000000002 /* CmuxMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMain.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
 		D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMainWindowConstrainFrameTests.swift; sourceTree = "<group>"; };
 		D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMainWindowFullScreenCapabilityTests.swift; sourceTree = "<group>"; };
@@ -7602,6 +7604,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
 				C97160000000000000000002 /* AppHostProcessReceipt.swift */,
 				A5001011 /* cmuxApp.swift */,
+				C12289000000000000000002 /* CmuxMain.swift */,
 				875200000000000000000002 /* cmuxApp+SurfaceNavigationMenu.swift */,
 				C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */,
 				80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */,
@@ -11785,6 +11788,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11C00010000000000000001 /* CmuxHostedSystemSymbolImage.swift in Sources */,
 				C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */,
 				E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */,
+				C12289000000000000000001 /* CmuxMain.swift in Sources */,
 				2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */,
 				CA1F0A01CA1F0A01CA1F0A01 /* CmuxModalAlertPresentation.swift in Sources */,
 				C54860110000000000000001 /* CmuxNavigationResolution.swift in Sources */,


### PR DESCRIPTION
## Summary

GUI-launched cmux processes can inherit a 256-descriptor soft limit, which their terminal shells and coding agents then inherit. Raise `RLIMIT_NOFILE` at process entry, before receipt writing, worker routing, or child creation, so agents have room to open their skill files.

Follow-up to https://github.com/manaflow-ai/cmux/pull/12289 by @sanshengai, who diagnosed the problem and proposed the startup fix. The implementation commit includes a co-author credit. This carries that behavior onto current main and addresses the [static-namespace review finding](https://github.com/manaflow-ai/cmux/pull/12289#issuecomment-5627228534).

- Use a constructable `FileDescriptorLimitController` with injected target limits and synchronous read/write operations. Document its public API and in-memory test setup.
- Preserve the source PR's 65,536 target and 10,240 / 8,192 fallbacks. Never lower an inherited soft limit or change the hard limit; ignore failed system calls.
- Exercise actual controller behavior through an isolated fake, covering finite/unlimited limits, rejected targets, failed reads/writes, and repeated calls.
- Move the existing `CmuxMain` entry point into its own small file and wire it into the app target, keeping `cmuxApp.swift` within its existing size allowance. Startup operations retain their previous order after the new limit adjustment.

This operation stays synchronous because it must finish before startup can spawn children or concurrent work. It adds no async tasks, locks, shared singleton, or global mutable state.

## Testing

Only non-build checks ran on Linux:

- `git diff --check origin/main...HEAD` — passed.
- `python3 scripts/swift_file_length_budget.py` — passed; all new Swift files are below 500 lines. No file-length or warning budgets were edited. The TSV budget file is absent in this checkout; the available guard uses the main-branch line counts.
- `bash scripts/check-pbxproj.sh` — passed after `python3 scripts/normalize-pbxproj.py cmux.xcodeproj/project.pbxproj`.
- `bash scripts/lint-pbxproj-test-wiring.sh` — passed (872 existing app-test files). The new tests are under the existing SwiftPM `CmuxFoundationTests` target, which is already included in package CI.
- `python3 scripts/check-workspace-package-groups.py --check` and `python3 scripts/check-package-resolved-policy.py` — passed.
- Ran the namespace-type Python checker embedded in `scripts/lint-ios-package-conventions.sh` against the source PR helper and this replacement: original failed as expected, replacement passed.
- Static Python audits confirmed that `CmuxMain.swift` belongs to the same Sources phase as `cmuxApp.swift`, that the moved startup body is unchanged apart from the new controller call, and that the warning budget is untouched.
- Localization audit: reviewed the new Swift/API comments and package README with a targeted `rg` search. Only developer documentation and test labels were added; no app/web strings or localization catalogs changed.

`bash scripts/lint-ios-package-conventions.sh` still fails repository-wide with 62 errors and 243 warnings across 114 files. A byte comparison confirmed that every reported file, the lint script, and its baselines are identical to current main (`c006e64ae3`). No findings refer to the new controller.

**Builds were not run.** Per the Linux override, no Swift compilation, Swift test execution, Xcode build, reload, remote/cloud build, app launch, or dogfood was performed. The tests are committed before the implementation, but no runtime red/green result is claimed. macOS compilation, the focused Swift test suite, and shell inheritance remain unverified.

The source PR's CLA signature and Vercel contributor-authorization failures require external action; this change does not resolve those administrative gates.

## Demo Video

Not recorded: application launch and dogfood are excluded by the Linux override.

## Checklist

- [x] Added behavior tests and documented their execution limitation.
- [x] Ran the non-build checks listed above.
- [x] Addressed the source PR's static-namespace finding and documented the new public API.
- [ ] macOS compilation and Swift tests verified.
- [ ] Shell inheritance verified in a running macOS build.
- [ ] Required GitHub checks complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758938&installation_model_id=21920&pr_number=12364&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12364&signature=42c33906e8d7c33503843354843d8a084fc377b993e4b16a316cbe016a6011d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Process-wide descriptor limits are changed synchronously at entry before all workers and shells spawn; behavior is bounded and tested but affects every child process.
> 
> **Overview**
> Adds **`FileDescriptorLimitController`** in **CmuxFoundation** so cmux can **raise `RLIMIT_NOFILE`’s soft limit at launch** before workers, terminals, or other children inherit launchd’s low GUI default (often 256). The policy tries **65,536**, then **10,240** / **8,192** if the kernel rejects a write; it **never lowers** an already-sufficient soft limit, **clamps to the hard ceiling**, and **no-ops** on failed reads/writes. **`readLimit` / `writeLimit` injection** keeps unit tests off the real process limit.
> 
> **`CmuxMain`** moves out of `cmuxApp.swift` into **`Sources/CmuxMain.swift`**; **`raiseSoftLimitIfNeeded()`** runs as the **first** step in `main()`, with receipt writing, debug logging, worker routing, and app startup unchanged afterward. README documents the API and test pattern; SwiftPM tests cover retries, hard caps, failures, and idempotency via an in-memory stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e05275d6020c0c58bf83b270fa17ec01337df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GUI-launched cmux processes can inherit a 256-descriptor soft limit, which their terminal shells and coding agents then inherit. This raises `RLIMIT_NOFILE` at process entry, before receipt writing, worker routing, or child creation, so agents have room to open their skill files.

**Changes**
- Adds a synchronous `FileDescriptorLimitController` with injected target limits and read/write operations.
- Targets 65,536 descriptors with 10,240 and 8,192 fallbacks for lower Darwin ceilings.
- Never lowers an inherited soft limit, preserves the hard limit, and ignores failed system calls.
- Moves the `CmuxMain` entry point into its own file to keep `cmuxApp.swift` within its file-length budget.
- Adds tests covering finite and unlimited limits, rejected targets, failed reads/writes, and repeated calls.

<sup>Written for commit c7e05275d6020c0c58bf83b270fa17ec01337df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved startup handling raises available file-descriptor limits when needed, supporting more concurrent terminals and worker processes.
  - Startup now initializes worker launches, application-host registration, logging, and resume-session security setup in a dedicated application entry point.

- **Documentation**
  - Added documentation describing file-descriptor limit behavior and safe testing practices.

- **Tests**
  - Added coverage for limit raising, hard-limit handling, failed operations, retries, and repeated startup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->