### PR TITLE
Fix cloud workspace sidebar directory and git provenance

### DIFF
--- a/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
+++ b/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension CloudWorkspaceRenameService {
+    @MainActor
     func updateCloudDirectories(localWorkspaceID: UUID, catalog: SurfaceCatalog) {
         guard let workspace = environment.workspace(localWorkspaceID) else { return }
         for projection in catalog.snapshot.projections where projection.workspaceID == localWorkspaceID && !projection.resource.machine.isLocal {

--- a/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
+++ b/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension CloudWorkspaceRenameService {
+    func updateCloudDirectories(localWorkspaceID: UUID, catalog: SurfaceCatalog) {
+        guard let workspace = environment.workspace(localWorkspaceID) else { return }
+        for projection in catalog.snapshot.projections where projection.workspaceID == localWorkspaceID && !projection.resource.machine.isLocal {
+            guard let resource = catalog.snapshot.resources.first(where: { $0.id == projection.resource }) else { continue }
+            if resource.kind == .terminal {
+                workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
+            } else {
+                workspace.clearRemotePanelDirectory(panelId: projection.panelID)
+            }
+        }
+    }
+}

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -118,36 +118,24 @@ final class SurfaceCatalog {
     nonisolated static let defaultAbandonedMaterializationTimeout: Duration = .seconds(30)
     nonisolated static let defaultRetiredMaterializationRetention: Duration = .seconds(30)
     nonisolated static let defaultCompletedMaterializationRetention: Duration = .seconds(30)
-    /// The coordinator never allows more than this many tasks from one machine to remain tracked
-    /// while cancellation is unresolved. This prevents one unhealthy machine from blocking
-    /// unrelated machines while also bounding repeated provider replacements.
     nonisolated static let defaultMaximumTrackedMaterializations = 16
-
     static let didChangeNotification = Notification.Name("cmux.surfaces.didChange")
-
     private(set) var machines: [SurfaceMachineID: SurfaceMachineInfo] = [:]
     private(set) var resources: [SurfaceResourceID: SurfaceResource] = [:]
-    private(set) var projections: Set<SurfaceProjection> = []
-    /// Resource IDs grouped by machine so providers can answer presence checks
-    /// without sorting the full catalog snapshot on every refresh.
+    private struct CloudProjectionKey: Hashable { let panelID: UUID; let workspaceID: UUID }
+    private var cloudProjectionIndex = Set<CloudProjectionKey>()
+    private var cloudProjectionIndexDirty = true
+    private(set) var projections: Set<SurfaceProjection> = [] { didSet { cloudProjectionIndexDirty = true } }
     private var resourceIDsByMachine: [SurfaceMachineID: Set<SurfaceResourceID>] = [:]
 
     /// The last accepted, revisioned graph for each cloud machine. Resource rows
     /// are derived from this state by the provider; keeping it here makes the
     /// complete state available to socket and agent callers without another cache.
     private(set) var cloudStates: [SurfaceMachineID: CloudVMState] = [:]
-    /// Whether each retained graph was observed on a live link. This is separate
-    /// from `CloudVMState` because freshness is local observation metadata, not
-    /// part of the daemon document or its cursor.
     private(set) var cloudStateObservations: [SurfaceMachineID: CloudVMStateObservation] = [:]
     private var providers: [SurfaceMachineID: any SurfaceProvider] = [:]
-    /// The process-wide ordering owner for remote rename intents. A remote identity can
-    /// have projections in several local windows, so this cannot live in a TabManager.
     let cloudRenameCoordinator = CloudRenameCoordinator()
-    /// Resolves local workspace owners for cloud rename write-through. The app installs
-    /// its live environment at the composition root; tests keep the no-op environment.
     private(set) var cloudWorkspaceRenameService: CloudWorkspaceRenameService
-    /// Keeps a mirrored local workspace's panes and its machine workspace's tabs in step.
     private(set) var cloudPlacementCoordinator: CloudPlacementCoordinator
     /// Materializations are asynchronous, so actor reentrancy can otherwise let two callers
     /// pass the reuse check before either provider has returned a projection.
@@ -270,6 +258,7 @@ final class SurfaceCatalog {
             remoteWorkspaceID: remoteWorkspaceID,
             generatedTitle: generatedTitle
         )
+        cloudWorkspaceRenameService.updateCloudDirectories(localWorkspaceID: localWorkspaceID, catalog: self)
     }
 
     // MARK: Providers
@@ -317,6 +306,7 @@ final class SurfaceCatalog {
         resourceIDsByMachine[machine] = nil
         let pending = pendingRestoredProjections.keys.filter { $0.resource.machine == machine }
         for record in pending { pendingRestoredProjections[record] = nil }
+        cloudProjectionIndexDirty = true
         cloudStates[machine] = nil
         cloudStateObservations[machine] = nil
         projections = projections.filter { $0.resource.machine != machine }
@@ -1174,16 +1164,18 @@ final class SurfaceCatalog {
         }
     }
 
-    /// Record a pane that shows a resource (materialized by a provider, or adopted from an
-    /// existing pane such as a local terminal the app created on its own).
     func record(_ projection: SurfaceProjection) {
         insertSupersedingLocalPlaceholder(cloudPlacementCoordinator.projectionInCurrentWorkspace(projection))
         reconcileCloudWorkspaceBinding(localWorkspaceID: projection.workspaceID)
+        if let resource = resources[projection.resource], !resource.machine.isLocal,
+           resource.kind == .terminal,
+           let workspace = cloudWorkspaceRenameService.environment.workspace(projection.workspaceID) {
+            workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
+        }
         notifyChange()
     }
 
-    /// A restored placeholder yields to its native pane without authoring a layout edit.
-    /// Keep the exact saved view, or the receipt of a backing tab just created for it.
+    /// Replaces a restored placeholder with its native pane without authoring a layout edit.
     func replaceProjection(
         _ previous: SurfaceProjection,
         withPanel panelID: UUID,
@@ -1192,8 +1184,7 @@ final class SurfaceCatalog {
     ) {
         let views = resources[previous.resource]?.remoteViews
         let exactView = views?.first { $0.tabID == previous.remoteTabID }
-        // A dead saved ID cannot describe the rematerialized terminal. A unique
-        // live view is unambiguous; several live views must remain unresolved.
+        // A dead saved ID is replaced only when one live view is unambiguous.
         let view = exactView ?? (views?.count == 1 ? views?.first : nil)
         let savedWorkspace = views == nil ? previous.remoteWorkspaceID : nil
         let savedTab = views == nil ? previous.remoteTabID : nil
@@ -1366,6 +1357,19 @@ final class SurfaceCatalog {
         projections.first { $0.panelID == panelID }
     }
 
+    func hasCloudProjection(panelID: UUID, workspaceID: UUID) -> Bool {
+        if cloudProjectionIndexDirty {
+            cloudProjectionIndex = Set(projections.filter { !$0.resource.machine.isLocal }.map {
+                CloudProjectionKey(panelID: $0.panelID, workspaceID: $0.workspaceID)
+            })
+            cloudProjectionIndex.formUnion(pendingRestoredProjections.compactMap { record, workspaceID in
+                record.resource.machine.isLocal ? nil : CloudProjectionKey(panelID: record.panelID, workspaceID: workspaceID)
+            })
+            cloudProjectionIndexDirty = false
+        }
+        return cloudProjectionIndex.contains(CloudProjectionKey(panelID: panelID, workspaceID: workspaceID))
+    }
+
     func resource(forPanel panelID: UUID) -> SurfaceResource? {
         projection(forPanel: panelID).flatMap { resources[$0.resource] }
     }
@@ -1388,6 +1392,7 @@ final class SurfaceCatalog {
                 ))
             } else {
                 pendingRestoredProjections[record] = workspaceID
+                cloudProjectionIndexDirty = true
             }
         }
         reconcileCloudWorkspaceBinding(localWorkspaceID: workspaceID)
@@ -1395,17 +1400,11 @@ final class SurfaceCatalog {
     }
 
     func projectionRecords(forWorkspace workspaceID: UUID) -> [SurfaceProjectionRecord] {
-        projections
-            .filter { $0.workspaceID == workspaceID }
-            .map {
-                SurfaceProjectionRecord(
-                    panelID: $0.panelID,
-                    resource: $0.resource,
-                    remoteWorkspaceID: $0.remoteWorkspaceID,
-                    remoteTabID: $0.remoteTabID
-                )
-            }
-            .sorted { $0.panelID.uuidString < $1.panelID.uuidString }
+        projections.compactMap { projection -> SurfaceProjectionRecord? in
+            guard projection.workspaceID == workspaceID else { return nil }
+            return SurfaceProjectionRecord(panelID: projection.panelID, resource: projection.resource,
+                remoteWorkspaceID: projection.remoteWorkspaceID, remoteTabID: projection.remoteTabID)
+        }.sorted { $0.panelID.uuidString < $1.panelID.uuidString }
     }
 
     /// Cloud machine IDs referenced by restored panes that are waiting for a
@@ -1444,6 +1443,7 @@ final class SurfaceCatalog {
                 remoteTabID: record.remoteTabID
             ))
             pendingRestoredProjections[record] = nil
+            cloudProjectionIndexDirty = true
             resolvedWorkspaceIDs.insert(workspaceID)
         }
         for workspaceID in resolvedWorkspaceIDs {

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -121,7 +121,6 @@ extension Workspace {
     }
 }
 
-
 /// Identifies one remote workspace placement for a local projection.
 struct CloudWorkspaceRemoteIdentity: Hashable, Sendable {
     let machine: SurfaceMachineID
@@ -227,8 +226,8 @@ final class CloudWorkspaceRenameService {
             machine: target.machine,
             remoteWorkspaceID: target.remoteWorkspaceID
         )
+        updateCloudDirectories(localWorkspaceID: localWorkspaceID, catalog: catalog)
     }
-
     /// The one remote cmux-tui workspace a local workspace stands for. The persisted
     /// binding wins; otherwise the projected cloud resources decide, but only when
     /// every view agrees on a single remote workspace — a local workspace composing
@@ -490,14 +489,15 @@ final class CloudWorkspaceRenameService {
                 propagateToCloud: false
             )
         }
-
         for projection in snapshot.projections where projection.resource.machine == machine {
             guard let workspace = localWorkspacesByID[projection.workspaceID],
-                  workspace.panels[projection.panelID] != nil,
-                  let resource = resourcesByID[projection.resource],
-                  resource.kind == .terminal
-            else { continue }
-
+                  workspace.panels[projection.panelID] != nil else { continue }
+            guard let resource = resourcesByID[projection.resource] else { continue }
+            guard resource.kind == .terminal else {
+                workspace.clearRemotePanelDirectory(panelId: projection.panelID)
+                continue
+            }
+            workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
             let tabID = remoteTabID(for: projection, resource: resource)
             guard let tabID, let tab = tabsByID[tabID] else { continue }
             let intentKey = CloudRenameCoordinator.Key.tab(machine: machine, id: tabID)

--- a/Sources/TabManager+SidebarGitHosting.swift
+++ b/Sources/TabManager+SidebarGitHosting.swift
@@ -25,7 +25,7 @@ extension TabManager: SidebarGitHosting {
 
     func isRemoteWorkspace(_ workspaceId: UUID) -> Bool? {
         guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return nil }
-        return workspace.isRemoteWorkspace || workspace.isRemoteTmuxMirror
+        return workspace.usesRemoteDirectoryProvenance
     }
 
     func panelIds(in workspaceId: UUID) -> [UUID] {
@@ -42,7 +42,9 @@ extension TabManager: SidebarGitHosting {
     }
 
     func isRemoteTerminalPanel(workspaceId: UUID, panelId: UUID) -> Bool {
-        tabs.first(where: { $0.id == workspaceId })?.isRemoteTerminalSurface(panelId) == true
+        guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return false }
+        return workspace.isRemoteTerminalSurface(panelId) ||
+            workspace.cloudDirectoryProvenanceRequired(panelId: panelId)
     }
 
     func gitProbeDirectory(workspaceId: UUID, panelId: UUID) -> String? {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -854,8 +854,8 @@ class TabManager: ObservableObject {
     }
 
     func gitProbeDirectory(for workspace: Workspace, panelId: UUID) -> String? {
-        // Match the sidebar directory fallback chain so hidden/background panels can
-        // still probe git metadata before OSC 7 has reported a live cwd.
+        // Cloud cwd belongs to another machine and is never a local git/gh probe target.
+        if workspace.cloudDirectoryProvenanceRequired(panelId: panelId) { return nil }
         if let directory = workspace.reportedPanelDirectory(panelId: panelId) { return normalizedWorkingDirectory(directory) }
         guard workspace.allowsLocalDirectoryFallback(panelId: panelId) else { return nil }
         let rawDirectory = workspace.terminalPanel(for: panelId)?.requestedWorkingDirectory ?? (!workspace.usesRemoteDirectoryProvenance && workspace.focusedPanelId == panelId ? workspace.currentDirectory : nil)

--- a/Sources/TerminalController+ControlSidebarContext2.swift
+++ b/Sources/TerminalController+ControlSidebarContext2.swift
@@ -55,6 +55,8 @@ extension TerminalController {
         guard let tab = controlSidebarResolveTabForReport(tabArg: tabArg) else {
             return false
         }
+        if tab.cloudVMBinding != nil { tab.clearSidebarGitMetadata(); return true }
+        if let focusedPanelId = tab.focusedPanelId, tab.cloudDirectoryProvenanceRequired(panelId: focusedPanelId) { tab.clearPanelGitBranch(panelId: focusedPanelId); return true }
         guard SidebarWorkspaceDetailDefaults.gitMetadataActivity(defaults: .standard).acceptsPassiveReports else {
             tab.gitBranch = nil
             return true

--- a/Sources/Workspace+SidebarDirectories.swift
+++ b/Sources/Workspace+SidebarDirectories.swift
@@ -21,7 +21,9 @@ extension Workspace {
                 return nil
             }
         }
-        let activeRemotePanelIds = panels.keys.filter { isRemoteTerminalSurface($0) }
+        let activeRemotePanelIds = panels.keys.filter {
+            isRemoteTerminalSurface($0) || cloudDirectoryProvenanceRequired(panelId: $0)
+        }
         guard !activeRemotePanelIds.isEmpty else { return nil }
         let reportedDirectories = activeRemotePanelIds.compactMap { trustedReportedPanelDirectory(panelId: $0) }
         guard reportedDirectories.count == activeRemotePanelIds.count else { return nil }
@@ -37,8 +39,22 @@ extension Workspace {
         reportedRemoteCurrentDirectory(allowLocalFallback: false)
     }
 
+    /// Directory metadata for a cloud-bound or cloud-projected panel is remote
+    /// state, even though its transport is not SSH.
     var usesRemoteDirectoryProvenance: Bool {
-        isRemoteWorkspace || isRemoteTmuxMirror
+        isRemoteWorkspace || isRemoteTmuxMirror || cloudVMBinding != nil ||
+            panels.keys.contains(where: { cloudDirectoryProvenanceRequired(panelId: $0) })
+    }
+
+    func cloudDirectoryProvenanceRequired(panelId: UUID) -> Bool {
+        cloudVMBinding != nil || SurfaceCatalog.shared.hasCloudProjection(panelID: panelId, workspaceID: id)
+    }
+
+    /// Applies the cwd carried by a terminal in an accepted cloud snapshot.
+    /// Branch and PR metadata remain absent until the cloud transport reports them.
+    func updateCloudPanelDirectory(panelId: UUID, directory: String?) {
+        guard let directory = normalizedSidebarDirectory(directory) else { return }
+        updateRemotePanelDirectoryWithMetadata(panelId: panelId, directory: directory)
     }
 
     var presentedCurrentDirectory: String? {
@@ -72,6 +88,7 @@ extension Workspace {
 
     func allowsLocalDirectoryFallback(panelId: UUID) -> Bool {
         if !usesRemoteDirectoryProvenance { return true }
+        if cloudDirectoryProvenanceRequired(panelId: panelId) { return false }
         guard !remoteDirectoryTrustRequiredPanelIds.contains(panelId),
               !isRemoteTerminalSurface(panelId),
               !isRemoteTmuxMirror else { return false }
@@ -112,9 +129,10 @@ extension Workspace {
     }
 
     func restoresLegacyRemoteDirectoryWithoutProvenance(_ snapshot: SessionPanelSnapshot) -> Bool {
-        guard remoteConfiguration != nil,
+        guard remoteConfiguration != nil || cloudVMBinding != nil,
               snapshot.directoryIsTrustedRemoteReport == nil,
               snapshot.directoryRequiresRemoteTrust == nil else { return false }
+        if cloudVMBinding != nil { return true }
         if let terminal = snapshot.terminal { return terminal.isRemoteTerminal != false }
         return snapshot.agentSession != nil
     }
@@ -282,11 +300,13 @@ extension Workspace {
     }
 
     var presentedGitBranch: SidebarGitBranchState? {
+        if let focusedPanelId, cloudDirectoryProvenanceRequired(panelId: focusedPanelId) { return nil }
         if usesRemoteDirectoryProvenance, presentedCurrentDirectory == nil { return nil }
         return gitBranch
     }
 
     func reportedPanelGitBranch(panelId: UUID) -> SidebarGitBranchState? {
+        guard !cloudDirectoryProvenanceRequired(panelId: panelId) else { return nil }
         guard let branch = panelGitBranches[panelId] else { return nil }
         if usesRemoteDirectoryProvenance, effectivePanelDirectory(panelId: panelId) == nil { return nil }
         return branch
@@ -301,4 +321,122 @@ extension Workspace {
         }
         return branches
     }
+
+    func updatePanelGitBranch(panelId: UUID, branch: String, isDirty: Bool) {
+        if cloudDirectoryProvenanceRequired(panelId: panelId) {
+            clearPanelGitBranch(panelId: panelId)
+            return
+        }
+        let state = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+        let existing = panelGitBranches[panelId]
+        let branchChanged = existing?.branch != nil && existing?.branch != branch
+        if existing?.branch != branch || existing?.isDirty != isDirty {
+            panelGitBranches[panelId] = state
+        }
+        if branchChanged {
+            if panelPullRequests[panelId] != nil {
+                panelPullRequests.removeValue(forKey: panelId)
+            }
+            if panelId == focusedPanelId, pullRequest != nil {
+                pullRequest = nil
+            }
+        }
+        if panelId == focusedPanelId, gitBranch != state {
+            gitBranch = state
+        }
+    }
+
+    func clearPanelGitBranch(panelId: UUID) {
+        if panelGitBranches[panelId] != nil {
+            panelGitBranches.removeValue(forKey: panelId)
+        }
+        if panelPullRequests[panelId] != nil {
+            panelPullRequests.removeValue(forKey: panelId)
+        }
+        if panelId == focusedPanelId {
+            if gitBranch != nil {
+                gitBranch = nil
+            }
+            if pullRequest != nil {
+                pullRequest = nil
+            }
+        }
+    }
+
+    func updatePanelPullRequest(
+        panelId: UUID,
+        number: Int,
+        label: String,
+        url: URL,
+        status: SidebarPullRequestStatus,
+        branch: String? = nil,
+        isStale: Bool = false
+    ) {
+        if cloudDirectoryProvenanceRequired(panelId: panelId) {
+            clearPanelPullRequest(panelId: panelId)
+            return
+        }
+        let existing = panelPullRequests[panelId]
+        let normalizedBranch = branch?.normalizedSidebarBranchName
+        let currentPanelBranch = panelGitBranches[panelId]?.branch.normalizedSidebarBranchName
+        let resolvedBranch: String? = {
+            if let normalizedBranch {
+                return normalizedBranch
+            }
+            if let currentPanelBranch {
+                return currentPanelBranch
+            }
+            guard let existing,
+                  existing.number == number,
+                  existing.label == label,
+                  existing.url == url,
+                  existing.status == status else {
+                return nil
+            }
+            return existing.branch
+        }()
+        let state = SidebarPullRequestState(
+            number: number,
+            label: label,
+            url: url,
+            status: status,
+            branch: resolvedBranch,
+            isStale: isStale
+        )
+        if existing != state {
+            panelPullRequests[panelId] = state
+        }
+        if panelId == focusedPanelId, pullRequest != state {
+            pullRequest = state
+        }
+    }
+
+    func clearPanelPullRequest(panelId: UUID) {
+        if panelPullRequests[panelId] != nil {
+            panelPullRequests.removeValue(forKey: panelId)
+        }
+        if panelId == focusedPanelId, pullRequest != nil {
+            pullRequest = nil
+        }
+    }
+
+    func clearSidebarPullRequestMetadata() {
+        if !panelPullRequests.isEmpty {
+            panelPullRequests.removeAll()
+        }
+        if pullRequest != nil {
+            pullRequest = nil
+        }
+    }
+
+    func clearSidebarGitMetadata() {
+        if !panelGitBranches.isEmpty {
+            panelGitBranches.removeAll()
+        }
+        clearSidebarPullRequestMetadata()
+        if gitBranch != nil {
+            gitBranch = nil
+        }
+    }
+
 }

--- a/Sources/Workspace+SidebarDirectories.swift
+++ b/Sources/Workspace+SidebarDirectories.swift
@@ -22,7 +22,9 @@ extension Workspace {
             }
         }
         let activeRemotePanelIds = panels.keys.filter {
-            isRemoteTerminalSurface($0) || cloudDirectoryProvenanceRequired(panelId: $0)
+            isRemoteTerminalSurface($0) ||
+                (cloudVMBinding != nil && terminalPanel(for: $0) != nil) ||
+                cloudProjectedResource(forPanel: $0)?.kind == .terminal
         }
         guard !activeRemotePanelIds.isEmpty else { return nil }
         let reportedDirectories = activeRemotePanelIds.compactMap { trustedReportedPanelDirectory(panelId: $0) }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -291,7 +291,16 @@ extension Workspace {
         // survive an app restart) inherits it through `newTerminalSurface`.
         workspaceEnvironment = Self.sanitizedWorkspaceEnvironment(snapshot.environment ?? [:])
 
-        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
+        let cloudProjectedPanelIDs = Set(
+            (snapshot.surfaceProjections ?? []).filter { !$0.resource.machine.isLocal }.map(\.panelID)
+        )
+        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { panel in
+            var panel = panel
+            if cloudProjectedPanelIDs.contains(panel.id), panel.directoryIsTrustedRemoteReport != true {
+                panel.directoryRequiresRemoteTrust = true
+            }
+            return (panel.id, panel)
+        })
         let restorableAgentIndex = restoreAgentIndex(for: snapshot.panels)
         let shouldRestoreSingleDefaultCloudTerminal =
             isDefaultFreestyleSSHDRemoteWorkspace &&
@@ -349,7 +358,10 @@ extension Workspace {
             clearProxyOnlyRemoteSidebarArtifacts()
         }
         progress = snapshot.progress.map { SidebarProgressState(value: $0.value, label: $0.label) }
-        gitBranch = snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty) }
+        let hasCloudProvenance = cloudVMBinding != nil || (snapshot.surfaceProjections ?? []).contains { !$0.resource.machine.isLocal }
+        gitBranch = hasCloudProvenance
+            ? nil
+            : snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty) }
 
         recomputeListeningPorts()
 
@@ -491,6 +503,9 @@ extension Workspace {
             ? (panelCustomTitleSources[panelId] ?? .user)
             : nil
         let directory: String? = {
+            if cloudDirectoryProvenanceRequired(panelId: panelId) {
+                return reportedPanelDirectory(panelId: panelId)
+            }
             if let directory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !directory.isEmpty {
                 return directory
@@ -1553,9 +1568,10 @@ extension Workspace {
             snapshot,
             workspaceId: snapshotWorkspaceId ?? id
         )
-        let restoresUntrustedSavedDirectory = snapshot.directoryIsTrustedRemoteReport != true &&
-            (snapshot.directoryRequiresRemoteTrust == true ||
-                restoresLegacyRemoteDirectoryWithoutProvenance(snapshot))
+        let restoresUntrustedSavedDirectory = cloudVMBinding != nil ||
+            (snapshot.directoryIsTrustedRemoteReport != true &&
+                (snapshot.directoryRequiresRemoteTrust == true ||
+                    restoresLegacyRemoteDirectoryWithoutProvenance(snapshot)))
         switch snapshot.type {
         case .terminal:
             let localTmuxStartCommand = sessionRestorePolicy
@@ -1726,7 +1742,7 @@ extension Workspace {
                 ?? (restoresUntrustedSavedDirectory ? nil : restorableAgent?.workingDirectory)
                 ?? (restoresUntrustedSavedDirectory ? nil : snapshot.directory)
             let workingDirectory = savedWorkingDirectory
-                ?? currentDirectory
+                ?? (restoresUntrustedSavedDirectory ? nil : currentDirectory)
             // A persisted terminal cwd can already be the stray fallback cwd
             // from a prior auto-resume restore; the transient rescue/guard must
             // remember where the resume launcher actually sends the agent.
@@ -2388,7 +2404,8 @@ extension Workspace {
 
         if restoredDirectoryRequiresRemoteTrust {
             clearPanelGitBranch(panelId: panelId)
-        } else if let branch = snapshot.gitBranch {
+        } else if let branch = snapshot.gitBranch,
+                  !cloudDirectoryProvenanceRequired(panelId: panelId) {
             panelGitBranches[panelId] = SidebarGitBranchState(branch: branch.branch, isDirty: branch.isDirty)
         } else {
             panelGitBranches.removeValue(forKey: panelId)
@@ -3075,7 +3092,19 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// machine's workspace. Set through `workspace.cloud_vm_bind` and persisted in the
     /// session snapshot (`SessionWorkspaceSnapshot.cloudVM`); the pane's one-shot link is
     /// not replayed on restore, only the binding is.
-    @Published var cloudVMBinding: WorkspaceCloudVMBinding?
+    @Published var cloudVMBinding: WorkspaceCloudVMBinding? {
+        didSet {
+            guard oldValue?.vmID != cloudVMBinding?.vmID else { return }
+            clearSidebarGitMetadata()
+            // A binding transition invalidates the previous machine's cwd
+            // report. Local PTY state can still be used after unbinding.
+            panelDirectories.removeAll()
+            panelDirectoryDisplayLabels.removeAll()
+            remoteDirectoryReportPanelIds.removeAll()
+            remoteDirectoryTrustRequiredPanelIds.removeAll()
+            notifyPresentedCurrentDirectoryChanged(from: nil, force: true)
+        }
+    }
 
     /// The binding a session snapshot restores, or nil when the snapshot has none or its
     /// machine id is malformed.
@@ -5913,6 +5942,17 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         remoteDirectoryTrustRequiredPanelIds.remove(panelId); remoteDirectoryReportPanelIds.remove(panelId)
     }
 
+    func clearRemotePanelDirectory(panelId: UUID) {
+        let previousPresentedDirectory = presentedCurrentDirectory
+        panelDirectories.removeValue(forKey: panelId)
+        panelDirectoryDisplayLabels.removeValue(forKey: panelId)
+        discardRemoteDirectoryTrustState(panelId: panelId)
+        clearPanelGitBranch(panelId: panelId)
+        if usesRemoteDirectoryProvenance {
+            notifyPresentedCurrentDirectoryChanged(from: previousPresentedDirectory, force: true)
+        }
+    }
+
     @discardableResult
     private func updatePanelDirectory(
         panelId: UUID,
@@ -5934,7 +5974,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
         let previousPresentedDirectory = presentedCurrentDirectory
         let isRemoteTerminalReport = isRemoteTerminalSurface(panelId)
-        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) { return false }
+        if source == .liveReport &&
+            (cloudDirectoryProvenanceRequired(panelId: panelId) ||
+                remoteDirectoryTrustRequiredPanelIds.contains(panelId)) {
+            return false
+        }
         let routedRemoteReport = source == .remoteReport && !allowsLocalDirectoryFallback(panelId: panelId)
         let establishesRemoteProvenance = source == .trustedRestoredRemoteSnapshotMetadata ||
             (source.establishesRemoteProvenance &&
@@ -6336,115 +6380,6 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return panel.isDirty
     }
 
-    func updatePanelGitBranch(panelId: UUID, branch: String, isDirty: Bool) {
-        let state = SidebarGitBranchState(branch: branch, isDirty: isDirty)
-        let existing = panelGitBranches[panelId]
-        let branchChanged = existing?.branch != nil && existing?.branch != branch
-        if existing?.branch != branch || existing?.isDirty != isDirty {
-            panelGitBranches[panelId] = state
-        }
-        if branchChanged {
-            if panelPullRequests[panelId] != nil {
-                panelPullRequests.removeValue(forKey: panelId)
-            }
-            if panelId == focusedPanelId, pullRequest != nil {
-                pullRequest = nil
-            }
-        }
-        if panelId == focusedPanelId, gitBranch != state {
-            gitBranch = state
-        }
-    }
-
-    func clearPanelGitBranch(panelId: UUID) {
-        if panelGitBranches[panelId] != nil {
-            panelGitBranches.removeValue(forKey: panelId)
-        }
-        if panelPullRequests[panelId] != nil {
-            panelPullRequests.removeValue(forKey: panelId)
-        }
-        if panelId == focusedPanelId {
-            if gitBranch != nil {
-                gitBranch = nil
-            }
-            if pullRequest != nil {
-                pullRequest = nil
-            }
-        }
-    }
-
-    func updatePanelPullRequest(
-        panelId: UUID,
-        number: Int,
-        label: String,
-        url: URL,
-        status: SidebarPullRequestStatus,
-        branch: String? = nil,
-        isStale: Bool = false
-    ) {
-        let existing = panelPullRequests[panelId]
-        let normalizedBranch = branch?.normalizedSidebarBranchName
-        let currentPanelBranch = panelGitBranches[panelId]?.branch.normalizedSidebarBranchName
-        let resolvedBranch: String? = {
-            if let normalizedBranch {
-                return normalizedBranch
-            }
-            if let currentPanelBranch {
-                return currentPanelBranch
-            }
-            guard let existing,
-                  existing.number == number,
-                  existing.label == label,
-                  existing.url == url,
-                  existing.status == status else {
-                return nil
-            }
-            return existing.branch
-        }()
-        let state = SidebarPullRequestState(
-            number: number,
-            label: label,
-            url: url,
-            status: status,
-            branch: resolvedBranch,
-            isStale: isStale
-        )
-        if existing != state {
-            panelPullRequests[panelId] = state
-        }
-        if panelId == focusedPanelId, pullRequest != state {
-            pullRequest = state
-        }
-    }
-
-    func clearPanelPullRequest(panelId: UUID) {
-        if panelPullRequests[panelId] != nil {
-            panelPullRequests.removeValue(forKey: panelId)
-        }
-        if panelId == focusedPanelId, pullRequest != nil {
-            pullRequest = nil
-        }
-    }
-
-    func clearSidebarPullRequestMetadata() {
-        if !panelPullRequests.isEmpty {
-            panelPullRequests.removeAll()
-        }
-        if pullRequest != nil {
-            pullRequest = nil
-        }
-    }
-
-    func clearSidebarGitMetadata() {
-        if !panelGitBranches.isEmpty {
-            panelGitBranches.removeAll()
-        }
-        clearSidebarPullRequestMetadata()
-        if gitBranch != nil {
-            gitBranch = nil
-        }
-    }
-
     func resetSidebarContext(reason: String = "unspecified") {
         statusEntries.removeAll()
         clearAllAgentPIDs(refreshPorts: false)
@@ -6625,6 +6560,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
     func sidebarPullRequestsInDisplayOrder(orderedPanelIds: [UUID]) -> [SidebarPullRequestState] {
         let validPanelPullRequests = panelPullRequests.filter { panelId, state in
+            guard !cloudDirectoryProvenanceRequired(panelId: panelId) else { return false }
             if usesRemoteDirectoryProvenance, effectivePanelDirectory(panelId: panelId) == nil {
                 return false
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -3308,6 +3308,7 @@
 		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11323020000000000000001 /* Workspace+CloudManualMirror.swift */; };
+		F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */; };
 		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */; };
 		7806088FC566EAEFDB186931 /* Workspace+CloudVPNSetupPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5748A8176DB3678214B1436 /* Workspace+CloudVPNSetupPane.swift */; };
@@ -6782,6 +6783,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C11323020000000000000001 /* Workspace+CloudManualMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudManualMirror.swift"; sourceTree = "<group>"; };
+		F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceRenameService+Directory.swift"; sourceTree = "<group>"; };
 		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPlacementFailure.swift"; sourceTree = "<group>"; };
 		E5748A8176DB3678214B1436 /* Workspace+CloudVPNSetupPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudVPNSetupPane.swift"; sourceTree = "<group>"; };
@@ -7420,6 +7422,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D01100800000000000000001 /* SurfaceCatalogQueryService.swift */,
 				278BEFB3583AED9627966DFF /* SurfaceSocketCommands.swift */,
 				47BBA1A8703756FDDFD53CF3 /* Workspace+SurfaceCatalog.swift */,
+				F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */,
 				C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */,
 				1EDD243C7C87A2AB78B12BAD /* LocalSurfaceProvider.swift */,
 				A1B2C3D4E5F6071827364960 /* CmuxTuiSurfaceProviderRegistry.swift */,
@@ -13306,6 +13309,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */,
+				F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */,
 				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */,
 				7806088FC566EAEFDB186931 /* Workspace+CloudVPNSetupPane.swift in Sources */,

--- a/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
+++ b/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
@@ -10,6 +10,98 @@ import Testing
 struct CloudSidebarSurfaceRegressionTests {
     private let machine = SurfaceMachineID.cloud("sidebar-vm")
 
+    @Test("Cloud-bound workspaces never use local sidebar provenance")
+    @MainActor
+    func cloudBindingRejectsLocalDirectoryAndGitStateIncludingRestore() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        workspace.updatePanelPullRequest(
+            panelId: panelID, number: 4, label: "PR", url: try #require(URL(string: "https://github.com/example/local/pull/4")), status: .open
+        )
+        workspace.cloudVMBinding = WorkspaceCloudVMBinding(
+            vmID: "cloud-sidebar-vm", isBase: false, remoteWorkspaceID: "ws_1"
+        )
+        #expect(workspace.usesRemoteDirectoryProvenance)
+        #expect(!workspace.allowsLocalDirectoryFallback(panelId: panelID))
+        #expect(!workspace.updatePanelDirectory(panelId: panelID, directory: "/Users/alice/local-checkout"))
+        #expect(workspace.effectivePanelDirectory(panelId: panelID) == nil)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        #expect(workspace.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+        #expect(workspace.sidebarPullRequestsInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+        let defaults = try #require(UserDefaults(suiteName: "cloud-sidebar-\(UUID())"))
+        let snapshot = SidebarWorkspaceSnapshotFactory(
+            workspace: workspace, settings: SidebarTabItemSettingsSnapshot(defaults: defaults), showsAgentActivity: false
+        ).makeSnapshot()
+        #expect(snapshot.compactDirectoryCandidates.isEmpty)
+        #expect(snapshot.compactGitBranchSummaryText == nil)
+        #expect(snapshot.branchDirectoryLines.isEmpty)
+        #expect(snapshot.pullRequestRows.isEmpty)
+        #expect(snapshot.finderDirectoryPath == nil)
+
+        let restored = Workspace()
+        _ = restored.restoreSessionSnapshot(workspace.sessionSnapshot(includeScrollback: false))
+        let restoredPanelID = try #require(restored.focusedPanelId)
+        #expect(restored.usesRemoteDirectoryProvenance)
+        #expect(restored.terminalPanel(for: restoredPanelID)?.requestedWorkingDirectory == nil)
+        #expect(restored.effectivePanelDirectory(panelId: restoredPanelID) == nil)
+        #expect(restored.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [restoredPanelID]).isEmpty)
+    }
+
+    @Test("a projected cloud panel cannot reuse local metadata after its remote cwd arrives")
+    @MainActor
+    func projectedPanelRejectsLocalMetadataWithoutWorkspaceBinding() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        let remoteMachine = SurfaceMachineID.cloud("sidebar-test-\(UUID())")
+        let resource = SurfaceResource(
+            id: SurfaceResourceID(machine: remoteMachine, kind: .terminal, key: "term_1"),
+            title: "terminal", detail: nil, lifecycle: .running,
+            agent: nil, remoteWorkspace: nil, port: nil, url: nil
+        )
+        let catalog = SurfaceCatalog.shared
+        catalog.upsert(resource)
+        catalog.record(SurfaceProjection(resource: resource.id, workspaceID: workspace.id, panelID: panelID))
+        defer {
+            catalog.endProjections(panelID: panelID)
+            catalog.remove(resource.id)
+        }
+        #expect(workspace.cloudVMBinding == nil)
+        #expect(workspace.usesRemoteDirectoryProvenance)
+        #expect(!workspace.allowsLocalDirectoryFallback(panelId: panelID))
+        #expect(workspace.effectivePanelDirectory(panelId: panelID) == nil)
+        workspace.updateRemotePanelDirectory(panelId: panelID, directory: "/home/cloud/project")
+        #expect(workspace.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+    }
+
+    @Test("daemon cwd enters the trusted remote directory path")
+    @MainActor
+    func daemonCwdIsPresentedForCloudProjection() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.cloudVMBinding = WorkspaceCloudVMBinding(vmID: machine.rawValue, isBase: false, remoteWorkspaceID: "ws_1")
+        let resource = SurfaceResource(
+            id: SurfaceResourceID(machine: machine, kind: .terminal, key: "term_1"),
+            title: "terminal", detail: "/home/cloud/project", lifecycle: .running,
+            agent: nil, remoteWorkspace: nil, port: nil, url: nil
+        )
+        let catalog = SurfaceCatalog()
+        catalog.upsert(resource)
+        catalog.record(SurfaceProjection(resource: resource.id, workspaceID: workspace.id, panelID: panelID))
+        let state = try #require(CmuxTuiSnapshotParser.state(fromSnapshot: [
+            "workspaces": [], "screens": [], "panes": [], "tabs": [],
+            "terminals": [["id": "term_1", "title": "terminal", "cwd": "/home/cloud/project", "lifecycle": "running"]],
+            "browsers": [], "agents": []
+        ], machine: machine))
+        let service = CloudWorkspaceRenameService(
+            environment: CloudWorkspaceRenameEnvironment(workspaces: { [workspace] })
+        )
+        service.reconcileRemoteState(machine: machine, state: state, catalog: catalog)
+        #expect(workspace.reportedPanelDirectory(panelId: panelID) == "/home/cloud/project")
+        #expect(workspace.presentedCurrentDirectory == "/home/cloud/project")
+    }
+
     private func nodes(link: SurfaceLinkState?, desktop: Bool = true) -> [CloudTreeNode] {
         let row = MachineSnapshot(
             id: machine.rawValue, provider: "freestyle", image: "desktop",


### PR DESCRIPTION
Cloud workspace sidebar rows could inherit the Mac launch directory, branch, and pull-request metadata because cmux-tui bindings and projections were outside the existing remote-directory provenance boundary. This change keeps Cloud rows tied to trusted machine state.

The fix:

- Treat `cloudVMBinding` and non-local `cloudProjectedResource` panels as remote directory provenance.
- Reject local cwd fallback and local `git`/`gh` probing for Cloud panels, including passive reports and restore paths.
- Feed cmux-tui terminal `cwd` values from accepted Cloud snapshots through the trusted remote-directory path; clear stale remote directory state when a terminal has no cwd or a non-terminal projection replaces it.
- Keep Cloud branch and PR rows empty until trusted remote metadata exists.
- Preserve the invariant across new bindings, projection reconciliation, and session restore, while retaining existing local and SSH behavior.
- Keep projection membership indexed so provenance checks do not rescan the catalog for every sidebar row.

Fixes #12347.

## Validation

- Regression commit `4742ba78b6` adds the failing Cloud provenance coverage; `df9b9651c6` implements the fix.
- Passed `python3 scripts/swift_file_length_budget.py`.
- Passed `./scripts/lint-pbxproj-test-wiring.sh`.
- Passed `python3 scripts/check-workspace-package-groups.py --check` and `python3 scripts/check-package-resolved-policy.py`.
- Tagged fleet build was attempted with `CMUX_DEV_BACKEND_MODE=off` through `reload-cloud.sh`. The build reached Swift compilation but was blocked by three pre-existing `origin/main` errors in `CmuxTuiSurfaceProvider+Environment.swift` (`waitForScreen` missing and an obsolete `fallbackTabID` argument); no error was reported in this issue's changed files.
- No live app was launched or user workspace disturbed.
