### PR TITLE
Cloud tree workspace titles use the full row width

### DIFF
--- a/Sources/Cloud/CloudTreeCellView.swift
+++ b/Sources/Cloud/CloudTreeCellView.swift
@@ -11,6 +11,7 @@ final class CloudTreeCellView: NSTableCellView {
 
     private let displayHost = CloudTreePassthroughHostingView(rootView: AnyView(EmptyView()))
     private var buttonsHost: NSHostingView<AnyView>?
+    private var buttonsLeadingConstraint: NSLayoutConstraint?
     private var buttonsTopConstraint: NSLayoutConstraint?
     private var buttonsCenterConstraint: NSLayoutConstraint?
     private var trackingArea: NSTrackingArea?
@@ -33,8 +34,13 @@ final class CloudTreeCellView: NSTableCellView {
             ),
             displayHost.topAnchor.constraint(equalTo: topAnchor),
             displayHost.bottomAnchor.constraint(equalTo: bottomAnchor),
-            displayHost.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
         ])
+        let trailing = displayHost.trailingAnchor.constraint(equalTo: trailingAnchor)
+        // Hover controls own the last few points on machine rows. Keeping this
+        // just below required lets their stronger constraint win while making
+        // every other row fill the cell's actual visible width.
+        trailing.priority = NSLayoutConstraint.Priority(rawValue: NSLayoutConstraint.Priority.required.rawValue - 1)
+        trailing.isActive = true
     }
 
     @available(*, unavailable)
@@ -66,6 +72,7 @@ final class CloudTreeCellView: NSTableCellView {
             buttons.rootView = AnyView(CloudTreeRowHoverButtons(kind: node.kind, machineActions: machineActions, nodeActions: nodeActions))
             buttons.isHidden = false
             buttons.alphaValue = hovered ? 1 : 0
+            buttonsLeadingConstraint?.isActive = true
             // Two-line machine cards pin the buttons to the name line; every
             // other row centers them vertically.
             let pinToNameLine = node.isMachineRow && style.machineRowLayout == .twoLine
@@ -74,6 +81,7 @@ final class CloudTreeCellView: NSTableCellView {
             buttonsCenterConstraint?.isActive = !pinToNameLine
         } else {
             buttonsHost?.isHidden = true
+            buttonsLeadingConstraint?.isActive = false
         }
         if case .machine(let machine, _) = node.kind {
             toolTip = [machine.displayName, machine.activityLabel, machine.image].joined(separator: "\n")
@@ -99,8 +107,11 @@ final class CloudTreeCellView: NSTableCellView {
         NSLayoutConstraint.activate([
             host.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -CloudTreeRowGrid.trailingPadding),
             top,
-            displayHost.trailingAnchor.constraint(lessThanOrEqualTo: host.leadingAnchor, constant: -CloudTreeRowGrid.trailingGap),
         ])
+        buttonsLeadingConstraint = displayHost.trailingAnchor.constraint(
+            lessThanOrEqualTo: host.leadingAnchor,
+            constant: -CloudTreeRowGrid.trailingGap
+        )
         buttonsTopConstraint = top
         buttonsCenterConstraint = center
         buttonsHost = host

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -186,13 +186,13 @@ struct CloudTreeRowContentView: View {
         .padding(.trailing, CloudTreeRowGrid.trailingPadding)
     }
 
+    /// Formats terminal totals for group and machine summaries.
     static func count(_ terminals: Int) -> String {
         terminals == 1
             ? String(localized: "cloudTree.workspace.terminalCount.one", defaultValue: "1 terminal")
             : String(format: String(localized: "cloudTree.workspace.terminalCount.other", defaultValue: "%d terminals"), terminals)
     }
 
-    /// Formats terminal totals for group and machine summaries.
     /// Formats the transport and screen label shown beneath a VNC display row.
     /// A key such as `display:1` becomes `noVNC · :1`; unknown key shapes retain
     /// the transport-only detail.

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -83,7 +83,7 @@ struct CloudTreeRowContentView: View {
             groupRow(title: String(localized: "cloudTree.group.displays", defaultValue: "Displays"), count: count)
         case .workspacesGroup:
             groupRow(title: String(localized: "cloudTree.group.workspaces", defaultValue: "Workspaces"))
-        case .workspace(_, let workspace, let terminalCount, _, _):
+        case .workspace(_, let workspace, _, _, _):
             // No open marker here (none on any row since #11069); the row's open
             // verb reads "Go to Workspace" when it is already showing locally.
             CloudTreeLeafRow(
@@ -91,10 +91,7 @@ struct CloudTreeRowContentView: View {
                 icon: "folder.fill",
                 tint: CloudTreeIconPalette.workspace,
                 title: workspace.name,
-                titleWeight: workspace.focused ? .medium : .regular,
-                detail: style.showsGroupCounts
-                    ? CloudTreeRowContentView.count(terminalCount)
-                    : nil
+                titleWeight: workspace.focused ? .medium : .regular
             )
         case .localWorkspace(let row):
             CloudTreeLeafRow(
@@ -102,8 +99,7 @@ struct CloudTreeRowContentView: View {
                 icon: "folder.fill",
                 tint: CloudTreeIconPalette.workspace,
                 title: row.title,
-                titleWeight: row.isSelected ? .medium : .regular,
-                detail: style.showsGroupCounts ? CloudTreeRowContentView.count(row.terminalCount) : nil
+                titleWeight: row.isSelected ? .medium : .regular
             )
         case .terminal(let row):
             CloudTreeTerminalRowContent(row: row, style: style)
@@ -196,7 +192,7 @@ struct CloudTreeRowContentView: View {
             : String(format: String(localized: "cloudTree.workspace.terminalCount.other", defaultValue: "%d terminals"), terminals)
     }
 
-    /// A workspace row's detail: the total terminal rows shown beneath it.
+    /// Formats terminal totals for group and machine summaries.
     /// Formats the transport and screen label shown beneath a VNC display row.
     /// A key such as `display:1` becomes `noVNC · :1`; unknown key shapes retain
     /// the transport-only detail.
@@ -325,7 +321,6 @@ struct CloudTreeLeafRow<Accessories: View>: View {
                         titleText
                         if let detail, !detail.isEmpty {
                             detailText(detail)
-                                .fixedSize(horizontal: true, vertical: false)
                         }
                     }
                     Spacer(minLength: CloudTreeRowGrid.trailingGap)
@@ -349,6 +344,7 @@ struct CloudTreeLeafRow<Accessories: View>: View {
             .underline(titleIsLink)
             .lineLimit(1)
             .truncationMode(.tail)
+            .layoutPriority(1)
     }
 
     private var titleColor: AnyShapeStyle {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -748,6 +748,7 @@
 		7E2EB619B840BCED615D6550 /* CloudTreeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D690BCAE82EB05A6790086AE /* CloudTreeStyle.swift */; };
 		C16B6FB2E23E52FB6F4FA4A7 /* CloudTreeStyleGalleryWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E4DB2770E4B0CBF4C388E5 /* CloudTreeStyleGalleryWindow.swift */; };
 		C986A0010000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986A0020000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift */; };
+		A12367000000000000000002 /* CloudTreeWorkspaceTitleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12367000000000000000001 /* CloudTreeWorkspaceTitleLayoutTests.swift */; };
 		BB4657280E610A6935E1906B /* CloudTuiClientPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */; };
 		17D9A335774C0C326A4B9B31 /* CloudTuiCommandLine+Placement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FCF680CF0C607A42C4C638 /* CloudTuiCommandLine+Placement.swift */; };
 		EFD39AB12F5DF90B066159C4 /* CloudTuiCommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */; };
@@ -4340,6 +4341,7 @@
 		D690BCAE82EB05A6790086AE /* CloudTreeStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeStyle.swift; sourceTree = "<group>"; };
 		46E4DB2770E4B0CBF4C388E5 /* CloudTreeStyleGalleryWindow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeStyleGalleryWindow.swift; sourceTree = "<group>"; };
 		C986A0020000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTreeSurfaceDragPasteboardWriter.swift; sourceTree = "<group>"; };
+		A12367000000000000000001 /* CloudTreeWorkspaceTitleLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeWorkspaceTitleLayoutTests.swift; sourceTree = "<group>"; };
 		8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiClientPaths.swift; sourceTree = "<group>"; };
 		79FCF680CF0C607A42C4C638 /* CloudTuiCommandLine+Placement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudTuiCommandLine+Placement.swift"; sourceTree = "<group>"; };
 		47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiCommandLine.swift; sourceTree = "<group>"; };
@@ -10202,6 +10204,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				9A986C3063FCE5F28AA10ACA /* MachinesPanelUncappedPlanTests.swift */,
 				E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */,
 				99BEA5821E46487A94B4E8B8 /* CloudTreeOneMachineManyWorkspacesTests.swift */,
+				A12367000000000000000001 /* CloudTreeWorkspaceTitleLayoutTests.swift */,
 				F739BB5F7AEF47A6A38D6B7C /* CloudWorkspaceMembershipTests.swift */,
 				F11347000000000000000004 /* CloudPortOpenRegressionTests.swift */,
 				F3E5958FB85E4B97957D4F73 /* CloudSidebarSurfaceRegressionTests.swift */,
@@ -13971,6 +13974,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B5C68F2FAFD21A103AFF429D /* CloudTreeMachineMenuTests.swift in Sources */,
 				C986A0030000000000000001 /* CloudTreeNativeDragOwnershipTests.swift in Sources */,
 				45F29E8BB64E4EE4BF204AC7 /* CloudTreeOneMachineManyWorkspacesTests.swift in Sources */,
+				A12367000000000000000002 /* CloudTreeWorkspaceTitleLayoutTests.swift in Sources */,
 				A838AA211BDA47268C683501 /* CloudTuiManualIOConnectionTests.swift in Sources */,
 				7A0CE1000000000000000106 /* CloudTunnelBackendSelectorTests.swift in Sources */,
 				7A0CE1000000000000000730 /* CloudTunnelBannerTests.swift in Sources */,

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -1,23 +1,26 @@
 import AppKit
-import Testing
+import XCTest
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
 @testable import cmux
 #endif
 
-@Suite("Cloud tree workspace title layout")
-struct CloudTreeWorkspaceTitleLayoutTests {
-    @Test("the hosted row content reaches the cell trailing edge")
-    func displayHostUsesVisibleCellWidth() throws {
+@MainActor
+final class CloudTreeWorkspaceTitleLayoutTests: XCTestCase {
+    func testDisplayHostUsesVisibleCellWidth() {
         let cell = CloudTreeCellView(frame: NSRect(x: 0, y: 0, width: 700, height: 24))
-        let host = try #require(cell.subviews.compactMap { $0 as? CloudTreePassthroughHostingView }.first)
-        let trailingConstraint = try #require(cell.constraints.first { constraint in
+        guard let host = cell.subviews.compactMap({ $0 as? CloudTreePassthroughHostingView }).first else {
+            return XCTFail("Cloud tree cell should host a pass-through display view")
+        }
+        guard let trailingConstraint = cell.constraints.first(where: { constraint in
             (constraint.firstItem as? NSView) === host
                 && constraint.firstAttribute == .trailing
                 && (constraint.secondItem as? NSView) === cell
-        })
+        }) else {
+            return XCTFail("Cloud tree display host should have a trailing constraint")
+        }
 
-        #expect(trailingConstraint.relation == .equal)
+        XCTAssertEqual(trailingConstraint.relation, .equal)
     }
 }

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Cloud tree workspace title layout")
+struct CloudTreeWorkspaceTitleLayoutTests {
+    @Test("the hosted row content reaches the cell trailing edge")
+    func displayHostUsesVisibleCellWidth() throws {
+        let cell = CloudTreeCellView(frame: NSRect(x: 0, y: 0, width: 700, height: 24))
+        let host = try #require(cell.subviews.compactMap { $0 as? CloudTreePassthroughHostingView }.first)
+        let trailingConstraint = try #require(cell.constraints.first { constraint in
+            (constraint.firstItem as? NSView) === host
+                && constraint.firstAttribute == .trailing
+                && (constraint.secondItem as? NSView) === cell
+        })
+
+        #expect(trailingConstraint.relation == .equal)
+    }
+}

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -22,5 +22,9 @@ final class CloudTreeWorkspaceTitleLayoutTests: XCTestCase {
         }
 
         XCTAssertEqual(trailingConstraint.relation, .equal)
+        XCTAssertEqual(
+            trailingConstraint.priority,
+            NSLayoutConstraint.Priority(rawValue: NSLayoutConstraint.Priority.required.rawValue - 1)
+        )
     }
 }


### PR DESCRIPTION
Fixes #12367.

Machines panel workspace rows now give the workspace title the row's visible width. Workspace rows no longer render the redundant terminal count; child terminal rows and the existing group/machine summaries still carry those counts. The shared leaf layout gives the title higher priority than optional detail text, and the AppKit hosting view is pinned to the cell trailing edge (with machine hover controls taking precedence when present), so resizing and in-place reloads use the real outline width.

Trade-off: terminal counts are intentionally removed from workspace rows because they duplicate the rows immediately below and were competing with the primary title. Group and machine summary counts remain available.

Tests and checks:
- `python3 scripts/swift_file_length_budget.py`
- `python3 scripts/normalize-pbxproj.py` (idempotence check)
- `git diff --check`
- Added `CloudTreeWorkspaceTitleLayoutTests.displayHostUsesVisibleCellWidth` as a regression test; the red test commit is `3025bf1a78`, followed by the fix commit `5655dfe056`.
- Tagged remote xctest/app verification is queued behind the shared build lock; clean cloud-Mac provisioning timed out before a GUI-ready host was assigned.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791760823&installation_model_id=21920&pr_number=12369&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12369&signature=fa62abccd144b554980f921b70d072c19b1d656c854626540e2ed1dc7a734833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only cloud tree layout and label changes with a focused regression test; no auth, data, or networking impact.
> 
> **Overview**
> Fixes cloud tree workspace title truncation by letting row content use the cell’s full visible width and simplifying what workspace rows show.
> 
> **AppKit cell layout (`CloudTreeCellView`)** pins the SwiftUI display host to the cell’s trailing edge at *required − 1* priority so non-machine rows stretch to the real outline width, while machine hover buttons keep a separate leading gap constraint that only activates when buttons are visible.
> 
> **SwiftUI row content** drops the per-workspace terminal count from remote and local workspace leaves (counts remain on group/machine summaries and child terminals). Leaf titles get `layoutPriority(1)` and inline detail no longer forces horizontal `fixedSize`, so titles win space over optional detail when both are present.
> 
> Adds **`CloudTreeWorkspaceTitleLayoutTests`** to lock in the display host’s equal trailing constraint and priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6044148a9b6d08c37b2be3db94f300d3a2f8abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives cloud tree workspace titles the full row width so they no longer truncate, and removes the redundant terminal count from workspace rows.

**Bug Fixes**
- Workspace row titles now fill the row's visible width; machine hover controls still take precedence when present.
- Terminal counts are removed from workspace rows because they duplicate the rows below; group and machine summaries keep their counts.
- Adds a regression test for the title layout.

<sup>Written for commit e6044148a9b6d08c37b2be3db94f300d3a2f8abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud tree row layout so hover actions align correctly when available.
  - Workspace and local workspace rows no longer show terminal-count details.
  - Improved inline row title layout, giving titles more room and reducing unnecessary horizontal constraints.
  - Improved spacing and trailing alignment for rows with and without hover actions.

- **Tests**
  - Added coverage for workspace title and trailing-layout behavior in cloud tree cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->