### PR TITLE
Fix Nightly compatibility warnings

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -57,7 +57,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
                     MobileBuildType.beta.token: Requirement(stableMinVersion: legacyStableMin),
-                    MobileBuildType.internal.token: Requirement(stableMinVersion: legacyStableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: legacyStableMin, nightly: nightly),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: legacyStableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                 ]
@@ -70,7 +70,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
                     MobileBuildType.beta.token: Requirement(stableMinVersion: irohStableMin),
-                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: irohStableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                 ]
@@ -82,7 +82,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
                     MobileBuildType.beta.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
-                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin),
+                    MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: stableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                 ]

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
@@ -296,6 +296,9 @@ import Testing
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.5")?.buildKinds["internal"]?.stableMinVersion == version("0.64.23"))
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.buildKinds["internal"]?.stableMinVersion == version("0.64.17"))
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.nightly?.minBuild == 3_345_650_013_202)
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.5")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
         // Versions below the first tier stay unconstrained.
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "0.9.9") == nil)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -178,7 +178,8 @@ private struct ComputerVisibilityRow: View {
                     ComputerBuildBadge(label: buildLabel)
                 }
                 if gateWarningPairingIDs.contains(computer.id)
-                    || MobileMacListAuthState.shared.compatibilityEntry(pairingID: computer.id).isOutdated {
+                    || (MobileMacListAuthState.shared.hasSnapshot
+                        && MobileMacListAuthState.shared.compatibilityEntry(pairingID: computer.id).isOutdated) {
                     Button {
                         showingHiddenVersionGateWarning = true
                     } label: {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -125,7 +125,9 @@ struct MacComputerDetailView: View {
     }
     var body: some View {
         Form {
-            if let listAuthEntry, listAuthEntry.isOutdated {
+            if MobileMacListAuthState.shared.hasSnapshot,
+               let listAuthEntry,
+               listAuthEntry.isOutdated {
                 MacComputerCompatibilitySection(entry: listAuthEntry)
             }
             connectionMethodSection

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -176,7 +176,8 @@ struct MacComputerRow: View {
     }
 
     private var showsListAuthWarning: Bool {
-        hasVersionGateWarning || listAuthEntry.isOutdated
+        hasVersionGateWarning
+            || (MobileMacListAuthState.shared.hasSnapshot && listAuthEntry.isOutdated)
     }
 
     /// Outdated rows carry a compact warning triangle beside the name; the

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -4,6 +4,7 @@ public import CmuxIrohTransport
 import CmuxIrxTransport
 public import CmuxMobileRPC
 import CmuxMobileShellModel
+import CmuxMobilePairedMac
 import CmuxMobileTransport
 public import Foundation
 

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -91,7 +91,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
         beta: { stableMinVersion: "0.64.17" },
-        internal: { stableMinVersion: "0.64.17" },
+        internal: {
+          stableMinVersion: "0.64.17",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         demo: { stableMinVersion: "0.64.17" },
         prod: {
           stableMinVersion: "0.64.23",
@@ -107,7 +110,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
         beta: { stableMinVersion: "0.64.20" },
-        internal: { stableMinVersion: "0.64.23" },
+        internal: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         demo: { stableMinVersion: "0.64.20" },
         prod: {
           stableMinVersion: "0.64.23",
@@ -125,7 +131,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
           stableMinVersion: "0.64.23",
           nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
         },
-        internal: { stableMinVersion: "0.64.23" },
+        internal: {
+          stableMinVersion: "0.64.23",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         demo: { stableMinVersion: "0.64.23" },
         prod: {
           stableMinVersion: "0.64.23",

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -96,6 +96,18 @@ describe("mobile-mac-compat route", () => {
     expect(entry.buildKinds?.beta.stableMinVersion).toBe("0.64.17");
     expect(mobileMacCompatList.entries[1].buildKinds?.internal.stableMinVersion).toBe("0.64.23");
     expect(mobileMacCompatList.entries[2].buildKinds?.internal.stableMinVersion).toBe("0.64.23");
+    expect(mobileMacCompatList.entries[0].buildKinds?.internal.nightly).toEqual({
+      minBaseVersion: "0.64.22",
+      minBuild: "3345650013202",
+    });
+    expect(mobileMacCompatList.entries[1].buildKinds?.internal.nightly).toEqual({
+      minBaseVersion: "0.64.22",
+      minBuild: "3345650013202",
+    });
+    expect(mobileMacCompatList.entries[2].buildKinds?.internal.nightly).toEqual({
+      minBaseVersion: "0.64.22",
+      minBuild: "3345650013202",
+    });
   });
 
   test("rejects conflicting legacy and build-kind minimums", () => {


### PR DESCRIPTION
The Computers screen briefly showed compatibility warnings while the first directory snapshot was still loading, then showed the Stable minimum for outdated INTERNAL Nightly Macs.

This adds the Nightly floor `0.64.22-nightly.3345650013202` to every INTERNAL iOS policy tier in both the backend payload and baked fallback. The row, hidden-computer row, and detail view now wait for the first directory snapshot before evaluating missing-version warnings, while still treating missing or invalid versions as outdated after the snapshot is present.

Validated with `bun test web/tests/mobile-mac-compat-route.test.ts` and the focused Swift package tests for `MobileMacListAuthState` and `MobileMacCompatPolicy`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791772229&installation_model_id=21920&pr_number=12385&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12385&signature=1769b7a9777866bab7365c38a30947ac429fb09d2a17a069edd3f9f521ff99a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Computers screen briefly showing compatibility warnings while the first directory snapshot loaded, and applies the Nightly floor `0.64.22-nightly.3345650013202` to INTERNAL Macs so outdated internal Nightly builds no longer fall back to the Stable minimum.

- INTERNAL iOS policy tiers now include the Nightly minimum in both the backend payload and baked fallback.
- The row, hidden-computer row, and detail view wait for the first directory snapshot before evaluating missing-version warnings; missing or invalid versions still count as outdated once the snapshot is present.

<sup>Written for commit 1d8169bb3e152900699adb0576fc1db36225376e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compatibility requirements for internal builds to include the appropriate nightly minimums across supported iOS versions.
  * Prevented outdated-version warnings from appearing before the account device list has finished loading, reducing premature or misleading warnings in computer lists and details.

* **New Features**
  * Added support for paired Mac functionality in the mobile runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->