### PR TITLE
Add Nightly compatibility floor for BETA

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatPolicy.swift
@@ -56,7 +56,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 nightly: nightly,
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
-                    MobileBuildType.beta.token: Requirement(stableMinVersion: legacyStableMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: legacyStableMin, nightly: nightly),
                     MobileBuildType.internal.token: Requirement(stableMinVersion: legacyStableMin, nightly: nightly),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: legacyStableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
@@ -69,7 +69,7 @@ public struct MobileMacCompatPolicy: Equatable, Sendable {
                 nightly: nightly,
                 buildKinds: [
                     MobileBuildType.dev.token: Requirement(stableMinVersion: devMin),
-                    MobileBuildType.beta.token: Requirement(stableMinVersion: irohStableMin),
+                    MobileBuildType.beta.token: Requirement(stableMinVersion: irohStableMin, nightly: nightly),
                     MobileBuildType.internal.token: Requirement(stableMinVersion: stableMin, nightly: nightly),
                     MobileBuildType.demo.token: Requirement(stableMinVersion: irohStableMin),
                     MobileBuildType.prod.token: Requirement(stableMinVersion: stableMin, nightly: nightly),

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacCompatPolicyTests.swift
@@ -299,6 +299,8 @@ import Testing
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.5")?.buildKinds["internal"]?.nightly?.minBuild == 3_345_650_013_202)
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.0")?.buildKinds["beta"]?.nightly?.minBuild == 3_345_650_013_202)
+        #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "1.0.4")?.buildKinds["beta"]?.nightly?.minBuild == 3_345_650_013_202)
         // Versions below the first tier stay unconstrained.
         #expect(MobileMacCompatPolicy.baked.tier(forIOSVersion: "0.9.9") == nil)
     }

--- a/web/data/mobile-mac-compat.ts
+++ b/web/data/mobile-mac-compat.ts
@@ -90,7 +90,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
       nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
-        beta: { stableMinVersion: "0.64.17" },
+        beta: {
+          stableMinVersion: "0.64.17",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         internal: {
           stableMinVersion: "0.64.17",
           nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
@@ -109,7 +112,10 @@ export const mobileMacCompatList: MobileMacCompatList = {
       nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
       buildKinds: {
         dev: { stableMinVersion: "0.64.0" },
-        beta: { stableMinVersion: "0.64.20" },
+        beta: {
+          stableMinVersion: "0.64.20",
+          nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },
+        },
         internal: {
           stableMinVersion: "0.64.23",
           nightly: { minBaseVersion: "0.64.22", minBuild: "3345650013202" },

--- a/web/tests/mobile-mac-compat-route.test.ts
+++ b/web/tests/mobile-mac-compat-route.test.ts
@@ -100,6 +100,14 @@ describe("mobile-mac-compat route", () => {
       minBaseVersion: "0.64.22",
       minBuild: "3345650013202",
     });
+    expect(mobileMacCompatList.entries[0].buildKinds?.beta.nightly).toEqual({
+      minBaseVersion: "0.64.22",
+      minBuild: "3345650013202",
+    });
+    expect(mobileMacCompatList.entries[1].buildKinds?.beta.nightly).toEqual({
+      minBaseVersion: "0.64.22",
+      minBuild: "3345650013202",
+    });
     expect(mobileMacCompatList.entries[1].buildKinds?.internal.nightly).toEqual({
       minBaseVersion: "0.64.22",
       minBuild: "3345650013202",


### PR DESCRIPTION
BETA iOS builds still had no per-build-kind Nightly floor in the older policy tiers. Add the same supported Nightly floor used by INTERNAL and App Store lanes to the backend list and baked fallback, with route and policy tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791773899&installation_model_id=21920&pr_number=12389&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12389&signature=be8ceca4664f60467350c68e60717596fb54613066e8037fef189e30bca09528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Nightly compatibility floor to BETA iOS builds so BETA users hit the same minimum Nightly version as INTERNAL and App Store builds.

**Bug Fixes**
- BETA build kinds in both older policy tiers now include a Nightly minimum, matching the INTERNAL and App Store floor.
- Updates the baked iOS policy, web data, and tests to cover the new BETA Nightly requirements.

<sup>Written for commit 9283aa209cdaf7bf318b7437dcf7e018d21ee9f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility Updates**
  - Beta builds for iOS versions 1.0.0–1.0.4 now enforce minimum nightly Mac compatibility requirements.
  - The required nightly compatibility level is aligned with the corresponding stable minimums, providing consistent validation across supported beta releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->