### PR TITLE
Cloud: surface restored terminal materialization failures

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -520058,6 +520058,124 @@
           }
         }
       }
+    },
+    "cloud.overlay.materializationFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud terminal could not start"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-Terminal konnte nicht gestartet werden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le terminal Cloud n’a pas pu démarrer"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذر تشغيل محطة Cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo iniciar el terminal de Cloud"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud 終端機無法啟動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud 终端无法启动"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud 터미널을 시작할 수 없습니다"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud ターミナルを起動できませんでした"
+          }
+        }
+      }
+    },
+    "cloud.overlay.materializationFailed.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The secure Cloud terminal endpoint is unavailable."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der sichere Cloud-Terminal-Endpunkt ist nicht verfügbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le point de terminaison sécurisé du terminal Cloud est indisponible."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطة نهاية محطة Cloud الآمنة غير متاحة."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El punto de conexión seguro del terminal de Cloud no está disponible."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全的 Cloud 終端機端點無法使用。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全的 Cloud 终端端点不可用。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보안 Cloud 터미널 엔드포인트를 사용할 수 없습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全な Cloud ターミナルエンドポイントを利用できません。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
@@ -233,9 +233,27 @@ extension CmuxTuiSurfaceProvider {
                 in: materialized.workspaceID,
                 remotePlacement: materialized.remotePlacement
             )
+            AppDelegate.shared?.workspace(containingSurfaceID: projection.panelID)?
+                .clearCloudMaterializationFailure(surfaceID: projection.panelID)
             SurfacePaneFactory.close(panelID: projection.panelID, in: projection.workspaceID)
         } catch {
             materializedPanels.remove(projection.panelID)
+            let detail = CloudMachineLink.errorText(error).isEmpty
+                ? String(localized: "cloud.overlay.materializationFailed.detail", defaultValue: "The secure Cloud terminal endpoint is unavailable.")
+                : CloudMachineLink.errorText(error)
+            var reference: String?
+            if let recorder = links.operations {
+                let context = recorder.begin(.terminal)
+                reference = "operation=\(context.operationID.uuidString.lowercased()) trace=\(context.traceID)"
+                await recorder.finish(context, error: error)
+            }
+            if let workspace = AppDelegate.shared?.workspace(containingSurfaceID: projection.panelID) {
+                workspace.setCloudMaterializationFailure(
+                    surfaceID: projection.panelID,
+                    detail: detail,
+                    reference: reference
+                )
+            }
         }
     }
 

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -445,6 +445,7 @@ extension Workspace {
         preservesTerminalForTransfer: Bool = false,
         preservesRemoteTerminalTracking: Bool = false
     ) -> WorkspaceRemoteConfiguration? {
+        cloudMaterializationFailures.removeValue(forKey: panelId)
         appLinkHandoffCoordinator.cancel(sourcePanelID: panelId)
         if publishSurfaceClosedEvent {
             publishCmuxSurfaceClosed(panelId, paneId: paneId, panel: panel, origin: origin)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3171,6 +3171,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     var pendingRemoteDisconnectReplacementsBySurfaceId: [UUID: PendingRemoteDisconnectReplacement] = [:]
     let remoteDisconnectPreparationService = RemoteDisconnectPreparationService()
     var remoteDisconnectPlaceholderPanelIds: Set<UUID> = []
+    /// A restored Cloud terminal can fail before its mirror session exists.
+    /// Keep that failure on the placeholder panel so it cannot remain blank.
+    private var cloudMaterializationFailures: [UUID: (detail: String, reference: String?)] = [:]
 
     private static let remoteErrorStatusKey = "remote.error"
     private static let remotePortConflictStatusKey = "remote.port_conflicts"
@@ -7548,6 +7551,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     }
 
     func cloudTerminalReconnectOverlayPresentation(forSurfaceId surfaceId: UUID) -> CloudTerminalReconnectOverlayPolicy.Presentation? {
+        if let failure = cloudMaterializationFailures[surfaceId] {
+            return Self.cloudMaterializationFailurePresentation(
+                detail: failure.detail,
+                reference: failure.reference
+            )
+        }
         if let resource = cloudProjectedResource(forPanel: surfaceId),
            let machineID = resource.id.machine.cloudMachineID,
            let session = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: machineID)?.manualMirrorSessions[surfaceId] {
@@ -7559,6 +7568,30 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             connectionState: remoteConnectionState,
             detail: remoteConnectionDetail
         )
+    }
+
+    nonisolated static func cloudMaterializationFailurePresentation(
+        detail: String,
+        reference: String?
+    ) -> CloudTerminalReconnectOverlayPolicy.Presentation {
+        var presentation = CloudTerminalReconnectOverlayPolicy.Presentation(
+            title: String(localized: "cloud.overlay.materializationFailed.title", defaultValue: "Cloud terminal could not start"),
+            detail: detail,
+            showsProgress: false,
+            showsReconnectButton: false
+        )
+        presentation.diagnosticReference = reference
+        return presentation
+    }
+
+    func setCloudMaterializationFailure(surfaceID: UUID, detail: String, reference: String?) {
+        cloudMaterializationFailures[surfaceID] = (detail: detail, reference: reference)
+        postRemoteConnectionPresentationDidChange()
+    }
+
+    func clearCloudMaterializationFailure(surfaceID: UUID) {
+        guard cloudMaterializationFailures.removeValue(forKey: surfaceID) != nil else { return }
+        postRemoteConnectionPresentationDidChange()
     }
 
     func postRemoteConnectionPresentationDidChange() {

--- a/cmuxTests/CloudManualMirrorTransportTests.swift
+++ b/cmuxTests/CloudManualMirrorTransportTests.swift
@@ -13,6 +13,19 @@ import Testing
 /// it never invokes the ratatui renderer or inspects source text.
 @Suite
 struct CloudManualMirrorTransportTests {
+    @Test("Restored Cloud terminal failures render a copyable error")
+    func restoredTerminalFailurePresentation() {
+        let presentation = Workspace.cloudMaterializationFailurePresentation(
+            detail: "The Cloud terminal endpoint was unavailable.",
+            reference: "operation=op trace=trace"
+        )
+
+        #expect(presentation.title == "Cloud terminal could not start")
+        #expect(presentation.detail == "The Cloud terminal endpoint was unavailable.")
+        #expect(!presentation.showsProgress)
+        #expect(!presentation.showsReconnectButton)
+        #expect(presentation.copyableError.contains("operation=op trace=trace"))
+    }
     private let commands = CloudTuiManualIOCommand()
     private let parser = CloudTuiLegacySnapshotParser()
 


### PR DESCRIPTION
When a restored Cloud terminal could not be re-materialized, cmux left the placeholder pane empty. The provider also dropped the error before creating a mirror session, so the user saw no error and no Cloud diagnostic.

This change records a foreground `.terminal` operation, stores the failure on the placeholder workspace, and renders a copyable pane overlay with the provider message and operation/trace reference. Successful re-materialization clears the overlay. Added localized title/detail strings and a regression test for the copyable failure presentation.

Validation:
- Tagged macOS build `nterr` passed.
- Localization catalog check passed, 6 catalogs and 9 locales.
- Test wiring lint passed, 877 test files.
- Focused test compilation reached the changed sources.
- End-to-end Cloud dogfood was blocked because the shared backend already had 12/12 running stacks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791774857&installation_model_id=21920&pr_number=12390&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12390&signature=53c726493993d8ecce05989c24761816530241b84b2c489953b3797234397aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces failures when a restored Cloud terminal cannot be re-materialized, so the placeholder pane now shows a copyable error overlay instead of staying blank.

**Changes**
- Records a foreground `.terminal` operation and stores the failure on the placeholder workspace.
- Renders a copyable overlay with the provider message and operation/trace reference.
- Clears the overlay on successful re-materialization and when the pane closes.
- Adds localized title/detail strings and a regression test.

<sup>Written for commit f85f9f40be4992fb62ec2f4fa875ebbce980e3fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud terminals that cannot start now display a clear, localized failure message instead of silently dropping the error.
  * Failure details and optional diagnostic references can be copied for troubleshooting.
  * The failure overlay no longer shows progress or an unavailable reconnect action.
  * Successfully restored terminals clear the previous failure state and close the temporary placeholder panel.
  * Added translations in English, German, French, Arabic, Spanish, Traditional Chinese, Simplified Chinese, Korean, and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->