### PR TITLE
Move FSEvent watcher startup off the main actor

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatchClock.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatchClock.swift
@@ -13,7 +13,7 @@ import Foundation
 /// deterministically with no real waiting.
 ///
 /// ```swift
-/// let watcher = RecursivePathWatcher(paths: paths, clock: SystemFileWatchClock())
+/// let watcher = await RecursivePathWatcher(paths: paths, clock: SystemFileWatchClock())
 /// ```
 public protocol FileWatchClock: Sendable {
     /// Suspends for `duration`, throwing `CancellationError` if the surrounding

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/RecursivePathWatcher.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/RecursivePathWatcher.swift
@@ -6,7 +6,7 @@ import Foundation
 /// for its domain) and consume ``events`` to react to changes:
 ///
 /// ```swift
-/// guard let watcher = RecursivePathWatcher(paths: paths) else { return }
+/// guard let watcher = await RecursivePathWatcher(paths: paths) else { return }
 /// let task = Task { @MainActor in
 ///     for await _ in watcher.events { reload() }
 /// }
@@ -22,14 +22,16 @@ import Foundation
 /// wait for changes to stop, which keeps reactions responsive without per-event
 /// churn.
 ///
-/// **Construction.** The `FSEventStream` is created synchronously in ``init``,
-/// so the watcher is already listening when it returns (nothing is missed in the
-/// gap a deferred start would open) and ``init`` fails (`nil`) if the stream
-/// cannot be created. The stream's `@Sendable` sink forwards into a private
-/// raw-event `AsyncStream` rather than capturing the actor, which is what lets
-/// creation happen in-`init`; a single actor-isolated pump drains that raw stream
-/// and applies the throttle. The pump's lifetime is the raw stream's: ``stop()``
-/// and `deinit` finish it.
+/// **Construction.** The `FSEventStream` is created synchronously during the
+/// asynchronous initializer, so the watcher is already listening when it
+/// returns (nothing is missed in the gap a deferred start would open) and the
+/// initializer fails (`nil`) if the stream cannot be created. Actor
+/// initialization runs on the watcher's executor, keeping the potentially
+/// blocking daemon registration off a caller's actor, including the main
+/// actor. The stream's `@Sendable` sink forwards into a private raw-event
+/// `AsyncStream` rather than capturing the actor; a single actor-isolated pump
+/// drains that raw stream and applies the throttle. The pump's lifetime is the
+/// raw stream's: ``stop()`` and `deinit` finish it.
 public struct RecursivePathChange: Equatable, Sendable {
     /// Absolute paths reported during one bounded coalescing window.
     public let paths: [String]
@@ -86,7 +88,7 @@ public actor RecursivePathWatcher {
     /// Bounds path accumulation across multiple callbacks in one window.
     private static let maximumPendingPathCount = 4_096
 
-    /// Creates and starts a watcher for `paths`.
+    /// Creates and starts a watcher for `paths` without blocking the caller's executor.
     ///
     /// - Parameters:
     ///   - paths: The files and directories to watch. Must be non-empty.
@@ -105,7 +107,7 @@ public actor RecursivePathWatcher {
         clock: any FileWatchClock = SystemFileWatchClock(),
         throttleInterval: Duration = .milliseconds(250),
         eventFilter: @escaping @Sendable (RecursivePathChange) -> Bool = { _ in true }
-    ) {
+    ) async {
         guard !paths.isEmpty else { return nil }
         self.watchedPaths = paths
         self.clock = clock

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileWatch/RecursivePathWatcherTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileWatch/RecursivePathWatcherTests.swift
@@ -76,18 +76,21 @@ extension RecursivePathWatcher {
 }
 
 @Suite struct RecursivePathWatcherTests {
-    @Test func emptyPathsFailsInitialization() {
-        let watcher = RecursivePathWatcher(paths: [])
+    @Test func emptyPathsFailsInitialization() async {
+        let watcher = await RecursivePathWatcher(paths: [])
         #expect(watcher == nil)
     }
 
-    @Test func realDirectoryStartsAndStops() async {
+    /// The production sidebar creates watchers from a main-actor service. Keep
+    /// this lifecycle check on that actor so the asynchronous initializer's
+    /// executor boundary remains part of the tested contract.
+    @Test @MainActor func realDirectoryStartsAndStops() async {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-file-watch-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        let watcher = RecursivePathWatcher(paths: [directory.path])
+        let watcher = await RecursivePathWatcher(paths: [directory.path])
         #expect(watcher != nil)
         #expect(watcher?.watchedPaths == [directory.path])
         await watcher?.stop()

--- a/Packages/macOS/CmuxGit/README.md
+++ b/Packages/macOS/CmuxGit/README.md
@@ -44,7 +44,7 @@ let meta = await git.workspaceMetadata(for: checkoutPath)
 if meta.isRepository, meta.isDirty { showDirtyDot() }
 
 if let paths = await git.watchedPaths(for: checkoutPath) {
-    let watcher = RecursivePathWatcher(paths: paths) // CmuxFileWatch
+    let watcher = await RecursivePathWatcher(paths: paths) // CmuxFileWatch
 }
 
 let slugs = await git.repositorySlugs(forDirectory: checkoutPath)

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/SidebarGitMetadataService+Watchers.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/SidebarGitMetadataService+Watchers.swift
@@ -45,13 +45,11 @@ extension SidebarGitMetadataService {
         Task { [weak self] in
             guard let gitMetadataService = self?.gitMetadataService else { return }
             let descriptor = await gitMetadataService.watchDescriptor(for: directory)
-            await MainActor.run { [weak self] in
-                self?.applyWorkspaceGitMetadataWatcherDescriptor(
-                    descriptor,
-                    for: key,
-                    request: request
-                )
-            }
+            await self?.applyWorkspaceGitMetadataWatcherDescriptor(
+                descriptor,
+                for: key,
+                request: request
+            )
         }
     }
 
@@ -59,13 +57,13 @@ extension SidebarGitMetadataService {
         _ descriptor: GitWorkspaceMetadataWatchDescriptor?,
         for key: WorkspaceGitProbeKey,
         request: WorkspaceGitMetadataWatcherDescriptorRequest
-    ) {
+    ) async {
         guard workspaceGitMetadataWatcherDescriptorRequestsByKey[key] == request else {
             return
         }
-        workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
 
         if workspaceGitMetadataWatcherDescriptorInvalidatedKeys.remove(key) != nil {
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
             guard sidebarGitMetadataActivePollingEnabled,
                   workspaceGitTrackedDirectoryByKey[key] == request.directory else {
                 stopWorkspaceGitMetadataWatcher(for: key)
@@ -82,15 +80,9 @@ extension SidebarGitMetadataService {
         guard sidebarGitMetadataActivePollingEnabled,
               workspaceGitTrackedDirectoryByKey[key] == request.directory,
               let descriptor else {
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
             stopWorkspaceGitMetadataWatcher(for: key)
             return
-        }
-
-        if let degradation = descriptor.degradation,
-           workspaceGitMetadataDegradationLoggedRepositoryRoots.insert(descriptor.repositoryRoot).inserted {
-            let message = "workspace.gitWatch.degraded " + degradation.logDescription
-            debugLog(message)
-            Self.gitWatchDiagnosticsLogger.info("\(message, privacy: .public)")
         }
 
         let watchedPathsKey = WorkspaceGitMetadataWatchedPathsKey(
@@ -99,65 +91,116 @@ extension SidebarGitMetadataService {
             eventCoalescingInterval: descriptor.eventCoalescingInterval
         )
         if workspaceGitMetadataWatchersByWatchedPathsKey[watchedPathsKey] != nil {
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
             setWorkspaceGitMetadataWatcherWatchedPathsKey(watchedPathsKey, for: key)
             moveWorkspaceGitSnapshotCacheEligibility(for: key, to: request.directory)
+            logWatcherDegradationIfNeeded(for: descriptor)
             return
         }
 
         stopWorkspaceGitMetadataWatcher(for: key)
-        if let watcher = RecursivePathWatcher(
+        workspaceGitMetadataWatcherDescriptorRequestsByKey[key] = request
+        guard let watcher = await RecursivePathWatcher(
             paths: descriptor.watchedPaths,
             throttleInterval: descriptor.eventCoalescingInterval,
             eventFilter: { descriptor.containsRelevantChange(
                 paths: $0.paths,
                 requiresFullRescan: $0.requiresFullRescan
             ) }
-        ) {
-            workspaceGitMetadataWatchersByWatchedPathsKey[watchedPathsKey] = watcher
-            setWorkspaceGitMetadataWatcherWatchedPathsKey(watchedPathsKey, for: key)
-            moveWorkspaceGitSnapshotCacheEligibility(for: key, to: request.directory)
-            let events = watcher.pathEvents
-            workspaceGitMetadataWatcherRefreshTasksByWatchedPathsKey[watchedPathsKey] = Task { @MainActor [weak self] in
-                for await change in events {
-                    guard let self else { break }
-                    // The watcher key includes the immutable filter identity,
-                    // watched roots, and throttle. Its event filter has already
-                    // evaluated this batch once, so every attached probe shares
-                    // the same relevance result.
-                    let keys = Array(
-                        self.workspaceGitMetadataWatcherProbeKeysByWatchedPathsKey[watchedPathsKey] ?? []
-                    )
-                    guard !keys.isEmpty else { continue }
-                    self.recordWorkspaceGitMetadataFilesystemEvent(for: keys)
-                    for key in keys {
-                        self.scheduleWorkspaceGitMetadataRefreshIfPossible(
-                            workspaceId: key.workspaceId,
-                            panelId: key.panelId,
-                            reason: "filesystemEvent"
-                        )
-                    }
-                    guard descriptor.containsGitMetadataChange(
-                        paths: change.paths,
-                        requiresFullRescan: change.requiresFullRescan
-                    ) else {
-                        continue
-                    }
-                    for key in keys {
-                        guard let directory = self.workspaceGitMetadataWatcherSourceDirectoryByKey[key] else {
-                            continue
-                        }
-                        self.updateWorkspaceGitMetadataWatcher(
-                            for: key,
-                            directory: directory,
-                            forceDescriptorRefresh: true
-                        )
-                    }
-                }
-            }
-        } else {
+        ) else {
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
             setWorkspaceGitMetadataWatcherSourceDirectory(request.directory, for: key)
             setWorkspaceGitMetadataWatcherWatchedPathsKey(nil, for: key)
+            return
         }
+
+        // Keep the descriptor request marked as pending while the asynchronous
+        // FSEventStream registration is in flight. A refresh request arriving
+        // during that gap marks this request invalid, so the newly-created
+        // watcher cannot be installed for stale paths.
+        guard workspaceGitMetadataWatcherDescriptorRequestsByKey[key] == request else {
+            await watcher.stop()
+            return
+        }
+        if workspaceGitMetadataWatcherDescriptorInvalidatedKeys.remove(key) != nil {
+            await watcher.stop()
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
+            guard sidebarGitMetadataActivePollingEnabled,
+                  workspaceGitTrackedDirectoryByKey[key] == request.directory else {
+                stopWorkspaceGitMetadataWatcher(for: key)
+                return
+            }
+            updateWorkspaceGitMetadataWatcher(
+                for: key,
+                directory: request.directory,
+                forceDescriptorRefresh: true
+            )
+            return
+        }
+        guard sidebarGitMetadataActivePollingEnabled,
+              workspaceGitTrackedDirectoryByKey[key] == request.directory else {
+            await watcher.stop()
+            workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
+            return
+        }
+
+        workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
+        workspaceGitMetadataWatchersByWatchedPathsKey[watchedPathsKey] = watcher
+        setWorkspaceGitMetadataWatcherWatchedPathsKey(watchedPathsKey, for: key)
+        moveWorkspaceGitSnapshotCacheEligibility(for: key, to: request.directory)
+        logWatcherDegradationIfNeeded(for: descriptor)
+        let events = watcher.pathEvents
+        workspaceGitMetadataWatcherRefreshTasksByWatchedPathsKey[watchedPathsKey] = Task { @MainActor [weak self] in
+            for await change in events {
+                guard let self else { break }
+                // The watcher key includes the immutable filter identity,
+                // watched roots, and throttle. Its event filter has already
+                // evaluated this batch once, so every attached probe shares
+                // the same relevance result.
+                let keys = Array(
+                    self.workspaceGitMetadataWatcherProbeKeysByWatchedPathsKey[watchedPathsKey] ?? []
+                )
+                guard !keys.isEmpty else { continue }
+                self.recordWorkspaceGitMetadataFilesystemEvent(for: keys)
+                for key in keys {
+                    self.scheduleWorkspaceGitMetadataRefreshIfPossible(
+                        workspaceId: key.workspaceId,
+                        panelId: key.panelId,
+                        reason: "filesystemEvent"
+                    )
+                }
+                guard descriptor.containsGitMetadataChange(
+                    paths: change.paths,
+                    requiresFullRescan: change.requiresFullRescan
+                ) else {
+                    continue
+                }
+                for key in keys {
+                    guard let directory = self.workspaceGitMetadataWatcherSourceDirectoryByKey[key] else {
+                        continue
+                    }
+                    self.updateWorkspaceGitMetadataWatcher(
+                        for: key,
+                        directory: directory,
+                        forceDescriptorRefresh: true
+                    )
+                }
+            }
+        }
+    }
+
+    private func logWatcherDegradationIfNeeded(
+        for descriptor: GitWorkspaceMetadataWatchDescriptor
+    ) {
+        guard let degradation = descriptor.degradation,
+              workspaceGitMetadataDegradationLoggedRepositoryRoots
+                  .insert(descriptor.repositoryRoot)
+                  .inserted else {
+            return
+        }
+        let message = "workspace.gitWatch.degraded " + degradation.logDescription
+        debugLog(message)
+        Self.gitWatchDiagnosticsLogger.info("\(message, privacy: .public)")
     }
 
     func workspaceGitSnapshotCacheGeneration(directory: String) -> UInt64? {


### PR DESCRIPTION
## Summary
- Make `RecursivePathWatcher` initialization asynchronous so `FSEventStreamStart` runs on the watcher executor instead of a caller's main actor.
- Keep sidebar git descriptor requests pending across asynchronous registration and discard/reschedule stale watchers when refreshes race startup.
- Update watcher documentation and main-actor lifecycle coverage.

## Testing
- `swift test --package-path Packages/macOS/CmuxFoundation --filter RecursivePathWatcherTests`
- `swift test --package-path Packages/macOS/CmuxSidebarGit --filter WatcherSafetyTests`
- Full `CmuxSidebarGit` package suite: 49 tests passed.
- Full `CmuxFoundation` package suite: 309 tests ran; unrelated `SSHForegroundAuthenticationRetryPolicyTests.processTreeTerminationUsesOneOverallDeadline` failed because the host exhausted process resources.
- Tagged reload attempted with `./scripts/reload.sh --tag i12313fix`; host Xcode failed because its derived data SDK stat cache was missing.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/12313

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791780060&installation_model_id=21920&pr_number=12392&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12392&signature=89912b2265f3e7c61942a15f34d5e8d841eb7724064572644ea96f1acf73670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `FSEventStreamStart` off the caller's main actor by making `RecursivePathWatcher` initialization asynchronous, so sidebar startup no longer blocks. Callers must now `await` watcher creation; sidebar code keeps descriptor requests pending across registration and discards stale watchers when refreshes race startup.

- Keeps the watcher already listening when the async initializer returns, so no events are missed and setup failures still return `nil`.
- Sidebar watcher requests remain marked pending while `FSEventStreamStart` is in flight, and stale watchers are stopped if a refresh invalidates them first.

<sup>Written for commit 0f260ed1966a4775559181669b16a9a993f485ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File watchers now initialize asynchronously, helping prevent blocking the calling actor while setup completes.
  - Watchers begin monitoring before initialization returns and report failure when monitoring cannot be started.
  - Git workspace monitoring now handles changing or invalidated requests more reliably, including cleanup and refresh behavior.

- **Documentation**
  - Updated usage examples and API documentation to reflect asynchronous watcher initialization and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->