### PR TITLE
fix(ci): keep external TestFlight beta current

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,12 +1,15 @@
-name: iOS TestFlight (CMUX INTERNAL)
+name: iOS TestFlight (CMUX INTERNAL + EXTERNAL)
 
 on:
-  # Poll main every 20 minutes and batch merges into one upload. The decide job
-  # skips scheduled runs when main is unchanged or the changes do not affect iOS.
+  # Poll main and batch merges into each app's upload lane. The decide job skips
+  # scheduled runs when main is unchanged or the changes do not affect iOS.
+  # Internal and external beta apps have independent App Store Connect histories.
   # Manual dispatch remains available for intentional rebuilds.
   schedule:
     # Check current main for a cmux INTERNAL upload every 20 minutes.
     - cron: "7,27,47 * * * *"
+    # Check current main for a cmux BETA external upload every hour.
+    - cron: "17 * * * *"
     # Twice-daily (every 12 hours) cmux DEMO upload of current main.
     - cron: "37 5,17 * * *"
   workflow_dispatch:
@@ -22,13 +25,16 @@ on:
       variant:
         description: >-
           Upload variant. internal (default) ships dev.cmux.app.internal /
-          "cmux INTERNAL"; demo ships dev.cmux.app.demo / "cmux DEMO" with the
-          DEMO-badged app icon and assigns to the cmux DEMO TestFlight group.
+          "cmux INTERNAL"; external ships dev.cmux.app.beta / "cmux BETA" to
+          external testers; demo ships dev.cmux.app.demo / "cmux DEMO" with
+          the DEMO-badged app icon and assigns to the cmux DEMO TestFlight
+          group.
         required: false
         default: internal
         type: choice
         options:
           - internal
+          - external
           - demo
 
 concurrency:
@@ -65,26 +71,31 @@ jobs:
             // downstream job reads needs.decide.outputs.variant instead of
             // re-deriving it from event fields.
             const internalCron = '7,27,47 * * * *';
+            const externalCron = '17 * * * *';
             const demoCron = '37 5,17 * * *';
             const requestedVariant = context.payload?.inputs?.variant;
             const schedule = context.payload?.schedule;
             let variant;
             if (context.eventName === 'schedule' && schedule === internalCron) {
               variant = 'internal';
+            } else if (context.eventName === 'schedule' && schedule === externalCron) {
+              variant = 'external';
             } else if (context.eventName === 'schedule' && schedule === demoCron) {
               variant = 'demo';
             } else if (
               context.eventName === 'workflow_dispatch' &&
-              ['internal', 'demo'].includes(requestedVariant)
+              ['internal', 'external', 'demo'].includes(requestedVariant)
             ) {
               variant = requestedVariant;
             } else {
               core.setFailed('unsupported TestFlight event, schedule, or variant');
               return;
             }
-            const canonicalArtifactName = variant === 'demo'
-              ? 'ios-testflight-build-metadata-demo'
-              : 'ios-testflight-build-metadata';
+            const canonicalArtifactName = {
+              internal: 'ios-testflight-build-metadata',
+              external: 'ios-testflight-build-metadata-external',
+              demo: 'ios-testflight-build-metadata-demo',
+            }[variant];
 
             // Per-SHA workflow concurrency preserves every push, but it also lets
             // several runs reach App Store Connect at once. Build numbers must be
@@ -175,11 +186,12 @@ jobs:
               }
             }
 
-            // Resolve the most recent successful canonical upload as the base for
-            // this build's "What to Test" commit range. Metadata artifacts are
-            // written only after the upload succeeds, and the repository artifact
-            // response includes the originating run's branch and head SHA. Looking
-            // them up directly keeps skipped schedule runs out of this history scan.
+            // Resolve the most recent successful upload for this lane as the base
+            // for this build's "What to Test" commit range. Metadata artifacts
+            // are written only after the upload succeeds, and the repository
+            // artifact response includes the originating run's branch and head
+            // SHA. Looking them up directly keeps skipped schedule runs out of
+            // this history scan.
             //
             // Manual marketing-version-override uploads are deliberately excluded
             // from this canonical lane. They ship the current main SHA under an
@@ -187,8 +199,8 @@ jobs:
             // they must not become the notes base for the next canonical main
             // upload. Override runs upload a dedicated
             // ios-testflight-build-metadata-override artifact instead of the
-            // canonical ios-testflight-build-metadata artifact, and we skip only
-            // those runs here.
+            // canonical artifact for the selected lane, and we skip only those
+            // runs here.
             //
             // Backward compatibility: before this patch there was no
             // marketing_version_override dispatch path in this workflow at all, so
@@ -556,6 +568,7 @@ jobs:
           # Optional manual one-off override that reuses an older approved beta
           # marketing version so external testers can install it immediately.
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
+          INPUT_VARIANT: ${{ needs.decide.outputs.variant }}
         run: |
           set -euo pipefail
           if [ "$IOS_TESTFLIGHT_UPLOAD_MODE" = "marketing_version_override" ]; then
@@ -574,15 +587,18 @@ jobs:
               --marketing-version "$INPUT_MARKETING_VERSION_OVERRIDE" \
               --skip-notes
           else
-            # Reuse the checked-in CMUX_IOS_BETA_MARKETING_VERSION for automatic betas.
-            # Main-push builds use:
-            # - "cmux INTERNAL" display name
-            # - dev.cmux.app.internal bundle ID (separate app, can coexist with external)
-            # - assigned to internal TestFlight group for dogfooding within the team
+            # Reuse the checked-in CMUX_IOS_BETA_MARKETING_VERSION for automatic
+            # betas. Internal and external variants select their bundle,
+            # display name, audience, and App Store Connect eligibility through
+            # the resolver above; their metadata artifacts keep notes and skip
+            # history independent.
             # --notes-from-range: auto-generate audience-appropriate "What to
             # Test" notes from the commits since the previous beta (skipped if we
             # have no base SHA yet).
             ARGS=(--lane beta --signing manual)
+            if [ "$INPUT_VARIANT" = "external" ]; then
+              ARGS+=(--external)
+            fi
             if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
               ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
             fi
@@ -614,8 +630,12 @@ jobs:
             echo
             echo "- lane: \`beta\` (bundle id \`${UPLOAD_BUNDLE_ID}\`, ${UPLOAD_AUDIENCE})"
             echo "- signing: manual (CI-imported iOS distribution cert + beta profile)"
-            if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
-              echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"
+            if [ "$UPLOAD_AUDIENCE" = "external TestFlight testers" ]; then
+              if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
+                echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"
+              else
+                echo "- marketing version: checked-in beta marketing version"
+              fi
               echo "- external groups: Founder's Edition and cmux Pro"
             else
               echo "- marketing version: checked-in beta marketing version"
@@ -651,14 +671,15 @@ jobs:
         # inside the IPA; without this artifact, a TestFlight crash whose
         # symbols ASC cannot serve is permanently unsymbolicatable (build
         # 20260730090940). Keyed by variant + CFBundleVersion so a crash
-        # report's build number finds the right bundle. The override path is
-        # excluded like the canonical metadata artifact: it archives on a fleet
-        # Mac via cloud-testflight.sh, not under CMUX_IOS_UPLOAD_DIR.
+        # report's build number finds the right bundle. Override builds archive
+        # on a fleet Mac via cloud-testflight.sh, so they remain excluded; the
+        # scheduled external lane archives under CMUX_IOS_UPLOAD_DIR and is
+        # persisted here like the internal and demo lanes.
         # Gated on the UPLOAD step's outcome, not whole-job success(): once the
         # IPA reached TestFlight its symbols must be persisted even if a later
         # step (summary/metadata artifact) failed, or a shipped build becomes
         # unsymbolicatable again.
-        if: ${{ !cancelled() && steps.upload.outcome == 'success' && steps.distribution.outputs.assign_internal_group == '1' }}
+        if: ${{ !cancelled() && steps.upload.outcome == 'success' && (steps.distribution.outputs.assign_internal_group == '1' || (steps.distribution.outputs.assign_external_group == '1' && steps.distribution.outputs.upload_mode == 'checked_in_version')) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-dsyms-${{ needs.decide.outputs.variant }}-${{ steps.upload.outputs.final_build_number }}
@@ -674,7 +695,7 @@ jobs:
         # build shows raw addresses. No --include-sources: the archive builds
         # on a fleet Mac, so its DWARF source paths do not exist on this
         # runner.
-        if: ${{ !cancelled() && steps.upload.outcome == 'success' && steps.distribution.outputs.assign_internal_group == '1' }}
+        if: ${{ !cancelled() && steps.upload.outcome == 'success' && (steps.distribution.outputs.assign_internal_group == '1' || (steps.distribution.outputs.assign_external_group == '1' && steps.distribution.outputs.upload_mode == 'checked_in_version')) }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: manaflow
@@ -692,9 +713,10 @@ jobs:
         run: |
           security delete-keychain ios-testflight.keychain >/dev/null 2>&1 || true
 
-  # Normal and demo runs assign their internal group after upload. A manual
-  # external marketing-version override assigns Founder's Edition and Pro
-  # inline in cloud-testflight.sh, so it must skip this internal-app lookup.
+  # Internal and demo runs assign their internal group after upload. External
+  # runs, including the scheduled external lane and a manual marketing-version
+  # override, assign Founder's Edition and Pro inline in upload-testflight.sh,
+  # so they skip this internal-app lookup.
   assign-internal-group:
     name: Assign build to internal TestFlight group
     needs: [decide, upload]

--- a/ios/README.md
+++ b/ios/README.md
@@ -123,12 +123,14 @@ reinstall, or operators need to cut an internal-only build on the higher version
 automatic App Store Connect export has produced IPAs whose signed app
 entitlements omit `aps-environment=production`. That upload is intentionally
 blocked because TestFlight push would silently fail. Scheduled `main` uploads
-ship only to the internal TestFlight group. A manual run with
-`marketing_version_override` switches to the external beta bundle, installs its
-provisioning profile, and assigns the processed build to both the Founder's
-Edition and Pro groups. That external override reuses an already approved
-marketing version and auto-submits the first build when Apple reports that Beta
-App Review is required.
+keep the internal `dev.cmux.app.internal` app and external `dev.cmux.app.beta`
+app current independently. The external lane uses the checked-in beta
+marketing version, installs the beta provisioning profile, and assigns the
+processed build to both the Founder's Edition and Pro groups. The first
+external build of a new marketing version is auto-submitted when Apple reports
+that Beta App Review is required. A manual run with
+`marketing_version_override` remains available as a recovery path that reuses
+an already approved marketing version.
 
 Required GitHub secrets:
 

--- a/ios/scripts/resolve_testflight_distribution.py
+++ b/ios/scripts/resolve_testflight_distribution.py
@@ -46,9 +46,9 @@ def resolve_distribution(
     override = marketing_version_override.strip()
     if variant not in {"internal", "external", "demo"}:
         raise ValueError(f"unsupported TestFlight variant: {variant}")
-    if override and variant != "internal":
+    if override and variant == "demo":
         raise ValueError(
-            "marketing_version_override requires variant=internal"
+            "marketing_version_override cannot be used with variant=demo"
         )
     if override:
         return _external_decision(

--- a/ios/scripts/resolve_testflight_distribution.py
+++ b/ios/scripts/resolve_testflight_distribution.py
@@ -21,29 +21,44 @@ class DistributionDecision(NamedTuple):
     review_note: str
 
 
+def _external_decision(
+    metadata_artifact: str,
+    upload_mode: str,
+) -> DistributionDecision:
+    return DistributionDecision(
+        bundle_id="dev.cmux.app.beta",
+        display_name="cmux BETA",
+        profile_type="beta",
+        expected_app_id="7WLXT3NR37.dev.cmux.app.beta",
+        assign_external_group=True,
+        assign_internal_group=False,
+        metadata_artifact=metadata_artifact,
+        upload_mode=upload_mode,
+        audience="external TestFlight testers",
+        review_note="Beta App Review may be required",
+    )
+
+
 def resolve_distribution(
     variant: str,
     marketing_version_override: str,
 ) -> DistributionDecision:
     override = marketing_version_override.strip()
-    if variant not in {"internal", "demo"}:
+    if variant not in {"internal", "external", "demo"}:
         raise ValueError(f"unsupported TestFlight variant: {variant}")
-    if override and variant == "demo":
+    if override and variant != "internal":
         raise ValueError(
-            "variant=demo cannot be combined with marketing_version_override"
+            "marketing_version_override requires variant=internal"
         )
     if override:
-        return DistributionDecision(
-            bundle_id="dev.cmux.app.beta",
-            display_name="cmux BETA",
-            profile_type="beta",
-            expected_app_id="7WLXT3NR37.dev.cmux.app.beta",
-            assign_external_group=True,
-            assign_internal_group=False,
+        return _external_decision(
             metadata_artifact="ios-testflight-build-metadata-override",
             upload_mode="marketing_version_override",
-            audience="external TestFlight testers",
-            review_note="Beta App Review may be required",
+        )
+    if variant == "external":
+        return _external_decision(
+            metadata_artifact="ios-testflight-build-metadata-external",
+            upload_mode="checked_in_version",
         )
     if variant == "demo":
         return DistributionDecision(

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -29,8 +29,12 @@ IOS_PATHS = (
 )
 IOS_SCHEDULES = (
     "7,27,47 * * * *",
+    "17 * * * *",
     "37 5,17 * * *",
 )
+INTERNAL_SCHEDULE = IOS_SCHEDULES[0]
+EXTERNAL_SCHEDULE = IOS_SCHEDULES[1]
+DEMO_SCHEDULE = IOS_SCHEDULES[2]
 def workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
 
@@ -185,9 +189,11 @@ def run_decision_scenario(
     decision_script = literal_block(decision_job, "script", indent=10)
     effective_variant = input_variant
     if event_name == "schedule":
-        if schedule == IOS_SCHEDULES[0]:
+        if schedule == INTERNAL_SCHEDULE:
             effective_variant = "internal"
-        elif schedule == IOS_SCHEDULES[1]:
+        elif schedule == EXTERNAL_SCHEDULE:
+            effective_variant = "external"
+        elif schedule == DEMO_SCHEDULE:
             effective_variant = "demo"
     try:
         produced_artifact_name = resolved_metadata_artifact(
@@ -641,7 +647,7 @@ def test_unchanged_scheduled_head_skips_without_comparing() -> None:
 def test_schedule_decision_routes_demo_cron_to_demo_history() -> None:
     first_run = run_decision_scenario(
         event_name="schedule",
-        schedule=IOS_SCHEDULES[1],
+        schedule=DEMO_SCHEDULE,
         input_variant="",
     )
     produced_artifact = first_run["producedArtifactName"]
@@ -655,7 +661,7 @@ def test_schedule_decision_routes_demo_cron_to_demo_history() -> None:
 
     result = run_decision_scenario(
         event_name="schedule",
-        schedule=IOS_SCHEDULES[1],
+        schedule=DEMO_SCHEDULE,
         input_variant="",
         prior_sha="demo-base-sha",
         prior_artifact=produced_artifact,
@@ -672,7 +678,7 @@ def test_schedule_decision_routes_demo_cron_to_demo_history() -> None:
 def test_schedule_decision_routes_internal_cron_to_internal_history() -> None:
     first_run = run_decision_scenario(
         event_name="schedule",
-        schedule=IOS_SCHEDULES[0],
+        schedule=INTERNAL_SCHEDULE,
         input_variant="",
     )
     produced_artifact = first_run["producedArtifactName"]
@@ -686,7 +692,7 @@ def test_schedule_decision_routes_internal_cron_to_internal_history() -> None:
 
     result = run_decision_scenario(
         event_name="schedule",
-        schedule=IOS_SCHEDULES[0],
+        schedule=INTERNAL_SCHEDULE,
         input_variant="",
         prior_sha="internal-base-sha",
         prior_artifact=produced_artifact,
@@ -697,6 +703,37 @@ def test_schedule_decision_routes_internal_cron_to_internal_history() -> None:
         "should_build": "false",
         "last_uploaded_sha": "internal-base-sha",
         "variant": "internal",
+    }
+
+
+def test_schedule_decision_routes_external_cron_to_external_history() -> None:
+    first_run = run_decision_scenario(
+        event_name="schedule",
+        schedule=EXTERNAL_SCHEDULE,
+        input_variant="",
+    )
+    produced_artifact = first_run["producedArtifactName"]
+    assert isinstance(produced_artifact, str)
+    assert first_run["outputs"] == {
+        "should_build": "true",
+        "last_uploaded_sha": "",
+        "variant": "external",
+    }
+    assert produced_artifact == "ios-testflight-build-metadata-external"
+
+    result = run_decision_scenario(
+        event_name="schedule",
+        schedule=EXTERNAL_SCHEDULE,
+        input_variant="",
+        prior_sha="external-base-sha",
+        prior_artifact=produced_artifact,
+        changed_files=("docs/cli-contract.md",),
+    )
+
+    assert result["outputs"] == {
+        "should_build": "false",
+        "last_uploaded_sha": "external-base-sha",
+        "variant": "external",
     }
 
 
@@ -718,7 +755,7 @@ def test_decision_rejects_unknown_schedule_and_dispatch_variant() -> None:
 def test_demo_history_skips_newer_internal_artifact() -> None:
     result = run_decision_scenario(
         event_name="schedule",
-        schedule=IOS_SCHEDULES[1],
+        schedule=DEMO_SCHEDULE,
         input_variant="",
         prior_uploads=(
             ("newer-internal-sha", "ios-testflight-build-metadata"),
@@ -1167,4 +1204,5 @@ if __name__ == "__main__":
     test_testflight_notes_use_the_same_ios_path_contract()
     test_scheduled_and_manual_runs_use_independent_concurrency_groups()
     test_automatic_lane_stays_on_cmux_internal_identity()
+    test_schedule_decision_routes_external_cron_to_external_history()
     print("all iOS TestFlight scheduling tests passed")

--- a/tests/test_ios_testflight_pro_distribution.py
+++ b/tests/test_ios_testflight_pro_distribution.py
@@ -77,6 +77,21 @@ def test_distribution_helper_resolves_manual_external_override() -> None:
     assert decision.metadata_artifact == "ios-testflight-build-metadata-override"
 
 
+def test_distribution_helper_resolves_automatic_external_upload() -> None:
+    helper = load_distribution_helper()
+
+    decision = helper.resolve_distribution("external", "")
+
+    assert decision.bundle_id == "dev.cmux.app.beta"
+    assert decision.display_name == "cmux BETA"
+    assert decision.profile_type == "beta"
+    assert decision.assign_external_group is True
+    assert decision.assign_internal_group is False
+    assert decision.metadata_artifact == "ios-testflight-build-metadata-external"
+    assert decision.upload_mode == "checked_in_version"
+    assert decision.audience == "external TestFlight testers"
+
+
 def test_workflow_executes_distribution_helper_and_consumes_its_outputs() -> None:
     text = workflow_text()
     upload_job = workflow_job(text, "upload")
@@ -85,6 +100,8 @@ def test_workflow_executes_distribution_helper_and_consumes_its_outputs() -> Non
     assert "python3 ./ios/scripts/resolve_testflight_distribution.py" in upload_job
     assert "IOS_BETA_BUNDLE_ID: ${{ steps.distribution.outputs.bundle_id }}" in upload_job
     assert "name: ${{ steps.distribution.outputs.metadata_artifact }}" in upload_job
+    assert "ARGS+=(--external)" in upload_job
+    assert "steps.distribution.outputs.assign_external_group == '1'" in upload_job
     assert "needs.upload.outputs.assign_internal_group == '1'" in assign_job
     assert "ASSIGN_BUNDLE_ID: ${{ needs.upload.outputs.bundle_id }}" in assign_job
 
@@ -99,6 +116,7 @@ if __name__ == "__main__":
     test_distribution_helper_resolves_automatic_internal_upload()
     test_distribution_helper_resolves_demo_upload()
     test_distribution_helper_resolves_manual_external_override()
+    test_distribution_helper_resolves_automatic_external_upload()
     test_workflow_executes_distribution_helper_and_consumes_its_outputs()
     test_ci_executes_this_testflight_workflow_guard()
     print("all iOS TestFlight Pro distribution tests passed")

--- a/tests/test_ios_testflight_pro_distribution.py
+++ b/tests/test_ios_testflight_pro_distribution.py
@@ -92,6 +92,29 @@ def test_distribution_helper_resolves_automatic_external_upload() -> None:
     assert decision.audience == "external TestFlight testers"
 
 
+def test_distribution_helper_allows_external_variant_recovery_override() -> None:
+    helper = load_distribution_helper()
+
+    decision = helper.resolve_distribution("external", "1.2.3")
+
+    assert decision.bundle_id == "dev.cmux.app.beta"
+    assert decision.assign_external_group is True
+    assert decision.assign_internal_group is False
+    assert decision.metadata_artifact == "ios-testflight-build-metadata-override"
+    assert decision.upload_mode == "marketing_version_override"
+
+
+def test_distribution_helper_rejects_demo_recovery_override() -> None:
+    helper = load_distribution_helper()
+
+    try:
+        helper.resolve_distribution("demo", "1.2.3")
+    except ValueError as error:
+        assert str(error) == "marketing_version_override cannot be used with variant=demo"
+    else:
+        raise AssertionError("demo recovery override should be rejected")
+
+
 def test_workflow_executes_distribution_helper_and_consumes_its_outputs() -> None:
     text = workflow_text()
     upload_job = workflow_job(text, "upload")
@@ -117,6 +140,8 @@ if __name__ == "__main__":
     test_distribution_helper_resolves_demo_upload()
     test_distribution_helper_resolves_manual_external_override()
     test_distribution_helper_resolves_automatic_external_upload()
+    test_distribution_helper_allows_external_variant_recovery_override()
+    test_distribution_helper_rejects_demo_recovery_override()
     test_workflow_executes_distribution_helper_and_consumes_its_outputs()
     test_ci_executes_this_testflight_workflow_guard()
     print("all iOS TestFlight Pro distribution tests passed")


### PR DESCRIPTION
Fixes #12366.

The external TestFlight app was only updated through a manual marketing-version override, so external testers could remain on a build predating the Tailscale readiness fix from #10473.

This change adds an independent scheduled external beta lane and dispatch option. It resolves the beta bundle/profile, marks uploads external-eligible, assigns the Founder's Edition and cmux Pro groups, submits Beta App Review when Apple requires it, and keeps external metadata/history separate from the internal and demo lanes. Focused tests cover cron routing, artifact history, distribution resolution, group/review behavior, and external notes.

Validation:
- `python3 tests/test_ios_testflight_external_distribution.py`
- `python3 tests/test_ios_testflight_notes.py`
- `python3 tests/test_ios_testflight_main_push_filter.py`
- `python3 tests/test_ios_testflight_pro_distribution.py`
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/cloud-testflight.sh`
- `python3 -m py_compile ios/scripts/resolve_testflight_distribution.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- package resolved/workspace grouping checks

The tagged macOS build check was attempted but could not start because this checkout had uninitialized submodules; the documented setup then stopped at the machine disk limit while cloning them (100% full, about 530 MB free).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791781214&installation_model_id=21920&pr_number=12395&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12395&signature=9f935942a246cb231fa5d5932d0401ed12b8c5f501553ffb38668713cdd76205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #12366. The external TestFlight app previously only got updates through manual marketing-version overrides, so external testers could remain on builds missing the Tailscale readiness fix from #10473. This adds an independent hourly scheduled external beta lane plus a dispatch option so the external app tracks main automatically.

- Resolves the `dev.cmux.app.beta` bundle and beta profile for external uploads.
- Assigns external builds to the Founder's Edition and cmux Pro groups and submits Beta App Review when Apple requires it.
- Keeps external metadata artifacts and notes history separate from the internal and demo lanes.
- Allows the manual `marketing_version_override` dispatch on the external variant to reuse an approved marketing version as a recovery path; demo still rejects the override.

<sup>Written for commit df18d1ae228573a8351ae80197c711db7c1c0ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an external beta distribution lane for scheduled and manually triggered TestFlight uploads.
  * External uploads use dedicated build metadata, App Store Connect history, beta versioning, tester groups, and Beta App Review submission when needed.
  * Added recovery support for external uploads using an approved marketing version override.

* **Documentation**
  * Updated iOS TestFlight documentation with external beta distribution details.

* **Tests**
  * Added coverage for external routing, artifact selection, upload arguments, tester groups, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->