### PR TITLE
Fix Claude lifecycle subcommand passthrough

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -1210,9 +1210,10 @@ claude_passthrough_option_flag() {
 
 claude_builtin_command_name() {
     case "$1" in
-        agents|attach|auth|auto-mode|config|api-key|daemon|doctor|install|mcp|\
+        agents|attach|auth|auto-mode|config|api-key|daemon|doctor|gateway|import|install|\
+        kill|logs|mcp|respawn|rm|\
         experimental-next|plugin|plugins|project|rc|remote-control|setup-token|\
-        ultrareview|update|upgrade)
+        stop|ultrareview|update|upgrade)
             return 0
             ;;
     esac

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1153,21 +1153,32 @@ def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> 
     expect("--session-id" not in real_argv, f"agents after global option passthrough: expected no --session-id injection, got {real_argv}", failures)
 
 
-def test_hidden_attach_subcommand_bypasses_hook_injection(failures: list[str]) -> None:
-    # `claude attach <id>` is a real subcommand (the attach door for `--bg`
-    # background sessions) but is hidden from `claude --help`, so it's easy to
-    # miss when refreshing the builtin-command list. Injecting
-    # --session-id/--settings ahead of it makes the CLI treat "attach" as the
-    # [prompt] positional and mint a fresh session instead of attaching.
-    code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
-        socket_state="live",
-        argv=["attach", "abc12345"],
+def test_new_claude_subcommands_bypass_hook_injection(failures: list[str]) -> None:
+    # These commands are real Claude subcommands, including lifecycle commands
+    # that are hidden from `claude --help`. Injecting --session-id/--settings
+    # ahead of them makes the CLI treat the command as prompt text instead of
+    # dispatching the requested subcommand.
+    subcommand_argvs = (
+        ["attach", "abc12345"],
+        ["logs", "abc12345"],
+        ["stop", "abc12345"],
+        ["kill", "abc12345"],
+        ["rm", "abc12345"],
+        ["respawn", "abc12345"],
+        ["gateway"],
+        ["import"],
     )
-    expect(code == 0, f"attach passthrough: wrapper exited {code}: {stderr}", failures)
-    expect(real_argv == ["attach", "abc12345"], f"attach passthrough: expected raw argv, got {real_argv}", failures)
-    expect("--settings" not in real_argv, f"attach passthrough: expected no --settings injection, got {real_argv}", failures)
-    expect("--session-id" not in real_argv, f"attach passthrough: expected no --session-id injection, got {real_argv}", failures)
-    expect(node_options == "__UNSET__", f"attach passthrough: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
+    for argv in subcommand_argvs:
+        label = " ".join(argv)
+        code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=argv,
+        )
+        expect(code == 0, f"{label} passthrough: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == argv, f"{label} passthrough: expected raw argv, got {real_argv}", failures)
+        expect("--settings" not in real_argv, f"{label} passthrough: expected no --settings injection, got {real_argv}", failures)
+        expect("--session-id" not in real_argv, f"{label} passthrough: expected no --session-id injection, got {real_argv}", failures)
+        expect(node_options == "__UNSET__", f"{label} passthrough: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
 
 
 def test_passthrough_flags_bypass_hook_injection(failures: list[str]) -> None:
@@ -2737,7 +2748,7 @@ def main() -> int:
     test_large_settings_file_is_merged_without_argv_growth(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
-    test_hidden_attach_subcommand_bypasses_hook_injection(failures)
+    test_new_claude_subcommands_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)
     test_live_socket_attaches_cmux_cua_when_available(failures)
     test_computer_use_wrapper_is_a_pure_proxy(failures)


### PR DESCRIPTION
## Summary

Fix the Claude wrapper so lifecycle and Agent View subcommands are passed to Claude unchanged. Previously, the wrapper injected a fresh session ID, hook settings, and Node options, causing Claude to interpret these commands as prompt text.

The allowlist now includes `logs`, `stop`, `kill`, `rm`, `respawn`, `gateway`, and `import` (with existing `attach` coverage), and the regression harness exercises each invocation.

Fixes #12284

## Verification

- `bash -n Resources/bin/cmux-claude-wrapper`
- Focused behavioral regression: `test_new_claude_subcommands_bypass_hook_injection` (all eight commands pass)
- Pre-fix control using the parent wrapper produces 28 expected assertion failures
- `git diff --check main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791781308&installation_model_id=21920&pr_number=12396&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12396&signature=2155f30e926f4d4305f56aa2f6c8777aa043696a6b28154ac098f1bf782410e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude wrapper so lifecycle and Agent View subcommands are passed through unchanged, preventing the wrapper from injecting session ID, hook settings, and Node options that caused Claude to treat these commands as prompt text.

- Expands the builtin-command allowlist with `logs`, `stop`, `kill`, `rm`, `respawn`, `gateway`, and `import` (in addition to existing `attach`).
- Updates the regression harness to exercise all eight subcommands.

Fixes #12284.

<sup>Written for commit e5b112068a36c2350c9c74489483bed969701c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude command subcommands such as `gateway`, `import`, `kill`, `logs`, `respawn`, and `rm` now run as standalone commands without receiving session-specific options.
  - Expanded pass-through handling prevents command-line hooks and environment settings from being injected into supported administrative and utility commands.
  - Improved coverage ensures these subcommands, along with existing commands such as `attach` and `stop`, preserve their original arguments and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->