### PR TITLE
fix: mark workspace-level notifications read on workspace resume

### DIFF
--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
@@ -55,8 +55,18 @@ public final class NotificationDismissalModel: NotificationDismissing {
         let shouldSuppressFlash = suppressFocusFlash
         suppressFocusFlash = false
         guard !shouldSuppressFlash else { return }
-        guard let surfaceId = host?.focusedSurfaceId(in: workspaceId) else { return }
-        dismissPanelNotificationOnFocus(workspaceId: workspaceId, panelId: surfaceId, context: context)
+        guard let host else { return }
+        if let surfaceId = host.focusedSurfaceId(in: workspaceId) {
+            dismissPanelNotificationOnFocus(workspaceId: workspaceId, panelId: surfaceId, context: context)
+        }
+        guard host.storeHasUnreadNotification(workspaceId: workspaceId, surfaceId: nil) ||
+            host.storeHasPendingNotification(workspaceId: workspaceId, surfaceId: nil) else {
+            return
+        }
+        // Workspace-level notifications have no surface to follow. They become
+        // visible when the workspace is resumed, so dismiss them independently
+        // of the focused-surface pass.
+        _ = dismissNotification(workspaceId: workspaceId, surfaceId: nil, context: context)
     }
 
     public func dismissPanelNotificationOnFocus(

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
@@ -46,6 +46,7 @@ public final class NotificationDismissalModel: NotificationDismissing {
         return context
     }
 
+    /// Dismisses notifications for the focused surface and the resumed workspace.
     public func dismissFocusedPanelNotificationIfActive(
         workspaceId: UUID,
         context: NotificationDismissalContext

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -306,6 +306,19 @@ struct NotificationDismissalModelTests {
         #expect(host.log == ["markRead:nil", "clearFocusedRead:nil"])
     }
 
+    @Test func workspaceLevelNotificationDismissesWithoutFocusedSurface() {
+        let (model, host, workspaceId, _) = makeModel()
+        host.focusedSurfaceIds[workspaceId] = nil
+        host.workspaceWideUnread = [workspaceId]
+
+        model.dismissFocusedPanelNotificationIfActive(
+            workspaceId: workspaceId,
+            context: .explicitWorkspaceResume
+        )
+
+        #expect(host.log == ["markRead:nil", "clearFocusedRead:nil"])
+    }
+
     @Test func pendingSelectionContextTakeClearsIt() {
         let (model, _, _, _) = makeModel()
         #expect(model.takePendingSelectionContext() == nil)

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -294,6 +294,18 @@ struct NotificationDismissalModelTests {
         ])
     }
 
+    @Test func workspaceLevelNotificationDismissesWhenFocusedSurfaceIsAlreadyRead() {
+        let (model, host, workspaceId, _) = makeModel()
+        host.workspaceWideUnread = [workspaceId]
+
+        model.dismissFocusedPanelNotificationIfActive(
+            workspaceId: workspaceId,
+            context: .explicitWorkspaceResume
+        )
+
+        #expect(host.log == ["markRead:nil", "clearFocusedRead:nil"])
+    }
+
     @Test func pendingSelectionContextTakeClearsIt() {
         let (model, _, _, _) = makeModel()
         #expect(model.takePendingSelectionContext() == nil)


### PR DESCRIPTION
## Problem
Workspace-level notifications with `surface_id: null` remained unread after selecting and focusing the workspace because dismissal only followed the focused surface.

## Fix
On workspace resume, run the existing focused-surface dismissal and then dismiss the workspace-level notification namespace when unread or policy-pending state exists. This keeps all notification mutations on the shared dismissal path.

Added a behavior regression test proving a workspace-level notification is marked read and its focused-read indicator is cleared when the focused surface is already read.

## Verification
- `swift test` in `Packages/macOS/CmuxNotifications` (114 tests passed)
- `bash scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/swift_file_length_budget.py`

Refs #12387

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791781853&installation_model_id=21920&pr_number=12398&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12398&signature=e8030dadc2e23685435c1ab968a7315f6d0581865e001330179790e07f549979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks workspace-level notifications read when the workspace is resumed. Previously, only notifications tied to the focused surface were dismissed, leaving workspace-level notifications with `surface_id: null` unread; now the shared dismissal path clears workspace-level unread and pending state, and focused-surface dismissal behavior is unchanged. Fixes #12387.

<sup>Written for commit 2f0ed62ff251fedbf648aa744fe84e8ac3a1b6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace-level unread or pending notifications are now dismissed when resuming a workspace, even if the focused surface is already read or unavailable.
  - Focused surface notifications continue to be dismissed when active.
  - Notification dismissal safely handles detached workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->