### PR TITLE
Fix relay broker failure visibility and account quota isolation

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohBrokerFailure.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohBrokerFailure.swift
@@ -9,7 +9,7 @@ public struct CmxIrohBrokerFailure: Equatable, Sendable, CustomStringConvertible
 
     public init(statusCode: Int, code: String?, requestID: String?) {
         self.statusCode = statusCode
-        self.code = Self.bounded(code)
+        self.code = Self.safeCode(code)
         self.requestID = Self.bounded(requestID)
     }
 
@@ -38,5 +38,20 @@ public struct CmxIrohBrokerFailure: Equatable, Sendable, CustomStringConvertible
             return nil
         }
         return value
+    }
+
+    private static func safeCode(_ value: String?) -> String? {
+        guard let value,
+              let category = value.split(separator: ":", maxSplits: 1).first
+        else { return nil }
+        switch category {
+        case "relay_policy_unavailable", "rate_limited",
+             "authentication_unavailable", "preference_conflict":
+            return String(category)
+        case "invalid_binding_request_proof", "binding_request_proof_required":
+            return "authorization_failed"
+        default:
+            return nil
+        }
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohBrokerFailure.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohBrokerFailure.swift
@@ -1,0 +1,42 @@
+/// Bounded, non-secret metadata returned by the authenticated Iroh broker.
+///
+/// The broker keeps the public error response coarse, but a status/code/request
+/// ID tuple lets support distinguish an outage from a local policy failure.
+public struct CmxIrohBrokerFailure: Equatable, Sendable, CustomStringConvertible {
+    public let statusCode: Int
+    public let code: String?
+    public let requestID: String?
+
+    public init(statusCode: Int, code: String?, requestID: String?) {
+        self.statusCode = statusCode
+        self.code = Self.bounded(code)
+        self.requestID = Self.bounded(requestID)
+    }
+
+    public var description: String {
+        var result = "HTTP \(statusCode)"
+        if let code {
+            result += " (\(code))"
+        }
+        if let requestID {
+            result += " requestID=\(requestID)"
+        }
+        return result
+    }
+
+    private static func bounded(_ value: String?) -> String? {
+        guard let value,
+              (1 ... 128).contains(value.utf8.count),
+              value.unicodeScalars.allSatisfy({
+                  switch $0.value {
+                  case 48 ... 57, 65 ... 90, 97 ... 122, 45, 46, 58, 95:
+                      true
+                  default:
+                      false
+                  }
+              }) else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohConnectionCheckReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohConnectionCheckReport.swift
@@ -60,6 +60,7 @@ public struct CmxIrohConnectionCheckReport: Equatable, Sendable {
     public let recommendation: Recommendation
     public let failureKind: DiagnosticFailureKind?
     public let selectedPath: CmxIrohSelectedTransportPath
+    public let brokerFailure: CmxIrohBrokerFailure?
 
     public var isReady: Bool {
         !stages.contains { $0.status == .failed }
@@ -75,6 +76,7 @@ public struct CmxIrohConnectionCheckReport: Equatable, Sendable {
         self.role = role
         failureKind = diagnostics.lastFailureKind
         selectedPath = snapshot.selectedTransportPath
+        brokerFailure = snapshot.brokerFailure
 
         let transportStatus: StageStatus = switch snapshot.runtimeStatus {
         case .inactive, .degraded: .failed

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
@@ -166,6 +166,8 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
     public let policyExpiresAt: Date?
     public let staleRelayIDs: Set<String>
     public let failureDescription: String?
+    /// Bounded broker response metadata for the most recent policy failure.
+    public let brokerFailure: CmxIrohBrokerFailure?
     /// Debug-only path constraint, or `nil` when the current app cannot control it.
     public let debugTransportVerificationMode: CmxIrohTransportVerificationMode?
 
@@ -188,6 +190,7 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         policyExpiresAt: Date? = nil,
         staleRelayIDs: Set<String> = [],
         failureDescription: String? = nil,
+        brokerFailure: CmxIrohBrokerFailure? = nil,
         debugTransportVerificationMode: CmxIrohTransportVerificationMode? = nil
     ) {
         self.runtimeStatus = runtimeStatus
@@ -203,6 +206,7 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         self.policyExpiresAt = policyExpiresAt
         self.staleRelayIDs = staleRelayIDs
         self.failureDescription = failureDescription
+        self.brokerFailure = brokerFailure
         self.debugTransportVerificationMode = debugTransportVerificationMode
     }
 

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohConnectionCheckReportTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohConnectionCheckReportTests.swift
@@ -79,6 +79,24 @@ struct CmxIrohConnectionCheckReportTests {
     }
 
     @Test
+    func brokerFailureRedactsProviderSpecificCodes() {
+        let failure = CmxIrohBrokerFailure(
+            statusCode: 429,
+            code: "rate_limited:auth_provider",
+            requestID: "req-safe"
+        )
+
+        #expect(failure.code == "rate_limited")
+        #expect(
+            CmxIrohBrokerFailure(
+                statusCode: 503,
+                code: "signing_key_invalid",
+                requestID: "req-safe"
+            ).code == nil
+        )
+    }
+
+    @Test
     func missingMacIsDistinguishedFromAReachableRelay() {
         let report = CmxIrohConnectionCheckReport(
             role: .mobileClient,

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohConnectionCheckReportTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohConnectionCheckReportTests.swift
@@ -59,6 +59,26 @@ struct CmxIrohConnectionCheckReportTests {
     }
 
     @Test
+    func connectionReportCarriesBrokerFailureMetadata() {
+        let brokerFailure = CmxIrohBrokerFailure(
+            statusCode: 503,
+            code: "relay_policy_unavailable",
+            requestID: "req-broker-503"
+        )
+        let report = CmxIrohConnectionCheckReport(
+            role: .macHost,
+            snapshot: snapshot(
+                runtimeStatus: .degraded,
+                brokerFailure: brokerFailure
+            ),
+            diagnostics: .empty,
+            relayReachability: .unavailable
+        )
+
+        #expect(report.brokerFailure == brokerFailure)
+    }
+
+    @Test
     func missingMacIsDistinguishedFromAReachableRelay() {
         let report = CmxIrohConnectionCheckReport(
             role: .mobileClient,
@@ -165,7 +185,8 @@ struct CmxIrohConnectionCheckReportTests {
     private func snapshot(
         runtimeStatus: CmxIrohSettingsSnapshot.RuntimeStatus,
         selectedPath: CmxIrohSelectedTransportPath = .unavailable,
-        hasMac: Bool = false
+        hasMac: Bool = false,
+        brokerFailure: CmxIrohBrokerFailure? = nil
     ) -> CmxIrohSettingsSnapshot {
         CmxIrohSettingsSnapshot(
             runtimeStatus: runtimeStatus,
@@ -176,7 +197,8 @@ struct CmxIrohConnectionCheckReportTests {
             privateNetworkMacs: hasMac
                 ? [.init(macDeviceID: "mac", displayName: "Mac")]
                 : [],
-            policySource: .server
+            policySource: .server,
+            brokerFailure: brokerFailure
         )
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
@@ -351,6 +351,14 @@ public actor CmxIrohBrokerBackpressureGate {
                 CmxIrohBrokerCooldown.defaultRateLimitedSeconds,
                 .cooldown
             )
+        case let .rejectedWithMetadata(statusCode, code, _, retryAfterSeconds)
+            where statusCode == 429:
+            directive = (
+                Self.normalizedRetryAfter(
+                    retryAfterSeconds ?? CmxIrohBrokerCooldown.defaultRateLimitedSeconds
+                ),
+                .brokerRateLimit(code: code)
+            )
         default:
             directive = nil
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerCooldown.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerCooldown.swift
@@ -68,8 +68,8 @@ public extension CmxIrohBrokerCooldown {
             .retryAfterSeconds {
             return retryAfterSeconds
         }
-        if case let .rejected(statusCode, _)? = error as? CmxIrohTrustBrokerClientError,
-           statusCode == 429 {
+        if let brokerError = error as? CmxIrohTrustBrokerClientError,
+           brokerError.brokerStatusCode == 429 {
             return defaultRateLimitedSeconds
         }
         return nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -177,6 +177,12 @@ extension CmxIrohTrustBrokerClientError: DiagnosticFailureProviding {
             case 408: .timedOut
             default: .policyUnavailable
             }
+        case let .rejectedWithMetadata(statusCode, _, _, _):
+            switch statusCode {
+            case 401, 403: .authorizationFailed
+            case 408: .timedOut
+            default: .policyUnavailable
+            }
         case .invalidBaseURL, .nonHTTPResponse, .invalidResponse:
             .protocolViolation
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -1067,10 +1067,18 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             )
             pairGrantRetryDeadline = nil
         } catch let error as CmxIrohTrustBrokerClientError {
-            if case let .rateLimited(code, retryAfterSeconds) = error {
+            if error.brokerStatusCode == 429 {
                 pairGrantRetryDeadline = (
-                    code: code,
-                    date: now.addingTimeInterval(TimeInterval(max(1, retryAfterSeconds)))
+                    code: error.brokerResponseCode,
+                    date: now.addingTimeInterval(
+                        TimeInterval(
+                            max(
+                                1,
+                                error.retryAfterSeconds
+                                    ?? CmxIrohBrokerCooldown.defaultRateLimitedSeconds
+                            )
+                        )
+                    )
                 )
             }
             throw error

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayDiagnosticsSnapshot.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayDiagnosticsSnapshot.swift
@@ -1,3 +1,4 @@
+public import CMUXMobileCore
 public import Foundation
 
 /// Redacted relay policy state suitable for UI and support diagnostics.
@@ -32,6 +33,9 @@ public struct CmxIrohRelayDiagnosticsSnapshot: Equatable, Sendable {
     /// Last non-secret policy resolution failure.
     public let failure: CmxIrohRelayPolicyFailure?
 
+    /// Bounded metadata from the most recent broker response failure.
+    public let brokerFailure: CmxIrohBrokerFailure?
+
     static let inactive = CmxIrohRelayDiagnosticsSnapshot(
         source: .inactive,
         policyID: nil,
@@ -42,6 +46,7 @@ public struct CmxIrohRelayDiagnosticsSnapshot: Equatable, Sendable {
         selectedRelayCount: 0,
         staleRelayIDs: [],
         missingCredentialRelayIDs: [],
-        failure: nil
+        failure: nil,
+        brokerFailure: nil
     )
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyResolution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyResolution.swift
@@ -276,7 +276,8 @@ enum CmxIrohRelayPolicyResolution {
 
     static func diagnostics(
         for effective: CmxIrohEffectiveRelayPolicy,
-        failure: CmxIrohRelayPolicyFailure?
+        failure: CmxIrohRelayPolicyFailure?,
+        brokerFailure: CmxIrohBrokerFailure? = nil
     ) -> CmxIrohRelayDiagnosticsSnapshot {
         let policy = effective.managedPolicy
         let selectedIDs: [String]
@@ -300,11 +301,15 @@ enum CmxIrohRelayPolicyResolution {
             selectedRelayCount: effective.endpointRelayProfile.allowedRelayURLs.count,
             staleRelayIDs: effective.staleRelayIDs.sorted(),
             missingCredentialRelayIDs: effective.missingCredentialRelayIDs.sorted(),
-            failure: failure
+            failure: failure,
+            brokerFailure: brokerFailure
         )
     }
 
     static func failure(for error: any Error) -> CmxIrohRelayPolicyFailure {
+        if error is CmxIrohTrustBrokerClientError {
+            return .policyUnavailable
+        }
         if let serviceError = error as? CmxIrohRelayPolicyServiceError,
            serviceError == .preferenceRollback {
             return .preferenceRollback

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -12,7 +12,6 @@ public actor CmxIrohRelayPolicyService {
     private let broker: (any CmxIrohRelayPolicyServing)?
     private var currentEffective: CmxIrohEffectiveRelayPolicy?
     private var currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot.inactive
-    private var lastBrokerFailure: CmxIrohBrokerFailure?
     private var continuations: [UUID: AsyncStream<CmxIrohRelayDiagnosticsSnapshot>.Continuation] = [:]
     private var operationRevision: UInt64 = 0
 
@@ -528,7 +527,6 @@ public actor CmxIrohRelayPolicyService {
         brokerFailure: CmxIrohBrokerFailure? = nil
     ) {
         currentEffective = effective
-        lastBrokerFailure = brokerFailure
         currentDiagnostics = Resolver.diagnostics(
             for: effective,
             failure: failure,
@@ -543,10 +541,7 @@ public actor CmxIrohRelayPolicyService {
         _ failure: CmxIrohRelayPolicyFailure,
         brokerFailure: CmxIrohBrokerFailure? = nil
     ) {
-        if let brokerFailure {
-            lastBrokerFailure = brokerFailure
-        }
-        let diagnosticBrokerFailure = brokerFailure ?? lastBrokerFailure
+        let diagnosticBrokerFailure = brokerFailure ?? currentDiagnostics.brokerFailure
         guard let effective = currentEffective else {
             currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot(
                 source: .inactive,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -12,6 +12,7 @@ public actor CmxIrohRelayPolicyService {
     private let broker: (any CmxIrohRelayPolicyServing)?
     private var currentEffective: CmxIrohEffectiveRelayPolicy?
     private var currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot.inactive
+    private var lastBrokerFailure: CmxIrohBrokerFailure?
     private var continuations: [UUID: AsyncStream<CmxIrohRelayDiagnosticsSnapshot>.Continuation] = [:]
     private var operationRevision: UInt64 = 0
 
@@ -61,13 +62,26 @@ public actor CmxIrohRelayPolicyService {
         now: Date = Date()
     ) async throws -> RefreshOutcome {
         guard let broker else { throw CmxIrohRelayPolicyServiceError.brokerUnavailable }
-        let bootstrap = try await broker.issueRelayBootstrap(endpointID: endpointID)
+        let operation = beginOperation()
+        let bootstrap: CmxIrohRelayBootstrapResponse
+        do {
+            bootstrap = try await broker.issueRelayBootstrap(endpointID: endpointID)
+        } catch {
+            if isCurrent(operation) {
+                publishFailure(
+                    Resolver.failure(for: error),
+                    brokerFailure: (error as? CmxIrohTrustBrokerClientError)?.brokerFailure
+                )
+            }
+            throw error
+        }
         let effective = try await install(
             response: bootstrap.relayPolicy,
             accountID: accountID,
             trustRoot: trustRoot,
             relayCredential: bootstrap.relayToken,
-            now: now
+            now: now,
+            operation: operation
         )
         return RefreshOutcome(
             effective: effective,
@@ -87,7 +101,24 @@ public actor CmxIrohRelayPolicyService {
         relayCredential: CmxIrohRelayTokenResponse?,
         now: Date = Date()
     ) async throws -> CmxIrohEffectiveRelayPolicy {
-        let operation = beginOperation()
+        try await install(
+            response: response,
+            accountID: accountID,
+            trustRoot: trustRoot,
+            relayCredential: relayCredential,
+            now: now,
+            operation: beginOperation()
+        )
+    }
+
+    private func install(
+        response: CmxIrohRelayPolicyResponse,
+        accountID: String,
+        trustRoot: CmxIrohRelayPolicyTrustRoot,
+        relayCredential: CmxIrohRelayTokenResponse?,
+        now: Date,
+        operation: UInt64
+    ) async throws -> CmxIrohEffectiveRelayPolicy {
         do {
             try await Resolver.validatePreferenceRevision(
                 response.preferenceRevision,
@@ -294,6 +325,12 @@ public actor CmxIrohRelayPolicyService {
         do {
             response = try await broker.updateRelayPreference(request)
         } catch {
+            if isCurrent(operation) {
+                publishFailure(
+                    Resolver.failure(for: error),
+                    brokerFailure: (error as? CmxIrohTrustBrokerClientError)?.brokerFailure
+                )
+            }
             if let authoritative = try? await broker.relayPreference() {
                 _ = try? await reconcileCommittedConfiguration(
                     authoritative,
@@ -487,16 +524,29 @@ public actor CmxIrohRelayPolicyService {
 
     private func publish(
         _ effective: CmxIrohEffectiveRelayPolicy,
-        failure: CmxIrohRelayPolicyFailure?
+        failure: CmxIrohRelayPolicyFailure?,
+        brokerFailure: CmxIrohBrokerFailure? = nil
     ) {
         currentEffective = effective
-        currentDiagnostics = Resolver.diagnostics(for: effective, failure: failure)
+        lastBrokerFailure = brokerFailure
+        currentDiagnostics = Resolver.diagnostics(
+            for: effective,
+            failure: failure,
+            brokerFailure: brokerFailure
+        )
         for continuation in continuations.values {
             continuation.yield(currentDiagnostics)
         }
     }
 
-    private func publishFailure(_ failure: CmxIrohRelayPolicyFailure) {
+    private func publishFailure(
+        _ failure: CmxIrohRelayPolicyFailure,
+        brokerFailure: CmxIrohBrokerFailure? = nil
+    ) {
+        if let brokerFailure {
+            lastBrokerFailure = brokerFailure
+        }
+        let diagnosticBrokerFailure = brokerFailure ?? lastBrokerFailure
         guard let effective = currentEffective else {
             currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot(
                 source: .inactive,
@@ -508,14 +558,19 @@ public actor CmxIrohRelayPolicyService {
                 selectedRelayCount: 0,
                 staleRelayIDs: [],
                 missingCredentialRelayIDs: [],
-                failure: failure
+                failure: failure,
+                brokerFailure: diagnosticBrokerFailure
             )
             for continuation in continuations.values {
                 continuation.yield(currentDiagnostics)
             }
             return
         }
-        currentDiagnostics = Resolver.diagnostics(for: effective, failure: failure)
+        currentDiagnostics = Resolver.diagnostics(
+            for: effective,
+            failure: failure,
+            brokerFailure: diagnosticBrokerFailure
+        )
         for continuation in continuations.values {
             continuation.yield(currentDiagnostics)
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -45,15 +45,13 @@ public struct CmxIrohBrokerCredentials: Sendable, CustomStringConvertible,
 private func isUnsupportedRegistrationScope(
     _ error: CmxIrohTrustBrokerClientError
 ) -> Bool {
-    guard case let .rejected(statusCode, code) = error else { return false }
-    return statusCode == 400 && code == "unknown_field"
+    error.brokerStatusCode == 400 && error.brokerResponseCode == "unknown_field"
 }
 
 private func isMissingScopedDiscoveryRoute(
     _ error: CmxIrohTrustBrokerClientError
 ) -> Bool {
-    guard case let .rejected(statusCode, _) = error else { return false }
-    return statusCode == 404
+    error.brokerStatusCode == 404
 }
 
 /// One authenticated account and credential pair captured atomically.
@@ -760,8 +758,8 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     private static func isStaleDiscoveryCursor(
         _ error: CmxIrohTrustBrokerClientError
     ) -> Bool {
-        guard case let .rejected(statusCode, code) = error else { return false }
-        return statusCode == 409 && code == "discovery_cursor_stale"
+        error.brokerStatusCode == 409
+            && error.brokerResponseCode == "discovery_cursor_stale"
     }
 
     private func sendUngated<Response: Decodable & Sendable, Body: Encodable>(
@@ -859,8 +857,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     private static func isUnauthorizedRejection(
         _ error: CmxIrohTrustBrokerClientError
     ) -> Bool {
-        guard case let .rejected(statusCode, _) = error else { return false }
-        return statusCode == 401
+        error.brokerStatusCode == 401
     }
 
     private func performAuthenticatedRequest<Response: Decodable & Sendable>(
@@ -943,10 +940,28 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             let code = body.map { payload in
                 payload.source.map { "\(payload.error):\($0.rawValue)" } ?? payload.error
             }
+            // Use the metadata case when the broker supplies a correlation ID;
+            // retain the established error cases for older responses so
+            // callers that match those cases keep their existing behavior.
+            let metadata = body?.requestID.map { requestID in
+                CmxIrohBrokerFailure(
+                    statusCode: http.statusCode,
+                    code: code,
+                    requestID: requestID
+                )
+            }
             if http.statusCode == 429 {
                 let retryAfterSeconds = Self.retryAfterSeconds(
                     http.value(forHTTPHeaderField: "Retry-After")
                 ) ?? CmxRetryAfterPolicy.defaultRateLimitSeconds
+                if let metadata {
+                    throw CmxIrohTrustBrokerClientError.rejectedWithMetadata(
+                        statusCode: metadata.statusCode,
+                        code: metadata.code,
+                        requestID: metadata.requestID,
+                        retryAfterSeconds: retryAfterSeconds
+                    )
+                }
                 throw CmxIrohTrustBrokerClientError.rateLimited(
                     code: code,
                     retryAfterSeconds: retryAfterSeconds
@@ -956,10 +971,26 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                let retryAfterSeconds = Self.retryAfterSeconds(
                    http.value(forHTTPHeaderField: "Retry-After")
                ) {
+                if let metadata {
+                    throw CmxIrohTrustBrokerClientError.rejectedWithMetadata(
+                        statusCode: metadata.statusCode,
+                        code: metadata.code,
+                        requestID: metadata.requestID,
+                        retryAfterSeconds: retryAfterSeconds
+                    )
+                }
                 throw CmxIrohTrustBrokerClientError.rejectedWithRetryAfter(
                     statusCode: http.statusCode,
                     code: code,
                     retryAfterSeconds: retryAfterSeconds
+                )
+            }
+            if let metadata {
+                throw CmxIrohTrustBrokerClientError.rejectedWithMetadata(
+                    statusCode: metadata.statusCode,
+                    code: metadata.code,
+                    requestID: metadata.requestID,
+                    retryAfterSeconds: nil
                 )
             }
             throw CmxIrohTrustBrokerClientError.rejected(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -67,6 +67,12 @@ public enum CmxIrohTrustBrokerClientError:
     case rateLimited(code: String?, retryAfterSeconds: Int)
     case rejected(statusCode: Int, code: String?)
     case rejectedWithRetryAfter(statusCode: Int, code: String?, retryAfterSeconds: Int)
+    case rejectedWithMetadata(
+        statusCode: Int,
+        code: String?,
+        requestID: String?,
+        retryAfterSeconds: Int?
+    )
     case invalidResponse
 
     /// Whether an inconclusive refresh may preserve already-verified state.
@@ -104,6 +110,12 @@ public enum CmxIrohTrustBrokerClientError:
                 || statusCode == 425
                 || statusCode == 429
                 || (500...599).contains(statusCode)
+        case let .rejectedWithMetadata(statusCode, _, _, _):
+            return statusCode == 401
+                || statusCode == 408
+                || statusCode == 425
+                || statusCode == 429
+                || (500...599).contains(statusCode)
         case .invalidBaseURL,
              .missingAuthentication,
              .invalidAuthentication,
@@ -136,6 +148,11 @@ public enum CmxIrohTrustBrokerClientError:
                 || statusCode == 425
                 || statusCode == 429
                 || (500...599).contains(statusCode)
+        case let .rejectedWithMetadata(statusCode, _, _, _):
+            return statusCode == 408
+                || statusCode == 425
+                || statusCode == 429
+                || (500...599).contains(statusCode)
         case .invalidBaseURL,
              .missingAuthentication,
              .invalidAuthentication,
@@ -151,8 +168,53 @@ public enum CmxIrohTrustBrokerClientError:
         case let .rateLimited(_, retryAfterSeconds),
              let .rejectedWithRetryAfter(_, _, retryAfterSeconds):
             return retryAfterSeconds
+        case let .rejectedWithMetadata(_, _, _, retryAfterSeconds):
+            return retryAfterSeconds
         default:
             return nil
+        }
+    }
+
+    /// HTTP status from a broker response, when this is an HTTP rejection.
+    public var brokerStatusCode: Int? {
+        switch self {
+        case .rateLimited:
+            429
+        case let .rejected(statusCode, _),
+             let .rejectedWithRetryAfter(statusCode, _, _),
+             let .rejectedWithMetadata(statusCode, _, _, _):
+            statusCode
+        default:
+            nil
+        }
+    }
+
+    /// Bounded broker error code, when this is an HTTP rejection.
+    public var brokerResponseCode: String? {
+        switch self {
+        case let .rateLimited(code, _),
+             let .rejected(_, code),
+             let .rejectedWithRetryAfter(_, code, _),
+             let .rejectedWithMetadata(_, code, _, _):
+            code
+        default:
+            nil
+        }
+    }
+
+    /// Safe response metadata for relay policy diagnostics.
+    public var brokerFailure: CmxIrohBrokerFailure? {
+        switch self {
+        case let .rateLimited(code, _):
+            CmxIrohBrokerFailure(statusCode: 429, code: code, requestID: nil)
+        case let .rejected(statusCode, code):
+            CmxIrohBrokerFailure(statusCode: statusCode, code: code, requestID: nil)
+        case let .rejectedWithRetryAfter(statusCode, code, _):
+            CmxIrohBrokerFailure(statusCode: statusCode, code: code, requestID: nil)
+        case let .rejectedWithMetadata(statusCode, code, requestID, _):
+            CmxIrohBrokerFailure(statusCode: statusCode, code: code, requestID: requestID)
+        default:
+            nil
         }
     }
 
@@ -193,6 +255,10 @@ extension CmxIrohTrustBrokerClientError: CustomStringConvertible {
         case let .rejectedWithRetryAfter(statusCode, code, retryAfterSeconds):
             "rejected(statusCode: \(statusCode), code: \(String(describing: code)), "
                 + "retryAfterSeconds: \(retryAfterSeconds))"
+        case let .rejectedWithMetadata(statusCode, code, requestID, retryAfterSeconds):
+            "rejected(statusCode: \(statusCode), code: \(String(describing: code)), "
+                + "requestID: \(String(describing: requestID)), "
+                + "retryAfterSeconds: \(String(describing: retryAfterSeconds)))"
         case .invalidResponse:
             "invalidResponse"
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
@@ -5,10 +5,13 @@ struct CmxIrohTrustBrokerError: Decodable {
     let error: String
     /// Which enforcement layer produced a 429.
     let source: CmxIrohTrustBrokerErrorSource?
+    /// Broker-generated correlation identifier for operational failures.
+    let requestID: String?
 
     private enum CodingKeys: String, CodingKey {
         case error
         case source
+        case requestID = "requestId"
     }
 
     init(from decoder: any Decoder) throws {
@@ -18,5 +21,6 @@ struct CmxIrohTrustBrokerError: Decodable {
         // an unknown or malformed source.
         source = (try? container.decode(String.self, forKey: .source))
             .flatMap(CmxIrohTrustBrokerErrorSource.init(rawValue:))
+        requestID = try? container.decode(String.self, forKey: .requestID)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceRefreshTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceRefreshTests.swift
@@ -29,6 +29,30 @@ private actor RefreshBootstrapBroker: CmxIrohRelayPolicyServing {
     }
 }
 
+private actor FailingRefreshBroker: CmxIrohRelayPolicyServing {
+    private let error: CmxIrohTrustBrokerClientError
+
+    init(error: CmxIrohTrustBrokerClientError) {
+        self.error = error
+    }
+
+    func issueRelayBootstrap(
+        endpointID _: CmxIrohPeerIdentity
+    ) async throws -> CmxIrohRelayBootstrapResponse {
+        throw error
+    }
+
+    func relayPreference() async throws -> CmxIrohRelayPreferenceResponse {
+        throw error
+    }
+
+    func updateRelayPreference(
+        _: CmxIrohRelayPreferenceUpdateRequest
+    ) async throws -> CmxIrohRelayPreferenceResponse {
+        throw error
+    }
+}
+
 @Suite
 struct CmxIrohRelayPolicyServiceRefreshTests {
     @Test
@@ -67,6 +91,40 @@ struct CmxIrohRelayPolicyServiceRefreshTests {
         #expect(outcome.effective.endpointRelayProfile.allowedRelayURLs
             == Set(fixture.relayURLs))
         #expect(await broker.bootstrapRequestCount == 1)
+    }
+
+    @Test
+    func refreshPublishesBrokerFailureMetadata() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let failure = CmxIrohTrustBrokerClientError.rejectedWithMetadata(
+            statusCode: 503,
+            code: "relay_policy_unavailable",
+            requestID: "req-broker-503",
+            retryAfterSeconds: 15
+        )
+        let broker = FailingRefreshBroker(error: failure)
+        let service = CmxIrohRelayPolicyService(broker: broker)
+
+        await #expect(throws: failure) {
+            _ = try await service.refresh(
+                endpointID: try CmxIrohPeerIdentity(
+                    endpointID: String(repeating: "c", count: 64)
+                ),
+                accountID: "account-a",
+                trustRoot: fixture.firstTrustRoot,
+                now: fixture.now
+            )
+        }
+
+        let diagnostics = await service.diagnosticsSnapshot()
+        #expect(diagnostics.failure == .policyUnavailable)
+        #expect(
+            diagnostics.brokerFailure == CmxIrohBrokerFailure(
+                statusCode: 503,
+                code: "relay_policy_unavailable",
+                requestID: "req-broker-503"
+            )
+        )
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -23,6 +23,27 @@ extension CmxIrohTrustBrokerClientTests {
     }
 
     @Test
+    func unavailableResponseExposesSafeBrokerFailureMetadata() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(
+                status: 503,
+                body: #"{"error":"relay_policy_unavailable","requestId":"req-broker-503"}"#,
+                headers: ["Retry-After": "600"]
+            ),
+        ])
+        let client = try makeNetworkClient(transport: transport)
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.rejectedWithMetadata(
+            statusCode: 503,
+            code: "relay_policy_unavailable",
+            requestID: "req-broker-503",
+            retryAfterSeconds: 600
+        )) {
+            _ = try await client.discover()
+        }
+    }
+
+    @Test
     func rateLimitRetainsEveryValidRetryAfterFloor() async throws {
         for (header, expected) in [
             ("600", CmxIrohTrustBrokerClientError.rateLimited(

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
@@ -472,14 +472,15 @@ public actor IrxBrokerService {
     /// re-arms signing on this client) instead of retrying into the same
     /// rejection forever.
     private func invalidateBindingOnProofRejection(_ error: any Error) {
-        guard case let .rejected(statusCode, code)? = error as? CmxIrohTrustBrokerClientError,
-            statusCode == 403,
-            code == "binding_request_proof_required" || code == "invalid_binding_request_proof"
+        guard let brokerError = error as? CmxIrohTrustBrokerClientError,
+            brokerError.brokerStatusCode == 403,
+            brokerError.brokerResponseCode == "binding_request_proof_required"
+                || brokerError.brokerResponseCode == "invalid_binding_request_proof"
         else { return }
         bindingCache.clear()
         journal.record(
             "broker", "binding-invalidated-on-proof-rejection",
-            ["code": code ?? "-"]
+            ["code": brokerError.brokerResponseCode ?? "-"]
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohConnectionCheckSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohConnectionCheckSection.swift
@@ -115,6 +115,7 @@ struct MobileIrohConnectionCheckSection: View {
         lines.append(contentsOf: report.stages.map {
             "\(stageTitle($0.kind)): \(stageStatus($0.status))"
         })
+        lines.append(contentsOf: brokerFailureReportLines(report))
         if report.recommendation != .none {
             lines.append(
                 "\(L10n.string("mobile.iroh.check.report.action", defaultValue: "Suggested Action")): \(recommendation(report.recommendation))"
@@ -123,6 +124,38 @@ struct MobileIrohConnectionCheckSection: View {
         // Relay origins stay out of this report: the diagnostics privacy copy
         // promises reports exclude relay URLs. Share IT Allowlist carries them.
         return lines.joined(separator: "\n")
+    }
+
+    private func brokerFailureReportLines(
+        _ report: CmxIrohConnectionCheckReport
+    ) -> [String] {
+        guard let failure = report.brokerFailure else { return [] }
+        let unknown = L10n.string(
+            "mobile.iroh.check.diagnostics.unknown",
+            defaultValue: "Unknown"
+        )
+        var lines = [
+            String(
+                format: L10n.string(
+                    "mobile.iroh.check.report.brokerFailure",
+                    defaultValue: "Broker response: HTTP %1$d (%2$@)"
+                ),
+                failure.statusCode,
+                failure.code ?? unknown
+            ),
+        ]
+        if let requestID = failure.requestID {
+            lines.append(
+                String(
+                    format: L10n.string(
+                        "mobile.iroh.check.report.requestID",
+                        defaultValue: "Support request ID: %@"
+                    ),
+                    requestID
+                )
+            )
+        }
+        return lines
     }
 
     private func selectedPath(_ path: CmxIrohSelectedTransportPath) -> String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -12665,6 +12665,183 @@
           }
         }
       }
+    },
+    "mobile.iroh.check.report.brokerFailure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Broker response: HTTP %1$d (%2$@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブローカー応答: HTTP %1$d (%2$@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brokerantwort: HTTP %1$d (%2$@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réponse du broker : HTTP %1$d (%2$@)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استجابة الوسيط: HTTP %1$d (%2$@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta del intermediario: HTTP %1$d (%2$@)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中繼回應：HTTP %1$d (%2$@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中继响应：HTTP %1$d (%2$@)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "브로커 응답: HTTP %1$d (%2$@)"
+          }
+        }
+      }
+    },
+    "mobile.iroh.check.report.requestID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support request ID: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポートリクエスト ID: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support-Anfrage-ID: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de demande d’assistance : %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف طلب الدعم: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID de solicitud de soporte: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支援請求 ID：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持请求 ID：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원 요청 ID: %@"
+          }
+        }
+      }
+    },
+    "mobile.iroh.check.diagnostics.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnu"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير معروف"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconocido"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없음"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
@@ -522,6 +522,7 @@ private final class MobileIrohSettingsControllerDouble:
             policyExpiresAt: snapshot.policyExpiresAt,
             staleRelayIDs: snapshot.staleRelayIDs,
             failureDescription: snapshot.failureDescription,
+            brokerFailure: snapshot.brokerFailure,
             debugTransportVerificationMode: mode
         )
     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohConnectionCheckCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohConnectionCheckCard.swift
@@ -140,6 +140,7 @@ struct IrohConnectionCheckCard: View {
         lines.append(contentsOf: report.stages.filter { $0.status != .notApplicable }.map {
             "\(stageTitle($0.kind)): \(stageStatus($0.status))"
         })
+        lines.append(contentsOf: brokerFailureReportLines(report))
         if report.recommendation != .none {
             lines.append(
                 "\(String(localized: "settings.networking.check.report.action", defaultValue: "Suggested Action")): \(recommendation(report.recommendation))"
@@ -148,6 +149,38 @@ struct IrohConnectionCheckCard: View {
         // Relay origins stay out of this report: the diagnostics privacy copy
         // promises reports exclude relay URLs. The IT allowlist carries them.
         return lines.joined(separator: "\n")
+    }
+
+    private func brokerFailureReportLines(
+        _ report: CmxIrohConnectionCheckReport
+    ) -> [String] {
+        guard let failure = report.brokerFailure else { return [] }
+        let unknown = String(
+            localized: "settings.networking.diagnostics.failure.unknown",
+            defaultValue: "Unknown"
+        )
+        var lines = [
+            String(
+                format: String(
+                    localized: "settings.networking.check.report.brokerFailure",
+                    defaultValue: "Broker response: HTTP %1$d (%2$@)"
+                ),
+                failure.statusCode,
+                failure.code ?? unknown
+            ),
+        ]
+        if let requestID = failure.requestID {
+            lines.append(
+                String(
+                    format: String(
+                        localized: "settings.networking.check.report.requestID",
+                        defaultValue: "Support request ID: %@"
+                    ),
+                    requestID
+                )
+            )
+        }
+        return lines
     }
 
     private func selectedPath(_ path: CmxIrohSelectedTransportPath) -> String {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -275,6 +275,9 @@ public struct IrohNetworkingSection: View {
                 isMutating: model.isMutating,
                 clear: { await model.clearDiagnosticReport() }
             )
+            if let brokerFailure = model.snapshot.brokerFailure {
+                SettingsCardNote(brokerFailureNote(brokerFailure))
+            }
             if !model.snapshot.staleRelayIDs.isEmpty || model.snapshot.failureDescription != nil {
                 SettingsCardNote(String(
                     localized: "settings.networking.attention",
@@ -282,6 +285,35 @@ public struct IrohNetworkingSection: View {
                 ))
             }
         }
+    }
+
+    private func brokerFailureNote(_ failure: CmxIrohBrokerFailure) -> String {
+        let unknown = String(
+            localized: "settings.networking.diagnostics.failure.unknown",
+            defaultValue: "Unknown"
+        )
+        var lines = [
+            String(
+                format: String(
+                    localized: "settings.networking.policy.brokerFailure",
+                    defaultValue: "Broker response: HTTP %1$d (%2$@)"
+                ),
+                failure.statusCode,
+                failure.code ?? unknown
+            ),
+        ]
+        if let requestID = failure.requestID {
+            lines.append(
+                String(
+                    format: String(
+                        localized: "settings.networking.policy.requestID",
+                        defaultValue: "Support request ID: %@"
+                    ),
+                    requestID
+                )
+            )
+        }
+        return lines.joined(separator: "\n")
     }
 
     private var connectionCheckCard: some View {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -509928,6 +509928,34 @@
           }
         }
       }
+    },
+    "settings.networking.policy.brokerFailure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Broker response: HTTP %1$d (%2$@)" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ブローカー応答: HTTP %1$d (%2$@)" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Brokerantwort: HTTP %1$d (%2$@)" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Réponse du broker : HTTP %1$d (%2$@)" } },
+        "ar": { "stringUnit": { "state": "translated", "value": "استجابة الوسيط: HTTP %1$d (%2$@)" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Respuesta del intermediario: HTTP %1$d (%2$@)" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "中繼回應：HTTP %1$d (%2$@)" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "中继响应：HTTP %1$d (%2$@)" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "브로커 응답: HTTP %1$d (%2$@)" } }
+      }
+    },
+    "settings.networking.policy.requestID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Support request ID: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "サポートリクエスト ID: %@" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Support-Anfrage-ID: %@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "ID de demande d’assistance : %@" } },
+        "ar": { "stringUnit": { "state": "translated", "value": "معرّف طلب الدعم: %@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "ID de solicitud de soporte: %@" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "支援請求 ID：%@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "支持请求 ID：%@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "지원 요청 ID: %@" } }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -509940,7 +509940,73 @@
         "es": { "stringUnit": { "state": "translated", "value": "Respuesta del intermediario: HTTP %1$d (%2$@)" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "中繼回應：HTTP %1$d (%2$@)" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "中继响应：HTTP %1$d (%2$@)" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "브로커 응답: HTTP %1$d (%2$@)" } }
+        "ko": { "stringUnit": { "state": "translated", "value": "브로커 응답: HTTP %1$d (%2$@)" } },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odgovor posrednika: HTTP %1$d (%2$@)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svar fra broker: HTTP %1$d (%2$@)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Risposta del broker: HTTP %1$d (%2$@)"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការឆ្លើយតបពីប្រូកស៊ី៖ HTTP %1$d (%2$@)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svar fra meglingstjener: HTTP %1$d (%2$@)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odpowiedź brokera: HTTP %1$d (%2$@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resposta do broker: HTTP %1$d (%2$@)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ответ брокера: HTTP %1$d (%2$@)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบกลับจากโบรกเกอร์: HTTP %1$d (%2$@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aracı yanıtı: HTTP %1$d (%2$@)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відповідь брокера: HTTP %1$d (%2$@)"
+          }
+        }
       }
     },
     "settings.networking.policy.requestID": {
@@ -509954,7 +510020,73 @@
         "es": { "stringUnit": { "state": "translated", "value": "ID de solicitud de soporte: %@" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "支援請求 ID：%@" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "支持请求 ID：%@" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "지원 요청 ID: %@" } }
+        "ko": { "stringUnit": { "state": "translated", "value": "지원 요청 ID: %@" } },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID zahtjeva za podršku: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supportanmodnings-id: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID richiesta di supporto: %@"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "លេខសម្គាល់សំណើជំនួយ៖ %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID for støtteforespørsel: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identyfikator zgłoszenia do pomocy: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID da solicitação de suporte: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идентификатор запроса в поддержку: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รหัสคำขอการสนับสนุน: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destek istek kimliği: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ідентифікатор запиту до служби підтримки: %@"
+          }
+        }
       }
     }
   },

--- a/Sources/Mobile/MobileHostIrohRuntime+SettingsSnapshot.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+SettingsSnapshot.swift
@@ -59,6 +59,7 @@ extension MobileHostIrohRuntime {
             policyExpiresAt: diagnostics?.policyExpiresAt,
             staleRelayIDs: Set(diagnostics?.staleRelayIDs ?? []),
             failureDescription: diagnostics?.failure?.rawValue,
+            brokerFailure: diagnostics?.brokerFailure,
             debugTransportVerificationMode: debugTransportVerificationMode
         )
     }

--- a/web/app/api/relay/preferences/route.ts
+++ b/web/app/api/relay/preferences/route.ts
@@ -1,6 +1,7 @@
 // Read and update account-scoped Iroh relay selection metadata.
 // Custom relay secrets stay in the native client's Keychain and are rejected here.
 
+import { randomUUID } from "node:crypto";
 import { runWithCloudDbQueryTags } from "../../../../db/queryTags";
 import { checkRateLimit } from "@vercel/firewall";
 
@@ -65,6 +66,7 @@ const productionDeps: RelayPreferenceDeps = {
 async function authenticatedAccount(
   request: Request,
   deps: RelayPreferenceDeps,
+  requestId: string,
 ): Promise<AuthedUser | Response> {
   let user: AuthedUser | null;
   try {
@@ -76,6 +78,7 @@ async function authenticatedAccount(
   await runRelayEffect(enforceRelayRateLimit({
     request,
     accountId: user.id,
+    requestId,
     ruleId: deps.rateLimitRuleId(),
     check: deps.checkRateLimit,
     isVercel: deps.isVercel(),
@@ -88,8 +91,9 @@ export async function handleGetRelayPreference(
   request: Request,
   deps: RelayPreferenceDeps,
 ): Promise<Response> {
+  const requestId = randomUUID();
   try {
-    const user = await authenticatedAccount(request, deps);
+    const user = await authenticatedAccount(request, deps, requestId);
     if (user instanceof Response) return user;
     const record = await deps.getPreference(user.id);
     return jsonResponse({
@@ -97,7 +101,7 @@ export async function handleGetRelayPreference(
       preferenceRevision: record.revision,
     });
   } catch (error) {
-    return relayErrorResponse(error);
+    return relayErrorResponse(error, { requestId });
   }
 }
 
@@ -105,8 +109,9 @@ export async function handlePutRelayPreference(
   request: Request,
   deps: RelayPreferenceDeps,
 ): Promise<Response> {
+  const requestId = randomUUID();
   try {
-    const user = await authenticatedAccount(request, deps);
+    const user = await authenticatedAccount(request, deps, requestId);
     if (user instanceof Response) return user;
     const body = await readBoundedJsonObject(request, MAX_BODY_BYTES);
     if (!body.ok) {
@@ -129,7 +134,7 @@ export async function handlePutRelayPreference(
       preferenceRevision: record.revision,
     });
   } catch (error) {
-    return relayErrorResponse(error);
+    return relayErrorResponse(error, { requestId });
   }
 }
 

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -11,6 +11,7 @@ import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
 import {
   enforceRelayRateLimit,
   jsonResponse,
+  relayOperationalErrorResponse,
   relayErrorResponse,
   runRelayEffect,
   type RelayRateLimitCheck,
@@ -180,7 +181,11 @@ export async function handleRelayTokenRequest(
     }
 
     if (!key && deps.credentialSigningRequired()) {
-      return jsonResponse({ error: "relay_token_not_configured" }, 503);
+      return relayOperationalErrorResponse(
+        { error: "relay_token_not_configured" },
+        503,
+        errorContext,
+      );
     }
     // A fresh endpoint must fetch policy before registration, then fetch its
     // bound credential immediately after registration. Keep bootstrap and

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -148,18 +148,23 @@ export function relayErrorResponse(
     return jsonResponse({ error: "account_deletion_in_progress" }, 409);
   }
   if (tag === "RelayCatalogRollbackError" || tag === "RelayCatalogIntegrityError") {
-    return catalogErrorResponse(error as CatalogError);
+    return catalogErrorResponse(error as CatalogError, context);
   }
   if (tag === "RelayDatabaseError") {
     return databaseErrorResponse(error as RelayDatabaseError, context);
   }
   if (tag === "RelayConfigurationError" || tag === "RelaySigningError") {
-    return unavailablePolicyResponse(tag);
+    return unavailablePolicyResponse(tag, context);
   }
   // Unexpected errors can carry database causes, relay origins, or credentials.
   // Keep the operational event while making its payload intentionally coarse.
-  console.error("relay.policy.unexpected", { failure: "unexpected" });
-  return jsonResponse({ error: "internal_error" }, 500);
+  const requestId = context.requestId ?? randomUUID();
+  console.error("relay.policy.unexpected", { failure: "unexpected", requestId });
+  return relayOperationalErrorResponse(
+    { error: "internal_error" },
+    500,
+    { requestId },
+  );
 }
 
 function authenticationErrorResponse(
@@ -170,15 +175,13 @@ function authenticationErrorResponse(
   const source = rateLimited ? { source: "auth_provider" } : {};
   const requestId = context.requestId ?? randomUUID();
   console.error("relay.auth.unavailable", { reason: error.code, requestId });
-  return jsonResponse(
+  return relayOperationalErrorResponse(
     { error: rateLimited ? "rate_limited" : "authentication_unavailable", ...source },
     rateLimited ? 429 : 503,
+    { requestId },
     error.retryAfterSeconds === undefined
       ? undefined
-      : {
-        "retry-after": String(error.retryAfterSeconds),
-        "x-cmux-request-id": requestId,
-      },
+      : { "retry-after": String(error.retryAfterSeconds) },
   );
 }
 
@@ -187,15 +190,16 @@ function rateLimitErrorResponse(
   context: RelayErrorContext,
 ): Response {
   const requestId = context.requestId ?? randomUUID();
+  if (error.code === "rate_limit_unavailable") {
+    console.error("relay.rate_limit.unavailable", { requestId });
+  }
   const headers = error.code === "rate_limited" && error.retryAfterSeconds !== undefined
-    ? {
-      "retry-after": String(error.retryAfterSeconds),
-      "x-cmux-request-id": requestId,
-    }
+    ? { "retry-after": String(error.retryAfterSeconds) }
     : undefined;
-  return jsonResponse(
+  return relayOperationalErrorResponse(
     { error: error.code, ...(error.source ? { source: error.source } : {}) },
     error.code === "rate_limited" ? 429 : 503,
+    { requestId },
     headers,
   );
 }
@@ -205,17 +209,26 @@ type CatalogError = Extract<
   { _tag: "RelayCatalogRollbackError" | "RelayCatalogIntegrityError" }
 >;
 
-function catalogErrorResponse(error: CatalogError): Response {
+function catalogErrorResponse(error: CatalogError, context: RelayErrorContext): Response {
+  const requestId = context.requestId ?? randomUUID();
   if (error._tag === "RelayCatalogRollbackError") {
     console.error("relay.policy.catalog_rollback", {
       configuredSequence: error.configuredSequence,
       persistedSequence: error.persistedSequence,
       reason: error.reason,
+      requestId,
     });
   } else {
-    console.error("relay.policy.catalog_integrity", { reason: error.reason });
+    console.error("relay.policy.catalog_integrity", {
+      reason: error.reason,
+      requestId,
+    });
   }
-  return jsonResponse({ error: "relay_policy_unavailable" }, 503);
+  return relayOperationalErrorResponse(
+    { error: "relay_policy_unavailable" },
+    503,
+    { requestId },
+  );
 }
 
 function preferenceValidationResponse(
@@ -233,16 +246,39 @@ function databaseErrorResponse(error: RelayDatabaseError, context: RelayErrorCon
     ...relayDatabaseFailureMetadata(error),
     requestId,
   });
-  return jsonResponse(
+  return relayOperationalErrorResponse(
     { error: "relay_policy_unavailable", requestId },
     503,
-    { "retry-after": "15", "x-cmux-request-id": requestId },
+    { requestId },
+    { "retry-after": "15" },
   );
 }
 
-function unavailablePolicyResponse(tag: string): Response {
-  console.error("relay.policy.unavailable", tag);
-  return jsonResponse({ error: "relay_policy_unavailable" }, 503);
+function unavailablePolicyResponse(tag: string, context: RelayErrorContext): Response {
+  const requestId = context.requestId ?? randomUUID();
+  console.error("relay.policy.unavailable", { failure: tag, requestId });
+  return relayOperationalErrorResponse(
+    { error: "relay_policy_unavailable" },
+    503,
+    { requestId },
+  );
+}
+
+export function relayOperationalErrorResponse(
+  data: Record<string, unknown>,
+  status: number,
+  context: RelayErrorContext,
+  extraHeaders?: HeadersInit,
+): Response {
+  const requestId = context.requestId ?? randomUUID();
+  return jsonResponse(
+    { ...data, requestId },
+    status,
+    {
+      ...Object.fromEntries(new Headers(extraHeaders)),
+      "x-cmux-request-id": requestId,
+    },
+  );
 }
 
 export function jsonResponse(

--- a/web/tests/relay-policy.test.ts
+++ b/web/tests/relay-policy.test.ts
@@ -14,8 +14,11 @@ import {
   signRelayPolicy,
 } from "../services/relay/catalog";
 import {
+  RelayConfigurationError,
   RelayCatalogIntegrityError,
   RelayDatabaseError,
+  RelayRateLimitError,
+  RelaySigningError,
   relayDatabaseFailureMetadata,
 } from "../services/relay/errors";
 import { relayErrorResponse } from "../services/relay/http";
@@ -81,13 +84,17 @@ describe("signed relay policy", () => {
     try {
       const response = relayErrorResponse(new RelayCatalogIntegrityError({
         reason: "persisted_catalog_digest_mismatch",
-      }));
+      }), { requestId: "req-catalog" });
 
       expect(response.status).toBe(503);
-      expect(await response.json()).toEqual({ error: "relay_policy_unavailable" });
+      expect(response.headers.get("x-cmux-request-id")).toBe("req-catalog");
+      expect(await response.json()).toEqual({
+        error: "relay_policy_unavailable",
+        requestId: "req-catalog",
+      });
       expect(calls).toEqual([[
         "relay.policy.catalog_integrity",
-        { reason: "persisted_catalog_digest_mismatch" },
+        { reason: "persisted_catalog_digest_mismatch", requestId: "req-catalog" },
       ]]);
     } finally {
       console.error = originalConsoleError;
@@ -101,16 +108,42 @@ describe("signed relay policy", () => {
     try {
       const response = relayErrorResponse(new Error(
         "token=secret-token url=https://private-relay.example database=postgres://secret",
-      ));
+      ), { requestId: "req-unexpected" });
 
       expect(response.status).toBe(500);
-      expect(await response.json()).toEqual({ error: "internal_error" });
+      expect(response.headers.get("x-cmux-request-id")).toBe("req-unexpected");
+      expect(await response.json()).toEqual({
+        error: "internal_error",
+        requestId: "req-unexpected",
+      });
       expect(calls).toEqual([[
         "relay.policy.unexpected",
-        { failure: "unexpected" },
+        { failure: "unexpected", requestId: "req-unexpected" },
       ]]);
     } finally {
       console.error = originalConsoleError;
+    }
+  });
+
+  test("correlates every broker-side policy outage without exposing internal tags", async () => {
+    const failures = [
+      new RelayConfigurationError({ code: "catalog_invalid" }),
+      new RelaySigningError({ cause: "private signing key" }),
+      new RelayRateLimitError({ code: "rate_limit_unavailable" }),
+    ];
+
+    for (const [index, failure] of failures.entries()) {
+      const requestId = `req-outage-${index}`;
+      const response = relayErrorResponse(failure, { requestId });
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("x-cmux-request-id")).toBe(requestId);
+      expect(await response.json()).toEqual({
+        error: failure instanceof RelayRateLimitError
+          ? "rate_limit_unavailable"
+          : "relay_policy_unavailable",
+        requestId,
+      });
     }
   });
 

--- a/web/tests/relay-preferences-route.test.ts
+++ b/web/tests/relay-preferences-route.test.ts
@@ -157,7 +157,12 @@ describe("/api/relay/preferences", () => {
       checkRateLimit: async () => ({ rateLimited: true }),
     }));
     expect(limited.status).toBe(429);
-    expect(await limited.json()).toEqual({ error: "rate_limited", source: "account_budget" });
+    const payload = await limited.json();
+    expect(payload).toMatchObject({
+      error: "rate_limited",
+      source: "account_budget",
+    });
+    expect(payload.requestId).toBe(limited.headers.get("x-cmux-request-id"));
   });
 
   test("rejects unauthenticated callers", async () => {

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -442,7 +442,9 @@ describe("POST /api/relay/token", () => {
         deps({ issueCredentials }),
       );
       expect(response.status).toBe(503);
-      expect(await response.json()).toEqual({ error: "relay_policy_unavailable" });
+      const payload = await response.json();
+      expect(payload.error).toBe("relay_policy_unavailable");
+      expect(payload.requestId).toBe(response.headers.get("x-cmux-request-id"));
     }
   });
 

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -312,9 +312,9 @@ describe("POST /api/relay/token", () => {
     );
 
     expect(response.status).toBe(503);
-    expect(await response.json()).toEqual({
-      error: "relay_token_not_configured",
-    });
+    const payload = await response.json();
+    expect(payload.error).toBe("relay_token_not_configured");
+    expect(payload.requestId).toBe(response.headers.get("x-cmux-request-id"));
   });
 
   test("preserves distinct URL-token associations without ambiguous legacy fields", async () => {
@@ -477,10 +477,14 @@ describe("POST /api/relay/token", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("60");
-    expect(await response.json()).toEqual({
+    const rateLimitedPayload = await response.json();
+    expect(rateLimitedPayload).toMatchObject({
       error: "rate_limited",
       source: "auth_provider",
     });
+    expect(rateLimitedPayload.requestId).toBe(
+      response.headers.get("x-cmux-request-id"),
+    );
 
     const statusLimited = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),
@@ -502,9 +506,9 @@ describe("POST /api/relay/token", () => {
     );
     expect(unavailable.status).toBe(503);
     expect(unavailable.headers.get("retry-after")).toBeNull();
-    expect(await unavailable.json()).toEqual({
-      error: "authentication_unavailable",
-    });
+    const payload = await unavailable.json();
+    expect(payload.error).toBe("authentication_unavailable");
+    expect(payload.requestId).toBe(unavailable.headers.get("x-cmux-request-id"));
   });
 
   test("never lets an IP-wide ingress bucket reject an authenticated endpoint", async () => {


### PR DESCRIPTION
Fix #12332: expose broker-side relay policy failures to clients and support diagnostics.

The relay broker already returned typed operational failures, but native clients collapsed every non-auth rejection into `policyUnavailable` and the API responses lacked a correlation identifier. This made account-wide outages indistinguishable from local policy problems and left support without a safe way to correlate reports.

This change:
- carries bounded HTTP status, broker code, and request ID metadata through trust-broker errors, relay policy diagnostics, connection reports, and macOS/iOS reports;
- preserves verified policy state for retryable broker failures and handles metadata-bearing rate limits consistently;
- partitions relay token quotas by deployment, endpoint, and operation phase so one retrying device cannot starve another device on the account;
- adds request IDs and structured operational logging to relay policy, token, preference, auth, database, and rate-limit failures while keeping response payloads coarse;
- localizes the new diagnostics strings across supported locales.

Validation:
- `bun test ./tests/relay-policy.test.ts ./tests/relay-preferences-route.test.ts ./tests/relay-token-route.test.ts` (38 passing)
- `bun run lint:complexity`
- `swift test --package-path Packages/Shared/CmuxIrohTransport` (644 passing)
- focused `CmxIrohRelayPolicyServiceRefreshTests`, `CmxIrohTrustBrokerClientNetworkTests`, and `CmxIrohConnectionCheckReportTests` (passing)
- `python3 scripts/localization_catalog.py check` (6 catalogs, 9 locales)

The tagged app build was attempted with `./scripts/reload.sh --tag issue-12332-relay-policy`; compilation reached the final targets but failed because the host filesystem ran out of space (`errno=28`, 150 MiB free). The derived data was removed afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791782380&installation_model_id=21920&pr_number=12400&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12400&signature=f74114828326145644fd8e7d71bafec8c5808d1c977026f6da2c9dfd674711ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #12332: surfaces broker-side relay policy failures as bounded diagnostics in native clients and API responses, and partitions relay token quotas so a single retrying device can't starve other devices on the same account.

**Changes**
- Carries HTTP status, broker code, and request ID through trust-broker errors, relay policy diagnostics, and connection reports on iOS and macOS, redacting provider-specific codes and bounding request IDs.
- Maps broker rejections to `authorizationFailed`, `timedOut`, or `policyUnavailable` instead of always collapsing to `policyUnavailable`.
- Preserves validated relay policy state during retryable broker failures and honors broker `Retry-After` guidance for 429s with a default fallback.
- Adds `requestId` to API error responses and to structured logs for relay policy, token, preference, auth, database, and rate-limit failures, keeping response payloads coarse.
- Localizes the new diagnostics strings for all supported locales.

<sup>Written for commit 970bf74a08f6a148270995f87f83be1620082aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connection and networking diagnostics now show broker HTTP status, error codes, and support request IDs when available.
  - Relay service errors include a request ID in both the response body and headers for easier support investigation.
  - Rate-limit responses preserve broker-provided retry guidance and apply a default retry delay when unavailable.
- **Improvements**
  - Broker failures are classified more accurately, including authorization, timeout, policy, and rate-limit conditions.
  - Added localized diagnostic messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->