### PR TITLE
fix: report goto_split failure at pane edges

### DIFF
--- a/Sources/Canvas/Workspace+CanvasLayout.swift
+++ b/Sources/Canvas/Workspace+CanvasLayout.swift
@@ -58,11 +58,15 @@ extension Workspace {
     }
 
     /// Canvas-mode directional focus: nearest pane spatially, then reveal it.
-    func moveCanvasFocus(direction: NavigationDirection) {
-        guard let from = focusedPanelId ?? orderedPanelIds.first else { return }
-        guard let target = canvasModel.pane(direction.canvasDirection, from: from) else { return }
+    @discardableResult
+    func moveCanvasFocus(direction: NavigationDirection) -> Bool {
+        guard let from = focusedPanelId ?? orderedPanelIds.first else { return false }
+        guard let target = canvasModel.pane(direction.canvasDirection, from: from) else {
+            return false
+        }
         focusPanel(target)
         canvasModel.viewport?.revealPane(target, animated: true)
+        return target != from
     }
 
     /// The bonsplit pane currently containing the panel's tab, used by

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4403,8 +4403,7 @@ class TabManager: ObservableObject {
     /// Move focus in the specified direction
     func moveSplitFocus(tabId: UUID, surfaceId: UUID, direction: NavigationDirection) -> Bool {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return false }
-        tab.moveFocus(direction: direction)
-        return true
+        return tab.moveFocus(direction: direction)
     }
 
     /// Cycle focus to the next or previous pane in tree order, wrapping at the ends.

--- a/Sources/Workspace+SurfaceNavigation.swift
+++ b/Sources/Workspace+SurfaceNavigation.swift
@@ -15,22 +15,25 @@ extension Workspace {
     /// Moves keyboard focus through the rendered pane hierarchy. A selected
     /// remote-tmux window owns a nested split tree, so it gets first refusal;
     /// an edge with no inner neighbor falls through to the workspace tree.
-    func moveFocus(direction: NavigationDirection) {
+    @discardableResult
+    func moveFocus(direction: NavigationDirection) -> Bool {
         if layoutMode == .canvas {
-            moveCanvasFocus(direction: direction)
-            return
+            return moveCanvasFocus(direction: direction)
         }
         if let focusedPanelId,
            let mirror = remoteTmuxWindowMirror(forPanelId: focusedPanelId) {
             switch mirror.navigateFocus(direction: direction) {
-            case .moved, .invalid:
-                return
+            case .moved:
+                return true
+            case .invalid:
+                return false
             case .edge:
                 break
             }
         }
 
         let previousFocusedPanelId = focusedPanelId
+        let previousFocusedPaneId = bonsplitController.focusedPaneId
         if let previousFocusedPanelId, let previous = panels[previousFocusedPanelId] {
             previous.unfocus()
         }
@@ -40,6 +43,8 @@ extension Workspace {
            let tabId = bonsplitController.selectedTab(inPane: paneId)?.id {
             applyTabSelection(tabId: tabId, inPane: paneId)
         }
+        return previousFocusedPanelId != focusedPanelId ||
+            previousFocusedPaneId != bonsplitController.focusedPaneId
     }
 
     /// Moves the focused surface into another pane, optionally creating a

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1698,6 +1698,7 @@
 		8561A0048561A0048561A004 /* GlobalSearchShortcutSettingsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0048561B0048561B004 /* GlobalSearchShortcutSettingsModelTests.swift */; };
 		3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */; };
 		8561A0038561A0038561A003 /* GlobalSearchVisiblePopoverShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0038561B0038561B003 /* GlobalSearchVisiblePopoverShortcutTests.swift */; };
+		D7AB12370000000000000001 /* GotoSplitActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB12370000000000000002 /* GotoSplitActionTests.swift */; };
 		CC000000A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000001A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift */; };
 		CC2639000000000000000001 /* GotoSplitCycleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */; };
 		5B11E5A100000000000000B1 /* GPUSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B11E5A100000000000000B2 /* GPUSpinner.swift */; };
@@ -5232,6 +5233,7 @@
 		8561B0048561B0048561B004 /* GlobalSearchShortcutSettingsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsModelTests.swift; sourceTree = "<group>"; };
 		3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsTests.swift; sourceTree = "<group>"; };
 		8561B0038561B0038561B003 /* GlobalSearchVisiblePopoverShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchVisiblePopoverShortcutTests.swift; sourceTree = "<group>"; };
+		D7AB12370000000000000002 /* GotoSplitActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotoSplitActionTests.swift; sourceTree = "<group>"; };
 		CC000001A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotoSplitCycleUITests.swift; sourceTree = "<group>"; };
 		CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/GotoSplitCycleUITestSupport.swift; sourceTree = "<group>"; };
 		5B11E5A100000000000000B2 /* GPUSpinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/GPUSpinner.swift; sourceTree = "<group>"; };
@@ -10117,6 +10119,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */,
 				D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */,
 				D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */,
+				D7AB12370000000000000002 /* GotoSplitActionTests.swift */,
 				804100000000000000000004 /* ReorderShortcutActionTests.swift */,
 				D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */,
 				4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */,
@@ -14309,6 +14312,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8561A0048561A0048561A004 /* GlobalSearchShortcutSettingsModelTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,
 				8561A0038561A0038561A003 /* GlobalSearchVisiblePopoverShortcutTests.swift in Sources */,
+				D7AB12370000000000000001 /* GotoSplitActionTests.swift in Sources */,
 					937700020000000000000001 /* GrokVaultAgentPersistenceTests.swift in Sources */,
 				9520A0019520A0019520A001 /* HermesFirstClassSupportTests.swift in Sources */,
 				4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */,

--- a/cmuxTests/GotoSplitActionTests.swift
+++ b/cmuxTests/GotoSplitActionTests.swift
@@ -1,0 +1,36 @@
+import Bonsplit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Goto split action", .serialized)
+struct GotoSplitActionTests {
+    @Test(arguments: [
+        NavigationDirection.left,
+        .right,
+        .up,
+        .down,
+    ])
+    func directionalGotoSplitReturnsFalseAtSinglePaneEdge(
+        _ direction: NavigationDirection
+    ) throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+
+        #expect(!manager.moveSplitFocus(
+            tabId: workspace.id,
+            surfaceId: panelId,
+            direction: direction
+        ))
+        #expect(workspace.bonsplitController.focusedPaneId == paneId)
+        #expect(workspace.focusedPanelId == panelId)
+    }
+}

--- a/cmuxTests/WorkspaceAdjacentPaneMoveTests.swift
+++ b/cmuxTests/WorkspaceAdjacentPaneMoveTests.swift
@@ -97,29 +97,6 @@ struct WorkspaceAdjacentPaneMoveTests {
         #expect(workspace.focusedPanelId == panelId)
     }
 
-    @Test(arguments: [
-        NavigationDirection.left,
-        .right,
-        .up,
-        .down,
-    ])
-    func directionalGotoSplitReturnsFalseAtSinglePaneEdge(
-        _ direction: NavigationDirection
-    ) throws {
-        let manager = TabManager()
-        let workspace = try #require(manager.selectedWorkspace)
-        let panelId = try #require(workspace.focusedPanelId)
-        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
-
-        #expect(!manager.moveSplitFocus(
-            tabId: workspace.id,
-            surfaceId: panelId,
-            direction: direction
-        ))
-        #expect(workspace.bonsplitController.focusedPaneId == paneId)
-        #expect(workspace.focusedPanelId == panelId)
-    }
-
     @Test func cycleFocusReturnsFalseInCanvasModeWithoutHiddenSplitMutation() throws {
         let workspace = Workspace()
         let leftPanelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/WorkspaceAdjacentPaneMoveTests.swift
+++ b/cmuxTests/WorkspaceAdjacentPaneMoveTests.swift
@@ -97,6 +97,29 @@ struct WorkspaceAdjacentPaneMoveTests {
         #expect(workspace.focusedPanelId == panelId)
     }
 
+    @Test(arguments: [
+        NavigationDirection.left,
+        .right,
+        .up,
+        .down,
+    ])
+    func directionalGotoSplitReturnsFalseAtSinglePaneEdge(
+        _ direction: NavigationDirection
+    ) throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+
+        #expect(!manager.moveSplitFocus(
+            tabId: workspace.id,
+            surfaceId: panelId,
+            direction: direction
+        ))
+        #expect(workspace.bonsplitController.focusedPaneId == paneId)
+        #expect(workspace.focusedPanelId == panelId)
+    }
+
     @Test func cycleFocusReturnsFalseInCanvasModeWithoutHiddenSplitMutation() throws {
         let workspace = Workspace()
         let leftPanelId = try #require(workspace.focusedPanelId)


### PR DESCRIPTION
Fix `goto_split:<direction>` to report whether directional focus actually moved.

`Workspace.moveFocus` now returns a movement result for split, canvas, and nested remote tmux navigation, and `TabManager.moveSplitFocus` propagates it to Ghostty’s action handler. A single-pane edge therefore returns `false`, matching Ghostty’s no-op behavior.

Tests:
- Added a parameterized regression test covering left, right, up, and down at a single-pane edge.
- Wired the test into the `cmuxTests` target.

Closes #12370

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791782501&installation_model_id=21920&pr_number=12401&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12401&signature=5b8eaa64ff35a388fee7b13bdd520e10b3aab3b839be15ac5ae6ad3cc1511076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `goto_split:<direction>` so it reports whether directional focus actually moved. Previously, `TabManager.moveSplitFocus` always returned `true`; now it returns `false` at a single-pane edge, matching Ghostty's no-op behavior.

- `Workspace.moveFocus` and `moveCanvasFocus` now return a movement result propagated to the action handler.
- Adds a parameterized regression test for left, right, up, and down at a single-pane edge.

<sup>Written for commit 33364624e6485ddb4dccb3be5b249144f5bffac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Focus navigation now accurately reports whether focus moved successfully.
  - Invalid directions and attempts to move beyond available panes no longer indicate a successful move.
  - Focus remains unchanged when navigation reaches the edge of a single-pane layout.

- **Tests**
  - Added coverage for split-focus navigation in all four directions, including edge-of-layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->