### PR TITLE
README: duplicate install section before license + add docs/blog/changelog/community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
   <a href="https://www.youtube.com/watch?v=i-WxO5YUTOs">▶ Demo video</a> · <a href="https://cmux.com/blog/zen-of-cmux">The Zen of cmux</a>
 </p>
 
+<p align="center">
+  <a href="https://cmux.com/docs/getting-started">Docs</a> · <a href="https://cmux.com/blog">Blog</a> · <a href="https://cmux.com/docs/changelog">Changelog</a> · <a href="https://cmux.com/community">Community</a>
+</p>
+
 ## Features
 
 <table>
@@ -448,6 +452,31 @@ cmux is free, open source, and always will be. If you'd like to support developm
 - **Early access: Cloud VMs**
 - **Early access: Voice mode**
 - **My personal iMessage/WhatsApp**
+
+## Install
+
+### DMG (recommended)
+
+<a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">
+  <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+</a>
+
+Open the `.dmg` and drag cmux to your Applications folder. cmux auto-updates via Sparkle, so you only need to download once.
+
+### Homebrew
+
+```bash
+brew tap manaflow-ai/cmux
+brew install --cask cmux
+```
+
+To update later:
+
+```bash
+brew upgrade --cask cmux
+```
+
+On first launch, macOS may ask you to confirm opening an app from an identified developer. Click **Open** to proceed.
 
 ## License
 


### PR DESCRIPTION
Two README improvements:

1. **Install section duplicated before License** - the full Install section (DMG + Homebrew) now also appears right before the License section, so people who scroll all the way down have an actionable next step.
2. **Links row near the top** - adds Docs, Blog, Changelog, and Community links pointing at the real cmux.com pages (https://cmux.com/docs/getting-started, /blog, /docs/changelog, /community - all verified live).

Scope note: applied to the main English README only. The 21 localized READMEs and other manaflow-ai repos were left untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791782869&installation_model_id=21920&pr_number=12402&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12402&signature=c12c6bbf2a1bc5e8ebb9b84223b68caae2c48ce925b43f7372a03538e1731686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a links row (Docs, Blog, Changelog, Community) near the top of the README and duplicates the Install section right before the License section so readers who scroll to the bottom have an actionable next step. Only the main English README is affected; localized READMEs are left unchanged.

<sup>Written for commit 642e42e8d206ec44bf542a757b9d889f5e8c274f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added centered links to documentation, blog, changelog, and community pages near the README introduction.
  - Added installation instructions for DMG and Homebrew packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->