### PR TITLE
web: remove Jobs from header nav

### DIFF
--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -2,10 +2,7 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
-import {
-  fallbackContentLocales,
-  jobsContentLocales,
-} from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
 import posthog from "posthog-js";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
 import { ContentLocaleLink } from "./content-locale-link";
@@ -39,14 +36,6 @@ export function NavLinks() {
       >
         {t("community")}
       </Link>
-      <ContentLocaleLink
-        href="/jobs"
-        currentLocale={locale}
-        contentLocales={jobsContentLocales}
-        className="hover:text-foreground transition-colors"
-      >
-        {t("jobs")}
-      </ContentLocaleLink>
       <ProUpgradeVisibility>
         <ContentLocaleLink
           href="/pricing"

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -2,10 +2,7 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
-import {
-  fallbackContentLocales,
-  jobsContentLocales,
-} from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
 import { NavLinks } from "./nav-links";
 import { DownloadButton } from "./download-button";
 import { ThemeToggle } from "../theme";
@@ -144,15 +141,6 @@ export function SiteHeader({
           >
             {t("community")}
           </Link>
-          <ContentLocaleLink
-            href="/jobs"
-            currentLocale={locale}
-            contentLocales={jobsContentLocales}
-            onClick={close}
-            className="hover:text-foreground transition-colors py-1"
-          >
-            {t("jobs")}
-          </ContentLocaleLink>
           <ProUpgradeVisibility>
             <ContentLocaleLink
               href="/pricing"


### PR DESCRIPTION
Removes the Jobs link from the site header - both the desktop nav (`nav-links.tsx`) and the mobile drawer (`site-header.tsx`). Jobs stays linked in the footer, and the `/jobs` pages themselves are untouched.

Also cleans up the now-unused `jobsContentLocales` imports in both files. The `nav.jobs` message catalog entry is kept since the footer and jobs pages still reference jobs strings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791782871&installation_model_id=21920&pr_number=12403&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12403&signature=9c665b5bfbf3afa4585bc9f3848f34657a25d9b0ef2fe45db5c9d287db49de1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Jobs link from the site header desktop nav and mobile drawer so the header is less crowded. Jobs stays available in the footer, and the `/jobs` pages are unchanged.

Removes the now-unused `jobsContentLocales` imports from `nav-links.tsx` and `site-header.tsx`. The `nav.jobs` message catalog entry stays because the footer and jobs pages still reference jobs strings.

<sup>Written for commit b3d1cc679e73d6cd32277e44b75227e13593146d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Jobs link from the main navigation and mobile menu.
  * Pricing navigation continues to use fallback locale support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->