### PR TITLE
Fix AskUserQuestion text contrast in light theme

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+CmuxThemeRepair.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+CmuxThemeRepair.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+extension GhosttyConfig {
+    /// Returns the final raw theme directive when it is inside a managed block.
+    static func lastCmuxManagedThemeDirective(in contents: String) -> String? {
+        lastCmuxManagedThemeDirectiveInfo(in: contents)?.value
+    }
+
+    /// Rewrites a stale managed theme in place so later directives retain their
+    /// original precedence during parsing.
+    static func contentsByRepairingCmuxManagedTheme(in contents: String) -> String {
+        guard let repairedThemeValue = normalizedCmuxManagedThemeValue(in: contents),
+              let directive = lastCmuxManagedThemeDirectiveInfo(in: contents) else {
+            return contents
+        }
+
+        var lines = contents.components(separatedBy: .newlines)
+        guard directive.lineIndex < lines.count,
+              let equalsIndex = lines[directive.lineIndex].firstIndex(of: "=") else {
+            return contents
+        }
+        let valueStart = lines[directive.lineIndex].index(after: equalsIndex)
+        lines[directive.lineIndex] = String(lines[directive.lineIndex][..<valueStart]) + " " + repairedThemeValue
+        return lines.joined(separator: "\n")
+    }
+
+    private static func lastCmuxManagedThemeDirectiveInfo(
+        in contents: String
+    ) -> (lineIndex: Int, value: String)? {
+        var insideManagedBlock = false
+        var rawThemeValue: String?
+        var rawThemeLineIndex: Int?
+        var lastThemeWasManaged = false
+
+        for (lineIndex, line) in contents.components(separatedBy: .newlines).enumerated() {
+            let trimmed = line.trimmingCharacters(
+                in: CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: "\u{FEFF}"))
+            )
+            switch trimmed {
+            case "# cmux themes start":
+                insideManagedBlock = true
+            case "# cmux themes end":
+                insideManagedBlock = false
+            default:
+                let parts = trimmed.split(separator: "=", maxSplits: 1).map(String.init)
+                guard parts.count == 2,
+                      parts[0].trimmingCharacters(in: .whitespacesAndNewlines) == "theme" else {
+                    continue
+                }
+                let value = parts[1]
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                if !value.isEmpty {
+                    rawThemeValue = value
+                    rawThemeLineIndex = lineIndex
+                }
+                lastThemeWasManaged = insideManagedBlock
+            }
+        }
+
+        guard lastThemeWasManaged,
+              let rawThemeValue,
+              let rawThemeLineIndex else {
+            return nil
+        }
+        return (lineIndex: rawThemeLineIndex, value: rawThemeValue)
+    }
+
+    // Shared by the primary config parser and this repair extension. It stays
+    // internal because Swift's `private` members cannot be referenced by a
+    // same-type extension in another file; callers outside this module do not
+    // need the tokenizer itself.
+    /// Splits a raw theme directive into its first light, dark, and fallback values.
+    ///
+    /// - Parameter rawThemeValue: The comma-separated value from a `theme` directive.
+    /// - Returns: The first recognized value for each conditional side and fallback.
+    static func conditionalThemeComponents(
+        from rawThemeValue: String
+    ) -> (light: String?, dark: String?, fallback: String?) {
+        var fallbackTheme: String?
+        var lightTheme: String?
+        var darkTheme: String?
+
+        for token in rawThemeValue.split(separator: ",").map(String.init) {
+            let entry = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !entry.isEmpty else { continue }
+
+            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count != 2 {
+                if fallbackTheme == nil {
+                    fallbackTheme = entry
+                }
+                continue
+            }
+
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+
+            switch key {
+            case "light":
+                if lightTheme == nil {
+                    lightTheme = value
+                }
+            case "dark":
+                if darkTheme == nil {
+                    darkTheme = value
+                }
+            default:
+                if fallbackTheme == nil {
+                    fallbackTheme = value
+                }
+            }
+        }
+
+        return (light: lightTheme, dark: darkTheme, fallback: fallbackTheme)
+    }
+
+    /// Returns a valid two-sided theme value for a stale cmux-managed override.
+    ///
+    /// Ghostty requires both `light:` and `dark:` entries in a conditional theme
+    /// value. Older cmux versions wrote only the selected side, so this helper
+    /// repairs that form in memory while the application loads its managed
+    /// configuration. It deliberately ignores unmarked user configuration and
+    /// leaves already-valid pairs and plain theme values unchanged.
+    ///
+    /// - Parameter contents: The complete contents of a cmux-managed config file.
+    /// - Returns: A normalized `light:…,dark:…` value when the managed block is
+    ///   single-sided, otherwise `nil`.
+    public static func normalizedCmuxManagedThemeValue(in contents: String) -> String? {
+        guard let rawThemeValue = lastCmuxManagedThemeDirectiveInfo(in: contents)?.value else { return nil }
+        let components = conditionalThemeComponents(from: rawThemeValue)
+        switch (components.light, components.dark) {
+        case let (light?, nil):
+            return "light:\(light),dark:\(light)"
+        case let (nil, dark?):
+            return "light:\(dark),dark:\(dark)"
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+CmuxThemeRepair.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+CmuxThemeRepair.swift
@@ -28,9 +28,7 @@ extension GhosttyConfig {
         in contents: String
     ) -> (lineIndex: Int, value: String)? {
         var insideManagedBlock = false
-        var rawThemeValue: String?
-        var rawThemeLineIndex: Int?
-        var lastThemeWasManaged = false
+        var lastThemeDirective: (lineIndex: Int, value: String, isManaged: Bool)?
 
         for (lineIndex, line) in contents.components(separatedBy: .newlines).enumerated() {
             let trimmed = line.trimmingCharacters(
@@ -51,19 +49,16 @@ extension GhosttyConfig {
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                     .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
                 if !value.isEmpty {
-                    rawThemeValue = value
-                    rawThemeLineIndex = lineIndex
+                    lastThemeDirective = (lineIndex, value, insideManagedBlock)
                 }
-                lastThemeWasManaged = insideManagedBlock
             }
         }
 
-        guard lastThemeWasManaged,
-              let rawThemeValue,
-              let rawThemeLineIndex else {
+        guard let directive = lastThemeDirective,
+              directive.isManaged else {
             return nil
         }
-        return (lineIndex: rawThemeLineIndex, value: rawThemeValue)
+        return (lineIndex: directive.lineIndex, value: directive.value)
     }
 
     // Shared by the primary config parser and this repair extension. It stays

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -788,7 +788,7 @@ public struct GhosttyConfig {
         }
 
         config.parse(
-            contents,
+            contentsByRepairingCmuxManagedTheme(in: contents),
             loadingThemesImmediatelyFor: preferredColorScheme
         )
 
@@ -985,6 +985,12 @@ public struct GhosttyConfig {
                 recursiveConfigPaths: &recursiveConfigPaths
             )
         }
+
+        // Keep discovery and the runtime loader aligned for legacy managed
+        // blocks that contain only one conditional theme side.
+        if let repairedThemeValue = normalizedCmuxManagedThemeValue(in: contents) {
+            summary.recordDirective(key: "theme", value: repairedThemeValue)
+        }
     }
 
     private static func parseIntegerLiteral(_ value: String) -> Int? {
@@ -1035,9 +1041,6 @@ public struct GhosttyConfig {
         )
     }
 
-    /// Loads the named theme into this config, resolving paired
-    /// `light:.../dark:...` themes for `preferredColorScheme` and searching the
-    /// given `environment`/`bundleResourceURL` theme directories.
     public mutating func loadTheme(
         _ name: String,
         environment: [String: String],
@@ -1069,8 +1072,6 @@ public struct GhosttyConfig {
         }
     }
 
-    /// The current light/dark terminal color-scheme preference, resolved from
-    /// the given defaults and optional system appearance.
     public static func currentColorSchemePreference(
         appAppearance _: NSAppearance? = nil,
         defaults: UserDefaults = .standard,
@@ -1148,7 +1149,6 @@ public struct GhosttyConfig {
         return rawThemeValue.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Returns the theme name that the raw `theme` value *explicitly* assigns to
     /// `preferredColorScheme` via ghostty's conditional `light:...`/`dark:...`
     /// syntax, or `nil` when that side is not conditionally specified.
     ///

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -968,9 +968,10 @@ public struct GhosttyConfig {
         recursiveConfigPaths: inout [String]
     ) {
         let resolved = (path as NSString).standardizingPath
-        guard let contents = try? String(contentsOfFile: resolved, encoding: .utf8) else {
+        guard let rawContents = try? String(contentsOfFile: resolved, encoding: .utf8) else {
             return
         }
+        let contents = contentsByRepairingCmuxManagedTheme(in: rawContents)
         let parentDir = (resolved as NSString).deletingLastPathComponent
 
         for line in contents.components(separatedBy: .newlines) {
@@ -984,12 +985,6 @@ public struct GhosttyConfig {
                 parentDir: parentDir,
                 recursiveConfigPaths: &recursiveConfigPaths
             )
-        }
-
-        // Keep discovery and the runtime loader aligned for legacy managed
-        // blocks that contain only one conditional theme side.
-        if let repairedThemeValue = normalizedCmuxManagedThemeValue(in: contents) {
-            summary.recordDirective(key: "theme", value: repairedThemeValue)
         }
     }
 
@@ -1041,6 +1036,9 @@ public struct GhosttyConfig {
         )
     }
 
+    /// Loads the named theme into this config, resolving paired
+    /// `light:.../dark:...` themes for `preferredColorScheme` and searching the
+    /// given `environment`/`bundleResourceURL` theme directories.
     public mutating func loadTheme(
         _ name: String,
         environment: [String: String],
@@ -1072,6 +1070,8 @@ public struct GhosttyConfig {
         }
     }
 
+    /// The current light/dark terminal color-scheme preference, resolved from
+    /// the given defaults and optional system appearance.
     public static func currentColorSchemePreference(
         appAppearance _: NSAppearance? = nil,
         defaults: UserDefaults = .standard,
@@ -1125,7 +1125,6 @@ public struct GhosttyConfig {
                 }
             }
         }
-
         switch preferredColorScheme {
         case .light:
             if let lightTheme {
@@ -1149,6 +1148,7 @@ public struct GhosttyConfig {
         return rawThemeValue.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Returns the theme name that the raw `theme` value *explicitly* assigns to
     /// `preferredColorScheme` via ghostty's conditional `light:...`/`dark:...`
     /// syntax, or `nil` when that side is not conditionally specified.
     ///

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigConditionalThemeApplicationTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigConditionalThemeApplicationTests.swift
@@ -82,4 +82,31 @@ import Testing
                 .caseInsensitiveCompare(Self.lightThemeBackgroundHex) == .orderedSame
         )
     }
+
+    /// Older cmux managed blocks could contain only a light-side theme. Repairing
+    /// that persisted value keeps Ghostty's background and foreground paired when
+    /// a light AskUserQuestion is rendered after switching appearances.
+    @Test func staleManagedLightThemeIsAppliedInDarkAppearance() throws {
+        let root = try makeThemesRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configURL = root.appendingPathComponent("config", isDirectory: false)
+        let themePath = root.appendingPathComponent("themes/Light Theme")
+        try """
+        # cmux themes start
+        theme = light:\(themePath.path)
+        # cmux themes end
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        var darkConfig = GhosttyConfig()
+        darkConfig.loadResolvedUserConfig(
+            configPaths: [configURL.path],
+            preferredColorScheme: .dark,
+            environment: ["GHOSTTY_RESOURCES_DIR": root.path],
+            bundleResourceURL: nil
+        )
+
+        #expect(darkConfig.backgroundColor.hexString() == Self.lightThemeBackgroundHex)
+        #expect(darkConfig.foregroundColor.hexString() == "#657B83")
+    }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigConditionalThemeApplicationTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigConditionalThemeApplicationTests.swift
@@ -109,4 +109,15 @@ import Testing
         #expect(darkConfig.backgroundColor.hexString() == Self.lightThemeBackgroundHex)
         #expect(darkConfig.foregroundColor.hexString() == "#657B83")
     }
+
+    @Test func emptyManagedThemeDoesNotRewriteExternalTheme() {
+        let contents = """
+        theme = light:User Theme
+        # cmux themes start
+        theme =
+        # cmux themes end
+        """
+
+        #expect(GhosttyConfig.contentsByRepairingCmuxManagedTheme(in: contents) == contents)
+    }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
@@ -182,16 +182,18 @@ private struct NoFontProbe: GhosttyFontProbing {
         ) == nil)
     }
 
-    @Test func staleManagedSingleSidedThemeGetsSymmetricOverride() {
-        let path = "/cfg/config"
-        let reader = FakeFileReader(contentsByPath: [
-            path: "# cmux themes start\ntheme = light:Light Theme\n# cmux themes end"
-        ])
+    @Test func staleManagedSingleSidedThemeGetsSymmetricOverride() throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-theme-override-\(UUID().uuidString)", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: path) }
+        try "# cmux themes start\ntheme = light:Light Theme\n# cmux themes end"
+            .write(to: path, atomically: true, encoding: .utf8)
+        let reader = FakeFileReader(contentsByPath: [path.path: try String(contentsOf: path)])
         let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
 
         #expect(discovery.conditionalThemeOverrideConfigContents(
             preferredColorScheme: .dark,
-            configPaths: [path]
+            configPaths: [path.path]
         ) == "theme = Light Theme")
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
@@ -181,4 +181,17 @@ private struct NoFontProbe: GhosttyFontProbing {
             configPaths: [path]
         ) == nil)
     }
+
+    @Test func staleManagedSingleSidedThemeGetsSymmetricOverride() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [
+            path: "# cmux themes start\ntheme = light:Light Theme\n# cmux themes end"
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+
+        #expect(discovery.conditionalThemeOverrideConfigContents(
+            preferredColorScheme: .dark,
+            configPaths: [path]
+        ) == "theme = Light Theme")
+    }
 }


### PR DESCRIPTION
Fixes #12323.

A legacy cmux-managed theme block can contain only a `light:` or `dark:` side. The host-layer resolver then sees a different effective background than Ghostty's surface renderer, leaving AskUserQuestion text with a bright/default foreground on a light background.

This change repairs stale single-sided managed theme directives in memory before parsing, preserves later directive precedence, and keeps discovery/override resolution aligned. Theme ownership remains attached to the accepted non-empty directive, so an empty managed directive cannot rewrite an external theme. Regression coverage covers persisted loading, discovery overrides, and that cross-boundary case.

Verification:
- `swift test --package-path Packages/macOS/CmuxTerminalCore --filter GhosttyConfigConditionalThemeApplicationTests` (4 passed)
- `swift test --package-path Packages/macOS/CmuxTerminalCore --filter GhosttyConfigDiscoveryThemeOverrideTests` (3 passed)
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`
- Tagged `./scripts/reload.sh --tag issue-12323-light` advanced through app compilation, then was stopped before final archive to preserve shared disk. This is infrastructure-only; no app launch or runtime dogfood was performed.
- Headless cloud reload was attempted; no shared fleet was configured and the direct/SSH backend host `cmux-dev-backend-1` did not resolve.
