### PR TITLE
Add local container socket capability leases

### DIFF
--- a/CLI/CMUXCLI+Remotes.swift
+++ b/CLI/CMUXCLI+Remotes.swift
@@ -1,6 +1,67 @@
 import Darwin
 import Foundation
 
+extension CMUXCLI {
+    static let localContainerUsage = String(localized: "cli.localContainer.usage", defaultValue: """
+        Usage: cmux local-container lease [--json]
+
+        Mint a same-user capability for a local container whose process ancestry
+        cannot be observed by cmux. The result includes the live socket path and
+        the capability used in a _cmux_capability_v1 command envelope.
+        """)
+
+    func runLocalContainerCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool
+    ) throws {
+        let subcommand = commandArgs.first?.lowercased() ?? "lease"
+        guard subcommand == "lease" || subcommand == "help" || subcommand == "--help" || subcommand == "-h" else {
+            throw CLIError(message: localContainerLocalizedFormat(
+                "cli.localContainer.unknownSubcommand",
+                defaultValue: "Unknown local-container subcommand: %@\n\n%@",
+                subcommand,
+                Self.localContainerUsage
+            ))
+        }
+        guard subcommand == "lease" else {
+            print(Self.localContainerUsage)
+            return
+        }
+        let response = try client.sendV2(method: "system.socket_capability_lease")
+        guard let socketPath = response["socket_path"] as? String,
+              let capability = response["capability"] as? String,
+              let protocolName = response["protocol"] as? String else {
+            throw CLIError(message: String(
+                localized: "cli.localContainer.invalidLease",
+                defaultValue: "The cmux socket did not return a usable local-container lease"
+            ))
+        }
+        if jsonOutput {
+            print(jsonString(response))
+            return
+        }
+        print("CMUX_SOCKET_PATH=\(localContainerShellQuote(socketPath))")
+        print("CMUX_SOCKET_CAPABILITY=\(localContainerShellQuote(capability))")
+        print("CMUX_SOCKET_CAPABILITY_PROTOCOL=\(localContainerShellQuote(protocolName))")
+    }
+
+    private func localContainerShellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+
+    private func localContainerLocalizedFormat(
+        _ key: String,
+        defaultValue: String,
+        _ arguments: CVarArg...
+    ) -> String {
+        String(
+            format: NSLocalizedString(key, bundle: .main, value: defaultValue, comment: ""),
+            arguments: arguments
+        )
+    }
+}
+
 // `cmux remotes` (alias `remote`): manage the team's device-registry routes so
 // remote Macs show up in the iOS app's device list and the phone can attach.
 // The CLI is presentation only; each verb maps to one `remotes.*` socket method

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6545,6 +6545,9 @@ struct CMUXCLI {
         case "remotes", "remote":
             try runRemotesCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
 
+        case "local-container":
+            try runLocalContainerCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
+
         case "ai-accounts":
             try runAIAccountsCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
 
@@ -18273,6 +18276,8 @@ struct CMUXCLI {
             return Self.vmAgentUsage.replacingOccurrences(of: "cmux vm agent", with: "cmux agent")
         case "remotes", "remote":
             return Self.remotesUsage
+        case "local-container":
+            return Self.localContainerUsage
         case "todo":
             return Self.todoUsage
         case "comments":
@@ -41362,6 +41367,7 @@ export default CMUXSessionRestore;
           \(localizedCoderouterCommands())
           vm <base|new|ls|domains|tree|self|status|stats|rename|pause|resume|snapshot|fork|restore|rm|run|route|agent|dev|prompt|exec|push|pull|wait|shell|tui|desktop|open|workspace|terminal|tab|layout|env|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]    (alias: cloud)
           remotes <list|add|remove> [--route <host:port>] [--tag <tag>] [--json]    (alias: remote)
+          local-container lease [--json]
           ai-accounts <list|upload|remove> [--team <id>] [--json]
           rpc <method> [json-params]
           \(simulatorCommandUsageLine)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketClientCapabilityLease.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketClientCapabilityLease.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// The credential handoff a local container needs to reach a cmux control socket.
+///
+/// The capability is audience-bound to the issuing cmux app and is accepted only
+/// for same-UID peers. The socket path is returned alongside it so callers do not
+/// accidentally bridge a stale development socket.
+public struct SocketClientCapabilityLease: Codable, Equatable, Sendable {
+    /// The live Unix socket path to bridge or mount into the container.
+    public let socketPath: String
+
+    /// The opaque capability to present in a `_cmux_capability_v1` envelope.
+    public let capability: String
+
+    /// The wire envelope understood by cmux control sockets.
+    public let protocolName: String
+
+    public init(socketPath: String, capability: String) {
+        self.socketPath = socketPath
+        self.capability = capability
+        protocolName = "_cmux_capability_v1"
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -79,6 +79,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
     static let socketWorkerMethods: Set<String> = Set([
         "system.ping",
         "system.capabilities",
+        "system.socket_capability_lease",
         "auth.status",
         "auth.sign_in_url",
         "auth.begin_sign_in",
@@ -353,6 +354,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
     static let mainThreadCallableSocketWorkerMethods: Set<String> = [
         "system.ping",
         "system.capabilities",
+        "system.socket_capability_lease",
         "surface.report_pwd",
         "surface.report_git_branch",
         "surface.clear_git_branch",

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketClientAuthorizationTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketClientAuthorizationTests.swift
@@ -65,6 +65,29 @@ struct SocketClientAuthorizationTests {
         ) == nil)
     }
 
+    @Test func localContainerLeaseAuthorizesSameUIDReparentedPeer() throws {
+        let authority = SocketClientCapabilityAuthority(
+            secret: Data(repeating: 0xA5, count: SocketClientCapabilityAuthority.secureByteCount),
+            audience: "com.cmuxterm.test"
+        )
+        let lease = SocketClientCapabilityLease(
+            socketPath: "/tmp/cmux.sock",
+            capability: authority.issueCapability(
+                nonce: Data(repeating: 0x5A, count: SocketClientCapabilityAuthority.secureByteCount)
+            )
+        )
+        let envelope = try #require(SocketClientCapabilityEnvelope(capability: lease.capability))
+
+        #expect(authorization.authorizedCommand(
+            envelope.wrap("notify --title done"),
+            accessMode: .cmuxOnly,
+            peerProcessID: 999,
+            peerHasSameUID: true,
+            capabilityAuthority: authority,
+            isDescendant: { _ in false }
+        ) == "notify --title done")
+    }
+
     @Test func cmuxOnlyRejectsCapabilityFromDifferentUser() throws {
         let authority = SocketClientCapabilityAuthority(
             secret: Data(repeating: 0xA5, count: SocketClientCapabilityAuthority.secureByteCount),

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketClientCapabilityTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketClientCapabilityTests.swift
@@ -57,6 +57,18 @@ struct SocketClientCapabilityTests {
         #expect(parsed.command == command)
     }
 
+    @Test func localContainerLeaseRoundTripsAndUsesCapabilityProtocol() throws {
+        let issuer = SocketClientCapabilityAuthority(secret: secret, audience: "com.cmuxterm.test")
+        let capability = issuer.issueCapability(nonce: nonce)
+        let lease = SocketClientCapabilityLease(socketPath: "/tmp/cmux.sock", capability: capability)
+        let encoded = try JSONEncoder().encode(lease)
+        let decoded = try JSONDecoder().decode(SocketClientCapabilityLease.self, from: encoded)
+
+        #expect(decoded == lease)
+        #expect(decoded.protocolName == "_cmux_capability_v1")
+        #expect(issuer.verifies(decoded.capability))
+    }
+
     @Test func secretStoreReusesPersistentSecret() {
         let store = SocketClientCapabilitySecretStore(
             loadSecret: { secret },

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -509928,7 +509928,184 @@
           }
         }
       }
-    }
+    },
+     "cli.localContainer.usage": {
+        "extractionState": "manual",
+        "localizations": {
+          "en": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Usage: cmux local-container lease [--json]\n\nMint a same-user capability for a local container whose process ancestry\ncannot be observed by cmux. The result includes the live socket path and\nthe capability used in a _cmux_capability_v1 command envelope."
+            }
+          },
+          "ja": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "使用法: cmux local-container lease [--json]\n\nローカルコンテナ用に同一ユーザーの機能を発行します。\nプロセスの祖先を cmux が観測できない場合に使用します。\n結果にはライブソケットパスと機能が含まれます。"
+            }
+          },
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Verwendung: cmux local-container lease [--json]\n\nStellt eine Berechtigung für einen lokalen Container aus.\ncmux kann dessen Prozessherkunft nicht beobachten.\nDas Ergebnis enthält Socket-Pfad und Berechtigung."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Utilisation : cmux local-container lease [--json]\n\nÉmet une capacité pour un conteneur local.\ncmux ne peut pas observer son ascendance de processus.\nLe résultat contient le chemin du socket et la capacité."
+            }
+          },
+          "ar": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "الاستخدام: cmux local-container lease [--json]\n\nإصدار قدرة لحاوية محلية.\nلا يستطيع cmux مراقبة تسلسل عملياتها.\nتتضمن النتيجة مسار المقبس والقدرة."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Uso: cmux local-container lease [--json]\n\nEmite una capacidad para un contenedor local.\ncmux no puede observar su árbol de procesos.\nEl resultado incluye la ruta del socket y la capacidad."
+            }
+          },
+          "zh-Hant": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "用法：cmux local-container lease [--json]\n\n為本機容器簽發能力。\ncmux 無法觀察其處理程序祖先。\n結果包含插槽路徑和能力。"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "用法：cmux local-container lease [--json]\n\n为本地容器签发能力。\ncmux 无法观察其进程祖先。\n结果包含套接字路径和能力。"
+            }
+          },
+          "ko": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "사용법: cmux local-container lease [--json]\n\n로컬 컨테이너에 대한 기능을 발급합니다.\ncmux가 프로세스 조상을 관찰할 수 없을 때 사용합니다.\n결과에 소켓 경로와 기능이 포함됩니다."
+            }
+          }
+        }
+      },
+      "cli.localContainer.unknownSubcommand": {
+        "extractionState": "manual",
+        "localizations": {
+          "en": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Unknown local-container subcommand: %@\n\n%@"
+            }
+          },
+          "ja": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "알 수 없는 local-container 하위 명령: %@\n\n%@"
+            }
+          },
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Unbekannter local-container-Unterbefehl: %@\n\n%@"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Sous-commande local-container inconnue : %@\n\n%@"
+            }
+          },
+          "ar": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "أمر local-container الفرعي غير معروف: %@\n\n%@"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Subcomando de local-container desconocido: %@\n\n%@"
+            }
+          },
+          "zh-Hant": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "未知的 local-container 子命令：%@\n\n%@"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "未知的 local-container 子命令：%@\n\n%@"
+            }
+          },
+          "ko": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "알 수 없는 local-container 하위 명령: %@\n\n%@"
+            }
+          }
+        }
+      },
+      "cli.localContainer.invalidLease": {
+        "extractionState": "manual",
+        "localizations": {
+          "en": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "The cmux socket did not return a usable local-container lease"
+            }
+          },
+          "ja": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "cmux ソケットが使用可能な local-container リースを返しませんでした"
+            }
+          },
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Der cmux-Socket hat keine verwendbare local-container-Lease zurückgegeben"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Le socket cmux n’a pas renvoyé de lease local-container utilisable"
+            }
+          },
+          "ar": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "لم يُرجع مقبس cmux عقدة local-container صالحة للاستخدام"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "El socket de cmux no devolvió una concesión de local-container utilizable"
+            }
+          },
+          "zh-Hant": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "cmux 插槽未傳回可用的 local-container 租約"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "cmux 套接字未返回可用的 local-container 租约"
+            }
+          },
+          "ko": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "cmux 소켓이 사용 가능한 local-container lease를 반환하지 않았습니다"
+            }
+          }
+        }
+      }
   },
   "version": "1.0"
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1731,6 +1731,27 @@ class TerminalController {
             return v2Ok(id: request.id, result: ["pong": true])
         case "system.capabilities":
             return v2Ok(id: request.id, result: v2CapabilitiesWithBrowserDesignMode())
+        case "system.socket_capability_lease":
+            guard let socketPath = currentSocketPathForRemoteRestore(),
+                  !socketPath.isEmpty else {
+                return v2Error(
+                    id: request.id,
+                    code: "socket_unavailable",
+                    message: String(
+                        localized: "cli.localContainer.invalidLease",
+                        defaultValue: "The cmux socket did not return a usable local-container lease"
+                    )
+                )
+            }
+            let lease = SocketClientCapabilityLease(
+                socketPath: socketPath,
+                capability: socketClientCapabilityAuthority.issueCapability()
+            )
+            return v2Ok(id: request.id, result: [
+                "socket_path": lease.socketPath,
+                "capability": lease.capability,
+                "protocol": lease.protocolName,
+            ])
         case "system.top":
             return v2Result(id: request.id, v2SystemTop(params: request.params))
         case "system.memory":
@@ -3063,6 +3084,7 @@ class TerminalController {
         var methods: [String] = [
             "system.ping",
             "system.capabilities",
+            "system.socket_capability_lease",
             "system.identify",
             "system.tree",
             "sidebar.custom.open",

--- a/scripts/localization-allowed-omissions.json
+++ b/scripts/localization-allowed-omissions.json
@@ -3029,4 +3029,17 @@
       "ja": "Command syntax is intentionally identical in this locale."
     }
   }
+,
+  "cli.localContainer.socketPath": {
+    "source": "CMUX_SOCKET_PATH=%@",
+    "class": "technical invariant"
+  },
+  "cli.localContainer.capability": {
+    "source": "CMUX_SOCKET_CAPABILITY=%@",
+    "class": "technical invariant"
+  },
+  "cli.localContainer.protocol": {
+    "source": "CMUX_SOCKET_CAPABILITY_PROTOCOL=%@",
+    "class": "technical invariant"
+  }
 }


### PR DESCRIPTION
## Problem
A local self-spawned container can reach the host cmux socket through `host.docker.internal` or a loopback bridge, but its process ancestry is unavailable, so normal socket authorization rejects it.

## Fix
- Add the authenticated `system.socket_capability_lease` v2 method.
- Add `cmux local-container lease [--json]`, which emits the socket path and `_cmux_capability_v1` capability for container launchers.
- Keep the lease same-UID and audience-bound through the existing HMAC capability authority; it does not broaden remote or cross-user access.
- Add focused serialization, authorization, and execution-policy tests.

Typical host-side setup:

```sh
eval "$(cmux local-container lease)"
```

A container bridge can pass `CMUX_SOCKET_PATH`, `CMUX_SOCKET_CAPABILITY`, and `CMUX_SOCKET_CAPABILITY_PROTOCOL` into the container and wrap requests with the existing capability envelope.

Fixes #12274

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791784117&installation_model_id=21920&pr_number=12408&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12408&signature=811d313f6f8528d1ee056b534c69ae33fac409c19e7be4b713f561dcafefbbdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `local-container lease` command that mints a same-user capability for local containers whose process ancestry cmux can't observe, so they can reach the control socket instead of being rejected.

**New Features**
- `cmux local-container lease [--json]` prints `CMUX_SOCKET_PATH`, `CMUX_SOCKET_CAPABILITY`, and `CMUX_SOCKET_CAPABILITY_PROTOCOL` for bridge setup.
- Adds `system.socket_capability_lease` to the v2 method list and execution policy.
- The lease stays same-UID and audience-bound via HMAC, so it doesn't widen remote or cross-user access.
- Adds tests for lease round-tripping, same-UID authorization, and execution policy inclusion.

Resolves #12274.

<sup>Written for commit a51e64a1ff16ca375b6a542b077a5e3c594319a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `cmux local-container lease` command.
  * Supports human-readable shell-export output and raw JSON output with `--json`.
  * Provides a secure socket capability lease for local container access.
  * Added localized command help and error messages.

* **Tests**
  * Added coverage for lease serialization, protocol validation, and authorization of reparented same-user processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->