### PR TITLE
iOS: show pairing guidance in 1.0.5 What's New

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
@@ -92,12 +92,21 @@ enum MobileWhatsNewCatalog {
     /// positions in the FULL catalog so remotely hiding one entry cannot
     /// shift how other entries compare against the marker.
     static func index(ofID id: String) -> Int? {
-        entries.firstIndex { $0.id == id }
+        if let index = entries.firstIndex(where: { $0.id == id }) {
+            return index
+        }
+        // 1.0.4 acknowledged this page under its original id. Treat that
+        // marker as older than the replacement page so an upgrade still
+        // presents the new release notes instead of going quiet.
+        if id == "connections.v1" {
+            return entries.count
+        }
+        return nil
     }
 
     static var connectionsUpdate: MobileWhatsNewPage {
         MobileWhatsNewPage(
-            id: "connections.v1",
+            id: "connections.1.0.5",
             releaseLabel: L10n.string(
                 "mobile.connectionsUpdate.releaseLabel",
                 defaultValue: "1.0.5 · August 2026"
@@ -149,6 +158,17 @@ enum MobileWhatsNewCatalog {
                     detail: L10n.string(
                         "mobile.connectionsUpdate.tailscale.detail",
                         defaultValue: "Choosing Tailscale Only shows exactly what's missing and offers the pairing-code scan right there. Nothing opens on its own."
+                    )
+                ),
+                .init(
+                    symbol: "iphone.gen3",
+                    title: L10n.string(
+                        "mobile.connectionsUpdate.pairing.title",
+                        defaultValue: "Enable iOS pairing"
+                    ),
+                    detail: L10n.string(
+                        "mobile.connectionsUpdate.pairing.detail",
+                        defaultValue: "If this iPhone is not paired yet, enable iOS Pairing in cmux on your Mac before connecting."
                     )
                 ),
             ]),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCenter.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCenter.swift
@@ -152,7 +152,7 @@ public final class MobileWhatsNewCenter {
             )
         }
         let withCompatibilityCopy = channelAllowed.map { page -> MobileWhatsNewPage in
-            guard page.id == "connections.v1" else { return page }
+            guard page.id == "connections.1.0.5" else { return page }
             var updated = page
             updated.footnote = MobileWhatsNewCatalog.macUpdateFootnote(
                 buildType: buildType,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -12655,6 +12655,28 @@
         }
       }
     },
+    "mobile.connectionsUpdate.pairing.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable iOS pairing"
+          }
+        }
+      }
+    },
+    "mobile.connectionsUpdate.pairing.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If this iPhone is not paired yet, enable iOS Pairing in cmux on your Mac before connecting."
+          }
+        }
+      }
+    },
     "mobile.settings.diagnostics.clear.failed": {
       "extractionState": "manual",
       "localizations": {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
@@ -48,6 +48,21 @@ import Testing
         #expect(!features.contains { $0.symbol == "exclamationmark.triangle.fill" })
     }
 
+    @Test func whatsNewExplainsIosPairingAndUsesTheNewReleaseID() {
+        let page = MobileWhatsNewCatalog.connectionsUpdate
+        #expect(page.id == "connections.1.0.5")
+        guard case .features(let features) = page.body else {
+            Issue.record("connections update page lost its feature rows")
+            return
+        }
+        #expect(features.contains { feature in
+            feature.symbol == "iphone.gen3"
+                && feature.title == "Enable iOS pairing"
+                && feature.detail.contains("enable iOS Pairing")
+        })
+        #expect(page.footnote?.contains("Requires cmux") == true)
+    }
+
     @Test func presenceFooterIsNeutralOnOfficialBuilds() {
         let official = MacComputerDetailView.presenceFooter(buildType: .prod)
         #expect(!official.contains("DEV"))

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWhatsNewChannelGateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWhatsNewChannelGateTests.swift
@@ -53,13 +53,27 @@ import Testing
         }
     }
 
+    @Test func acknowledgedPreOnePointZeroFiveEntryStillShowsReplacementPage() {
+        let suiteName = "MobileWhatsNewChannelGateTests-legacy-marker-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set("connections.v1", forKey: MobileWhatsNewCenter.markerKey)
+        let center = MobileWhatsNewCenter(
+            apiBaseURL: nil,
+            appVersion: "1.0.5",
+            buildType: .beta,
+            defaults: defaults
+        )
+        #expect(center.unseenPages.map(\.id) == ["connections.1.0.5"])
+    }
+
     @Test func legacyPayloadWithoutChannelFieldsKeepsTeamBehavior() async {
         // The pre-channel server payload shape must keep decoding and must
         // keep meaning "team lanes only" (not "everyone").
-        let payload = #"{"visibleEntryIds":["connections.v1"],"announcements":[]}"#
+        let payload = #"{"visibleEntryIds":["connections.1.0.5"],"announcements":[]}"#
         let team = makeCenter(buildType: .beta, payload: payload)
         await team.refresh()
-        #expect(team.visibleBinaryEntries.map(\.id) == ["connections.v1"])
+        #expect(team.visibleBinaryEntries.map(\.id) == ["connections.1.0.5"])
 
         let official = makeCenter(buildType: .prod, payload: payload)
         await official.refresh()
@@ -70,15 +84,15 @@ import Testing
     @Test func remoteEntryChannelsOptABinaryEntryIntoOfficial() async {
         let payload = #"""
         {
-          "visibleEntryIds": ["connections.v1"],
-          "entryChannels": { "connections.v1": ["dev", "beta", "internal", "prod"] },
+          "visibleEntryIds": ["connections.1.0.5"],
+          "entryChannels": { "connections.1.0.5": ["dev", "beta", "internal", "prod"] },
           "announcements": []
         }
         """#
         let center = makeCenter(buildType: .prod, payload: payload)
         await center.refresh()
-        #expect(center.visibleBinaryEntries.map(\.id) == ["connections.v1"])
-        #expect(center.unseenPages.map(\.id) == ["connections.v1"])
+        #expect(center.visibleBinaryEntries.map(\.id) == ["connections.1.0.5"])
+        #expect(center.unseenPages.map(\.id) == ["connections.1.0.5"])
     }
 
     @Test func remoteEntryChannelsCanAlsoNarrowTeamBuilds() async {
@@ -86,8 +100,8 @@ import Testing
         // operator can retract an entry from a single lane remotely.
         let payload = #"""
         {
-          "visibleEntryIds": ["connections.v1"],
-          "entryChannels": { "connections.v1": ["prod"] },
+          "visibleEntryIds": ["connections.1.0.5"],
+          "entryChannels": { "connections.1.0.5": ["prod"] },
           "announcements": []
         }
         """#

--- a/web/data/whats-new.ts
+++ b/web/data/whats-new.ts
@@ -80,13 +80,13 @@ export interface WhatsNewList {
 }
 
 export const whatsNewList: WhatsNewList = {
-  // Binary catalog ids the app may show. "connections.v1" ships in the iOS
+  // Binary catalog ids the app may show. "connections.1.0.5" ships in the iOS
   // binary catalog, so only binaries that carry the page can render it; the
   // list needs no extra version gating for binary pages. Remove an id here
   // to hide its page remotely. With no `entryChannels` override, every id
   // keeps its compiled-in audience — team lanes only — so none of this
-  // renders on the official App Store app. To show connections.v1 there:
-  // entryChannels: { "connections.v1": ["dev", "beta", "internal", "prod"] }.
-  visibleEntryIds: ["connections.v1"],
+  // renders on the official App Store app. To show connections.1.0.5 there:
+  // entryChannels: { "connections.1.0.5": ["dev", "beta", "internal", "prod"] }.
+  visibleEntryIds: ["connections.1.0.5"],
   announcements: [],
 };

--- a/web/tests/whats-new-route.test.ts
+++ b/web/tests/whats-new-route.test.ts
@@ -14,7 +14,7 @@ const { GET, validateList } = await import("../app/api/whats-new/route");
  */
 describe("whats-new route channel targeting", () => {
   const base: WhatsNewList = {
-    visibleEntryIds: ["connections.v1"],
+    visibleEntryIds: ["connections.1.0.5"],
     announcements: [],
   };
   const announcement = {
@@ -50,7 +50,7 @@ describe("whats-new route channel targeting", () => {
   test("accepts a valid per-entry channel override including prod", () => {
     const list: WhatsNewList = {
       ...base,
-      entryChannels: { "connections.v1": ["dev", "beta", "internal", "prod"] },
+      entryChannels: { "connections.1.0.5": ["dev", "beta", "internal", "prod"] },
     };
     expect(validateList(list)).toEqual(list);
   });
@@ -76,7 +76,7 @@ describe("whats-new route channel targeting", () => {
   test("rejects unknown channel tokens (they fail closed on device)", () => {
     const list = {
       ...base,
-      entryChannels: { "connections.v1": ["official"] },
+      entryChannels: { "connections.1.0.5": ["official"] },
     } as unknown as WhatsNewList;
     expect(() => validateList(list)).toThrow(/must be one of dev, beta, internal, demo, prod/);
   });
@@ -84,10 +84,10 @@ describe("whats-new route channel targeting", () => {
   test("rejects an empty channel list (hidden everywhere is a retraction, not targeting)", () => {
     const list: WhatsNewList = {
       ...base,
-      entryChannels: { "connections.v1": [] },
+      entryChannels: { "connections.1.0.5": [] },
     };
     expect(() => validateList(list)).toThrow(
-      "entryChannels[connections.v1] must list at least one channel",
+      "entryChannels[connections.1.0.5] must list at least one channel",
     );
     const announcementList: WhatsNewList = {
       ...base,
@@ -101,10 +101,10 @@ describe("whats-new route channel targeting", () => {
   test("rejects duplicate channels", () => {
     const list: WhatsNewList = {
       ...base,
-      entryChannels: { "connections.v1": ["beta", "beta"] },
+      entryChannels: { "connections.1.0.5": ["beta", "beta"] },
     };
     expect(() => validateList(list)).toThrow(
-      "entryChannels[connections.v1] contains duplicate channel beta",
+      "entryChannels[connections.1.0.5] contains duplicate channel beta",
     );
   });
 


### PR DESCRIPTION
Updates the beta What's New page for the 1.0.5 release.

- Uses a release-specific catalog ID, so users who acknowledged the 1.0.4 `connections.v1` page receive the replacement page.
- Adds a feature row explaining that an unpaired iPhone requires iOS Pairing to be enabled in cmux on the Mac.
- Keeps the orange compatibility notice at the bottom with the exact stable and NIGHTLY minimums from the mac-compat policy.
- Publishes the new ID through the remote What's New list and updates coverage.

Validation:
- `bun test tests/whats-new-route.test.ts` (9 passed)
- Fleet iOS archive build succeeded.
- Isolated fleet simulator install and launch succeeded; screenshot and recording are in `artifacts/verify-remote/20260911-225503-wn15-ios-cmux9s-v`.
- UI/catalog coverage added for the replacement marker and pairing copy.

The layout follows Apple's iOS guidance for focused sheets and discoverable key information: [Designing for iOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-ios).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791784669&installation_model_id=21920&pr_number=12409&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12409&signature=61f3d886904c336c25396129adb225e6058ab33f5072132e292344e04a14b2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the 1.0.5 beta What's New page to add pairing guidance and ensure users who already saw the 1.0.4 page still get the new release notes.

- Changes the page ID from `connections.v1` to `connections.1.0.5`; the old acknowledgment marker is treated as older, so an upgrade still shows the replacement page.
- Adds a feature row explaining that an unpaired iPhone requires iOS Pairing to be enabled in cmux on the Mac.
- Publishes the new ID through the remote What's New list and updates UI, catalog, and channel-gate tests.

<sup>Written for commit 22dc155fb305352daaaa1edee91f7536294406fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iOS pairing guidance row to the Connections update notes, including instructions for enabling pairing on Mac.
  - Updated the What's New release entry to version 1.0.5.

- **Bug Fixes**
  - Upgrades from version 1.0.4 now correctly display the Connections update notes instead of showing no update.

- **Compatibility**
  - The Connections update continues to display the macOS compatibility requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->