### PR TITLE
Fix stale portal layers after workspace switches

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1919,6 +1919,7 @@ final class WindowBrowserPortal: NSObject {
         weak var webView: WKWebView?
         weak var containerView: WindowBrowserSlotView?
         weak var anchorView: NSView?
+        let workspaceID: UUID?
         var visibleInUI: Bool
         var zPriority: Int
         var dropZone: DropZone?
@@ -2888,16 +2889,21 @@ final class WindowBrowserPortal: NSObject {
         entry.containerView?.removeFromSuperview()
     }
 
-    /// Update the visibleInUI/zPriority state on an existing entry without rebinding.
-    /// Used when a bind is deferred (host not yet in window) so stale portal syncs
-    /// do not keep an old anchor visible.
     @discardableResult
     func updateEntryVisibility(forWebViewId webViewId: ObjectIdentifier, visibleInUI: Bool, zPriority: Int) -> Bool {
-        guard var entry = entriesByWebViewId[webViewId],
-              entry.visibleInUI != visibleInUI || entry.zPriority != zPriority else { return false }
-        entry.visibleInUI = visibleInUI; entry.zPriority = zPriority
+        guard var entry = entriesByWebViewId[webViewId] else { return false }
+        let effectiveVisibleInUI = visibleInUI && Workspace.portalRenderingEnabled(for: entry.workspaceID)
+        guard entry.visibleInUI != effectiveVisibleInUI || entry.zPriority != zPriority else { return false }
+        entry.visibleInUI = effectiveVisibleInUI; entry.zPriority = zPriority
         entriesByWebViewId[webViewId] = entry
         return true
+    }
+    func hideWebViews(forWorkspaceID workspaceID: UUID) {
+        for webViewId in entriesByWebViewId.compactMap({ webViewId, entry in
+            entry.workspaceID == workspaceID ? webViewId : nil
+        }) {
+            _ = hideWebView(withId: webViewId, source: "workspaceRetire")
+        }
     }
 
     func isWebViewBoundToAnchor(withId webViewId: ObjectIdentifier, anchorView: NSView) -> Bool {
@@ -3111,10 +3117,9 @@ final class WindowBrowserPortal: NSObject {
         let webViewId = ObjectIdentifier(webView)
         let anchorId = ObjectIdentifier(anchorView)
         let previousEntry = entriesByWebViewId[webViewId]
-        // A non-nil context supplied by a reconciler is an atomic ownership
-        // seed. Otherwise retain the entry snapshot until SwiftUI delivers its
-        // next authoritative update.
         let resolvedPaneDropContext = paneDropContext ?? previousEntry?.paneDropContext
+        let workspaceID = resolvedPaneDropContext?.isDockHosted == true ? nil : (resolvedPaneDropContext?.workspaceId ?? previousEntry?.workspaceID)
+        let effectiveVisibleInUI = visibleInUI && Workspace.portalRenderingEnabled(for: workspaceID)
         let shouldPreserveExternalFullscreenHost =
             webView.cmuxIsManagedByExternalFullscreenWindow(relativeTo: window)
         let containerView = ensureContainerView(
@@ -3122,6 +3127,7 @@ final class WindowBrowserPortal: NSObject {
                 webView: nil,
                 containerView: nil,
                 anchorView: nil,
+                workspaceID: nil,
                 visibleInUI: false,
                 zPriority: 0,
                 dropZone: nil,
@@ -3162,7 +3168,8 @@ final class WindowBrowserPortal: NSObject {
             webView: webView,
             containerView: containerView,
             anchorView: anchorView,
-            visibleInUI: visibleInUI,
+            workspaceID: workspaceID,
+            visibleInUI: effectiveVisibleInUI,
             zPriority: zPriority,
             dropZone: previousEntry?.dropZone,
             paneDropContext: resolvedPaneDropContext,
@@ -3376,19 +3383,12 @@ final class WindowBrowserPortal: NSObject {
             containerView.setDesignComposer(nil)
             containerView.setOmnibarSuggestions(nil)
             if entry.visibleInUI {
-                // Anchor/geometry recovery can hide a still-owned slot for one
-                // pass. Keep its Dock classification through that transient
-                // state; an explicit visibility update or release clears it.
                 containerView.setPaneDropContext(nil)
             } else {
                 containerView.clearPaneDropContext()
             }
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
-            // Tab/workspace visibility changes should hide the portal slot without forcing
-            // WebKit through `_exitInWindow`/`_enterInWindow`, which fires visibilitychange
-            // and can trigger page reloads. Reserve the full lifecycle notify for cases
-            // where the visible surface is actually leaving the window/render tree.
             if entry.visibleInUI,
                !containerView.isHidden,
                webView.cmuxBrowserViewportPresentationView.superview === containerView {
@@ -3939,9 +3939,6 @@ final class WindowBrowserPortal: NSObject {
             guard entry.webView != nil else { return webViewId }
             guard let container = entry.containerView else { return webViewId }
             guard let anchor = entry.anchorView else {
-                // Workspace switching hides retiring browser portals before SwiftUI unmounts
-                // their anchor views. Keep the hidden WKWebView/slot alive so switching back
-                // can rebind the existing view instead of forcing a full WebKit reload.
                 return nil
             }
             if container.superview == nil || !container.isDescendant(of: hostView) {
@@ -3952,9 +3949,6 @@ final class WindowBrowserPortal: NSObject {
                 anchor.superview == nil ||
                 (installedReferenceView.map { !anchor.isDescendant(of: $0) } ?? false)
             if anchorInvalidForCurrentHost {
-                // Hidden browser portals can legitimately be off-tree between workspace
-                // deactivation and the next rebind. Preserve them until an explicit detach
-                // (panel close, window teardown, or web view replacement) says otherwise.
                 return nil
             }
             return nil
@@ -4208,6 +4202,12 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         if portal.hideWebView(withId: webViewId, source: source) { postRegistryDidChange(for: webView) }
+    }
+    /// Hides every registered browser portal owned by one inactive workspace.
+    static func hideWebViews(forWorkspaceID workspaceID: UUID) {
+        for portal in portalsByWindowId.values {
+            portal.hideWebViews(forWorkspaceID: workspaceID)
+        }
     }
 
     static func discard(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11654,11 +11654,10 @@ final class GhosttySurfaceScrollView: NSView {
     func beginPortalGeometrySettlement() { surfaceView.beginPortalGeometrySettlement() }
     func finishPortalGeometrySettlement() { surfaceView.finishPortalGeometrySettlement() }
 
-    func setVisibleInUI(_ visible: Bool) {
+    func setVisibleInUI(_ requestedVisible: Bool) {
+        let visible = requestedVisible && (isRightSidebarDockSurface || Workspace.portalRenderingEnabled(for: surfaceView.terminalSurface?.tabId))
         let wasVisible = surfaceView.isVisibleInUI
-        // Make the AppKit portal presentable before asking Ghostty to realize its
-        // drawable. Ghostty remains occluded until after the enqueue below, so it
-        // cannot draw into a released swap chain during this short transition.
+        // Make the portal presentable before asking Ghostty to realize its drawable.
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
         surfaceView.terminalSurface?.setRendererPortalVisible(visible)
@@ -11739,7 +11738,8 @@ final class GhosttySurfaceScrollView: NSView {
         return convert(bounds, to: nil)
     }
 
-    func setActive(_ active: Bool) {
+    func setActive(_ requestedActive: Bool) {
+        let active = requestedActive && (isRightSidebarDockSurface || Workspace.portalRenderingEnabled(for: surfaceView.terminalSurface?.tabId))
         let wasActive = isActive
         if !active {
             surfaceView.cancelKeyboardCopyMode()

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -703,6 +703,7 @@ final class WindowTerminalPortal: NSObject {
     struct Entry {
         weak var hostedView: GhosttySurfaceScrollView?
         weak var anchorView: NSView?
+        let workspaceID: UUID?
         var visibleInUI: Bool
         var awaitingGeometrySettlement: Bool
         var zPriority: Int
@@ -1523,45 +1524,36 @@ final class WindowTerminalPortal: NSObject {
 #endif
     }
 
-    /// Update the visibleInUI flag on an existing entry without rebinding.
-    /// Used when a deferred bind is pending — this ensures synchronizeHostedView
-    /// won't hide a view that updateNSView has already marked as visible.
+    func hideEntries(forWorkspaceID workspaceID: UUID) {
+        for hostedId in entriesByHostedId.compactMap({ hostedId, entry in
+            entry.workspaceID == workspaceID ? hostedId : nil
+        }) {
+            hideEntry(forHostedId: hostedId)
+        }
+    }
+
     @discardableResult
     func updateEntryVisibility(forHostedId hostedId: ObjectIdentifier, visibleInUI: Bool) -> Bool {
         let needsReattach = visibleInUI && hostedViewNeedsPortalReattachForVisiblePresentation(withId: hostedId)
         guard var entry = entriesByHostedId[hostedId] else { return needsReattach }
-        let becameVisible = visibleInUI && !entry.visibleInUI
-        let becameHidden = !visibleInUI && entry.visibleInUI
-        entry.visibleInUI = visibleInUI
+        let effectiveVisibleInUI = visibleInUI && Workspace.portalRenderingEnabled(for: entry.workspaceID)
+        let becameVisible = effectiveVisibleInUI && !entry.visibleInUI
+        let becameHidden = !effectiveVisibleInUI && entry.visibleInUI
+        entry.visibleInUI = effectiveVisibleInUI
         if becameVisible {
             lastHierarchySyncSignature = nil
             geometrySettlementPassesRemaining = 4
             entry.awaitingGeometrySettlement = true
             entry.hostedView?.beginPortalGeometrySettlement()
-        } else if !visibleInUI {
+        } else if !effectiveVisibleInUI {
             entry.awaitingGeometrySettlement = false
             entry.hostedView?.finishPortalGeometrySettlement()
             entry.transientRecoveryRetriesRemaining = 0
         }
         entriesByHostedId[hostedId] = entry
         if becameHidden {
-            // Visibility updates are coalesced. Clear the presentation edge
-            // synchronously so a hide -> show in one turn can notify again.
             clearPresentationNotificationState(for: hostedId)
         }
-        // A view that just became visible may still hold the frame it was
-        // born with (bind can seed from a pre-settle anchor reading, and a
-        // hidden entry's frame is deliberately left alone). Visibility is a
-        // sizing input like any other: it schedules a pass rather than
-        // trusting that some earlier one already ran.
-        //
-        // A flip to invisible must schedule the same pass: the hide is applied
-        // by synchronizeHostedView (shouldHide reads entry.visibleInUI), and a
-        // selection-only tab switch produces no window geometry churn that
-        // would run one otherwise. An unscheduled hide left the deselected
-        // terminal's layer rendering above SwiftUI chrome — the previous
-        // terminal's content filled the browser omnibar band until unrelated
-        // churn (sidebar toggle, window resize) healed it.
         if becameVisible || becameHidden {
             scheduleExternalGeometrySynchronize(forceImmediate: false)
         }
@@ -1660,8 +1652,9 @@ final class WindowTerminalPortal: NSObject {
         entriesByHostedId[hostedId] = Entry(
             hostedView: hostedView,
             anchorView: anchorView,
-            visibleInUI: visibleInUI,
-            awaitingGeometrySettlement: visibleInUI,
+            workspaceID: hostedView.isRightSidebarDockSurface ? nil : hostedView.surfaceView.terminalSurface?.tabId,
+            visibleInUI: visibleInUI && (hostedView.isRightSidebarDockSurface || Workspace.portalRenderingEnabled(for: hostedView.surfaceView.terminalSurface?.tabId)),
+            awaitingGeometrySettlement: visibleInUI && (hostedView.isRightSidebarDockSurface || Workspace.portalRenderingEnabled(for: hostedView.surfaceView.terminalSurface?.tabId)),
             zPriority: zPriority,
             transientRecoveryRetriesRemaining: 0
         )
@@ -2907,6 +2900,13 @@ enum TerminalWindowPortalRegistry {
         let hostedId = ObjectIdentifier(hostedView)
         guard let windowId = hostedToWindowId[hostedId], let portal = portalsByWindowId[windowId] else { return }
         portal.hideEntry(forHostedId: hostedId)
+    }
+
+    /// Hides every registered terminal portal owned by one inactive workspace.
+    static func hideHostedViews(forWorkspaceID workspaceID: UUID) {
+        for portal in portalsByWindowId.values {
+            portal.hideEntries(forWorkspaceID: workspaceID)
+        }
     }
 
     /// Permanently detach a hosted terminal view from the window-level portal.

--- a/Sources/Workspace+PortalRenderingAuthority.swift
+++ b/Sources/Workspace+PortalRenderingAuthority.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Workspace {
+    /// Returns the authoritative portal-rendering state for a workspace id.
+    ///
+    /// Portal registries can outlive the SwiftUI representable that created an
+    /// entry. They use this query at every bind/visibility boundary so queued
+    /// callbacks cannot make an inactive workspace visible again. A missing
+    /// app delegate is limited to isolated registry tests, where no workspace
+    /// lifecycle exists to authorize or deny a portal.
+    @MainActor
+    static func portalRenderingEnabled(for workspaceID: UUID?) -> Bool {
+        guard let workspaceID else { return true }
+        guard let appDelegate = AppDelegate.shared else { return true }
+        guard let manager = appDelegate.tabManagerFor(tabId: workspaceID),
+              let workspace = manager.tabs.first(where: { $0.id == workspaceID }) else {
+            return false
+        }
+        return manager.selectedTabId == workspaceID && workspace.isPortalRenderingEnabled
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4547,6 +4547,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     private var layoutFollowUpStalledAttemptCount = 0
     private var pendingReparentFocusSuppressionViews: [ObjectIdentifier: GhosttySurfaceScrollView] = [:]
     private var portalRenderingEnabled = true
+    var isPortalRenderingEnabled: Bool { portalRenderingEnabled }
     private var agentHibernationAutoResumePresentationVisible = true
     private var isAttemptingLayoutFollowUp = false
     private var isNormalizingPinnedTabOrder = false
@@ -4563,7 +4564,6 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         get { surfaceRegistry.nonFocusSplitFocusReassertGeneration }
         set { surfaceRegistry.nonFocusSplitFocusReassertGeneration = newValue }
     }
-
     /// Captured detach transfer payloads; stored in the split-layout
     /// sub-model. Mutations go through the model's detach-choreography
     /// verbs; this read-only view feeds the empty/count checks.
@@ -11600,6 +11600,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             clearLayoutFollowUp()
             hideAllTerminalPortalViews()
             hideAllBrowserPortalViews()
+            TerminalWindowPortalRegistry.hideHostedViews(forWorkspaceID: id)
+            BrowserWindowPortalRegistry.hideWebViews(forWorkspaceID: id)
         }
     }
 
@@ -11609,8 +11611,6 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         guard isVisible else { return }
         _ = resumeVisibleAgentHibernationPanels(panelIds: agentHibernationVisiblePanelIdsForCurrentLayout())
     }
-
-    // MARK: - Utility
 
     /// Create a new terminal panel (used when replacing the last panel)
     @discardableResult

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -3367,6 +3367,7 @@
 		8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
 		797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */; };
+		D12393010000000000000001 /* Workspace+PortalRenderingAuthority.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12393010000000000000002 /* Workspace+PortalRenderingAuthority.swift */; };
 		791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */; };
 		51A3E82C604B4E8CB2E62730 /* Workspace+RemotePTYRespawnRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37996A7C5AD2472083D94F54 /* Workspace+RemotePTYRespawnRouting.swift */; };
 		7989B0057989B0057989B005 /* Workspace+RemoteRelayCommandRewrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1057989B1057989B105 /* Workspace+RemoteRelayCommandRewrite.swift */; };
@@ -6879,6 +6880,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+NotificationsPane.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
 		797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PersistentRemotePTYReattach.swift"; sourceTree = "<group>"; };
+		D12393010000000000000002 /* Workspace+PortalRenderingAuthority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PortalRenderingAuthority.swift"; sourceTree = "<group>"; };
 		791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteDisconnectPlaceholder.swift"; sourceTree = "<group>"; };
 		37996A7C5AD2472083D94F54 /* Workspace+RemotePTYRespawnRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemotePTYRespawnRouting.swift"; sourceTree = "<group>"; };
 		7989B1057989B1057989B105 /* Workspace+RemoteRelayCommandRewrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteRelayCommandRewrite.swift"; sourceTree = "<group>"; };
@@ -8225,6 +8227,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
+				D12393010000000000000002 /* Workspace+PortalRenderingAuthority.swift */,
 				8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */,
 				791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */,
 				797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */,
@@ -13473,6 +13476,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
 				797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */,
+				D12393010000000000000001 /* Workspace+PortalRenderingAuthority.swift in Sources */,
 				791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */,
 				51A3E82C604B4E8CB2E62730 /* Workspace+RemotePTYRespawnRouting.swift in Sources */,
 				7989B0057989B0057989B005 /* Workspace+RemoteRelayCommandRewrite.swift in Sources */,

--- a/cmuxTests/WorkspaceSwitchRendererProtectionTests.swift
+++ b/cmuxTests/WorkspaceSwitchRendererProtectionTests.swift
@@ -96,4 +96,31 @@ struct WorkspaceSwitchRendererProtectionTests {
 
         #expect(!selected.contains(switchTargetID))
     }
+
+    @Test
+    func inactiveWorkspaceCannotAuthorizePortalPresentation() throws {
+        let originalAppDelegate = AppDelegate.shared
+        let appDelegate = originalAppDelegate ?? AppDelegate()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let originalTabManager = appDelegate.tabManager
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        AppDelegate.shared = appDelegate
+        appDelegate.tabManager = manager
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            appDelegate.tabManager = originalTabManager
+            AppDelegate.shared = originalAppDelegate
+        }
+
+        let selectedWorkspace = try #require(manager.selectedWorkspace)
+        let inactiveWorkspace = manager.addWorkspace(select: false, placementOverride: .end)
+
+        #expect(Workspace.portalRenderingEnabled(for: selectedWorkspace.id))
+        #expect(!Workspace.portalRenderingEnabled(for: inactiveWorkspace.id))
+
+        manager.selectedTabId = inactiveWorkspace.id
+
+        #expect(!Workspace.portalRenderingEnabled(for: selectedWorkspace.id))
+        #expect(Workspace.portalRenderingEnabled(for: inactiveWorkspace.id))
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/12393

Workspace switches could leave portal-backed terminal and browser layers visible after SwiftUI had selected another workspace. The visible SwiftUI tree and the AppKit portal registries each tracked visibility independently, so retained representables and queued callbacks could resurrect an inactive layer.

This change makes the workspace lifecycle the authority for portal presentation. Terminal and browser registry entries retain their owning workspace ID, registry binds and visibility updates are clamped by the authoritative selected workspace/lifecycle state, and workspace retirement explicitly hides every matching registered entry, including entries no longer reachable through the mounted panel tree. Dock-hosted surfaces remain window-owned and are exempt from workspace gating.

Trade-offs:

- Retained portal entries are still kept for fast workspace switching, but inactive entries cannot become visible or active through stale callbacks.
- The registry performs an app-level workspace lookup at the visibility boundary; missing workspace metadata is treated as an isolated registry/test case and does not authorize a known workspace.
- The visual repro was verified with a tagged cloud-built app by creating a mixed terminal/browser workspace, creating a second workspace, and rapidly switching between them. The final selected workspace contained only its own content.

Tests and validation:

- `python3 scripts/swift_file_length_budget.py`
- `bash scripts/lint-pbxproj-test-wiring.sh`
- Tagged cloud build: `CMUX_DEV_BACKEND_MODE=local CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-12393-workspace-switch-ghosting --launch`
- Tagged debug CLI workspace listing and rapid-switch visual verification
- Focused remote `WorkspaceSwitchRendererProtectionTests` was attempted through the fleet xctest runner but remained queued behind shared capacity; CI should provide the test-target execution.

The fix is intentionally not merged; it needs maintainer review and dogfood confirmation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791785611&installation_model_id=21920&pr_number=12414&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12414&signature=b08b43f8a6a7d8d5573eb1d6a5e3397e825c4befaace17f23e4c4da0329eb333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale terminal and browser portal layers staying visible after workspace switches by making the workspace lifecycle the authority for portal presentation.

- Terminal and browser portal entries record the workspace that owns them; dock-hosted surfaces stay window-owned and are exempt.
- Bind and visibility updates are clamped against the selected workspace plus its `portalRenderingEnabled` state, so stale callbacks can't resurrect an inactive layer.
- Retiring a workspace hides every registered entry for it, including entries no longer reachable through the mounted panel tree.
- Retained entries are still kept for fast workspace switching but can't become visible while their workspace is inactive.
- Adds unit coverage asserting that an inactive workspace can't authorize portal presentation.

<sup>Written for commit a81d39e61f621a52a72d9bb0e64bfe78024c6919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal rendering is now controlled independently for each workspace.
  * Disabling portal rendering hides that workspace’s hosted terminal and browser views.
  * Portal views are preserved for rebinding when anchors are temporarily unavailable.

* **Bug Fixes**
  * Prevented inactive workspaces from displaying portal content.
  * Improved portal visibility and activity handling when switching workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->