### PR TITLE
cmux-tui: pass the zig target on a native windows-gnu host

### DIFF
--- a/cmux-tui/crates/ghostty-vt-sys/build.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build.rs
@@ -50,7 +50,12 @@ fn main() {
         .arg("-Demit-lib-vt=true")
         .arg("-Demit-xcframework=false")
         .arg("-Doptimize=ReleaseFast");
-    if target != host
+    // Pass the target whenever we know it, not only when cross-compiling.
+    // zig defaults to the msvc ABI on Windows, so a native *-windows-gnu
+    // host (no Visual Studio, e.g. a rustup gnu toolchain with MSYS2) would
+    // otherwise get `-target native-native-msvc` and fail the zig build with
+    // "failed to find libc installation: WindowsSdkNotFound".
+    if (target != host || target.contains("windows-gnu"))
         && let Some(zig_target) = zig_target_for_rust_target(&target)
     {
         command.arg(format!("-Dtarget={zig_target}"));


### PR DESCRIPTION
## What's broken

`ghostty-vt-sys/build.rs` forwards `-Dtarget` to `zig build` only when the cargo target differs from the host:

```rust
if target != host
    && let Some(zig_target) = zig_target_for_rust_target(&target)
```

On a native `x86_64-pc-windows-gnu` toolchain the two match, so zig gets no target and falls back to its Windows default, the msvc ABI:

```
zig build-lib ... -target native-native-msvc ...
error: failed to find libc installation: WindowsSdkNotFound
```

A machine with no Visual Studio is exactly why its Rust host is `windows-gnu` to begin with, so the msvc fallback can never succeed. `cargo build -p cmux-tui` fails before any crate compiles.

CI doesn't hit this: its Windows runners build from an msvc host to a gnu target, so `target != host` holds and the target is forwarded.

## Fix

Forward the target on a native windows-gnu host too.

`zig_target_for_rust_target` already maps `x86_64-pc-windows-gnu` → `x86_64-windows-gnu`; this just lets the native case reach it. The file already branches on `target.contains("windows-gnu")` a few lines down for the MinGW archive name, so the shape matches what's there.

## Verification

Windows 11, Rust 1.95.0 (gnu host), zig 0.16.0, MSYS2 mingw-w64 gcc 16.2.0 + lld 22.1.8.

**Before:** zig build fails with `WindowsSdkNotFound`.

**After:** `cargo build -p cmux-tui` finishes, and the binary actually works:

```
$ cmux --version
cmux 0.1.0

$ cmux server status --session wintest
status   running
socket   C:\Users\...\AppData\Local\Temp\cmux-tui-somes\wintest.sock

$ cmux --session wintest terminal list
TITLE      C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe
LIFECYCLE  running   RUNNING true   80x24

$ cmux --session wintest terminal <id> screen read
PS C:\...\cmux-tui>
>> echo WINDOWS_PTY_WORKS
WINDOWS_PTY_WORKS
PS C:\...\cmux-tui>
```

`cargo fmt -p ghostty-vt-sys -- --check` is clean.

## Blast radius

Only the native windows-gnu case changes:

| case | before | after |
|---|---|---|
| macOS / Linux native | no target passed | unchanged |
| windows-msvc native | no target passed | unchanged |
| CI msvc host → gnu target | target passed | unchanged |
| any cross-compile | target passed | unchanged |
| **windows-gnu native** | **no target → fails** | **target passed → builds** |

## Note on the docs

`cmux-tui/docs/getting-started.md` says Windows support via ConPTY is planned for phase 2, and `cmux-tui-artifacts.yml` carries "no Windows PTY backend yet". With this build fix the PTY path already works through `portable-pty`'s `ConPtySystem` — the round-trip above is a real PowerShell child. Happy to send a docs update separately if that reading is right.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791786564&installation_model_id=21920&pr_number=12416&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12416&signature=38fc0ece8036e5597762c84b29448d98d1f71fa931aba37ccbfb851a00aa9ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` builds on native Windows GNU hosts by passing the zig target even when not cross-compiling.

- Previously, `ghostty-vt-sys` forwarded `-Dtarget` only when the Cargo target differed from the host, so a native `x86_64-pc-windows-gnu` toolchain got no target and zig fell back to the msvc ABI, failing with `WindowsSdkNotFound`.
- Now the target is passed for any Windows GNU target, matching the existing condition for MinGW archive names. Only the native windows-gnu case changes; other native and cross-compile cases are unaffected.

<sup>Written for commit 1ff7b32fe38357125084ed018600cd16c85b010e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures on native Windows GNU environments caused by incorrect target selection.
  * Improved build reliability by ensuring supported Rust targets use the appropriate platform configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->