### PR TITLE
cmux-tui: do not query the host terminal when the reply cannot be read

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
@@ -962,6 +962,21 @@ struct ParsedTerminalProbe {
 /// make terminals that ignore the Kitty APC wait for the full timeout.
 pub fn probe_terminal(known_cell_pixels: Option<(u16, u16)>) -> StartupTerminalProbe {
     let ioctl_pixels = ioctl_cell_pixels();
+    // Only ask when the reply can be read back. `read_stdin_until` is a
+    // non-unix no-op, so on Windows these queries would be answered by the
+    // host terminal and left in stdin, and the normal input loop would then
+    // deliver `CSI 4;h;w t` and the DA1 reply to the focused pane as typed
+    // input. Nothing is lost by staying quiet: `ioctl_cell_pixels` is already
+    // `None` here so the pixel query could not resolve anything, and graphics
+    // stay off because `GraphicsWriter::platform_supported()` is `cfg!(unix)`.
+    // `host_colors::probe_default_colors` gates its own probe the same way.
+    if !cfg!(unix) {
+        return StartupTerminalProbe {
+            cell_pixels: resolve_cell_pixels(known_cell_pixels, ioctl_pixels),
+            graphics_supported: false,
+            pending_input: StartupTerminalInput::default(),
+        };
+    }
     let terminal_size = crossterm::terminal::size().ok();
     let query_window_pixels =
         ioctl_pixels.is_none() && terminal_size.is_some_and(|(cols, rows)| cols > 0 && rows > 0);


### PR DESCRIPTION
## What's broken

`probe_terminal` writes `CSI 14 t`, the kitty graphics query, and DA1 to stdout on every platform, then calls `read_stdin_until` to consume the replies:

```rust
if query_window_pixels {
    let _ = write!(stdout, "\x1b[14t");
}
let _ = write!(stdout, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
let _ = stdout.flush();

let bytes = read_stdin_until(TERMINAL_PROBE_TIMEOUT, terminal_probe_complete);
```

That reader is unix-only. The `cfg(not(unix))` arm returns an empty `Vec` without reading anything.

So on Windows the queries go out, the host terminal answers, and nothing drains stdin. The replies survive into the normal input loop and are delivered to the focused pane as typed input. A freshly started session opens with its shell prompt already dirty:

```
PS C:\Users\somes> [4;600;1200t[?61;4;6;7;14;21;22;23;24;28;32;42;52c
```

`[4;600;1200t` is the `CSI 14 t` window-size reply; `[?61;…c` is DA1.

## Fix

Return early on `!cfg!(unix)`, before anything is written.

## Why nothing is lost

None of the three probe results can differ on Windows:

| field | today on Windows | why |
|---|---|---|
| `cell_pixels` | fallback `(8, 16)` | `ioctl_cell_pixels` is a `cfg(not(unix))` `None`, and `queried_pixels` needs a reply that is never read |
| `graphics_supported` | `false` | the caller ands it with `GraphicsWriter::platform_supported()`, which is `cfg!(unix)` |
| `pending_input` | empty | same missing read |

The early return reproduces each of those exactly, so the only behavior that changes is that the garbage stops.

## Prior art in this crate

`host_colors::probe_default_colors` already gates its probe this way — its `cfg(not(unix))` arm returns defaults and writes nothing. This brings the graphics probe in line with it.

I used a runtime `!cfg!(unix)` early return rather than a second `#[cfg]` function body, so there is one function and every path still compiles on both platforms.

## Verification

Windows 11, Rust 1.95.0 (gnu host), zig 0.16.0.

- **Before:** every new session's prompt starts with the two replies above
- **After:** prompt is clean
- `cargo build -p cmux-tui` succeeds, `cargo fmt -p cmux-tui -- --check` is clean

Unix is untouched — the branch is not taken there, so the probe still writes, reads, and parses exactly as before. I have no macOS or Linux machine, so that leg is by inspection plus the unchanged code path, not a run.

## Note on reviewing this on Windows

Building `cmux-tui` on a Windows host currently fails before this code is reached, for an unrelated reason in `ghostty-vt-sys/build.rs` — #12416. That one is needed first if you want to reproduce this locally on Windows rather than read it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791789376&installation_model_id=21920&pr_number=12419&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12419&signature=8c0cbe09ce64756900ea95351313b88e2be55c76979e833ff1c0cbdae803ae85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal probe garbage on Windows by skipping host queries when replies can't be read.

- On non-unix, `probe_terminal` now returns early with fallback values instead of writing `CSI 14 t`, the Kitty graphics query, and DA1 to stdout.
- Previously on Windows, those queries went out but replies were never read, so the host terminal's answers leaked into the normal input loop and appeared as typed input in a fresh session.
- No functionality is lost: `cell_pixels` already defaulted, `graphics_supported` is always false on non-unix, and `pending_input` was empty. Unix behavior is unchanged.

<sup>Written for commit 7a9208e71ae89243b6de813542ac188f04bb392d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal behavior on non-Unix platforms by preventing graphics capability checks from leaving unexpected responses in input.
  * Non-Unix environments now use known terminal cell metrics and keep graphics disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->