### PR TITLE
Cloud: stop deterministic provider failure storms

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
@@ -149,6 +149,10 @@ public struct MobileAnalyticsComposition {
         ]
         if let bundleIdentifier = Bundle.main.bundleIdentifier {
             properties["bundle_identifier"] = .string(bundleIdentifier)
+            let normalized = bundleIdentifier.lowercased()
+            let channel = normalized.contains("nightly") ? "nightly"
+                : normalized.contains("debug") ? "dev" : "production"
+            properties["client_channel"] = .string(channel)
         }
         if let version = info?["CFBundleShortVersionString"] as? String {
             properties["app_version"] = .string(version)

--- a/web/app/api/vm/[id]/exec/route.ts
+++ b/web/app/api/vm/[id]/exec/route.ts
@@ -55,6 +55,19 @@ export async function POST(
           details: { field: "command" },
         });
       }
+      const commandBytes = Buffer.byteLength(command, "utf8");
+      const MAX_PROVIDER_COMMAND_BYTES = 64 * 1024;
+      if (commandBytes > MAX_PROVIDER_COMMAND_BYTES) {
+        return vmErrorResponse({
+          error: "vm_command_too_large",
+          status: 413,
+          message: `Cloud VM commands must be 64 KiB or smaller. This command is ${commandBytes} bytes.`,
+          action: "Split the command into smaller requests or upload a script and execute the script path.",
+          phase: "exec",
+          retryable: false,
+          details: { commandBytes, maxCommandBytes: MAX_PROVIDER_COMMAND_BYTES },
+        });
+      }
       // Clamp the timeout so a client can't tie up provider quota on a runaway exec. Upper
       // bound matches the provider defaults (15 min on Freestyle); negative / non-number
       // values fall back to 30s.
@@ -69,7 +82,7 @@ export async function POST(
       if (!account.ok) return account.response;
       setSpanAttributes(span, {
         "cmux.vm.id": id,
-        "cmux.command_length": command.length,
+        "cmux.command_length": commandBytes,
         "cmux.timeout_ms": timeoutMs,
       });
       const run = await runVmRoute(execVm({

--- a/web/services/observability/mobileNetworkOutcome.ts
+++ b/web/services/observability/mobileNetworkOutcome.ts
@@ -30,7 +30,7 @@ const transports = new Set(["unknown", "iroh", "tailscale", "websocket", "debugL
 
 const allowedPropertyKeys = new Set([
   "phase", "outcome", "duration_ms", "runtime_role", "user_usable",
-  "failure", "transport", "platform", "app_version", "build_number",
+  "failure", "transport", "platform", "client_channel", "app_version", "build_number",
   "bundle_identifier", "os_version", "device_model",
 ]);
 
@@ -44,6 +44,7 @@ export type MobileNetworkOutcome = {
   readonly failure?: string;
   readonly transport?: string;
   readonly platform?: "ios";
+  readonly clientChannel?: "dev" | "nightly" | "production" | "unknown";
   readonly appVersion?: string;
   readonly buildNumber?: string;
   readonly bundleIdentifier?: string;
@@ -67,7 +68,7 @@ export function parseMobileNetworkOutcome(candidate: unknown): MobileNetworkOutc
 }
 
 type CoreObservation = Pick<MobileNetworkOutcome, "phase" | "outcome" | "durationMs" | "userUsable" | "failure" | "transport">;
-type Metadata = Pick<MobileNetworkOutcome, "platform" | "appVersion" | "buildNumber" | "bundleIdentifier" | "osVersion" | "deviceModel">;
+type Metadata = Pick<MobileNetworkOutcome, "platform" | "clientChannel" | "appVersion" | "buildNumber" | "bundleIdentifier" | "osVersion" | "deviceModel">;
 
 function validTimestamp(value: unknown): value is string {
   return typeof value === "string"
@@ -100,14 +101,16 @@ function parseCore(properties: Record<string, unknown>): CoreObservation | null 
 
 function parseMetadata(properties: Record<string, unknown>): Metadata | null {
   const platform = optionalExact(properties.platform, "ios");
+  const clientChannel = optionalSetValue(properties.client_channel, new Set(["dev", "nightly", "production", "unknown"]));
   const appVersion = optionalMachineString(properties.app_version);
   const buildNumber = optionalMachineString(properties.build_number);
   const bundleIdentifier = optionalMachineString(properties.bundle_identifier);
   const osVersion = optionalMachineString(properties.os_version);
   const deviceModel = optionalMachineString(properties.device_model, true);
-  if ([platform, appVersion, buildNumber, bundleIdentifier, osVersion, deviceModel].includes(false)) return null;
+  if ([platform, clientChannel, appVersion, buildNumber, bundleIdentifier, osVersion, deviceModel].includes(false)) return null;
   return {
     ...(platform === "ios" ? { platform } : {}),
+    ...(typeof clientChannel === "string" ? { clientChannel } : {}),
     ...(typeof appVersion === "string" ? { appVersion } : {}),
     ...(typeof buildNumber === "string" ? { buildNumber } : {}),
     ...(typeof bundleIdentifier === "string" ? { bundleIdentifier } : {}),
@@ -136,6 +139,7 @@ export async function emitMobileNetworkOutcomes(
       "cmux.mobile.failure": observation.failure,
       "cmux.mobile.transport": observation.transport,
       "cmux.mobile.platform": observation.platform,
+      "cmux.client.channel": observation.clientChannel,
       "cmux.mobile.app_version": observation.appVersion,
       "cmux.mobile.build_number": observation.buildNumber,
       "cmux.mobile.bundle_identifier": observation.bundleIdentifier,

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -383,7 +383,9 @@ export function reconcileVmProviderStatuses(input: {
           ensureNetwork(owner.provider, { slug: networkSlugForUser(owner.userId), heal: true }).pipe(
             Effect.catchAll(() => Effect.void),
           ),
-        { concurrency: 4, discard: true },
+        // Freestyle returns 429 when several VPC rule heals run together.
+        // One owner at a time keeps healing bounded.
+        { concurrency: 1, discard: true },
       );
     }
     let updated = 0;
@@ -2822,6 +2824,7 @@ export function getVmStats(input: {
   readonly providerVmId: string;
 }) {
   return Effect.gen(function* () {
+    const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input);
     // No resume preflight on purpose: a reading must never wake a sleeping machine.
@@ -2834,7 +2837,19 @@ export function getVmStats(input: {
         }),
       );
     }
-    return yield* providers.getStats(vm.provider, input.providerVmId);
+    return yield* providers.getStats(vm.provider, input.providerVmId).pipe(
+      Effect.catchAll((error) => {
+        if (!isProviderNotFoundError(error)) return Effect.fail(error);
+        return Effect.gen(function* () {
+          yield* repo.markProviderObservedStatus({
+            id: vm.id,
+            providerVmId: input.providerVmId,
+            status: "destroyed",
+          }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+          return yield* Effect.fail(new VmNotFoundError({ vmId: input.providerVmId }));
+        });
+      }),
+    );
   });
 }
 

--- a/web/tests/mobile-network-observability-route.test.ts
+++ b/web/tests/mobile-network-observability-route.test.ts
@@ -62,6 +62,7 @@ describe("iOS mobile network observability route", () => {
         duration_ms: 1_250,
         failure: "timedOut",
         transport: "iroh",
+        client_channel: "nightly",
       }),
     ]));
 
@@ -75,6 +76,7 @@ describe("iOS mobile network observability route", () => {
       durationMs: 1_250,
       failure: "timedOut",
       transport: "iroh",
+      clientChannel: "nightly",
     });
     expect(flushTimeouts).toEqual([1_000]);
   });

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -2206,6 +2206,28 @@ describe("VM REST auth", () => {
     expect(runVmWorkflow).not.toHaveBeenCalled();
   });
 
+  test("rejects commands larger than the Freestyle provider limit before workflow", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const context = { params: Promise.resolve({ id: "provider-vm-1" }) };
+    const response = await execRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-1/exec", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ command: "x".repeat(64 * 1024 + 1) }),
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(413);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      error: "vm_command_too_large",
+      details: { maxCommandBytes: 64 * 1024 },
+    });
+    expect(payload.action).toContain("upload a script");
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
   test("does not echo unsupported VM service override values", async () => {
     getUser.mockResolvedValue(authedStackUser());
 


### PR DESCRIPTION
## Summary
- Reject oversized VM exec commands before reaching Freestyle, with a copyable 413 error.
- Mark provider-deleted VMs destroyed after stats 404s and stop future polling.
- Serialize owner network healing to avoid Freestyle capacity 429 storms.
- Include the iOS app channel in mobile connectivity telemetry and Axiom spans.

## Testing
- `bun test tests/mobile-network-observability-route.test.ts tests/vm-route-auth.test.ts tests/vm-route-workflow.test.ts tests/vm-freestyle-provider.test.ts` (150 passed)
- `bun run db:check` passed.
- `bun run lint:complexity` passed.

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/12399

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791789558&installation_model_id=21920&pr_number=12420&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12420&signature=61f43f446fe868008add1f22bbacbde5577a495fa6b7c3432a74ec4b2c284c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops deterministic Cloud provider failure storms and adds the iOS client channel to mobile connectivity telemetry.

**Bug Fixes**
- Rejects VM exec commands over 64 KiB with a copyable 413 error before they reach Freestyle.
- Marks provider-deleted VMs as destroyed when stats return 404 and stops polling them.
- Serializes owner network healing so Freestyle capacity 429s no longer cascade.

**New Features**
- Exposes `client_channel` (dev, nightly, production) in iOS mobile network outcomes and Axiom spans.

Related to #12399.

<sup>Written for commit f431829ab168e8195269c610c5906e6ea536c260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - VM command requests larger than 64 KiB are now rejected with a clear error and guidance to upload a script instead.
  - Missing VM providers are handled more reliably, with affected VMs marked accordingly and a consistent not-found error returned.
  - VM network recovery operations now run sequentially to improve reliability.

- **Observability**
  - Mobile network telemetry now identifies development, nightly, and production channels more accurately.
  - Command-size metrics now measure UTF-8 byte length for accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->