### PR TITLE
fix: restore Cloud observability type safety

### DIFF
--- a/web/services/observability/mobileNetworkOutcome.ts
+++ b/web/services/observability/mobileNetworkOutcome.ts
@@ -101,7 +101,9 @@ function parseCore(properties: Record<string, unknown>): CoreObservation | null 
 
 function parseMetadata(properties: Record<string, unknown>): Metadata | null {
   const platform = optionalExact(properties.platform, "ios");
-  const clientChannel = optionalSetValue(properties.client_channel, new Set(["dev", "nightly", "production", "unknown"]));
+  const clientChannel = optionalSetValue(properties.client_channel, new Set(["dev", "nightly", "production", "unknown"])) as
+    | MobileNetworkOutcome["clientChannel"]
+    | false;
   const appVersion = optionalMachineString(properties.app_version);
   const buildNumber = optionalMachineString(properties.build_number);
   const bundleIdentifier = optionalMachineString(properties.bundle_identifier);

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -2822,7 +2822,7 @@ export function getVmStats(input: {
   readonly billingTeamId?: string | null;
   readonly teamIds?: readonly string[];
   readonly providerVmId: string;
-}) {
+}): VmWorkflowProgram<VMStats> {
   return Effect.gen(function* () {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
@@ -2838,6 +2838,7 @@ export function getVmStats(input: {
       );
     }
     return yield* providers.getStats(vm.provider, input.providerVmId).pipe(
+      Effect.mapError((error): VmWorkflowError => error),
       Effect.catchAll((error) => {
         if (!isProviderNotFoundError(error)) return Effect.fail(error);
         return Effect.gen(function* () {


### PR DESCRIPTION
The Cloud observability hardening merged in #12420 passed focused runtime tests but failed Vercel's production TypeScript check. This fixes the workflow error union and narrows the client channel metadata type so production builds type check.

Validation:
- 150 focused web tests pass
- TypeScript output contains no errors in the changed files
- Local production build reaches environment validation; deployment environment is required for the complete build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792273&installation_model_id=21920&pr_number=12422&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12422&signature=8db8050403dfc4f184740613c1f045a30a9c7501373ccd2c7e858ce01372e761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud observability type errors that failed Vercel's production TypeScript check, restoring type safety without changing runtime behavior.

- Narrowed the `clientChannel` metadata type in `mobileNetworkOutcome.ts` to match `MobileNetworkOutcome`.
- Added an explicit return type to `getVmStats` and mapped errors to `VmWorkflowError`.

<sup>Written for commit 476b226ff3c39a9adb56096c9e5cde2f873aa9e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when retrieving virtual machine statistics, providing more consistent responses for provider errors and unavailable virtual machines.
- **Reliability**
  - Strengthened internal type safety for mobile network outcome processing without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->