### PR TITLE
fix: classify development mobile telemetry builds

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
@@ -150,8 +150,11 @@ public struct MobileAnalyticsComposition {
         if let bundleIdentifier = Bundle.main.bundleIdentifier {
             properties["bundle_identifier"] = .string(bundleIdentifier)
             let normalized = bundleIdentifier.lowercased()
+            // All development bundle identifiers use the `dev.` namespace;
+            // beta and test bundles may omit the word `debug` entirely.
             let channel = normalized.contains("nightly") ? "nightly"
-                : normalized.contains("debug") ? "dev" : "production"
+                : normalized.hasPrefix("dev.") || normalized.contains("debug") || normalized.contains(".beta") || normalized.contains(".test") ? "dev"
+                : "production"
             properties["client_channel"] = .string(channel)
         }
         if let version = info?["CFBundleShortVersionString"] as? String {


### PR DESCRIPTION
Development iOS bundle identifiers use the `dev.` namespace and beta/test suffixes, so checking only `debug` misclassified their telemetry as production. Classify those identifiers as `dev` while retaining the nightly override.

Validation:
- Swift parse check passes
- Full Swift package tests are blocked because the checkout lacks the GhosttyKit binary artifact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791794507&installation_model_id=21920&pr_number=12423&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12423&signature=ce5c363e3e1db8d174ca2d5d3ca05ce39ee2d8daad8b3fd6e0aaa819a2114681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS telemetry channel classification so development builds are no longer reported as production.

Previously only bundle identifiers containing `debug` were classified as `dev`. Development iOS bundles use the `dev.` namespace and `.beta`/`.test` suffixes, so those builds fell through to `production`. The update classifies them as `dev` and keeps the nightly override. Swift parse passes; full package tests are blocked because the checkout lacks the GhosttyKit binary artifact.

<sup>Written for commit 6405e364f57616cf717f8f45cd2b9a9964cd2051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytics environment classification so development, beta, test, and nightly builds are categorized more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->