### PR TITLE
Fix stale proxy tunnel fatal callbacks

### DIFF
--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBroker.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBroker.swift
@@ -29,6 +29,7 @@ public final class RemoteProxyBroker: @unchecked Sendable {
         var configuration: WorkspaceRemoteConfiguration
         var remotePath: String
         var tunnel: (any RemoteProxyTunneling)?
+        var tunnelGeneration: UUID?
         var endpoint: BrowserProxyEndpoint?
         var restartTask: Task<Void, Never>?
         var restartToken: UUID?
@@ -436,6 +437,7 @@ public final class RemoteProxyBroker: @unchecked Sendable {
         }
 
         do {
+            let tunnelGeneration = UUID()
             let tunnel = tunnelProvider.makeTunnel(
                 configuration: entry.configuration,
                 remotePath: entry.remotePath,
@@ -443,7 +445,11 @@ public final class RemoteProxyBroker: @unchecked Sendable {
             ) { [weak self] detail in
                 guard let self else { return }
                 self.queue.async {
-                    self.handleTunnelFailureLocked(key: key, detail: detail)
+                    self.handleTunnelFailureLocked(
+                        key: key,
+                        tunnelGeneration: tunnelGeneration,
+                        detail: detail
+                    )
                 }
             }
             if let snapshot = entry.ptyLifecycleSnapshot {
@@ -451,6 +457,7 @@ public final class RemoteProxyBroker: @unchecked Sendable {
             }
             try tunnel.start()
             entry.tunnel = tunnel
+            entry.tunnelGeneration = tunnelGeneration
             entry.ptyLifecycleSnapshot = nil
             let endpoint = BrowserProxyEndpoint(host: "127.0.0.1", port: localPort)
             entry.endpoint = endpoint
@@ -465,8 +472,14 @@ public final class RemoteProxyBroker: @unchecked Sendable {
         }
     }
 
-    private func handleTunnelFailureLocked(key: String, detail: String) {
-        guard let entry = entries[key], entry.tunnel != nil else { return }
+    private func handleTunnelFailureLocked(
+        key: String,
+        tunnelGeneration: UUID,
+        detail: String
+    ) {
+        guard let entry = entries[key],
+              entry.tunnel != nil,
+              entry.tunnelGeneration == tunnelGeneration else { return }
         stopEntryRuntimeLocked(entry, preservePTYLifecycle: true)
         let retryDelay = Self.retryDelay(baseDelay: 3.0, retry: entry.restartRetryCount + 1)
         notifyLocked(entry, update: .error("\(detail)\(Self.retrySuffix(delay: retryDelay))"))
@@ -555,6 +568,7 @@ public final class RemoteProxyBroker: @unchecked Sendable {
             entry.tunnel?.stop()
         }
         entry.tunnel = nil
+        entry.tunnelGeneration = nil
         entry.endpoint = nil
     }
 

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteProxyBrokerStaleGenerationTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteProxyBrokerStaleGenerationTests.swift
@@ -1,0 +1,49 @@
+import CmuxCore
+import Foundation
+import Testing
+@testable import CmuxRemoteWorkspace
+
+@Suite("RemoteProxyBroker stale tunnel generations", .serialized)
+struct RemoteProxyBrokerStaleGenerationTests {
+    private func makeConfiguration() -> WorkspaceRemoteConfiguration {
+        WorkspaceRemoteConfiguration(
+            destination: "test@example.invalid",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil
+        )
+    }
+
+    @Test("fatal callback from a replaced tunnel cannot stop its successor")
+    func staleFatalCallbackCannotStopSuccessor() throws {
+        let provider = FakeTunnelProvider()
+        let broker = RemoteProxyBroker(tunnelProvider: provider, clock: ManualRetryClock())
+        let configuration = makeConfiguration()
+
+        let leaseA = broker.acquire(configuration: configuration, remotePath: "/old/path") { _ in }
+        defer { leaseA.release() }
+        let staleFatalError = try #require(provider.fatalErrorCallback(at: 0))
+
+        let leaseB = broker.acquire(configuration: configuration, remotePath: "/new/path") { _ in }
+        defer { leaseB.release() }
+        #expect(provider.tunnels.count == 2)
+        let successor = try #require(provider.tunnels.last)
+        #expect(successor.remotePath == "/new/path")
+        #expect(successor.stopCount == 0)
+
+        staleFatalError("stale failure from replaced tunnel")
+
+        // This synchronous broker call is submitted after the stale callback's
+        // queue hop, so it deterministically observes the callback's effect.
+        let sessions = try broker.listPTY(configuration: configuration)
+        #expect(sessions.first?["session_id"] as? String == "s-1")
+        #expect(successor.stopCount == 0)
+        #expect(provider.tunnels.count == 2)
+    }
+}


### PR DESCRIPTION
## Summary

* Prevent a stale fatal callback from a replaced proxy tunnel from tearing down its healthy replacement.
* Assign each tunnel instance a generation UUID and ignore callbacks from generations that are no longer current.
* Add a regression test covering the A → B → delayed A failure ordering.

## Testing

* `swift test --package-path Packages/macOS/CmuxRemoteWorkspace --filter RemoteProxyBrokerStaleGenerationTests.staleFatalCallbackCannotStopSuccessor`
* `swift test --package-path Packages/macOS/CmuxRemoteWorkspace --filter RemoteProxyBrokerTests.fatalFailureRestarts`
* `swift test --package-path Packages/macOS/CmuxRemoteWorkspace`

Full package: 108 tests across 20 suites.

## Demo Video

N/A — this is an internal tunnel lifecycle race covered by the regression test.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

* [x] I tested the change locally
* [x] I added or updated tests for behavior changes
* [x] I updated docs/changelog if needed
* [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
* [ ] All code review bot comments are resolved
* [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791795227&installation_model_id=21920&pr_number=12424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12424&signature=954d17a3a20fca8cc6d78d7908336389c2a946c497bda8354a006496c975c874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where a stale fatal callback from a replaced proxy tunnel could tear down its healthy replacement. Each tunnel instance now carries a generation UUID, and callbacks from generations that are no longer current are ignored.

- Adds a regression test that reproduces the A → B → delayed A failure ordering.

<sup>Written for commit 4908559066ea99de27001f4ce638d43a1e06966b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delayed failure notifications from an earlier tunnel connection from stopping its replacement.
  - Improved reliability when remote tunnel connections are retried or replaced.

- **Tests**
  - Added coverage confirming stale tunnel failures do not interrupt active successor connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->