### PR TITLE
fix(ci): install Metal Toolchain before GhosttyKit fallback

### DIFF
--- a/scripts/ensure-ghosttykit.sh
+++ b/scripts/ensure-ghosttykit.sh
@@ -223,6 +223,9 @@ else
     echo "==> Seeding cache from prebuilt GhosttyKit.xcframework"
   else
     echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
+    if [[ -x "$SCRIPT_DIR/ensure-metal-toolchain.sh" ]]; then
+      "$SCRIPT_DIR/ensure-metal-toolchain.sh"
+    fi
     (
       cd ghostty
       # -Di18n=false: compiling Ghostty's .po catalogs needs gettext's

--- a/scripts/ensure-metal-toolchain.sh
+++ b/scripts/ensure-metal-toolchain.sh
@@ -9,7 +9,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 0
 fi
 
-if xcrun --sdk macosx metal -version >/dev/null 2>&1; then
+if xcrun --sdk macosx metal -v >/dev/null 2>&1; then
   echo "Metal Toolchain is available"
   exit 0
 fi
@@ -17,7 +17,7 @@ fi
 echo "Metal Toolchain is missing; downloading it for the selected Xcode..."
 xcodebuild -downloadComponent MetalToolchain
 
-if ! xcrun --sdk macosx metal -version >/dev/null 2>&1; then
+if ! xcrun --sdk macosx metal -v >/dev/null 2>&1; then
   echo "error: Metal Toolchain is still unavailable after download" >&2
   exit 1
 fi

--- a/scripts/ensure-metal-toolchain.sh
+++ b/scripts/ensure-metal-toolchain.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ghostty's Zig build invokes Apple's `metal` compiler for every macOS and iOS
+# slice. Some Blacksmith images ship Xcode without the separately downloadable
+# Metal Toolchain, so xcrun finds the tool name but the compiler fails at build
+# time. Make the fallback self-healing and keep this a no-op on Linux.
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if xcrun --sdk macosx metal -version >/dev/null 2>&1; then
+  echo "Metal Toolchain is available"
+  exit 0
+fi
+
+echo "Metal Toolchain is missing; downloading it for the selected Xcode..."
+xcodebuild -downloadComponent MetalToolchain
+
+if ! xcrun --sdk macosx metal -version >/dev/null 2>&1; then
+  echo "error: Metal Toolchain is still unavailable after download" >&2
+  exit 1
+fi
+echo "Metal Toolchain is ready"


### PR DESCRIPTION
Blacksmith macOS runners can have Xcode without the separately downloadable Metal Toolchain. When the prebuilt GhosttyKit is unavailable, `ensure-ghosttykit.sh` then fails during Zig shader compilation with “cannot execute tool 'metal'”.

Add an idempotent `ensure-metal-toolchain.sh` helper. It is a no-op on Linux, verifies the selected macOS Xcode can run Metal, downloads the missing component with `xcodebuild -downloadComponent MetalToolchain`, and verifies it again. `ensure-ghosttykit.sh` calls it immediately before any fallback GhosttyKit build, covering shared Blacksmith reload builds and other callers of that helper.

Validation: `bash -n` passed, `git diff --check` passed, and a stubbed Darwin path verified the missing, download, and ready transitions. A live download was not run on this Mac.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791796958&installation_model_id=21920&pr_number=12425&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12425&signature=14588a18c6893734c4bb3cdb874550dd0db80731ed507ee9e3048c40fe1577aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GhosttyKit fallback builds on Blacksmith macOS runners where Xcode is present but the separately downloadable Metal Toolchain is not, preventing the "cannot execute tool 'metal'" failure. Adds `ensure-metal-toolchain.sh` which is idempotent, does nothing on Linux, and downloads the missing component when needed. `ensure-ghosttykit.sh` now calls it before any fallback build.

<sup>Written for commit 7f0e54aad15cc52721f5d7de463b08df51175645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local macOS builds now automatically check for the required Apple Metal Toolchain and download it when unavailable.
  * Non-macOS environments skip this check automatically.

* **Bug Fixes**
  * Improved reliability of local builds that generate the macOS framework by ensuring the necessary Metal tools are available first.
  * Clear error reporting is provided if the toolchain cannot be installed or verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->