### PR TITLE
fix: mark workspace-level notifications read on workspace focus

### DIFF
--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalHosting.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalHosting.swift
@@ -87,6 +87,10 @@ public protocol NotificationDismissalHosting: AnyObject {
 
     /// Marks the workspace's (or surface's) notifications read.
     func storeMarkRead(workspaceId: UUID, surfaceId: UUID?)
+    /// Marks read only the notifications recorded against the workspace itself,
+    /// with no surface and no panel, leaving every surface-scoped notification
+    /// and every unread indicator as it is.
+    func storeMarkWorkspaceLevelNotificationsRead(workspaceId: UUID)
     /// Clears the workspace-level manual unread indicator; returns whether
     /// anything was cleared.
     @discardableResult

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
@@ -163,6 +163,18 @@ public final class NotificationDismissalModel: NotificationDismissing {
                 host.storeHasVisibleNotificationIndicator(workspaceId: workspaceId, surfaceId: $0)
             }
         }
+        // A notification recorded against the workspace itself, with no surface
+        // and no panel (cmux's own memory-pressure alert is one), matches no
+        // surface-scoped mark-read, so focusing the workspace left it unread and
+        // its sidebar count only cleared through an explicit "Mark Workspace as
+        // Read". Sweep it together with the dismissal of the workspace's focused
+        // surface, the moment the workspace is in front of the user; the other
+        // surfaces in the workspace keep their own unread state. See issue
+        // #12387.
+        let hasWorkspaceLevelUnreadNotification = !notificationSurfaceIds.isEmpty &&
+            host.storeHasUnreadNotification(workspaceId: workspaceId, surfaceId: nil) &&
+            (host.focusedSurfaceId(in: workspaceId)
+                .map { notificationSurfaceIds.contains($0) } ?? false)
         let manualStoreSurfaceIds = notificationSurfaceIds.filter {
             host.storeHasManualUnread(workspaceId: workspaceId, surfaceId: $0)
         }
@@ -171,7 +183,8 @@ public final class NotificationDismissalModel: NotificationDismissing {
         let canDismissRestoredUnreadIndicator = context.canDismissRestoredUnreadIndicator &&
             (hasRestoredPanelUnread || hasRestoredWorkspaceUnread)
         let canDismissUnreadIndicator = canDismissManualUnreadIndicator || canDismissRestoredUnreadIndicator
-        guard hasUnreadNotification || hasPendingNotification || hasFocusedIndicator || canDismissUnreadIndicator else {
+        guard hasUnreadNotification || hasPendingNotification || hasFocusedIndicator ||
+            hasWorkspaceLevelUnreadNotification || canDismissUnreadIndicator else {
             return false
         }
         if hasUnreadNotification || hasPendingNotification {
@@ -182,6 +195,9 @@ public final class NotificationDismissalModel: NotificationDismissing {
                     host.storeMarkRead(workspaceId: workspaceId, surfaceId: surfaceId)
                 }
             }
+        }
+        if hasWorkspaceLevelUnreadNotification {
+            host.storeMarkWorkspaceLevelNotificationsRead(workspaceId: workspaceId)
         }
         var didDismissUnreadIndicator = false
         if context.canDismissManualUnreadIndicator {

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -98,6 +98,13 @@ private final class FakeHost: NotificationDismissalHosting {
 
     func storeMarkRead(workspaceId: UUID, surfaceId: UUID?) {
         log.append("markRead:\(short(surfaceId))")
+        // Mirror the store: a surface-scoped mark-read clears that surface's
+        // notifications, and a nil target clears the workspace's own.
+        guard let surfaceId else {
+            workspaceWideUnread.remove(workspaceId)
+            return
+        }
+        unreadNotificationSurfaces.remove(surfaceId)
     }
 
     func storeClearManualUnread(workspaceId: UUID) -> Bool {
@@ -418,5 +425,48 @@ struct NotificationDismissalModelTests {
             workspaceId: workspaceId, surfaceId: nil, context: .activeFocus
         ))
         #expect(host.log.contains("markRead:nil"))
+    }
+
+    // MARK: Workspace-level notifications (issue #12387)
+
+    @Test func focusedSurfaceDismissalMarksWorkspaceLevelNotificationRead() {
+        let (model, host, workspaceId, panelId) = makeModel()
+        // A notification recorded against the workspace itself, with no surface
+        // and no panel (cmux's own memory-pressure alert is one).
+        host.workspaceWideUnread = [workspaceId]
+
+        #expect(model.dismissNotification(
+            workspaceId: workspaceId, surfaceId: panelId, context: .explicitWorkspaceResume
+        ))
+        #expect(!host.workspaceWideUnread.contains(workspaceId))
+    }
+
+    @Test func workspaceLevelMarkReadLeavesOtherSurfacesUnread() {
+        let (model, host, workspaceId, panelId) = makeModel()
+        let otherSurface = UUID()
+        host.workspaceWideUnread = [workspaceId]
+        host.unreadNotificationSurfaces = [otherSurface]
+
+        #expect(model.dismissNotification(
+            workspaceId: workspaceId, surfaceId: panelId, context: .explicitWorkspaceResume
+        ))
+        #expect(!host.workspaceWideUnread.contains(workspaceId))
+        // Another pane in the same workspace keeps its own unread notification.
+        #expect(host.unreadNotificationSurfaces == [otherSurface])
+    }
+
+    @Test func nonFocusedSurfaceDismissalLeavesWorkspaceLevelNotificationUnread() {
+        let (model, host, workspaceId, panelId) = makeModel()
+        let otherSurface = UUID()
+        host.focusedSurfaceIds[workspaceId] = panelId
+        host.workspaceWideUnread = [workspaceId]
+        host.unreadNotificationSurfaces = [otherSurface]
+
+        // Clicking a banner for a surface the workspace is not focused on is not
+        // the user reading the workspace's own notifications.
+        #expect(model.dismissNotificationOnDirectInteraction(
+            workspaceId: workspaceId, surfaceId: otherSurface
+        ))
+        #expect(host.workspaceWideUnread.contains(workspaceId))
     }
 }

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -107,6 +107,11 @@ private final class FakeHost: NotificationDismissalHosting {
         unreadNotificationSurfaces.remove(surfaceId)
     }
 
+    func storeMarkWorkspaceLevelNotificationsRead(workspaceId: UUID) {
+        log.append("markWorkspaceLevelRead")
+        workspaceWideUnread.remove(workspaceId)
+    }
+
     func storeClearManualUnread(workspaceId: UUID) -> Bool {
         log.append("storeClearManualUnread")
         return manualWorkspaceUnread.contains(workspaceId)

--- a/Sources/TabManager+NotificationDismissalHosting.swift
+++ b/Sources/TabManager+NotificationDismissalHosting.swift
@@ -114,6 +114,11 @@ extension TabManager: NotificationDismissalHosting {
         AppDelegate.shared?.notificationStore?.markRead(forTabId: workspaceId, surfaceId: surfaceId)
     }
 
+    func storeMarkWorkspaceLevelNotificationsRead(workspaceId: UUID) {
+        AppDelegate.shared?.notificationStore?
+            .markWorkspaceLevelNotificationsRead(forTabId: workspaceId)
+    }
+
     @discardableResult
     func storeClearManualUnread(workspaceId: UUID) -> Bool {
         AppDelegate.shared?.notificationStore?.clearManualUnread(forTabId: workspaceId) ?? false

--- a/Sources/TerminalNotificationStore+WorkspaceNotifications.swift
+++ b/Sources/TerminalNotificationStore+WorkspaceNotifications.swift
@@ -12,4 +12,23 @@ extension TerminalNotificationStore {
             .sorted(by: Self.notificationSortPrecedes)
         return Array(sorted.prefix(Self.workspaceContextMenuNotificationLimit))
     }
+
+    /// Marks read only the notifications recorded against the workspace itself,
+    /// with no surface and no panel, such as cmux's own memory-pressure alert.
+    /// Surface-scoped notifications, every manual or restored unread indicator,
+    /// and in-flight policy work stay as they are, so reading the workspace's own
+    /// notifications cannot swallow another pane's unread state.
+    func markWorkspaceLevelNotificationsRead(forTabId tabId: UUID) {
+        // History keeps records the active list has already dropped, so the feed
+        // is marked by target while the active notifications are marked by id:
+        // that is the path which also withdraws their delivered Mac banners.
+        notificationFeedHistory.markRead(inWorkspace: tabId, surfaceId: nil)
+        let activeIDs = Set(
+            notifications.lazy
+                .filter { !$0.isRead && $0.matches(tabId: tabId, surfaceId: nil) }
+                .map(\.id)
+        )
+        guard !activeIDs.isEmpty else { return }
+        markNotificationFeedRead(ids: activeIDs)
+    }
 }

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1799,6 +1799,46 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertNil(store.latestNotification(forTabId: tab))
     }
 
+    func testWorkspaceLevelMarkReadKeepsOtherPanesUnread() {
+        let tab = UUID()
+        let surface = UUID()
+        let manualUnreadSurface = UUID()
+        let workspaceLevelNotification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: nil,
+            title: "Workspace level",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+        let surfaceNotification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: surface,
+            title: "Surface scoped",
+            subtitle: "",
+            body: "",
+            createdAt: Date().addingTimeInterval(-1),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([workspaceLevelNotification, surfaceNotification])
+        store.markWindowDockSurfaceUnread(windowId: tab, surfaceId: manualUnreadSurface)
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: tab, surfaceId: nil))
+
+        store.markWorkspaceLevelNotificationsRead(forTabId: tab)
+
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: tab, surfaceId: nil))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: tab, surfaceId: surface))
+        XCTAssertTrue(store.hasManualUnread(forTabId: tab, surfaceId: manualUnreadSurface))
+
+        store.clearNotifications(forTabId: tab)
+        store.clearWindowDockSurfaceUnread(windowId: tab, surfaceId: manualUnreadSurface)
+    }
+
     func testClearLatestNotificationRemovesOnlyCurrentSidebarPreviewSource() {
         let tab = UUID()
         let latestSurface = UUID()

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -99,6 +99,8 @@ Inside a machine:
 
 Use `Cmd+Shift+U` to jump to the latest unread notification. Use `Ctrl+Cmd+U` to mark the current item as oldest unread and jump to the next latest unread. Both shortcuts are configurable in Settings > Keyboard Shortcuts and in `~/.config/cmux/cmux.json`.
 
+Focusing a pane marks that pane's notifications read. A notification posted without a surface belongs to the workspace instead of to a pane (cmux's own memory-pressure warning is one), so the same focus marks the workspace's own notifications read. The other panes in that workspace keep their unread state. "Mark Workspace as Read" in the workspace context menu still clears everything in the workspace at once.
+
 ## Suppress only the focused surface
 
 By default cmux withdraws a delivered banner when its workspace becomes visible/active, which can retract a banner for a non-focused surface (e.g. a second agent in the same visible workspace) before you notice it. Set the opt-in flag below to `true` so the auto-withdraw fires **only** for the exact focused surface — matching the delivery gate. A banner for a non-focused surface then stays up until you focus that surface (or click/dismiss it). Workspace-visible-but-not-focused surfaces and surfaces in non-visible workspaces keep their banners; explicit "mark workspace read" and clicking/typing still clear notifications as before.


### PR DESCRIPTION
## Summary

- **What changed?** A dismissal that targets a workspace's focused surface now also marks read the notifications recorded against the workspace itself, the ones stored with no surface and no panel.
- Plus one paragraph in `docs/notifications.md`: it described reading as focusing a pane, which is what made the old behavior look unintended.
- **Why?** Fixes #12387. Those notifications are unreachable from every implicit mark-read, so a workspace kept an unread count after the user selected it and focused its terminal, while the surface-scoped notifications in the same workspace cleared normally.

### Why it happened

`NotificationDismissalModel.dismissNotification` resolves its target into `notificationSurfaceIds` (the requested surface plus its resolved panel id) and marks read once per entry through `storeMarkRead(workspaceId:surfaceId:)`. `TerminalNotification.matches(tabId:surfaceId:)` matches a notification whose `surfaceId` and `panelId` are both `nil` only when the requested surface is `nil`, and the unread index stores it under the key `(tabId, nil)`. No surface-scoped mark-read reaches that key.

Both implicit paths pass a concrete surface, never `nil`: workspace selection (`TabManager` selection side effects to `dismissFocusedPanelNotificationIfActive`) and surface focus (`ghosttyDidFocusSurface` to `dismissPanelNotificationOnFocus`). So the workspace-level notification only cleared through the explicit "Mark Workspace as Read" menu item (`markRead(forTabId:)`) or through the notification's own click.

That is not a rare shape. Five in-app notifications are recorded with no surface today: the aggregate and the critical memory-pressure warnings (`AppDelegate+PaneMemoryGuardrail`), the crash breadcrumb, the SSH reconnect pause (`Workspace`), and checklist-complete (`Workspace+TodoNotifications`). The memory-pressure one is what #12387 reports, because it repeats on a cooldown while memory stays tight, so the count is relit faster than the menu item clears it.

### Scope

The sweep runs only when the dismissal targets the workspace's focused surface, and it goes through a store operation that touches nothing else:

- other surfaces in the same workspace keep their unread notifications
- every manual and restored unread indicator survives, workspace-level and per-surface
- in-flight policy evaluation is untouched
- a dismissal aimed at a surface the workspace is not focused on leaves the workspace-level notification unread
- the existing `surfaceId == nil` dismissal path is unchanged
- no flash is triggered for the workspace-level sweep alone, since it is not the panel's notification

Reusing `markRead(forTabId:surfaceId: nil)` was not an option. It is the explicit whole-workspace action: it clears every surface's manual unread, the panel-derived and restored indicators, and discards every in-flight policy request for the workspace. Selecting a workspace must not do that.

## Testing

- `swift test --package-path Packages/macOS/CmuxNotifications`: 116 tests in 10 suites pass.
- `xcodebuild -scheme cmux -configuration Debug -destination 'platform=macOS' build-for-testing`: `** TEST BUILD SUCCEEDED **`, no new warnings.
- `xcodebuild -scheme cmux-unit ... build-for-testing`: `** TEST BUILD SUCCEEDED **`.
- `-only-testing:cmuxTests/NotificationDockBadgeTests/testWorkspaceLevelMarkReadKeepsOtherPanesUnread`: passes.
- The neighbouring app-host suites show no change from this PR: `NotificationDockBadgeTests`, `WorkspaceManualUnreadTests`, `NotificationDismissSyncTests`, `FocusedNotificationIndicatorTests`. 93 of 96 pass. The same 3 cases fail identically with the change reverted to the base commit in the same environment (`testNotificationClickActionRoundTripsAndIsStored`, `testJumpToLatestManualPanelUnreadFlashesAfterSwitchingAway`, `testJumpToLatestRestoredWorkspaceUnreadFlashesOnceAfterSwitchingAway`), same assertions and same lines. They want a console session and a notification-authorized host, which my run did not have.

Three new cases in `NotificationDismissalModelTests`:

- a dismissal of the focused surface marks the workspace-level notification read
- the same dismissal leaves another pane's unread notification alone
- a dismissal of a non-focused surface leaves the workspace-level notification unread

The first two fail on the test-only commit and pass on the fix commit, so the coverage is proven to catch the bug. The recording fake now mirrors the store's mark-read scoping, which is why the expectations read state instead of the mutation log.

`NotificationAndMenuBarTests.testWorkspaceLevelMarkReadKeepsOtherPanesUnread` covers the store operation directly: the workspace-level notification goes read while a surface-scoped notification and a per-surface manual unread indicator both survive.

These local checks are clean: `scripts/lint-pbxproj-test-wiring.sh`, `scripts/check-pbxproj.sh`, `scripts/localization_catalog.py check`, `scripts/lint-xcstrings.py`, `scripts/check-workspace-package-groups.py --check`, `scripts/check-package-resolved-policy.py`.

## Demo Video

Not captured. The sidebar count this fixes only moves once per arriving workspace-level notification, so the `cmux list-notifications --json` table in #12387 is the legible form of the same evidence: with a workspace-level notification (`surface_id` null) and a surface-scoped one in the same workspace, select the workspace and focus its terminal, then re-read the list. Before, only the surface-scoped notification flipped to `is_read: true`. Now both do, and another pane's unread notification is untouched. Happy to record one if you want it on the PR.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (`docs/notifications.md`; no changelog entry, that is written at release cut)
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
