### PR TITLE
Fix Cloud error cards over working terminals

### DIFF
--- a/Sources/CloudTerminalOverlayCoordinator.swift
+++ b/Sources/CloudTerminalOverlayCoordinator.swift
@@ -1,6 +1,5 @@
 import AppKit
 import CmuxTerminal
-import CmuxTerminalCore
 import os
 
 private let cloudTerminalPresentationLogger = Logger(
@@ -8,7 +7,8 @@ private let cloudTerminalPresentationLogger = Logger(
 )
 
 /// Owns one status card across the representable anchor and the native portal.
-/// Session, layout, visibility, and rendered-frame events all reconcile this owner.
+/// The attachment session owns connection health. Layout and visibility only
+/// choose where to present that state, never whether the connection has failed.
 @MainActor
 final class CloudTerminalOverlayCoordinator {
     weak var session: CloudTuiManualMirrorSession?
@@ -16,8 +16,6 @@ final class CloudTerminalOverlayCoordinator {
     private weak var anchor: GhosttyTerminalView.HostContainerView?
     private var anchorOwnership: (generation: UInt64, serial: UInt64)?
     private var anchorVisible = false
-    private var renderDemand: (any RenderDemandRetention)?
-    private var onRenderedFrame: (() -> Void)?
     private var lastDestination: Destination = .hidden
 
     private enum Destination: String {
@@ -58,28 +56,11 @@ final class CloudTerminalOverlayCoordinator {
             presented = hostedView.window != nil && !hostedView.isHidden
                 && hostedView.bounds.width > 1 && hostedView.bounds.height > 1
         }
-        let rendererReady = presented
-            && hostedView.surfaceView.terminalSurface?.isRendererPresented == true
-            && hostedView.surfaceView.renderedFrameSequence > 0
-        var presentation: CloudTerminalReconnectOverlayPolicy.Presentation?
+        let presentation: CloudTerminalReconnectOverlayPolicy.Presentation?
         if let session {
             presentation = session.connectionPresentation
-            if session.phase != .stopped, presentation == nil, !rendererReady {
-                presentation = unavailablePresentation
-            }
         } else {
             presentation = legacyPresentation
-        }
-        let needsFrame = visible && session != nil && session?.phase != .stopped && !rendererReady
-        if needsFrame, renderDemand == nil {
-            renderDemand = hostedView.surfaceView.localRenderedFrameNotificationDemand.retain()
-            onRenderedFrame = { [weak hostedView] in
-                hostedView?.synchronizeCloudTerminalReconnectOverlay()
-            }
-        } else if !needsFrame {
-            renderDemand?.release()
-            renderDemand = nil
-            onRenderedFrame = nil
         }
 
         let destination: NSView = presented ? hostedView : ((anchor as NSView?) ?? hostedView)
@@ -91,7 +72,7 @@ final class CloudTerminalOverlayCoordinator {
         )
         let next: Destination = overlay == nil ? .hidden : (presented ? .terminal : .anchor)
         if next != lastDestination, let session {
-            cloudTerminalPresentationLogger.notice("pane terminal=\(session.terminalID, privacy: .private(mask: .hash)) destination=\(next.rawValue, privacy: .public) bound=\(presented) rendererReady=\(rendererReady)")
+            cloudTerminalPresentationLogger.notice("pane terminal=\(session.terminalID, privacy: .private(mask: .hash)) destination=\(next.rawValue, privacy: .public) bound=\(presented) phase=\(String(describing: session.phase), privacy: .public)")
         }
         lastDestination = next
     }
@@ -102,13 +83,6 @@ final class CloudTerminalOverlayCoordinator {
         session = nil
         overlay?.removeFromSuperview()
         overlay = nil
-        renderDemand?.release()
-        renderDemand = nil
-        onRenderedFrame = nil
-    }
-
-    func renderedFrameArrived() {
-        onRenderedFrame?()
     }
 
     /// Applies a snapshot by moving the existing card; no second fallback view
@@ -135,16 +109,4 @@ final class CloudTerminalOverlayCoordinator {
         }
     }
 
-    private var unavailablePresentation: CloudTerminalReconnectOverlayPolicy.Presentation {
-        .init(
-            title: String(localized: "cloud.overlay.manual.unavailable.title", defaultValue: "Cloud terminal unavailable"),
-            detail: String(localized: "cloud.overlay.manual.unavailable.detail", defaultValue: "The terminal view is unavailable. Reconnect to restore it."),
-            showsProgress: false,
-            showsReconnectButton: true
-        )
-    }
-
-    deinit {
-        renderDemand?.release()
-    }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4035,7 +4035,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         if reasons.contains(.notification),
            renderedFrameNotificationDemandIsActive {
-            terminalSurface?.hostedView.cloudTerminalOverlay.renderedFrameArrived()
             NotificationCenter.default.post(
                 name: .ghosttyDidRenderFrame,
                 object: self

--- a/cmuxTests/CloudManualMirrorPresentationTests.swift
+++ b/cmuxTests/CloudManualMirrorPresentationTests.swift
@@ -18,6 +18,81 @@ struct CloudManualMirrorPresentationTests {
     }
 
     @Test @MainActor
+    func usableAttachmentClearsTheCardWithoutRendererObservations() async throws {
+        let fixture = try CloudManualMirrorSocketFixture()
+        defer { fixture.close() }
+        let session = CloudTuiManualMirrorSession(
+            machineID: "machine", terminalID: "term_live", remoteSurfaceID: 17,
+            onNeedsReconnect: {}
+        )
+        defer { session.stop() }
+        let frame = NSRect(x: 0, y: 0, width: 480, height: 320)
+        let hosted = GhosttySurfaceScrollView(surfaceView: GhosttyNSView(frame: frame))
+        let anchor = GhosttyTerminalView.HostContainerView(frame: frame)
+        let owner = hosted.cloudTerminalOverlay
+        owner.session = session
+        owner.updateAnchor(anchor, visible: true, ownershipGeneration: 1)
+        func synchronize() {
+            owner.synchronize(hostedView: hosted, contentFrame: frame, legacyPresentation: nil) {}
+        }
+
+        session.reconnect(socketPath: fixture.socketPath)
+        synchronize()
+        #expect(owner.overlay?.currentPresentation?.showsProgress == true)
+        let identify = try #require(await fixture.nextCommand(timeout: .seconds(5)))
+        fixture.send(["id": identify.id, "ok": true, "data": ["protocol": 8]])
+        let clientInfo = try #require(await fixture.nextCommand(timeout: .seconds(5)))
+        fixture.send(["id": clientInfo.id, "ok": true])
+        let attach = try #require(await fixture.nextCommand(timeout: .seconds(5)))
+        #expect(attach.cmd == "attach-surface")
+        fixture.send(["id": attach.id, "ok": true, "data": [:]])
+        var deadline = ContinuousClock.now + .seconds(5)
+        while session.phase != .attached, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(session.phase == .attached)
+        synchronize()
+        #expect(owner.overlay?.currentPresentation?.showsProgress == true)
+
+        fixture.send([
+            "event": "vt-state", "surface": 17, "cols": 80, "rows": 24,
+            "data": Data("cmux@cloud> ".utf8).base64EncodedString()
+        ])
+        deadline = ContinuousClock.now + .seconds(5)
+        while session.connectionPresentation != nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(session.connectionPresentation == nil)
+        session.inputRouter.send(.bytes(Data("pwd\n".utf8)))
+        let input = try #require(await fixture.nextCommand(timeout: .seconds(5)))
+        #expect(input.cmd == "send")
+        #expect(input.surface == 17)
+        // Renderer observations are absent, as during a portal handoff. A
+        // healthy byte attachment must not become a connection failure.
+        #expect(hosted.surfaceView.renderedFrameSequence == 0)
+        synchronize()
+        #expect(owner.overlay == nil)
+        for visible in [false, true] {
+            owner.updateAnchor(anchor, visible: visible, ownershipGeneration: 1)
+            synchronize()
+            #expect(owner.overlay == nil)
+        }
+
+        // A real transport failure must still be shown after successful use.
+        fixture.send(["event": "detached", "surface": 17])
+        deadline = ContinuousClock.now + .seconds(5)
+        while session.phase != .disconnected, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(session.phase == .disconnected)
+        synchronize()
+        let error = try #require(owner.overlay?.currentPresentation)
+        #expect(error.showsReconnectButton)
+        #expect(!error.showsProgress)
+        #expect(!error.copyableError.isEmpty)
+    }
+
+    @Test @MainActor
     func unavailableSurfaceResolutionRequestsRefreshOnceAndRemainsRetryable() {
         var reconnectRequests = 0
         let session = CloudTuiManualMirrorSession(


### PR DESCRIPTION
A usable Cloud terminal on nightly 3468420969101 showed “Cloud terminal unavailable” over its live prompt. The local log records `attached replay=true` at 2026-09-12 03:22:10 PDT, followed by an error card with `bound=true rendererReady=false`.

The attachment session now owns the connection card. Portal placement decides where to display it; renderer bookkeeping cannot convert a successful attachment into a connection error. Remove the card's frame-notification demand and callback. Actual disconnects retain reconnect and right-click Copy Error.

The regression completes the socket handshake, receives replay, sends input, exercises hide/reveal without renderer observations, and checks that a real detach still shows a copyable error. Tests and fix are separate commits.

Validation:
- Swift syntax and test wiring checks pass.
- Regression fails on the old code at both stale-card assertions: https://github.com/manaflow-ai/cmux/actions/runs/34688608196
- All 31 focused tests pass, including the regression: https://github.com/manaflow-ai/cmux/actions/runs/34688609294
- Tagged app build and local signing passed: https://github.com/manaflow-ai/cmux/actions/runs/34688594982
- Tagged app `cldcard` launched and signed in. Direct development API requests succeeded. Live VM verification is UNVERIFIED: the development provider failed during private-network announcement while creating the disposable test VM; no active test VM remains in the account list.

No new user-facing strings. Existing disconnected-state text and Copy Error behavior remain localized.
