### PR TITLE
clarify Cloud VM port access copy

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -5861,121 +5861,121 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Optional private IP access for other apps"
+            "value": "Open cmux VM ports in Chrome, Safari, and other apps"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Optionaler Zugriff auf private IPs für andere Apps"
+            "value": "cmux-VM-Ports in Chrome, Safari und anderen Apps öffnen"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accès facultatif aux IP privées pour les autres apps"
+            "value": "Ouvrir les ports des VM cmux dans Chrome, Safari et d’autres apps"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acceso opcional a IP privadas para otras apps"
+            "value": "Abrir los puertos de las VM de cmux en Chrome, Safari y otras apps"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ほかのアプリからプライベートIPへアクセスする任意の設定"
+            "value": "Chrome、Safariなどのアプリでcmux VMのポートを開く"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为其他应用提供可选的私有 IP 访问"
+            "value": "在 Chrome、Safari 和其他应用中打开 cmux VM 端口"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "為其他 App 提供選用的私有 IP 存取"
+            "value": "在 Chrome、Safari 和其他 App 中開啟 cmux VM 連接埠"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다른 앱의 비공개 IP 접근을 위한 선택 설정"
+            "value": "Chrome, Safari 및 다른 앱에서 cmux VM 포트 열기"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "وصول اختياري إلى عناوين IP الخاصة للتطبيقات الأخرى"
+            "value": "فتح منافذ أجهزة cmux الافتراضية في Chrome وSafari وتطبيقات أخرى"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opcionalni pristup privatnim IP adresama za druge aplikacije"
+            "value": "Otvorite cmux VM portove u Chromeu, Safariju i drugim aplikacijama"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Valgfri privat IP-adgang for andre apps"
+            "value": "Åbn cmux-VM-porte i Chrome, Safari og andre apps"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accesso facoltativo agli IP privati per altre app"
+            "value": "Apri le porte delle VM cmux in Chrome, Safari e altre app"
           }
         },
         "km": {
           "stringUnit": {
             "state": "translated",
-            "value": "ចូលប្រើ IP ឯកជនសម្រាប់កម្មវិធីផ្សេងៗជាជម្រើស"
+            "value": "បើកច្រក cmux VM ក្នុង Chrome, Safari និងកម្មវិធីផ្សេងៗ"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Valgfri privat IP-tilgang for andre apper"
+            "value": "Åpne cmux-VM-porter i Chrome, Safari og andre apper"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opcjonalny dostęp innych aplikacji do prywatnych adresów IP"
+            "value": "Otwórz porty maszyn wirtualnych cmux w Chrome, Safari i innych aplikacjach"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acesso opcional a IPs privados para outros apps"
+            "value": "Abra as portas das VMs cmux no Chrome, Safari e outros apps"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Необязательный доступ других приложений к частным IP"
+            "value": "Открывайте порты виртуальных машин cmux в Chrome, Safari и других приложениях"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การเข้าถึง IP ส่วนตัวสำหรับแอปอื่นแบบไม่บังคับ"
+            "value": "เปิดพอร์ต VM ของ cmux ใน Chrome, Safari และแอปอื่นๆ"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diğer uygulamalar için isteğe bağlı özel IP erişimi"
+            "value": "cmux VM bağlantı noktalarını Chrome, Safari ve diğer uygulamalarda açın"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Необов’язковий доступ інших програм до приватних IP"
+            "value": "Відкривайте порти віртуальних машин cmux у Chrome, Safari та інших програмах"
           }
         }
       }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -92,7 +92,7 @@ struct MachinesPanelView: View {
                             ? String(localized: "cloud.vpn.setup.title", defaultValue: "Cloud VPN")
                             : String(localized: "machines.menu.setupVPN", defaultValue: "Set Up cmux VPN…"))
                             .cmuxFont(size: 12, weight: .medium)
-                        Text(String(localized: "cloud.vpn.setup.entry.subtitle", defaultValue: "Optional private IP access for other apps"))
+                        Text(String(localized: "cloud.vpn.setup.entry.subtitle", defaultValue: "Open cmux VM ports in Chrome, Safari, and other apps"))
                             .cmuxFont(size: 11)
                             .foregroundStyle(.secondary)
                     }


### PR DESCRIPTION
Clarify the Cloud VPN entry subtitle so users understand the result: “Open cmux VM ports in Chrome, Safari, and other apps.” Updated all supported app languages and the English fallback.

Validation: localization parity and diff checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791803871&installation_model_id=21920&pr_number=12431&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12431&signature=076529d269fc2c373788fe34155106bd4f38bc472d7325754637ff821a896c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Cloud VPN entry subtitle to explain what the toggle does: opening cmux VM ports in Chrome, Safari, and other apps. Updates the English default in `MachinesPanelView.swift` and all 20 supported translations in `Localizable.xcstrings`.

<sup>Written for commit b11f280278370696ec697019249309d0cbbc617f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Cloud VPN setup description to clarify that it opens cmux VM ports in Chrome, Safari, and other apps.
  * Updated the corresponding localized text across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->