### PR TITLE
fix: keep targeted tmux-compat reads within one burst

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2989,6 +2989,16 @@ final class SocketClient {
         let relayToken: Data
     }
 
+    /// Cached `pane.list` payloads keyed by workspace id.
+    ///
+    /// The tmux compatibility layer resolves the same workspace's pane list
+    /// several times while resolving a single `-t` target (once inside
+    /// `tmuxResolvePaneTarget` to pick the workspace, again for the pane id,
+    /// and again for `canonicalCallerPane`). Pane topology cannot change
+    /// between those reads, so reuse the first response instead of spending
+    /// one read-plane token per call.
+    private var paneListCache: [String: [String: Any]] = [:]
+
     private let path: String
     private(set) var socketFD: Int32 = -1
     private var streamReadBuffer = Data()
@@ -4024,6 +4034,20 @@ final class SocketClient {
             candidate = parent
         }
         return nil
+    }
+
+    /// `pane.list` for a workspace, reusing the response for the lifetime of
+    /// this client. Callers that mutate pane topology must call
+    /// `invalidatePaneListCache()`.
+    func paneListSnapshot(workspaceId: String) throws -> [String: Any] {
+        if let cached = paneListCache[workspaceId] { return cached }
+        let payload = try sendV2(method: "pane.list", params: ["workspace_id": workspaceId])
+        paneListCache[workspaceId] = payload
+        return payload
+    }
+
+    func invalidatePaneListCache() {
+        paneListCache.removeAll()
     }
 
     func sendV2(
@@ -23016,7 +23040,7 @@ struct CMUXCLI {
             return normalizedHandle
         }
 
-        let payload = try client.sendV2(method: "pane.list", params: ["workspace_id": workspaceId])
+        let payload = try client.paneListSnapshot(workspaceId: workspaceId)
         let panes = payload["panes"] as? [[String: Any]] ?? []
         for pane in panes {
             let id = pane["id"] as? String
@@ -23467,7 +23491,7 @@ struct CMUXCLI {
         if let resolvedPaneId {
             context["pane_id"] = "%\(tmuxStableNumericId(resolvedPaneId))"
             context["pane_uuid"] = resolvedPaneId
-            let panePayload = try client.sendV2(method: "pane.list", params: ["workspace_id": canonicalWorkspaceId])
+            let panePayload = try client.paneListSnapshot(workspaceId: canonicalWorkspaceId)
             let panes = panePayload["panes"] as? [[String: Any]] ?? []
             if let pane = panes.first(where: { ($0["id"] as? String) == resolvedPaneId }) {
                 if let index = intFromAny(pane["index"]) {
@@ -26646,7 +26670,7 @@ struct CMUXCLI {
                 client: client
             )
             // Enrich with geometry for format strings like #{pane_width},#{window_width}
-            let panePayload = try client.sendV2(method: "pane.list", params: ["workspace_id": target.workspaceId])
+            let panePayload = try client.paneListSnapshot(workspaceId: target.workspaceId)
             let panesList = panePayload["panes"] as? [[String: Any]] ?? []
             let containerFrame = panePayload["container_frame"] as? [String: Any]
             if let targetPaneId = target.paneId,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4050,12 +4050,37 @@ final class SocketClient {
         paneListCache.removeAll()
     }
 
+    /// Methods that cannot change which panes exist, where they sit, or which
+    /// one is active. Every other method drops the `pane.list` cache, so a
+    /// command that reads a pane list, mutates the workspace, then reads again
+    /// observes the mutation. Unknown methods invalidate.
+    private static let paneTopologyPreservingMethods: Set<String> = [
+        "pane.list",
+        "pane.surfaces",
+        "surface.list",
+        "surface.current",
+        "surface.read_text",
+        "surface.read_selection",
+        "workspace.list",
+        "workspace.current",
+        "window.list",
+        "window.current",
+        "window.displays",
+        "system.top",
+        "system.memory",
+        "system.tree",
+        "system.identify",
+    ]
+
     func sendV2(
         method: String,
         params: [String: Any] = [:],
         responseTimeout: TimeInterval? = nil,
         deadline: Date? = nil
     ) throws -> [String: Any] {
+        if !Self.paneTopologyPreservingMethods.contains(method) {
+            paneListCache.removeAll()
+        }
         var tracedParams = params
         if method.hasPrefix("vm.") {
             for (key, env) in [("cloud_operation_id", "CMUX_CLOUD_OPERATION_ID"),

--- a/tests/test_cli_tmux_compat_targeted_read_budget.py
+++ b/tests/test_cli_tmux_compat_targeted_read_budget.py
@@ -47,10 +47,11 @@ READ_PLANE_SWIFT = (
 )
 
 # These assertions are about how many reads a command issues, never about how
-# fast it runs, so the timeout only has to stop a hung process. Keep it far
-# above any plausible CLI latency on a loaded shared runner, and allow an
-# override for slower environments.
-CLI_TIMEOUT_SECONDS = float(os.environ.get("CMUX_CLI_TEST_TIMEOUT_SECONDS", "300"))
+# fast it runs, so nothing here may fail on elapsed time. Hangs are caught by
+# the `timeout-minutes` guard on the CI job that runs these scripts; set
+# CMUX_CLI_TEST_TIMEOUT_SECONDS to add a local one when running by hand.
+_cli_timeout = os.environ.get("CMUX_CLI_TEST_TIMEOUT_SECONDS")
+CLI_TIMEOUT_SECONDS = float(_cli_timeout) if _cli_timeout else None
 
 
 def read_polling_burst() -> int:

--- a/tests/test_cli_tmux_compat_targeted_read_budget.py
+++ b/tests/test_cli_tmux_compat_targeted_read_budget.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the read-plane budget of targeted `cmux __tmux-compat`
+commands.
+
+`ControlClientRateLimiter` gives every control-socket connection a burst of
+read-plane ("polling") tokens. A single tmux compatibility command runs on one
+connection, so its whole fan-out has to fit in that burst.
+
+`display-message` without `-t` already fits. Adding `-t <pane>` makes the CLI
+resolve the target first, and that resolution re-reads the same workspace's
+pane list several times, which pushed the command past the burst.
+
+This test drives the real CLI against a fake control socket that applies the
+same token bucket, so it fails when the fan-out grows again rather than when a
+hand-maintained list of method names falls out of date.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socketserver
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+PANE_ID = "33333333-3333-4333-8333-333333333333"
+SURFACE_ID = "44444444-4444-4444-8444-444444444444"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTROL_SOCKET_SOURCES = (
+    REPO_ROOT / "Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket"
+)
+RATE_LIMITER_SWIFT = CONTROL_SOCKET_SOURCES / "Server/ControlClientRateLimiter.swift"
+READ_PLANE_SWIFT = (
+    CONTROL_SOCKET_SOURCES / "Wire/ControlCommandExecutionPolicy+ReadPlane.swift"
+)
+
+
+def read_polling_burst() -> int:
+    """The default burst from `ControlClientRateLimiter.Configuration`."""
+    source = RATE_LIMITER_SWIFT.read_text(encoding="utf-8")
+    match = re.search(r"\bburst:\s*Int\s*=\s*(\d+)", source)
+    if match is None:
+        raise RuntimeError(f"could not read the default burst from {RATE_LIMITER_SWIFT}")
+    return int(match.group(1))
+
+
+def read_polling_methods() -> frozenset[str]:
+    """The method names `ControlCommandExecutionPolicy` charges tokens for."""
+    source = READ_PLANE_SWIFT.read_text(encoding="utf-8")
+    match = re.search(
+        r"pollingMethods\s*:\s*Set<String>\s*=\s*\[(.*?)\]", source, re.DOTALL
+    )
+    if match is None:
+        raise RuntimeError(f"could not read pollingMethods from {READ_PLANE_SWIFT}")
+    methods = frozenset(re.findall(r'"([^"]+)"', match.group(1)))
+    if not methods:
+        raise RuntimeError(f"pollingMethods in {READ_PLANE_SWIFT} parsed as empty")
+    return methods
+
+
+class FakeCmuxState:
+    """A single workspace holding a single pane, plus the shared token bucket."""
+
+    def __init__(self, burst: int, polling_methods: frozenset[str]) -> None:
+        self.burst = burst
+        self.polling_methods = polling_methods
+        self.polling_calls: list[str] = []
+        self.tokens = burst
+
+    def reset_budget(self) -> None:
+        self.polling_calls = []
+        self.tokens = self.burst
+
+    def admit(self, method: str) -> None:
+        if method not in self.polling_methods:
+            return
+        self.polling_calls.append(method)
+        if self.tokens <= 0:
+            raise RateLimited(method)
+        self.tokens -= 1
+
+    def handle(self, method: str, params: dict[str, object]) -> dict[str, object]:
+        self.admit(method)
+
+        if method == "workspace.list":
+            return {
+                "window_id": "window-1",
+                "window_ref": "window:1",
+                "workspaces": [
+                    {
+                        "id": WORKSPACE_ID,
+                        "ref": "workspace:1",
+                        "index": 0,
+                        "title": "cmux",
+                    }
+                ],
+            }
+        if method == "workspace.current":
+            return {"workspace_id": WORKSPACE_ID, "workspace_ref": "workspace:1"}
+        if method == "window.list":
+            return {"windows": [{"id": "window-1", "ref": "window:1", "index": 0}]}
+        if method == "surface.current":
+            return {
+                "workspace_id": WORKSPACE_ID,
+                "workspace_ref": "workspace:1",
+                "pane_id": PANE_ID,
+                "pane_ref": "pane:1",
+                "surface_id": SURFACE_ID,
+                "surface_ref": "surface:1",
+            }
+        if method == "surface.list":
+            return {
+                "surfaces": [
+                    {
+                        "id": SURFACE_ID,
+                        "ref": "surface:1",
+                        "focused": True,
+                        "pane_id": PANE_ID,
+                        "pane_ref": "pane:1",
+                        "title": "leader",
+                    }
+                ]
+            }
+        if method == "pane.list":
+            return {
+                "workspace_id": WORKSPACE_ID,
+                "workspace_ref": "workspace:1",
+                "container_frame": {"width": 760, "height": 672},
+                "panes": [
+                    {
+                        "id": PANE_ID,
+                        "ref": "pane:1",
+                        "index": 0,
+                        "focused": True,
+                        "columns": 94,
+                        "rows": 37,
+                        "selected_surface_id": SURFACE_ID,
+                        "selected_surface_ref": "surface:1",
+                        "surface_count": 1,
+                        "surface_ids": [SURFACE_ID],
+                        "surface_refs": ["surface:1"],
+                    }
+                ],
+            }
+        if method == "pane.surfaces":
+            return {
+                "surfaces": [
+                    {
+                        "id": SURFACE_ID,
+                        "ref": "surface:1",
+                        "selected": True,
+                        "title": "leader",
+                    }
+                ]
+            }
+        raise RuntimeError(f"Unsupported fake cmux method: {method}")
+
+
+class RateLimited(RuntimeError):
+    def __init__(self, method: str) -> None:
+        super().__init__(f"Polling rate limited for this connection ({method})")
+
+
+class FakeCmuxHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        while True:
+            line = self.rfile.readline()
+            if not line:
+                return
+
+            decoded_line = line.decode("utf-8").rstrip("\r\n")
+            capability_prefix = "_cmux_capability_v1 "
+            if decoded_line.startswith(capability_prefix):
+                envelope_parts = decoded_line.split(" ", 2)
+                if len(envelope_parts) != 3 or not envelope_parts[2]:
+                    self.wfile.write(b"ERROR: malformed capability envelope\n")
+                    self.wfile.flush()
+                    continue
+                decoded_line = envelope_parts[2]
+
+            request = json.loads(decoded_line)
+            try:
+                result = self.server.state.handle(  # type: ignore[attr-defined]
+                    request["method"],
+                    request.get("params", {}),
+                )
+                response = {"ok": True, "result": result, "id": request.get("id")}
+            except RateLimited as exc:
+                response = {
+                    "ok": False,
+                    "error": {"code": "rate_limited", "message": str(exc)},
+                    "id": request.get("id"),
+                }
+            except Exception as exc:
+                response = {
+                    "ok": False,
+                    "error": {"code": "not_found", "message": str(exc)},
+                    "id": request.get("id"),
+                }
+
+            self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
+            self.wfile.flush()
+
+
+class FakeCmuxUnixServer(socketserver.ThreadingUnixStreamServer):
+    allow_reuse_address = True
+
+    def __init__(self, socket_path: str, state: FakeCmuxState) -> None:
+        self.state = state
+        super().__init__(socket_path, FakeCmuxHandler)
+
+
+def run_cli(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+    args: list[str],
+    tmux_pane: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CMUX_SOCKET_PATH"] = str(socket_path)
+    env["CMUX_WORKSPACE_ID"] = WORKSPACE_ID
+    env["CMUX_PANE_ID"] = PANE_ID
+    env["CMUX_SURFACE_ID"] = SURFACE_ID
+    env["HOME"] = str(fake_home)
+    if tmux_pane is None:
+        env.pop("TMUX_PANE", None)
+    else:
+        env["TMUX_PANE"] = tmux_pane
+    return subprocess.run(
+        [cli_path, "--socket", str(socket_path), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+
+def resolve_pane_handle(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+    state: FakeCmuxState,
+) -> str:
+    """The `%<id>` handle a shell in the pane would see as `$TMUX_PANE`."""
+    state.reset_budget()
+    proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        ["__tmux-compat", "list-panes", "-F", "#{pane_id}"],
+    )
+    handle = proc.stdout.strip()
+    if proc.returncode != 0 or not handle.startswith("%"):
+        raise AssertionError(
+            "could not resolve the pane handle\n"
+            f"  stdout={proc.stdout.strip()}\n"
+            f"  stderr={proc.stderr.strip()}"
+        )
+    return handle
+
+
+def assert_fits_in_one_burst(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+    state: FakeCmuxState,
+    label: str,
+    args: list[str],
+    tmux_pane: str | None = None,
+) -> None:
+    state.reset_budget()
+    proc = run_cli(cli_path, socket_path, fake_home, args, tmux_pane=tmux_pane)
+    spent = len(state.polling_calls)
+    detail = (
+        f"{label}\n"
+        f"  polling calls={spent} (burst={state.burst})\n"
+        f"  order={' -> '.join(state.polling_calls)}\n"
+        f"  stdout={proc.stdout.strip()}\n"
+        f"  stderr={proc.stderr.strip()}"
+    )
+    if spent > state.burst:
+        raise AssertionError(
+            f"{label} exceeded the per-connection read-plane burst\n{detail}"
+        )
+    if proc.returncode != 0 or "rate_limited" in proc.stdout + proc.stderr:
+        raise AssertionError(f"{label} did not succeed\n{detail}")
+    if proc.stdout.strip() != "cmux:0":
+        raise AssertionError(f"{label} produced unexpected output\n{detail}")
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+        burst = read_polling_burst()
+        polling_methods = read_polling_methods()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    fmt = "#{session_name}:#{window_index}"
+    try:
+        with tempfile.TemporaryDirectory(prefix="cmux-tmux-read-budget-") as td:
+            tmp = Path(td)
+            socket_path = tmp / "fake-cmux.sock"
+            state = FakeCmuxState(burst, polling_methods)
+            server = FakeCmuxUnixServer(str(socket_path), state)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            fake_home = tmp / "home"
+            fake_home.mkdir(parents=True, exist_ok=True)
+
+            try:
+                handle = resolve_pane_handle(
+                    cli_path, socket_path, fake_home, state
+                )
+                assert_fits_in_one_burst(
+                    cli_path,
+                    socket_path,
+                    fake_home,
+                    state,
+                    "display-message without -t",
+                    ["__tmux-compat", "display-message", "-p", fmt],
+                    tmux_pane=handle,
+                )
+                # The reported failure: `tmux display-message -t "$TMUX_PANE"`.
+                assert_fits_in_one_burst(
+                    cli_path,
+                    socket_path,
+                    fake_home,
+                    state,
+                    'display-message -t "$TMUX_PANE"',
+                    ["__tmux-compat", "display-message", "-t", handle, "-p", fmt],
+                    tmux_pane=handle,
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+    except AssertionError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    print("PASS: targeted tmux-compat reads fit in one read-plane burst")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_tmux_compat_targeted_read_budget.py
+++ b/tests/test_cli_tmux_compat_targeted_read_budget.py
@@ -11,9 +11,11 @@ connection, so its whole fan-out has to fit in that burst.
 resolve the target first, and that resolution re-reads the same workspace's
 pane list several times, which pushed the command past the burst.
 
-This test drives the real CLI against a fake control socket that applies the
-same token bucket, so it fails when the fan-out grows again rather than when a
-hand-maintained list of method names falls out of date.
+These tests drive the real CLI against a fake control socket that applies the
+same token bucket, so they fail when the fan-out grows again rather than when a
+hand-maintained list of method names falls out of date. They also cover the
+other side of reusing a pane list: a command that mutates pane topology has to
+see the result of its own mutation.
 """
 
 from __future__ import annotations
@@ -32,6 +34,8 @@ from claude_teams_test_utils import resolve_cmux_cli
 WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
 PANE_ID = "33333333-3333-4333-8333-333333333333"
 SURFACE_ID = "44444444-4444-4444-8444-444444444444"
+NEW_PANE_ID = "66666666-6666-4666-8666-666666666666"
+NEW_SURFACE_ID = "77777777-7777-4777-8777-777777777777"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTROL_SOCKET_SOURCES = (
@@ -41,6 +45,12 @@ RATE_LIMITER_SWIFT = CONTROL_SOCKET_SOURCES / "Server/ControlClientRateLimiter.s
 READ_PLANE_SWIFT = (
     CONTROL_SOCKET_SOURCES / "Wire/ControlCommandExecutionPolicy+ReadPlane.swift"
 )
+
+# These assertions are about how many reads a command issues, never about how
+# fast it runs, so the timeout only has to stop a hung process. Keep it far
+# above any plausible CLI latency on a loaded shared runner, and allow an
+# override for slower environments.
+CLI_TIMEOUT_SECONDS = float(os.environ.get("CMUX_CLI_TEST_TIMEOUT_SECONDS", "300"))
 
 
 def read_polling_burst() -> int:
@@ -74,6 +84,7 @@ class FakeCmuxState:
         self.polling_methods = polling_methods
         self.polling_calls: list[str] = []
         self.tokens = burst
+        self.split_created = False
 
     def reset_budget(self) -> None:
         self.polling_calls = []
@@ -117,40 +128,83 @@ class FakeCmuxState:
                 "surface_ref": "surface:1",
             }
         if method == "surface.list":
-            return {
-                "surfaces": [
+            surfaces = [
+                {
+                    "id": SURFACE_ID,
+                    "ref": "surface:1",
+                    "focused": not self.split_created,
+                    "pane_id": PANE_ID,
+                    "pane_ref": "pane:1",
+                    "title": "leader",
+                }
+            ]
+            if self.split_created:
+                surfaces.append(
                     {
-                        "id": SURFACE_ID,
-                        "ref": "surface:1",
+                        "id": NEW_SURFACE_ID,
+                        "ref": "surface:2",
                         "focused": True,
-                        "pane_id": PANE_ID,
-                        "pane_ref": "pane:1",
-                        "title": "leader",
+                        "pane_id": NEW_PANE_ID,
+                        "pane_ref": "pane:2",
+                        "title": "teammate",
                     }
-                ]
-            }
+                )
+            return {"surfaces": surfaces}
         if method == "pane.list":
+            panes = [
+                {
+                    "id": PANE_ID,
+                    "ref": "pane:1",
+                    "index": 0,
+                    "focused": not self.split_created,
+                    "columns": 94,
+                    "rows": 37,
+                    "selected_surface_id": SURFACE_ID,
+                    "selected_surface_ref": "surface:1",
+                    "surface_count": 1,
+                    "surface_ids": [SURFACE_ID],
+                    "surface_refs": ["surface:1"],
+                }
+            ]
+            if self.split_created:
+                panes.append(
+                    {
+                        "id": NEW_PANE_ID,
+                        "ref": "pane:2",
+                        "index": 1,
+                        "focused": True,
+                        "columns": 47,
+                        "rows": 37,
+                        "selected_surface_id": NEW_SURFACE_ID,
+                        "selected_surface_ref": "surface:2",
+                        "surface_count": 1,
+                        "surface_ids": [NEW_SURFACE_ID],
+                        "surface_refs": ["surface:2"],
+                    }
+                )
             return {
                 "workspace_id": WORKSPACE_ID,
                 "workspace_ref": "workspace:1",
                 "container_frame": {"width": 760, "height": 672},
-                "panes": [
-                    {
-                        "id": PANE_ID,
-                        "ref": "pane:1",
-                        "index": 0,
-                        "focused": True,
-                        "columns": 94,
-                        "rows": 37,
-                        "selected_surface_id": SURFACE_ID,
-                        "selected_surface_ref": "surface:1",
-                        "surface_count": 1,
-                        "surface_ids": [SURFACE_ID],
-                        "surface_refs": ["surface:1"],
-                    }
-                ],
+                "panes": panes,
             }
+        if method == "surface.split":
+            self.split_created = True
+            return {"surface_id": NEW_SURFACE_ID, "pane_id": NEW_PANE_ID}
+        if method in {"surface.send_text", "surface.select", "workspace.select"}:
+            return {"ok": True}
         if method == "pane.surfaces":
+            if self.split_created and params.get("pane_id") == NEW_PANE_ID:
+                return {
+                    "surfaces": [
+                        {
+                            "id": NEW_SURFACE_ID,
+                            "ref": "surface:2",
+                            "selected": True,
+                            "title": "teammate",
+                        }
+                    ]
+                }
             return {
                 "surfaces": [
                     {
@@ -241,7 +295,7 @@ def run_cli(
         text=True,
         check=False,
         env=env,
-        timeout=30,
+        timeout=CLI_TIMEOUT_SECONDS,
     )
 
 
@@ -298,6 +352,62 @@ def assert_fits_in_one_burst(
         raise AssertionError(f"{label} produced unexpected output\n{detail}")
 
 
+def assert_split_reports_the_new_pane(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+    state: FakeCmuxState,
+    handle: str,
+) -> None:
+    """`split-window -P` must describe the pane the split just created.
+
+    Target resolution reads the pane list before `surface.split` runs, and the
+    `-P` format context reads it again afterwards. The second read has to see
+    the new pane.
+    """
+    state.reset_budget()
+    state.split_created = False
+    proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "split-window",
+            "-h",
+            "-t",
+            handle,
+            "-P",
+            "-F",
+            "#{pane_id} #{pane_index} #{pane_active}",
+        ],
+        tmux_pane=handle,
+    )
+    detail = (
+        f"  stdout={proc.stdout.strip()}\n"
+        f"  stderr={proc.stderr.strip()}\n"
+        f"  order={' -> '.join(state.polling_calls)}"
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"split-window -P returned non-zero\n{detail}")
+    fields = proc.stdout.strip().split(" ")
+    if len(fields) != 3:
+        raise AssertionError(
+            "split-window -P reported a stale pane list: the format context "
+            "resolved the new pane's id but not its position, so "
+            f"`#{{pane_index}}`/`#{{pane_active}}` came back empty\n{detail}"
+        )
+    pane_id, pane_index, pane_active = fields
+    if pane_id == handle:
+        raise AssertionError(f"split-window -P named the target pane\n{detail}")
+    if (pane_index, pane_active) != ("1", "1"):
+        raise AssertionError(
+            "split-window -P described the new pane with the pre-split layout: "
+            f"expected index 1 and active 1, got {pane_index!r}/{pane_active!r}"
+            f"\n{detail}"
+        )
+
+
 def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
@@ -342,6 +452,9 @@ def main() -> int:
                     ["__tmux-compat", "display-message", "-t", handle, "-p", fmt],
                     tmux_pane=handle,
                 )
+                assert_split_reports_the_new_pane(
+                    cli_path, socket_path, fake_home, state, handle
+                )
             finally:
                 server.shutdown()
                 server.server_close()
@@ -350,7 +463,10 @@ def main() -> int:
         print(f"FAIL: {exc}")
         return 1
 
-    print("PASS: targeted tmux-compat reads fit in one read-plane burst")
+    print(
+        "PASS: targeted tmux-compat reads fit in one read-plane burst "
+        "and stay fresh across a split"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- **What changed?** `pane.list` responses are cached per workspace for the lifetime of a `SocketClient`, and the read-only tmux compatibility lookups (`tmuxCanonicalPaneId`, `tmuxFormatContext`, and the `display-message` geometry enrichment) go through that cache.
- **Why?** `display-message -t <pane>` still fails with `rate_limited` after #12061. Resolving the target re-reads the same workspace's pane list three times before the format fan-out runs, so a single connection spends 10 read-plane tokens against a burst of 9.

`#11803` was fixed for the untargeted form only. #12061's test models `tmuxFormatContext`, which is the path taken without `-t`; adding `-t` introduces target resolution on top of it, and that is what goes over budget.

Measured on `origin/main` (309513b408) with one workspace and one pane — the smallest possible setup:

| command | before | after |
|---|---|---|
| `display-message -p '#{session_name}:#{window_index}'` | 7 reads, ok | 6 reads, ok |
| `display-message -t "$TMUX_PANE" -p '#{session_name}:#{window_index}'` | **10 reads, `rate_limited`** | 6 reads, ok |
| `list-panes -t "$TMUX_PANE"` | 8 reads, ok | 6 reads, ok |

Read order before the fix:

```
pane.list → pane.list → pane.list → pane.surfaces → workspace.list
→ surface.current → surface.list → pane.list → surface.list → pane.list
```

Pane topology cannot change while one read-only command runs, so the reused payload is identical. A command that mutates the workspace is a different matter: `split-window -t <pane>` loads the pane list while resolving the target, and its `-P` format context reads it again after `surface.split`. The cache is therefore dropped at the `SocketClient.sendV2` boundary — only methods that cannot change which panes exist, where they sit, or which one is active keep it, and anything else, including a method the set does not recognise, invalidates. A future mutating RPC fails safe rather than silently serving a stale list.

## Testing

`tests/test_cli_tmux_compat_targeted_read_budget.py` runs the real CLI against a fake control socket that applies the same token bucket, following the shape of `tests/test_cli_tmux_compat_split_window_surface_ref.py`. It resolves the pane handle the way a shell in the pane would (`list-panes -F '#{pane_id}'`) and then exercises the reported failure, `display-message -t "$TMUX_PANE"`.

The burst and the polling method names are parsed from `ControlClientRateLimiter.swift` and `ControlCommandExecutionPolicy+ReadPlane.swift` rather than copied, so the test cannot drift from the limiter it models, and it fails loudly if those declarations move.

It covers both directions: the targeted read fan-out stays inside one burst, and `split-window -P` describes the pane the split created rather than the pre-split layout.

Verified against four CLI builds from this branch:

| build | result |
|---|---|
| unpatched `origin/main` | `FAIL … polling calls=10 (burst=9)`, exit 1 |
| cache in `tmuxCanonicalPaneId` only | PASS (8 reads), exit 0 |
| cache without the boundary invalidation | `FAIL … split-window -P described the new pane with the pre-split layout`, exit 1 |
| this PR | PASS (6 reads), exit 0 |

The stale case printed `%6298629473962215337  1` for `#{pane_id} #{pane_index} #{pane_active}`: the id was right because it comes from the `surface.split` response, while the index and active flag came from the pane list loaded before the split.

The script sets no subprocess deadline, so a slow runner cannot turn a correct command into a failure; hangs stay bounded by the `timeout-minutes` guard on the CI job. `CMUX_CLI_TEST_TIMEOUT_SECONDS` adds one back for running the file by hand.

Also verified manually against a debug build over its control socket, five runs each: unpatched failed 5/5, patched succeeded 5/5, with byte-identical output for every command the unpatched build could complete (`display-message` with and without `-t`, `list-panes -a`, `list-panes -t`, `list-windows`, and geometry formats such as `#{pane_width}x#{pane_height}`).

Existing `tests/test_cli_*tmux*` results are unchanged by this patch: `test_cli_claude_teams_tmux_sequence.py` passes before and after, and the other three fail identically before and after in my environment for unrelated setup reasons.

## Demo Video

Not applicable — CLI behavior change, covered by the numbers and the test above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb2ZeaCpaRo1EgEPZaJdE9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791849864&installation_model_id=21920&pr_number=12434&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12434&signature=1f81a3b7333d2cf73df061cf7b30b9bef805acb0c250606664a2786403488efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `display-message -t <pane>` failing with `rate_limited` by caching the workspace pane list in `SocketClient` and dropping that cache whenever a command can change pane topology, so targeted tmux-compat reads fit within the read-plane burst.

- Target resolution previously re-read the same workspace's `pane.list` three times, spending 10 read-plane tokens against a burst of 9; the cache drops the targeted fan-out to 6 reads.
- Read-only lookups (`tmuxCanonicalPaneId`, `tmuxFormatContext`, geometry enrichment) reuse the cached payload; the cache is invalidated automatically at the RPC boundary unless the method belongs to a fixed set of pane-topology-preserving methods, so mutations like `surface.split` are always observed.
- Adds a regression test that runs the real CLI against a fake control socket applying the same token bucket, parsing the burst and polling method names from their Swift sources; the fake validates that every call targets the hosted workspace, pane, and surface. It asserts that `split-window -P` describes the pane the split created and imposes no wall-clock deadline, so slow runners can't fail a correct command (hangs are caught by the CI job timeout; `CMUX_CLI_TEST_TIMEOUT_SECONDS` adds one for manual runs).

<sup>Written for commit 281b285e0c632efe222ff8e67367787ec67a359f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness for tmux-compatible commands by reusing pane information when appropriate.

- **Bug Fixes**
  - Reduced redundant pane-list requests while ensuring newly split panes are reflected immediately.
  - Improved reliability of targeted display-message commands within connection polling limits.

- **Tests**
  - Added coverage for rate limiting, unsupported commands, malformed responses, error handling, and accurate pane reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
