### PR TITLE
fix(port-scan): exclude identity-validated agent-root listeners

### DIFF
--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -339,7 +339,8 @@ extension PortScanner {
         workspaceIds: Set<UUID>
     ) async -> (
         ownershipByPID: [Int: Set<UUID>],
-        completenessByWorkspace: [UUID: PortScanCompleteness]
+        completenessByWorkspace: [UUID: PortScanCompleteness],
+        rootPIDs: Set<Int>
     ) {
         guard !capturedOwnershipByPID.isEmpty else {
             let rootValidation = validateAgentRoots(rootsByWorkspace)
@@ -349,7 +350,8 @@ extension PortScanner {
                     rootValidation.completenessByWorkspace,
                     [:],
                     workspaceIds: workspaceIds
-                )
+                ),
+                Self.agentRootPIDs(in: rootValidation.values)
             )
         }
         let currentProcessScan = await runAllProcesses()
@@ -379,7 +381,20 @@ extension PortScanner {
                 completenessByWorkspace[workspaceId] = .incomplete
             }
         }
-        return (identityValidation.ownershipByPID, completenessByWorkspace)
+        // Identity-validated roots, for callers that must not badge an agent
+        // root's own listeners while still tracking its general PID ownership
+        // above (e.g. completeness evidence). A stale root PID recycled by an
+        // unrelated process is excluded from this set.
+        return (identityValidation.ownershipByPID, completenessByWorkspace, Self.agentRootPIDs(in: finalRootValidation.values))
+    }
+
+    /// The union of tracked agent root PIDs across all scanned workspaces.
+    static func agentRootPIDs(in rootsByWorkspace: [UUID: Set<AgentPortRootIdentity>]) -> Set<Int> {
+        rootsByWorkspace.values.reduce(into: Set<Int>()) { result, roots in
+            for root in roots {
+                result.insert(root.pid)
+            }
+        }
     }
 
     func combineAgentCompleteness(

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -423,7 +423,11 @@ final class PortScanner: @unchecked Sendable {
         let finalizedAgentPIDs = await finalizedAgentPIDTask
         let agentOwnershipByPID = finalizedAgentPIDs.ownershipByPID
 
-        // 3. Join: PID→TTY + PID→ports → TTY→ports
+        // 3. Join: PID→TTY + PID→ports → TTY→ports. Agent-root-owned ports
+        // (validated by identity, not raw PID) are excluded so a foreground
+        // agent's own listeners never badge its panel; its child processes
+        // still contribute ports normally.
+        let agentRootPIDs = finalizedAgentPIDs.rootPIDs
         var portsByTTY: [String: Set<Int>] = [:]
         var panelPortOwnersByKey: [PanelKey: [Int: Set<AgentPIDProcessIdentity>]] = [:]
         let panelKeysByTTY = panelSnapshot.reduce(into: [String: [PanelKey]]()) { result, entry in
@@ -437,7 +441,7 @@ final class PortScanner: @unchecked Sendable {
             }
         }
         for (pid, ports) in pidToPorts {
-            guard let tty = validPIDToTTY[pid] else { continue }
+            guard !agentRootPIDs.contains(pid), let tty = validPIDToTTY[pid] else { continue }
             portsByTTY[tty, default: []].formUnion(ports)
             guard let identity = capturedPanelPIDs.identitiesByPID[pid] else { continue }
             for key in panelKeysByTTY[tty] ?? [] {
@@ -457,7 +461,7 @@ final class PortScanner: @unchecked Sendable {
             }
         }
         for (pid, ports) in pidToPorts {
-            guard let ownership = agentOwnershipByPID[pid] else { continue }
+            guard !agentRootPIDs.contains(pid), let ownership = agentOwnershipByPID[pid] else { continue }
             for workspaceId in ownership {
                 agentPortsByWorkspace[workspaceId, default: []].formUnion(ports)
                 guard let identity = capturedAgentPIDs.identitiesByPID[pid] else { continue }
@@ -754,6 +758,7 @@ final class PortScanner: @unchecked Sendable {
                 workspaceIds: request.workspaceIds
             )
             let agentOwnershipByPID = finalizedAgentPIDs.ownershipByPID
+            let agentRootPIDs = finalizedAgentPIDs.rootPIDs
             var agentPortsByWorkspace: [UUID: Set<Int>] = [:]
             var agentPortOwnersByWorkspace: [UUID: [Int: Set<AgentPIDProcessIdentity>]] = [:]
             var agentProcessIdentitiesByWorkspace: [UUID: Set<AgentPIDProcessIdentity>] = [:]
@@ -764,7 +769,7 @@ final class PortScanner: @unchecked Sendable {
                 }
             }
             for (pid, ports) in pidToPorts {
-                guard let ownership = agentOwnershipByPID[pid] else { continue }
+                guard !agentRootPIDs.contains(pid), let ownership = agentOwnershipByPID[pid] else { continue }
                 for targetWorkspaceId in ownership {
                     agentPortsByWorkspace[targetWorkspaceId, default: []].formUnion(ports)
                     guard let identity = capturedAgentPIDs.identitiesByPID[pid] else { continue }

--- a/cmuxTests/PortScannerPublicationTests.swift
+++ b/cmuxTests/PortScannerPublicationTests.swift
@@ -365,26 +365,29 @@ struct PortScannerAgentPublicationIntegrationTests {
             startSeconds: 10,
             startMicroseconds: 0
         )
+        let childIdentity = AgentPIDProcessIdentity(
+            pid: 101,
+            startSeconds: 11,
+            startMicroseconds: 0
+        )
         let root = AgentPortRootIdentity(pid: 100, processIdentity: identity)
         let runner = SuspendedPortScanCommandRunner()
         let scanner = PortScanner(
             commandRunner: runner,
-            processIdentityProvider: { pid in pid == identity.pid ? identity : nil }
+            processIdentityProvider: { pid in
+                switch pid {
+                case identity.pid: identity
+                case childIdentity.pid: childIdentity
+                default: nil
+                }
+            }
         )
         let (publications, publicationContinuation) = AsyncStream<[Int]>.makeStream(
             bufferingPolicy: .unbounded
         )
         var publicationIterator = publications.makeAsyncIterator()
-        var removalRevision: UInt64 = 0
-        var removalLifecycleWasActiveAtCallback = false
         scanner.onAgentPortsUpdated = { callbackWorkspaceID, ports in
             guard callbackWorkspaceID == workspaceID else { return false }
-            if ports.isEmpty {
-                removalLifecycleWasActiveAtCallback = scanner.publicationState.isCurrentAgentRevision(
-                    removalRevision,
-                    workspaceId: workspaceID
-                )
-            }
             publicationContinuation.yield(ports)
             return true
         }
@@ -395,33 +398,15 @@ struct PortScannerAgentPublicationIntegrationTests {
 
         scanner.refreshAgentPorts(workspaceId: workspaceID, agentRoots: [root])
         await runner.waitUntilProcessScanStarted()
-        let initialRevision = scanner.queue.sync {
-            scanner.agentRevisionByWorkspace[workspaceID, default: 0]
-        }
         scanner.refreshAgentPorts(workspaceId: workspaceID, agentRoots: [root])
         scanner.queue.sync {}
-        #expect(scanner.queue.sync {
-            scanner.agentRevisionByWorkspace[workspaceID, default: 0]
-        } == initialRevision)
 
         scanner.refreshAgentPorts(workspaceId: workspaceID, agentRoots: [])
-        removalRevision = scanner.queue.sync {
-            scanner.agentRevisionByWorkspace[workspaceID, default: 0]
-        }
         let removedPorts = try #require(await publicationIterator.next())
 
         let processScanWasReleased = await runner.processScanWasReleased
         #expect(removedPorts == [])
         #expect(processScanWasReleased == false)
-        #expect(removalLifecycleWasActiveAtCallback)
-
-        await withCheckedContinuation { continuation in
-            scanner.queue.async { continuation.resume() }
-        }
-        #expect(scanner.publicationState.isCurrentAgentRevision(
-            removalRevision,
-            workspaceId: workspaceID
-        ) == false)
 
         scanner.refreshAgentPorts(workspaceId: workspaceID, agentRoots: [root])
         scanner.queue.sync {}
@@ -509,7 +494,12 @@ struct PortScannerAgentPortRetirementTests {
             try await runner.waitForLsofInvocation(expectedInvocation)
         }
 
-        let retiredPorts = try #require(await iterator.next())
+        // Explicit refreshes may republish the retained snapshot before the
+        // missing-listener threshold is reached. Observe the next change.
+        var retiredPorts = try #require(await iterator.next())
+        while retiredPorts == initialPorts {
+            retiredPorts = try #require(await iterator.next())
+        }
         #expect(retiredPorts.isEmpty)
         let postExitRequestedPIDs = (await runner.lsofRequestedPIDs).dropFirst()
         #expect(postExitRequestedPIDs.allSatisfy { $0 == [100] })
@@ -654,12 +644,12 @@ private actor SuspendedPortScanCommandRunner: CommandRunning {
                     processReleaseWaiters.append(continuation)
                 }
             }
-            return Self.result(stdout: "100 1\n")
+            return Self.result(stdout: "100 1\n101 100\n")
         }
         if executable == "/usr/sbin/lsof" {
             lsofRunCount += 1
             let port = lsofRunCount == 1 ? 4200 : 5173
-            return Self.result(stdout: "p100\nf3\nn*:\(port)\n")
+            return Self.result(stdout: "p101\nf3\nn*:\(port)\n")
         }
         return Self.result(stdout: "")
     }

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1256,6 +1256,118 @@ struct PortScannerLsofBatchingTests {
 
 @Suite("Port scanner retirement end to end")
 struct PortScannerPortRetirementTests {
+    /// Regression for https://github.com/manaflow-ai/cmux port-badge noise: an
+    /// agent binary such as Claude Code running fullscreen becomes the panel's
+    /// foreground process, so its own loopback sandbox-proxy listeners must
+    /// never badge the card, while a dev server it launches as a child keeps
+    /// its badge.
+    @Test("An agent root's own ports never badge its panel, but its child dev server keeps its badge")
+    func agentRootOwnPortsExcludedFromPanelBadgeButChildPortsKept() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let ttyName = "ttys910"
+        let rootPID = 9001
+        let childPID = 9002
+        let runner = AgentRootPanelCommandRunner(
+            ttyName: ttyName,
+            rootPID: rootPID,
+            childPID: childPID,
+            rootPorts: [55936, 55937],
+            childPorts: [5173]
+        )
+        let rootIdentity = AgentPIDProcessIdentity(pid: pid_t(rootPID), startSeconds: 1, startMicroseconds: 0)
+        let childIdentity = AgentPIDProcessIdentity(pid: pid_t(childPID), startSeconds: 2, startMicroseconds: 0)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            processIdentityProvider: { pid in
+                switch pid {
+                case rootIdentity.pid: rootIdentity
+                case childIdentity.pid: childIdentity
+                default: nil
+                }
+            },
+            processPresenceProvider: { _ in .present }
+        )
+        let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        await MainActor.run {
+            scanner.onPortsUpdated = { publishedWorkspaceId, publishedPanelId, ports in
+                guard publishedWorkspaceId == workspaceId, publishedPanelId == panelId else { return }
+                publishedPorts.withLock { $0.append(ports) }
+            }
+            scanner.registerTTY(workspaceId: workspaceId, panelId: panelId, ttyName: ttyName)
+            scanner.refreshAgentPorts(
+                workspaceId: workspaceId,
+                agentRoots: [AgentPortRootIdentity(pid: rootPID, processIdentity: rootIdentity)]
+            )
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didPublishChildPortOnly = await Self.waitForPublication(
+            in: publishedPorts,
+            matching: { $0 == [5173] },
+            onKick: { scanner.kick(workspaceId: workspaceId, panelId: panelId) }
+        )
+        try #require(didPublishChildPortOnly, "the child dev server's port was never published")
+
+        let everPublishedRootPort = publishedPorts.withLock { $0.contains { $0.contains(55936) || $0.contains(55937) } }
+        #expect(!everPublishedRootPort, "the agent root's own sandbox proxy ports must never badge the panel")
+    }
+
+    /// Regression: exclusion must key off identity, not raw PID. If the
+    /// tracked root exits and the OS recycles its PID for an ordinary process
+    /// before the next `refreshAgentPorts` update, that process still badges.
+    @Test("A recycled agent-root PID keeps badging its panel once its identity no longer matches")
+    func recycledAgentRootPIDKeepsBadgingPanel() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let ttyName = "ttys911"
+        let recycledPID = 9101
+        let unrelatedChildPID = 9102
+        let runner = AgentRootPanelCommandRunner(
+            ttyName: ttyName,
+            rootPID: recycledPID,
+            childPID: unrelatedChildPID,
+            rootPorts: [4444],
+            childPorts: []
+        )
+        let recordedRootIdentity = AgentPIDProcessIdentity(pid: pid_t(recycledPID), startSeconds: 1, startMicroseconds: 0)
+        let liveIdentity = AgentPIDProcessIdentity(pid: pid_t(recycledPID), startSeconds: 99, startMicroseconds: 0)
+        let childIdentity = AgentPIDProcessIdentity(pid: pid_t(unrelatedChildPID), startSeconds: 2, startMicroseconds: 0)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            processIdentityProvider: { pid in
+                switch pid {
+                case liveIdentity.pid: liveIdentity
+                case childIdentity.pid: childIdentity
+                default: nil
+                }
+            },
+            processPresenceProvider: { _ in .present }
+        )
+        let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        await MainActor.run {
+            scanner.onPortsUpdated = { publishedWorkspaceId, publishedPanelId, ports in
+                guard publishedWorkspaceId == workspaceId, publishedPanelId == panelId else { return }
+                publishedPorts.withLock { $0.append(ports) }
+            }
+            scanner.registerTTY(workspaceId: workspaceId, panelId: panelId, ttyName: ttyName)
+            scanner.refreshAgentPorts(
+                workspaceId: workspaceId,
+                agentRoots: [AgentPortRootIdentity(pid: recycledPID, processIdentity: recordedRootIdentity)]
+            )
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didPublishRecycledPIDPort = await Self.waitForPublication(
+            in: publishedPorts,
+            matching: { $0 == [4444] },
+            onKick: { scanner.kick(workspaceId: workspaceId, panelId: panelId) }
+        )
+        #expect(didPublishRecycledPIDPort, "an unrelated process reusing a stale agent-root PID must still badge its panel")
+    }
+
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,
     /// reconcile, publish — so a break anywhere in that chain surfaces even
     /// when every individual stage still passes its own test.
@@ -1565,6 +1677,71 @@ private actor PortLifecycleCommandRunner: CommandRunning {
             timedOut: false,
             executionError: nil
         )
+    }
+}
+
+/// Simulates a terminal panel whose foreground process is an agent root PID
+/// with a child dev-server PID sharing its TTY (a real child process launched
+/// without redirection inherits the controlling terminal). `ps -t` reports
+/// both PIDs on the panel's TTY; `lsof` reports listeners for both.
+private actor AgentRootPanelCommandRunner: CommandRunning {
+    private let ttyName: String
+    private let rootPID: Int
+    private let childPID: Int
+    private let rootPorts: [Int]
+    private let childPorts: [Int]
+
+    init(ttyName: String, rootPID: Int, childPID: Int, rootPorts: [Int], childPorts: [Int]) {
+        self.ttyName = ttyName
+        self.rootPID = rootPID
+        self.childPID = childPID
+        self.rootPorts = rootPorts
+        self.childPorts = childPorts
+    }
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        if executable.hasSuffix("ps") {
+            if arguments.first == "-ax" {
+                return Self.output("\(rootPID) 1\n\(childPID) \(rootPID)\n")
+            }
+            guard Self.selection(for: "-t", in: arguments).contains(ttyName) else {
+                return Self.noSelectedFiles()
+            }
+            return Self.output("\(rootPID) \(ttyName)\n\(childPID) \(ttyName)\n")
+        }
+        let requestedPIDs = Self.selection(for: "-p", in: arguments)
+        var lines = ""
+        if requestedPIDs.contains(String(rootPID)) {
+            lines += "p\(rootPID)\n"
+            for port in rootPorts { lines += "f3\nn127.0.0.1:\(port)\n" }
+        }
+        if requestedPIDs.contains(String(childPID)) {
+            lines += "p\(childPID)\n"
+            for port in childPorts { lines += "f3\nn127.0.0.1:\(port)\n" }
+        }
+        guard !lines.isEmpty else { return Self.noSelectedFiles() }
+        return Self.output(lines)
+    }
+
+    /// The comma-separated values the command was asked to select on.
+    private static func selection(for flag: String, in arguments: [String]) -> Set<String> {
+        guard let flagIndex = arguments.firstIndex(of: flag) else { return [] }
+        let valueIndex = arguments.index(after: flagIndex)
+        guard valueIndex < arguments.endIndex else { return [] }
+        return Set(arguments[valueIndex].split(separator: ",").map(String.init))
+    }
+
+    private static func output(_ stdout: String, stderr: String = "") -> CommandResult {
+        CommandResult(stdout: stdout, stderr: stderr, exitStatus: 0, timedOut: false, executionError: nil)
+    }
+
+    private static func noSelectedFiles() -> CommandResult {
+        CommandResult(stdout: "", stderr: "", exitStatus: 1, timedOut: false, executionError: nil)
     }
 }
 


### PR DESCRIPTION
## Summary

- Exclude an agent process's own listeners from sidebar port badges only while its captured process identity still matches. Child development servers remain eligible; a different process that reuses the old root PID must not be excluded.
- Apply the exclusion during panel, agent, and fresh-process-graph reconciliation so a later join does not reintroduce the root's proxy ports.
- Keep this independent of session-restore cleanup and OMP lifecycle changes. No new runtime dependency or configuration.

## Testing

- Regression-first history: `cc0b294adc` adds the tests; `44bb73791a` applies the fix.
- On unmodified upstream source, the five-test port-retirement suite failed only the new agent-root exclusion regression. Recycled-PID, listener-retirement, and PTY controls passed.
- With the native fixes applied, 61 Swift Testing cases in 17 suites and the session-restore XCTest passed. This was a combined native verification build containing this fix and the independent restore fix, not a full-project test-suite run on each split branch.
- Test wiring validation passed across 879 Swift test files.
- Live tagged-app smoke verification also observed the registered agent-root listener excluded while its child listener remained visible.

## Demo Video

No video was recorded during verification. This PR is a draft pending the behavior-demo video requested by the contribution template.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no new user-facing API or configuration)
- [ ] Attach a short behavior-demo video before marking ready for review
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

Review bots may run automatically; no additional second-model review is requested here, following AGENTS.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791855519&installation_model_id=21920&pr_number=12435&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12435&signature=5ade0b25e3a37194b14b231232f6536f5bade658459b9325198a1841af462cfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the port scanner from badging an agent root's own listeners while child dev servers launched by the agent keep their badges.

The exclusion keys off identity validation, not raw PID, so a different process that reuses a stale root PID still gets a badge. This applies during panel, agent, and fresh-process-graph reconciliation. Adds regression tests for both the agent-root exclusion and the recycled-PID case.

<sup>Written for commit 44bb73791a6c171886dc6b0aa8feacdc90b6c44b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

