### PR TITLE
fix(session): discard persisted listening ports on restore

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2394,11 +2394,12 @@ extension Workspace {
             panelGitBranches.removeValue(forKey: panelId)
         }
 
-        if snapshot.terminal?.hibernation != nil {
-            surfaceListeningPorts.removeValue(forKey: panelId)
-        } else {
-            surfaceListeningPorts[panelId] = Array(Set(snapshot.listeningPorts)).sorted()
-        }
+        // Listening ports are ephemeral runtime state: the snapshot's listeners
+        // are usually dead by relaunch, and a panel running a fullscreen agent
+        // never re-registers with PortScanner to correct them. Live listeners
+        // re-badge on the first scan burst, so restoring nothing is strictly
+        // more accurate than trusting the snapshot either way.
+        surfaceListeningPorts.removeValue(forKey: panelId)
 
         if let ttyName = snapshot.ttyName?.trimmingCharacters(in: .whitespacesAndNewlines), !ttyName.isEmpty {
             restorePersistedSurfaceTTYName(ttyName, panelId: panelId)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -3973,6 +3973,37 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertNotEqual(restoredTab.title, "Terminal")
     }
 
+    /// Regression for ghost port badges after app relaunch: listening ports are
+    /// ephemeral runtime state, but `applySessionPanelMetadata` restored them from
+    /// the session snapshot verbatim for any non-hibernated panel. A restored panel
+    /// running a fullscreen agent never returns to a shell prompt, so no
+    /// `report_tty`/`ports_kick` ever re-registers it with `PortScanner` — the
+    /// resurrected dead ports (e.g. Claude Code's rotated sandbox proxies) stayed on
+    /// the workspace card forever. Live listeners re-badge within the first scan
+    /// burst, so restoring nothing is strictly more accurate.
+    func testRestoreDoesNotResurrectPersistedListeningPorts() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
+
+        var snapshot = manager.sessionSnapshot(includeScrollback: false)
+        let workspaceIndex = try XCTUnwrap(snapshot.workspaces.firstIndex { $0.workspaceId == workspace.id })
+        let panelIndex = try XCTUnwrap(snapshot.workspaces[workspaceIndex].panels.firstIndex { $0.id == panelId })
+        snapshot.workspaces[workspaceIndex].panels[panelIndex].listeningPorts = [62181, 62191]
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+        drainMainQueue()
+
+        let restoredWorkspace = try XCTUnwrap(restored.selectedWorkspace)
+        XCTAssertTrue(
+            restoredWorkspace.surfaceListeningPorts.values.flatMap(\.self).isEmpty,
+            "Persisted listening ports must not be resurrected on restore"
+        )
+        XCTAssertTrue(restoredWorkspace.listeningPorts.isEmpty)
+    }
+
     private static func persistentSSHWorkspaceSnapshot(
         panel: SessionPanelSnapshot,
         focusedPanelId: UUID


### PR DESCRIPTION
## Summary

- Do not restore cached listening ports as current sidebar state. Ports describe live processes, not durable session metadata.
- Clear restored panel port state and recompute the workspace aggregate; current scanning can repopulate it from live listeners.
- Preserve the snapshot schema and decoding compatibility. This PR is independent of agent-root port filtering and includes no OMP lifecycle changes.

## Testing

- Regression-first history: `5fb21479eb` adds the test; `eaf49a00a4` applies the fix.
- `TabManagerSessionSnapshotTests.testRestoreDoesNotResurrectPersistedListeningPorts` failed two assertions against unmodified upstream source, then passed with the fix.
- With the native fixes applied, the restore XCTest plus 61 Swift Testing cases in 17 suites passed. This was a combined native verification build containing this fix and the independent agent-root exclusion fix, not a full-project test-suite run on each split branch.
- Test wiring validation passed across 879 Swift test files.
- No new video-based manual verification is claimed for the split branch.

## Demo Video

No video was recorded during verification. This PR is a draft pending the behavior-demo video requested by the contribution template.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (snapshot format and public configuration are unchanged)
- [ ] Attach a short behavior-demo video before marking ready for review
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

Review bots may run automatically; no additional second-model review is requested here, following AGENTS.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791855519&installation_model_id=21920&pr_number=12436&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12436&signature=090a076dcda7b6951a355635613ac161dd248e9b9b3dff508c146ac6015ac652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops restoring cached listening ports on session restore so relaunched workspaces no longer show ghost port badges for dead processes.

Restore used to write the snapshot's listening ports back into `surfaceListeningPorts` for non-hibernated panels; now it clears them for every panel and lets the port scanner repopulate them from live listeners. This fixes the case where a restored panel running a fullscreen agent never re-registers with `PortScanner`, leaving stale ports on the workspace card forever. The snapshot schema and decoding behavior are unchanged.

**Bug Fixes**
- Adds a regression test verifying that persisted listening ports are ignored during restore.

<sup>Written for commit eaf49a00a470e24e80c6a57b30569295ff0557cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

