### PR TITLE
Hide Cloud workspaces without terminals

### DIFF
--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -881,10 +881,8 @@ enum CloudTreeNodeBuilder {
         return children
     }
 
-    /// The Workspaces group is a placement projection of the daemon graph. A
-    /// resource can appear once for every exact tab view, while an empty workspace
-    /// still gets a row from machine info. This is the sole tree construction path
-    /// for workspace rows, so ordering and rename identity cannot diverge.
+    /// Builds terminal-backed Cloud workspace rows; empty daemon workspaces remain
+    /// available to lookup and persistence but are omitted from the sidebar.
     private static func workspacesGroupNode(
         machine: SurfaceMachineID,
         info: SurfaceMachineInfo,
@@ -912,7 +910,7 @@ enum CloudTreeNodeBuilder {
             rows.displays.append(RemoteResourcePlacement(resource: member.resource, workspace: rows.workspace, view: nil))
             byWorkspace[member.workspaceID] = rows
         }
-        let workspaces = byWorkspace.values.sorted { lhs, rhs in
+        let workspaces = byWorkspace.values.filter { !$0.terminals.isEmpty }.sorted { lhs, rhs in
             lhs.workspace.index != rhs.workspace.index ? lhs.workspace.index < rhs.workspace.index : lhs.workspace.id < rhs.workspace.id
         }
         let workspaceNodes = workspaces.map { rows in

--- a/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
+++ b/Sources/Cloud/CloudTreeRemoteWorkspaces.swift
@@ -34,8 +34,9 @@ enum CloudTreeRemoteWorkspaceLookup: Equatable {
 
 extension CloudTreeNodeBuilder {
     /// Every cmux-tui workspace on a machine, in the daemon's order: the ones the
-    /// machine itself reports (so an empty workspace still gets a row) plus any
-    /// that a resource's views name before the machine list has caught up.
+    /// machine itself reports (including empty workspaces needed by lookup and
+    /// persistence) plus any that a resource's views name before the machine list
+    /// has caught up. The sidebar applies its terminal-membership filter separately.
     static func remoteWorkspaces(info: SurfaceMachineInfo?, resources: [SurfaceResource]) -> [SurfaceRemoteWorkspace] {
         var byID: [String: SurfaceRemoteWorkspace] = [:]
         for workspace in info?.remoteWorkspaces ?? [] {

--- a/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
+++ b/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
@@ -73,6 +73,8 @@ struct CloudSidebarSurfaceRegressionTests {
     @MainActor
     func workspaceVisibilityFollowsDaemonChanges(incremental: Bool) throws {
         let catalog = SurfaceCatalog()
+        let provider = CloudPlacementTestProvider(machine: machine)
+        catalog.register(provider)
         let initial = try visibilityState()
         publishVisibility(initial, to: catalog, incremental: false)
         #expect(workspaceIDs(catalog.snapshot) == ["ws_side"])
@@ -135,9 +137,10 @@ struct CloudSidebarSurfaceRegressionTests {
         let returned = try #require(catalog.resources[terminalID])
         // Terminal kill and accepted create receipts update resources before the
         // next complete graph; both must update visibility without a fleet poll.
-        catalog.remove(terminalID)
+        catalog.remove(terminalID, from: provider)
+        #expect(catalog.resources[terminalID] == nil)
         #expect(workspaceRows(catalog.snapshot).isEmpty)
-        catalog.upsert(returned)
+        catalog.upsert(returned, from: provider)
         #expect(workspaceIDs(catalog.snapshot) == ["ws_main"])
         publishVisibility(try #require(catalog.cloudStates[machine]), to: catalog, incremental: false)
         #expect(workspaceIDs(catalog.snapshot) == ["ws_main"], "a full refresh agrees with the event stream")
@@ -169,14 +172,17 @@ struct CloudSidebarSurfaceRegressionTests {
     @MainActor
     func retainedAndLegacyTerminalsRemainVisible(lifecycle: SurfaceLifecycle) throws {
         let catalog = SurfaceCatalog()
+        let provider = CloudPlacementTestProvider(machine: machine)
+        catalog.register(provider)
         publishVisibility(try visibilityState(), to: catalog, incremental: false)
         var terminal = try #require(catalog.snapshot.resources.first { $0.kind == .terminal })
         terminal.lifecycle = lifecycle
         terminal.remoteViews = nil
-        catalog.upsert(terminal)
+        catalog.upsert(terminal, from: provider)
         #expect(workspaceIDs(catalog.snapshot) == ["ws_side"], "retained terminal output is valid workspace content")
         terminal.remoteViews = []
-        catalog.upsert(terminal)
+        catalog.upsert(terminal, from: provider)
+        #expect(catalog.resources[terminal.id]?.remoteViews == [])
         #expect(workspaceRows(catalog.snapshot).isEmpty, "explicit detachment overrides a legacy workspace hint")
     }
 

--- a/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
+++ b/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
@@ -68,4 +68,180 @@ struct CloudSidebarSurfaceRegressionTests {
             return false
         })
     }
+
+    @Test("Cloud workspaces disappear on the last terminal move or close and return on creation", arguments: [false, true])
+    @MainActor
+    func workspaceVisibilityFollowsDaemonChanges(incremental: Bool) throws {
+        let catalog = SurfaceCatalog()
+        let initial = try visibilityState()
+        publishVisibility(initial, to: catalog, incremental: false)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_side"])
+
+        // Repro: the focused, empty workspace acquires a terminal, which then
+        // moves into another workspace while the original daemon record survives.
+        try updateVisibility([
+            ["kind": "upsert", "resource": "tab", "id": "tab_new", "value": terminalTab(pane: "pane_main")],
+            ["kind": "upsert", "resource": "terminal", "id": "term_new", "value": [
+                "id": "term_new", "title": "New shell", "lifecycle": "running"
+            ]]
+        ], in: catalog, incremental: incremental)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_main", "ws_side"])
+        let created = catalog.snapshot
+        let localWorkspace = UUID()
+        let terminalID = SurfaceResourceID(machine: machine, kind: .terminal, key: "term_new")
+        catalog.record(SurfaceProjection(
+            resource: terminalID, workspaceID: localWorkspace, panelID: UUID(),
+            remoteWorkspaceID: "ws_main", remoteTabID: "tab_new"
+        ))
+        let openRow = try #require(workspaceRows(catalog.snapshot).first { $0.searchableTitle == "main" })
+        guard case .workspace(_, let workspace, let count, _, let openIn) = openRow.kind else {
+            Issue.record("Expected the created workspace row")
+            return
+        }
+        #expect(workspace.focused && count == 1 && openIn == localWorkspace)
+
+        try updateVisibility([
+            ["kind": "upsert", "resource": "tab", "id": "tab_new", "value": terminalTab(pane: "pane_side")]
+        ], in: catalog, incremental: incremental)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_side"], "stale local projections and daemon focus cannot keep an empty row")
+        #expect(CloudTreeNodeBuilder.structureSignature(visibilityNodes(created)) !=
+            CloudTreeNodeBuilder.structureSignature(visibilityNodes(catalog.snapshot)))
+        #expect(catalog.cloudStates[machine]?.workspaces.first?.focused == true)
+        #expect(CloudTreeNodeBuilder.lookupRemoteWorkspace("ws_main", on: machine, snapshot: catalog.snapshot) ==
+            .found(workspace, .none))
+
+        try updateVisibility([
+            ["kind": "delete", "resource": "tab", "id": "tab_existing"],
+            ["kind": "delete", "resource": "terminal", "id": "term_existing"]
+        ], in: catalog, incremental: incremental)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_side"], "removing one of two terminals keeps the workspace")
+        try updateVisibility([
+            ["kind": "delete", "resource": "tab", "id": "tab_new"]
+        ], in: catalog, incremental: incremental)
+        #expect(workspaceRows(catalog.snapshot).isEmpty)
+        #expect(catalog.resources[terminalID]?.remoteViews == [])
+        #expect(CloudTreeNodeBuilder.flattened(visibilityNodes(catalog.snapshot)).contains {
+            $0.id == CloudTreeNodeBuilder.nodeID(resource: terminalID)
+        }, "detaching a terminal preserves its process in the machine pool")
+        #expect(catalog.cloudStates[machine]?.workspaces.count == 2)
+        #expect(CloudTreeNodeBuilder.flattened(visibilityNodes(catalog.snapshot)).contains {
+            $0.id == CloudTreeNodeBuilder.nodeID(workspacesPlaceholder: machine)
+        })
+
+        try updateVisibility([
+            ["kind": "upsert", "resource": "tab", "id": "tab_new", "value": terminalTab(pane: "pane_main")]
+        ], in: catalog, incremental: incremental)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_main"])
+        let returned = try #require(catalog.resources[terminalID])
+        // Terminal kill and accepted create receipts update resources before the
+        // next complete graph; both must update visibility without a fleet poll.
+        catalog.remove(terminalID)
+        #expect(workspaceRows(catalog.snapshot).isEmpty)
+        catalog.upsert(returned)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_main"])
+        publishVisibility(try #require(catalog.cloudStates[machine]), to: catalog, incremental: false)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_main"], "a full refresh agrees with the event stream")
+    }
+
+    @Test("Visibility preserves workspace metadata and nonterminal content")
+    @MainActor
+    func hiddenWorkspacesKeepPersistentState() throws {
+        let catalog = SurfaceCatalog()
+        var document = try #require(visibilityState().snapshotObject())
+        document["terminals"] = [] as [[String: Any]]
+        document["tabs"] = [
+            ["id": "tab_docs", "pane_id": "pane_main", "content_kind": "browser", "content_id": "docs"],
+            ["id": "tab_desktop", "pane_id": "pane_side", "content_kind": "display", "content_id": "display:1"]
+        ]
+        document["browsers"] = [["id": "docs", "tab_id": "tab_docs", "title": "Docs", "url": "https://cmux.com/docs"]]
+        let state = try #require(CmuxTuiSnapshotParser.state(fromSnapshot: document, machine: machine))
+        publishVisibility(state, to: catalog, incremental: false)
+        let before = catalog.snapshot
+        #expect(workspaceRows(catalog.snapshot).isEmpty)
+        #expect(catalog.snapshot == before && catalog.cloudStates[machine] == state, "visibility never deletes persistent state")
+        #expect(try catalog.remoteWorkspaceGroup(machine: machine, workspaceID: "ws_main").placements.count == 1)
+        #expect(try catalog.remoteWorkspaceGroup(machine: machine, workspaceID: "ws_side").placements.count == 1)
+    }
+
+    @Test("Workspace visibility counts retained and legacy terminal placements", arguments: [
+        SurfaceLifecycle.launching, .running, .exited, .unavailable
+    ])
+    @MainActor
+    func retainedAndLegacyTerminalsRemainVisible(lifecycle: SurfaceLifecycle) throws {
+        let catalog = SurfaceCatalog()
+        publishVisibility(try visibilityState(), to: catalog, incremental: false)
+        var terminal = try #require(catalog.snapshot.resources.first { $0.kind == .terminal })
+        terminal.lifecycle = lifecycle
+        terminal.remoteViews = nil
+        catalog.upsert(terminal)
+        #expect(workspaceIDs(catalog.snapshot) == ["ws_side"], "retained terminal output is valid workspace content")
+        terminal.remoteViews = []
+        catalog.upsert(terminal)
+        #expect(workspaceRows(catalog.snapshot).isEmpty, "explicit detachment overrides a legacy workspace hint")
+    }
+
+    private func visibilityState() throws -> CloudVMState {
+        let ids = ["main", "side"]
+        let document: [String: Any] = [
+            "cursor": ["generation": "visibility", "revision": "1"],
+            "workspaces": ids.enumerated().map {
+                ["id": "ws_\($0.element)", "name": $0.element, "index": $0.offset, "focused": $0.offset == 0] as [String: Any]
+            },
+            "screens": ids.map { ["id": "screen_\($0)", "workspace_id": "ws_\($0)"] },
+            "panes": ids.map { ["id": "pane_\($0)", "screen_id": "screen_\($0)"] },
+            "tabs": [["id": "tab_existing", "pane_id": "pane_side", "content_kind": "terminal", "content_id": "term_existing"]],
+            "terminals": [["id": "term_existing", "title": "Existing shell", "lifecycle": "running"]],
+            "browsers": [], "agents": []
+        ]
+        return try #require(CmuxTuiSnapshotParser.state(fromSnapshot: document, machine: machine))
+    }
+
+    private func terminalTab(pane: String) -> [String: Any] {
+        ["id": "tab_new", "pane_id": pane, "content_kind": "terminal", "content_id": "term_new"]
+    }
+
+    @MainActor
+    private func updateVisibility(_ changes: [[String: Any]], in catalog: SurfaceCatalog, incremental: Bool) throws {
+        let previous = try #require(catalog.cloudStates[machine])
+        let cursor = try #require(previous.cursor)
+        let next = CloudVMCursor(generation: cursor.generation, revision: cursor.revision + 1)
+        let delta: [String: Any] = [
+            "kind": "delta", "previous_revision": String(cursor.revision), "revision": String(next.revision),
+            "changes": changes
+        ]
+        let state = try #require(CmuxTuiSnapshotParser.applying(
+            deltaPayload: JSONSerialization.data(withJSONObject: delta), cursor: next, to: previous
+        ))
+        publishVisibility(state, to: catalog, incremental: incremental)
+    }
+
+    @MainActor
+    private func publishVisibility(_ state: CloudVMState, to catalog: SurfaceCatalog, incremental: Bool) {
+        let info = SurfaceMachineInfo(
+            id: machine, name: machine.rawValue, status: "running", image: nil, hasDesktop: true,
+            memoryMb: nil, diskMb: nil, linkState: .connected, linkError: nil,
+            cpuPercent: nil, memoryUsedMb: nil, diskUsedMb: nil,
+            remoteWorkspaces: state.workspaces.map {
+                SurfaceRemoteWorkspace(id: $0.id, name: $0.name, index: $0.index, focused: $0.focused)
+            }
+        )
+        let resources = CmuxTuiSnapshotParser.resources(from: state)
+        if incremental { catalog.applyCloudStateDelta(state, resources: resources, info: info) }
+        else { catalog.replaceCloudState(state, resources: resources, info: info) }
+    }
+
+    private func visibilityNodes(_ snapshot: SurfaceCatalogSnapshot) -> [CloudTreeNode] {
+        CloudTreeNodeBuilder.nodes(machines: [], snapshot: snapshot, localWorkspaces: [], includeLocalMachine: false)
+    }
+
+    private func workspaceRows(_ snapshot: SurfaceCatalogSnapshot) -> [CloudTreeNode] {
+        CloudTreeNodeBuilder.flattened(visibilityNodes(snapshot)).filter { $0.structureTag == "workspace" }
+    }
+
+    private func workspaceIDs(_ snapshot: SurfaceCatalogSnapshot) -> [String] {
+        workspaceRows(snapshot).compactMap {
+            if case .workspace(_, let workspace, _, _, _) = $0.kind { return workspace.id }
+            return nil
+        }
+    }
 }

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -849,7 +849,7 @@ struct CloudTreeOneMachineManyWorkspacesTests {
             "the machine lists it, so it exists — with nothing in it"
         )
         #expect(CloudTreeNodeBuilder.lookupRemoteWorkspace("scratch", on: machine, snapshot: snapshot) == .ambiguous([scratchA, scratchB]))
-        // The rows agree: both scratch workspaces show under the one machine, each empty.
-        #expect(rows(snapshot).filter { $0.structureTag == "workspace" }.map(\.children.count) == [0, 0])
+        // Empty daemon workspaces remain resolvable, but the Cloud sidebar omits them.
+        #expect(rows(snapshot).filter { $0.structureTag == "workspace" }.isEmpty)
     }
 }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -439,9 +439,9 @@ final class MachinesPanelModelTests: XCTestCase {
             includeLocalMachine: true
         )
         let ids = CloudTreeNodeBuilder.flattened(nodes).map(\.id)
-        // One machine, many workspaces: the Workspaces group leads (every workspace the
-        // machine reports, pointer rows under each), then Ports, VNC Displays (one row
-        // per screen), and last, its own section, Terminals (every terminal the machine owns).
+        // One machine, many workspaces: the Workspaces group leads (nonempty workspace
+        // pointers), then Ports, VNC Displays (one row per screen), and last, its own
+        // section, Terminals (every terminal the machine owns).
         XCTAssertEqual(ids, [
             "machine:local",
             "machine:local/ws/\(local.uuidString)",
@@ -450,12 +450,9 @@ final class MachinesPanelModelTests: XCTestCase {
             "machine:vivid-newt/workspaces",
             "machine:vivid-newt/ws/ws_main",
             "machine:vivid-newt/ws/ws_main/resource:vivid-newt/terminal/term_1/tab:tab_1",
-            "machine:vivid-newt/ws/ws_main/resource:vivid-newt/display/display:1",
             "machine:vivid-newt/ws/ws_side",
             "machine:vivid-newt/ws/ws_side/resource:vivid-newt/terminal/term_1/tab:tab_9",
             "machine:vivid-newt/ws/ws_side/resource:vivid-newt/display/display:1/tab:tab_desk",
-            "machine:vivid-newt/ws/ws_empty",
-            "machine:vivid-newt/ws/ws_empty/resource:vivid-newt/display/display:1",
             "machine:vivid-newt/ports",
             "resource:vivid-newt/browser/port:3000",
             "machine:vivid-newt/displays",
@@ -503,20 +500,15 @@ final class MachinesPanelModelTests: XCTestCase {
         if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_side"]!.kind {
             XCTAssertEqual(openIn, remoteSideLocalWorkspace, "term_1's second remote view uses its own local workspace")
         } else { XCTFail("expected ws_side row") }
-        if case .workspace(_, _, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
-            XCTAssertNil(openIn, "nothing of it is open anywhere")
-        } else { XCTFail("expected ws_empty row") }
+        XCTAssertNil(openByID["machine:vivid-newt/ws/ws_empty"], "empty workspaces are omitted from the Cloud sidebar")
         // Desktop rows: a workspace's own display pointer opens inside the local
         // workspace showing that remote workspace; the pool row keeps the global jump.
-        if case .display(_, let openIn, _) = openByID["machine:vivid-newt/ws/ws_main/resource:vivid-newt/display/display:1"]!.kind {
-            XCTAssertEqual(openIn, local, "ws_main shows locally, so its Desktop opens there")
-        } else { XCTFail("expected ws_main display row") }
+        if case .display(_, let openIn, _) = openByID["machine:vivid-newt/ws/ws_side/resource:vivid-newt/display/display:1/tab:tab_desk"]!.kind {
+            XCTAssertEqual(openIn, remoteSideLocalWorkspace, "the actual desktop placement opens in ws_side")
+        } else { XCTFail("expected ws_side display row") }
         if case .display(_, let openIn, _) = openByID["resource:vivid-newt/display/display:1"]!.kind {
             XCTAssertNil(openIn, "the pool Desktop keeps the global open-or-focus")
         } else { XCTFail("expected pool display row") }
-        if case .display(_, let openIn, _) = openByID["machine:vivid-newt/ws/ws_empty/resource:vivid-newt/display/display:1"]!.kind {
-            XCTAssertNil(openIn, "ws_empty shows nowhere locally")
-        } else { XCTFail("expected ws_empty display row") }
         XCTAssertNil(CloudTreeNodeBuilder.localWorkspaceShowing(
             remoteWorkspaceID: wsEmpty.id,
             placements: [],
@@ -527,8 +519,7 @@ final class MachinesPanelModelTests: XCTestCase {
             CloudTreeNodeBuilder.flattened(nodes).first { $0.id == "machine:vivid-newt/ws/ws_side" }?.dragGroup?.resources,
             [remoteA.id, display.id]
         )
-        // An implicit display row (no view pins it) shows under the workspace but
-        // stays out of the workspace's open/drag group.
+        // The workspace's open/drag group carries only actual remote placements.
         XCTAssertEqual(
             CloudTreeNodeBuilder.flattened(nodes).first { $0.id == "machine:vivid-newt/ws/ws_main" }?.dragGroup?.resources,
             [remoteA.id]
@@ -555,11 +546,7 @@ final class MachinesPanelModelTests: XCTestCase {
             XCTAssertEqual(row.resource.agent?.source, "claude")
             XCTAssertEqual(row.remoteView?.tabID, "tab_9")
         } else { XCTFail("expected pointer row") }
-        // The empty workspace still gets a row (from the machine info), with no pointers.
-        if case .workspace(_, let workspace, let count, _, _) = byID["machine:vivid-newt/ws/ws_empty"]!.kind {
-            XCTAssertEqual(workspace.name, "scratch")
-            XCTAssertEqual(count, 0)
-        } else { XCTFail("expected empty workspace row") }
+        XCTAssertNil(byID["machine:vivid-newt/ws/ws_empty"], "zero-terminal workspaces are not sidebar rows")
         if case .terminalsPool(_, let count) = byID["machine:vivid-newt/terminals"]!.kind {
             XCTAssertEqual(count, 2, "every terminal the machine owns")
         } else { XCTFail("expected terminals pool") }
@@ -573,13 +560,12 @@ final class MachinesPanelModelTests: XCTestCase {
         if case .localWorkspace(let row) = flattened[1].kind { XCTAssertEqual(row.title, "cmux90"); XCTAssertTrue(row.isSelected) } else { XCTFail("expected local workspace") }
         XCTAssertEqual(flattened.compactMap { $0.dragResource?.id.rawValue }, [
             "local/terminal/AAA",
+            "vivid-newt/terminal/term_1",
             "vivid-newt/terminal/term_1", "vivid-newt/display/display:1",
-            "vivid-newt/terminal/term_1", "vivid-newt/display/display:1",
-            "vivid-newt/display/display:1",
             "vivid-newt/browser/port:3000",
             "vivid-newt/display/display:1",
             "vivid-newt/terminal/term_1", "vivid-newt/terminal/term_2",
-        ], "one drag resource per pointer (or implicit display) row, then the port, the screen, then the Terminals rows")
+        ], "one drag resource per actual pointer row, then the port, the screen, then the Terminals rows")
         XCTAssertTrue(flattened[0].isMachineRow)
         XCTAssertTrue(flattened[3].isMachineRow)
         XCTAssertEqual(flattened[3].machine, .cloud("vivid-newt"))


### PR DESCRIPTION
After a terminal moves or closes, cmux-tui can retain its empty workspace record. The Cloud outline now includes a workspace only while it has terminal placements, and derives that visibility again on every catalog update. A terminal created or placed back into the workspace restores its row.

Workspace records, focus, saved content, and CLI lookup remain intact. Retained exited terminals and legacy terminal placements still count. The requested terminal-only listing also omits browser/display-only workspace rows; their content remains available through workspace lookup/open and the machine resource pools.

Closes https://github.com/manaflow-ai/cmux/issues/12405

## Validation

- Regression commit: `427f7a12c9bf5ca1b48be46872cf2d781a0d7617` (tests before the fix).
- Fix commit: `467f2f20eb18ffe2b8c771f7a9c530255b44342b`.
- Tests exercise daemon snapshots/deltas through the catalog for creation, movement, partial removal, detachment, return, immediate resource removal/upsert, persistent state, and retained/legacy terminals.
- Test target wiring: passed.
- Swift file length check: passed. This clone has no `.github/swift-file-length-budget.tsv`; its checker compares existing files against the merge-base lengths. No budget overrides or warning-budget edits.
- Localization audit: sidebar visibility changes only; no new user-facing strings. Six catalogs checked across all nine locales, with zero parity errors.
- Fleet tagged Debug build on pushed HEAD: passed; no diagnostics in either changed production Swift file. The global warning checker flags four existing diagnostics in unchanged CLI/CloudOperationRecorder files; warning budgets were left untouched. The test target also retains its existing XCTest import warning, present in the before-fix run; no new warning was introduced.
- [Before-fix regression run](https://github.com/manaflow-ai/cmux/actions/runs/34732931156): failed on empty rows as expected.
- [Final regression run](https://github.com/manaflow-ai/cmux/actions/runs/34733728100): passed all 7 tests (17 parameterized cases), with the selected-test execution guard confirming execution. No local Xcode tests were run.

- Dogfood: [issue-12405-hide-empty-cloud](http://127.0.0.1:17320/issue-12405-hide-empty-cloud), built with hosted Cloud endpoints. The same tagged app launched on a leased Mac and answered identify/workspace/capture-pane commands.
- Manual limitation: the live Cloud create/reattach sequence was not exercised. The required ~/.secrets/cmuxterm-dev.env file has no complete agent credential pair, so the live Cloud flow could not be authenticated; no demo video is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud sidebar workspace rows now appear only when the workspace contains terminal placements.
  - Empty workspaces remain available for lookup and persistence but are no longer displayed as sidebar rows.
  - Workspace visibility now updates correctly when terminals are created, moved, detached, or closed.
  - Non-terminal content, such as browser and display tabs, no longer causes a workspace to appear in the sidebar.
  - Retained and legacy terminal placements continue to display correctly throughout their lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->