### PR TITLE
Cloud shortcuts inherit the active remote working directory

### DIFF
--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -201,6 +201,20 @@ struct CloudTuiCommandLine: Sendable {
         return arguments
     }
 
+    /// `terminal <term_id> process show` (spec `terminal.process.get`): reads
+    /// the foreground process cwd live from the PTY's controlling terminal.
+    static func processInfoArguments(socketPath: String, terminalID: String) -> [String] {
+        ["--socket", socketPath, "--json", "terminal", terminalID, "process", "show"]
+    }
+
+    /// Extracts the live foreground cwd. The sibling `cwd` field is the spawn
+    /// directory and is stale after the shell changes directory.
+    static func foregroundWorkingDirectory(fromProcessInfo result: [String: Any]) -> String? {
+        guard let cwd = result["foreground_cwd"] as? String else { return nil }
+        let trimmed = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// `terminal <term_id> output read [--after <offset>] [--max-bytes <n>]` (spec
     /// `terminal.output_read`): the terminal's retained OUTPUT as text — the whole build log,
     /// not the 24 rows currently on screen — with `{text, start_offset, next_offset, complete}`;

--- a/Sources/Surfaces/CmuxTuiSurfaceProvider+TerminalIO.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProvider+TerminalIO.swift
@@ -6,6 +6,31 @@ import Foundation
 /// completion and give me the result" into `wait-exit` + `output` instead of a prompt
 /// regex and a screenful of text.
 extension CmuxTuiSurfaceProvider {
+    /// Returns the cwd of the process group currently owning the remote PTY.
+    /// This is deliberately a live process query: the snapshot's `cwd` is the
+    /// terminal's spawn directory and remains stale after a remote `cd`.
+    func currentWorkingDirectory(of resource: SurfaceResource) async -> String? {
+        guard resource.kind == .terminal else { return nil }
+        do {
+            let connected = try await links.connected(machineID: machineID)
+            guard let link = await links.link(machineID: machineID) else { return nil }
+            let data = try await link.run(
+                arguments: CloudTuiCommandLine.processInfoArguments(
+                    socketPath: connected.socketPath,
+                    terminalID: resource.id.key
+                )
+            )
+            guard let result = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return CloudTuiCommandLine.foregroundWorkingDirectory(fromProcessInfo: result)
+        } catch {
+            // Directory inheritance is best effort. A daemon without the process
+            // query capability must retain the existing workspace fallback.
+            return nil
+        }
+    }
+
     /// Block until the remote terminal's process exits or `timeoutMs` elapses (the same
     /// clamp as `waitForScreen`: nil/non-positive → 30 s, at most an hour). The daemon's
     /// answer: `{state: "exited", terminal_id, lifecycle, outcome: {kind: exit, code} |

--- a/Sources/Surfaces/SurfaceProvider.swift
+++ b/Sources/Surfaces/SurfaceProvider.swift
@@ -26,6 +26,10 @@ protocol SurfaceProvider: AnyObject {
     /// Create a new terminal on this machine (remote providers create it in the cmux-tui
     /// session; the local provider spawns a shell) and return its resource.
     func createTerminal(command: [String]?, cwd: String?, name: String?, remoteWorkspaceID: String?) async throws -> SurfaceResource
+    /// Read the live working directory of a terminal's foreground process. Remote
+    /// providers use this when a shortcut creates a sibling terminal; providers that
+    /// cannot inspect a process return nil and preserve their normal daemon fallback.
+    func currentWorkingDirectory(of resource: SurfaceResource) async -> String?
     /// Called when a pane projecting one of this provider's resources goes away. Remote
     /// providers do nothing (the resource lives on); the local provider drops the resource.
     func projectionDidEnd(_ projection: SurfaceProjection)
@@ -63,6 +67,10 @@ extension SurfaceProvider {
 
     func refresh(force: Bool) async {
         await refresh()
+    }
+
+    func currentWorkingDirectory(of resource: SurfaceResource) async -> String? {
+        nil
     }
 
     func materialize(_ resource: SurfaceResource, remoteView: SurfaceRemoteView?, at destination: SurfaceDestination, focus: Bool) async throws -> SurfaceProjection {

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -45,9 +45,7 @@ extension Workspace {
         )
     }
 
-    /// Routes a bonsplit UI split (the pane-divider split button) whose source pane
-    /// projects a cloud resource: the already-created empty pane receives the machine's
-    /// new terminal as its first tab. Returns false when the source is not cloud-anchored.
+    /// Routes a bonsplit UI split whose source pane projects a cloud resource.
     func routeCloudPaneUISplit(from sourcePanelID: UUID, into newPane: PaneID) -> Bool {
         guard let resource = cloudProjectedResource(forPanel: sourcePanelID) else { return false }
         return routeCloudPaneTerminalCreate(
@@ -84,8 +82,9 @@ extension Workspace {
         let machine = resource.machine
         Task { @MainActor in
             do {
+                let workingDirectory = await provider.currentWorkingDirectory(of: resource)
                 let created = try await provider.createTerminal(
-                    command: nil, cwd: nil, name: nil, remoteWorkspaceID: remoteWorkspaceID
+                    command: nil, cwd: workingDirectory, name: nil, remoteWorkspaceID: remoteWorkspaceID
                 )
                 _ = try await catalog.project(
                     created.id,

--- a/cmuxTests/SurfacePaneFactoryFocusTests.swift
+++ b/cmuxTests/SurfacePaneFactoryFocusTests.swift
@@ -38,6 +38,96 @@ import Testing
         #expect(workspace.panelIdFromSurfaceId(selectedSurface) == created.panelID)
     }
 
+    @Test("Cloud shortcut inheritance uses the live remote foreground cwd")
+    func cloudShortcutInheritanceUsesLiveRemoteForegroundCwd() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let sourcePanelID = try #require(workspace.focusedPanelId)
+        let machine = SurfaceMachineID.cloud("cwd-\(UUID().uuidString)")
+        let provider = CloudCreationProvider(machine: machine, workingDirectory: "/remote/project-a")
+        let catalog = SurfaceCatalog.shared
+        catalog.register(provider)
+        defer { catalog.unregister(machine: machine) }
+
+        let remoteWorkspace = SurfaceRemoteWorkspace(id: "ws-project", name: "project", index: 0, focused: true)
+        let resource = SurfaceResource(
+            id: SurfaceResourceID(machine: machine, kind: .terminal, key: "term-source"),
+            title: "shell",
+            // The public snapshot cwd is the spawn directory. The provider's live
+            // process query below is deliberately different.
+            detail: "/remote/home",
+            lifecycle: .running,
+            agent: nil,
+            remoteWorkspace: remoteWorkspace,
+            remoteViews: [SurfaceRemoteView(tabID: "tab-source", workspace: remoteWorkspace)],
+            port: nil,
+            url: nil
+        )
+        catalog.upsert(resource, from: provider)
+        catalog.record(SurfaceProjection(
+            resource: resource.id,
+            workspaceID: workspace.id,
+            panelID: sourcePanelID,
+            remoteWorkspaceID: remoteWorkspace.id,
+            remoteTabID: "tab-source"
+        ))
+
+        #expect(workspace.routeCloudPaneTerminalTab(inPane: paneID, focus: false))
+        for _ in 0..<20 where provider.createdWorkingDirectory == nil {
+            await Task.yield()
+        }
+        #expect(provider.createdWorkingDirectory == "/remote/project-a")
+        #expect(provider.createdRemoteWorkspaceID == remoteWorkspace.id)
+    }
+
+    @MainActor
+    private final class CloudCreationProvider: SurfaceProvider {
+        let machine: SurfaceMachineID
+        let info: SurfaceMachineInfo
+        let workingDirectory: String?
+        private(set) var createdWorkingDirectory: String?
+        private(set) var createdRemoteWorkspaceID: String?
+
+        init(machine: SurfaceMachineID, workingDirectory: String?) {
+            self.machine = machine
+            self.workingDirectory = workingDirectory
+            info = SurfaceMachineInfo(
+                id: machine, name: machine.rawValue, status: "running", image: nil,
+                hasDesktop: false, memoryMb: nil, diskMb: nil, linkState: .connected,
+                linkError: nil, cpuPercent: nil, memoryUsedMb: nil, diskUsedMb: nil
+            )
+        }
+
+        func refresh() async {}
+
+        func currentWorkingDirectory(of _: SurfaceResource) async -> String? {
+            workingDirectory
+        }
+
+        func createTerminal(command _: [String]?, cwd: String?, name: String?, remoteWorkspaceID: String?) async throws -> SurfaceResource {
+            createdWorkingDirectory = cwd
+            createdRemoteWorkspaceID = remoteWorkspaceID
+            return SurfaceResource(
+                id: SurfaceResourceID(machine: machine, kind: .terminal, key: "term-created"),
+                title: name ?? "shell",
+                detail: cwd,
+                lifecycle: .launching,
+                agent: nil,
+                remoteWorkspace: nil,
+                port: nil,
+                url: nil
+            )
+        }
+
+        func materialize(_ resource: SurfaceResource, at destination: SurfaceDestination, focus _: Bool) async throws -> SurfaceProjection {
+            SurfaceProjection(resource: resource.id, workspaceID: destination.workspaceID, panelID: UUID())
+        }
+
+        func projectionDidEnd(_: SurfaceProjection) {}
+    }
+
     @Test func unfocusedTabStaysBehindTheCurrentOne() throws {
         let harness = try Harness()
         defer { harness.tearDown() }

--- a/cmuxTests/SurfacePaneFactoryFocusTests.swift
+++ b/cmuxTests/SurfacePaneFactoryFocusTests.swift
@@ -82,6 +82,21 @@ import Testing
         #expect(provider.createdRemoteWorkspaceID == remoteWorkspace.id)
     }
 
+    @Test("Cloud process cwd parsing ignores the recorded spawn directory")
+    func cloudProcessCwdParsingIgnoresSpawnDirectory() {
+        #expect(CloudTuiCommandLine.processInfoArguments(socketPath: "/tmp/cloud.sock", terminalID: "term-source") == [
+            "--socket", "/tmp/cloud.sock", "--json", "terminal", "term-source", "process", "show"
+        ])
+        #expect(CloudTuiCommandLine.foregroundWorkingDirectory(fromProcessInfo: [
+            "cwd": "/remote/home",
+            "foreground_cwd": "/remote/project-a"
+        ]) == "/remote/project-a")
+        #expect(CloudTuiCommandLine.foregroundWorkingDirectory(fromProcessInfo: [
+            "cwd": "/remote/home",
+            "foreground_cwd": ""
+        ]) == nil)
+    }
+
     @MainActor
     private final class CloudCreationProvider: SurfaceProvider {
         let machine: SurfaceMachineID


### PR DESCRIPTION
## Problem
Cloud keyboard shortcuts that create a terminal, tab, or split start the new remote shell in the machine home directory instead of the active source terminal's current remote directory.

## Change
Cloud shortcut routing now queries cmux-tui's live foreground process cwd for the exact projected source terminal, then passes that path through the existing same-machine/workspace terminal creation request. The recorded spawn cwd is intentionally ignored because it is stale after a remote `cd`; unavailable or empty live reports preserve the existing daemon fallback. Local and SSH creation paths are unchanged.

## Validation
- Added a behavior regression covering Cloud tab creation from a projected terminal with distinct spawn and live directories, including exact remote workspace routing.
- Added coverage for the `terminal … process show` argv and foreground cwd parsing.
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`

Closes https://github.com/manaflow-ai/cmux/issues/12448

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791861218&installation_model_id=21920&pr_number=12450&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12450&signature=c66ef6a24e4b6e36dc06da48723a7c033b03a197cc70f1cbce78eaaf373f0f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud shortcuts that create a terminal, tab, or split now start the new remote shell in the source terminal's live remote working directory instead of the machine home directory.

- Reads the foreground process cwd via `terminal process show` for the projected source terminal and passes it through the existing creation request.
- Falls back to the prior daemon behavior when the live cwd is unavailable or empty; local and SSH creation paths are unchanged.
- Adds regression and parsing tests.
- Closes #12448.

<sup>Written for commit dee790660c5c70bb55eee12a3b20be27e57edb27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

