### PR TITLE
Fix Agent notification semantics CI reliability

### DIFF
--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
 
       - name: Download pre-built GhosttyKit.xcframework
         env:

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9407,8 +9407,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             destination: CloudWorkspaceGroupDestination(
                 tabManager: context.tabManager,
                 groupId: workspaceGroupTarget?.groupId,
-                placement: workspaceGroupTarget?.placement ?? groupPlacement,
-                referenceWorkspaceId: workspaceGroupTarget?.referenceWorkspaceId ?? anchorId,
+                placement: workspaceGroupTarget?.placement ?? context.tabManager.defaultNewWorkspacePlacementInGroup,
+                referenceWorkspaceId: workspaceGroupTarget?.referenceWorkspaceId,
                 initialWorkspaceId: initialWorkspaceId
             )
         )

--- a/cmuxTests/ClaudeHookLiveDeliveryTargetTestSupport.swift
+++ b/cmuxTests/ClaudeHookLiveDeliveryTargetTestSupport.swift
@@ -234,6 +234,9 @@ enum ClaudeHookLiveDeliveryHarness {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        let exitSignal = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exitSignal.signal() }
+
         do {
             try process.run()
         } catch {
@@ -242,15 +245,10 @@ enum ClaudeHookLiveDeliveryHarness {
         stdinPipe.fileHandleForWriting.write(Data(standardInput.utf8))
         try? stdinPipe.fileHandleForWriting.close()
 
-        let exitSignal = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            exitSignal.signal()
-        }
         let timedOut = exitSignal.wait(timeout: .now() + processWallBound) == .timedOut
         if timedOut {
             process.terminate()
-            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut, process.isRunning {
                 kill(process.processIdentifier, SIGKILL)
                 _ = exitSignal.wait(timeout: .now() + 1)
             }

--- a/cmuxTests/ClaudeHookSurfaceResolutionSwiftTests.swift
+++ b/cmuxTests/ClaudeHookSurfaceResolutionSwiftTests.swift
@@ -863,6 +863,12 @@ struct ClaudeHookSurfaceResolutionSwiftTests {
         process.standardInput = stdinPipe ?? FileHandle.nullDevice
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
+        // Process can finish while the test host is busy servicing another
+        // fixture. Observe termination directly instead of queueing a blocking
+        // waitUntilExit() on the shared global pool, where the waiter can be
+        // starved and report a successful child as a timeout.
+        let exitSignal = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exitSignal.signal() }
 
         do {
             try process.run()
@@ -874,16 +880,10 @@ struct ClaudeHookSurfaceResolutionSwiftTests {
             try? stdinPipe.fileHandleForWriting.close()
         }
 
-        let exitSignal = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            exitSignal.signal()
-        }
-
-        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut && process.isRunning
         if timedOut {
             process.terminate()
-            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut, process.isRunning {
                 kill(process.processIdentifier, SIGKILL)
                 _ = exitSignal.wait(timeout: .now() + 1)
             }


### PR DESCRIPTION
The Agent notification semantics workflow has been red for multiple independent reasons. This narrow repair removes shared false failures and unblocks the app-host target:

- pin Depot's Bun setup to the repository-standard 1.3.14 release, avoiding the unversioned latest-tag lookup that hit GitHub installation API rate limits;
- observe Claude hook child termination through `Process.terminationHandler` registered before launch, instead of queueing `waitUntilExit()` on the shared global pool. Historical runs exited with status 0 and passed notification assertions but were marked timed out after 32 seconds;
- restore the two-line Cloud workspace destination fallback from owner PR #12447. The current `main` merge ref had `groupPlacement`/`anchorId` out of scope in `AppDelegate.swift`, so the reusable app-host job failed before any selected notification suite could run. This commit is only a compile/build unblock; no other Cloud implementation changes are included.

The selected app-host suites remain intact. Other branch-specific Cloud compile/project failures are not included here and remain with their owning PRs. The existing Codex resume exclusion remains unchanged because its fixture is still invalid independently of this lane.

Evidence includes runs 34678931824 and 34733959463 (false timeout reports), passing control run 34677727467, same-SHA Bun setup reruns 34662051243, 34661829831, and 34661935672, and our initial PR run 34735981138 (main AppDelegate compile blocker). See umbrella issue #12232 for the broader CI effort.

A deterministic pre-fix regression test for the scheduler race is not practical: the failure requires the shared global queue to miss a `waitUntilExit()` observer after the child has already exited. The existing semantic tests provide the behavior coverage; the fix removes the race-prone observer rather than adding a timing retry.
