### PR TITLE
Verify signed Codex owners before account changes

### DIFF
--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -8,6 +8,7 @@ import {
   resolveCodeRouterRequestContext,
 } from "../../../../services/coderouter/requestContext";
 import { accountsWithUsage } from "../../../../services/coderouter/usage";
+import { CodexSignatureError } from "../../../../services/coderouter/codexSignature";
 import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
 import {
   addCoderouterBreadcrumb,
@@ -131,6 +132,9 @@ export function makeCoderouterAccountsPostHandler(
       headers: { "cache-control": "no-store" },
     });
   } catch (error) {
+    if (error instanceof CodexSignatureError) {
+      return Response.json({ error: "invalid_credential", message: "Sign in to Codex again before adding this account." }, { status: 400, headers: { "cache-control": "no-store" } });
+    }
     reportCoderouterFailure("rds", error, { operation: "add_account" });
     return Response.json(
       {

--- a/web/scripts/coderouter/migrate-owner-identities.ts
+++ b/web/scripts/coderouter/migrate-owner-identities.ts
@@ -2,6 +2,7 @@ import { decryptCredential } from "../../services/coderouter/encryption";
 import { needsCodexOwnerMigration, withCodexOwner } from "../../services/coderouter/codexIdentity";
 import { bindCodexOwnerIdentity, listAccounts, listCoderouterTeamIds, listEncryptedCredentials } from "../../services/coderouter/repository";
 import { closeCloudDbForTests } from "../../db/client";
+import { cloudDbConfig } from "../../db/config";
 import { Signer } from "@aws-sdk/rds-signer";
 import { loadTargetEnv, projects } from "../cloud-vm/projects.mjs";
 
@@ -10,13 +11,20 @@ if (targetIndex !== -1) {
   const target = process.argv[targetIndex + 1];
   if (target !== "staging" && target !== "production") throw new Error("--target must be staging or production");
   const env = loadTargetEnv(projects[target]);
-  const signer = new Signer({ hostname: env.PGHOST, port: Number(env.PGPORT), username: env.PGUSER, region: env.AWS_REGION });
-  const url = new URL(`postgres://${env.PGHOST}:${env.PGPORT}/${env.PGDATABASE}`);
-  url.username = env.PGUSER;
-  url.password = await signer.getAuthToken();
-  url.searchParams.set("sslmode", "verify-full");
+  const config = cloudDbConfig(env);
+  let databaseURL: string;
+  if (config.driver === "url") {
+    databaseURL = config.url;
+  } else {
+    const signer = new Signer({ hostname: config.host, port: config.port, username: config.user, region: config.awsRegion });
+    const url = new URL(`postgres://${config.host}:${config.port}/${config.database}`);
+    url.username = config.user;
+    url.password = await signer.getAuthToken();
+    url.searchParams.set("sslmode", "verify-full");
+    databaseURL = url.href;
+  }
   process.env.CMUX_DB_DRIVER = "url";
-  process.env.DATABASE_URL = url.href;
+  process.env.DATABASE_URL = databaseURL;
   process.env.AWS_REGION = env.AWS_REGION;
   delete process.env.DIRECT_DATABASE_URL;
   delete process.env.VERCEL;

--- a/web/scripts/coderouter/migrate-owner-identities.ts
+++ b/web/scripts/coderouter/migrate-owner-identities.ts
@@ -1,5 +1,5 @@
 import { decryptCredential } from "../../services/coderouter/encryption";
-import { withCodexOwner } from "../../services/coderouter/codexIdentity";
+import { needsCodexOwnerMigration, withCodexOwner } from "../../services/coderouter/codexIdentity";
 import { bindCodexOwnerIdentity, listAccounts, listCoderouterTeamIds, listEncryptedCredentials } from "../../services/coderouter/repository";
 import { closeCloudDbForTests } from "../../db/client";
 import { Signer } from "@aws-sdk/rds-signer";
@@ -41,7 +41,7 @@ try {
         const identified = withCodexOwner(credential);
         const account = byId.get(envelope.accountId);
         if (!account || account.providerAccountId !== credential.accountId) throw new Error("workspace mismatch");
-        if (account.providerUserId === identified.userId) continue;
+        if (!needsCodexOwnerMigration(account, identified)) continue;
         pending++;
         if (!apply) continue;
         const changed = await bindCodexOwnerIdentity({ teamId, accountId: envelope.accountId, expectedKey: credential.accountId, expectedRevision: envelope.credentialRevision, credential: identified });

--- a/web/services/coderouter/accounts.ts
+++ b/web/services/coderouter/accounts.ts
@@ -19,13 +19,16 @@ import {
 import { deleteVaultCredential } from "./vault";
 import { reportCoderouterFailure } from "./observability";
 import { providerIdentityKey, withCodexOwner } from "./codexIdentity";
+import { verifyCodexCredential } from "./codexSignature";
 
 export async function addAccount(
   teamId: string,
   credential: CodeRouterCredential,
   keys?: CredentialKeyService,
+  verify: typeof verifyCodexCredential = verifyCodexCredential,
 ): Promise<{ accountId: string; alreadyExists: boolean }> {
   if (credential.provider === "codex") {
+    await verify(credential);
     credential = withCodexOwner(credential);
     await upgradeLegacyCodexIdentity(teamId, credential.accountId, keys);
   }

--- a/web/services/coderouter/codexIdentity.ts
+++ b/web/services/coderouter/codexIdentity.ts
@@ -1,4 +1,4 @@
-import type { CodeRouterCredential, CodexCredential } from "./types";
+import type { CodeRouterAccountSummary, CodeRouterCredential, CodexCredential } from "./types";
 
 export type CodexOwner = { readonly userId: string; readonly workspaceId: string };
 const AUTH_CLAIM = "https://api.openai.com/auth";
@@ -75,7 +75,15 @@ function claimValues(claims: readonly Record<string, unknown>[], names: readonly
 }
 
 function validID(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0 && value.length <= 512 && value.trim() === value && !/[\u0000-\u0020\u007f]/.test(value);
+  return typeof value === "string" && value.length > 0 && value.length <= 512 && value.trim() === value && [...value].every(character => character.charCodeAt(0) > 0x20 && character.charCodeAt(0) !== 0x7f);
+}
+
+export function needsCodexOwnerMigration(account: Pick<CodeRouterAccountSummary, "providerAccountId" | "providerUserId">, credential: CodexCredential): boolean {
+  const owner = codexOwner(credential);
+  if (account.providerAccountId !== owner.workspaceId) throw new CodexOwnerMismatch();
+  if (account.providerUserId === undefined) return true;
+  if (account.providerUserId !== owner.userId) throw new CodexOwnerMismatch();
+  return false;
 }
 
 function jwtClaims(token: string): Record<string, unknown> {

--- a/web/services/coderouter/codexSignature.ts
+++ b/web/services/coderouter/codexSignature.ts
@@ -1,0 +1,26 @@
+import { createRemoteJWKSet, errors, jwtVerify, type JWTVerifyGetKey } from "jose";
+import type { CodexCredential } from "./types";
+
+const ISSUER = "https://auth.openai.com";
+const keys = createRemoteJWKSet(new URL(`${ISSUER}/.well-known/jwks.json`), { timeoutDuration: 5_000 });
+
+export class CodexSignatureError extends Error {
+  constructor() { super("Codex credential signature is invalid"); }
+}
+
+/** Only a provider-signed, current login may create or replace an account. */
+export async function verifyCodexCredential(credential: CodexCredential, key: JWTVerifyGetKey = keys): Promise<void> {
+  try {
+    await jwtVerify(credential.idToken, key, {
+      issuer: ISSUER, audience: "app_EMoamEEZ73f0CkXaXp7hrann", algorithms: ["RS256"],
+      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30,
+    });
+    await jwtVerify(credential.accessToken, key, {
+      issuer: ISSUER, audience: "https://api.openai.com/v1", algorithms: ["RS256"],
+      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30,
+    });
+  } catch (error) {
+    if (error instanceof errors.JOSEError && error.code !== "ERR_JWKS_TIMEOUT" && error.code !== "ERR_JWKS_INVALID") throw new CodexSignatureError();
+    throw error;
+  }
+}

--- a/web/tests/coderouter-owner-db-behavior.test.ts
+++ b/web/tests/coderouter-owner-db-behavior.test.ts
@@ -29,11 +29,11 @@ function credential(user: string, workspace: string, email = "shared@example.com
 }
 
 dbTest("separates users in one workspace and preserves records when email changes", async () => {
-  const first = await addAccount(team, credential("user-1", "workspace"), keys);
-  const second = await addAccount(team, credential("user-2", "workspace"), keys);
-  const personal = await addAccount(team, credential("user-1", "personal"), keys);
+  const first = await addAccount(team, credential("user-1", "workspace"), keys, async () => {});
+  const second = await addAccount(team, credential("user-2", "workspace"), keys, async () => {});
+  const personal = await addAccount(team, credential("user-1", "personal"), keys, async () => {});
   expect(new Set([first.accountId, second.accountId, personal.accountId]).size).toBe(3);
-  const renamed = await addAccount(team, credential("user-1", "workspace", "renamed@example.com"), keys);
+  const renamed = await addAccount(team, credential("user-1", "workspace", "renamed@example.com"), keys, async () => {});
   expect(renamed).toEqual({ accountId: first.accountId, alreadyExists: true });
   const accounts = await listAccounts(team);
   expect(accounts).toHaveLength(3);
@@ -41,7 +41,7 @@ dbTest("separates users in one workspace and preserves records when email change
 });
 
 dbTest("concurrent adds create one record for one owner", async () => {
-  const results = await Promise.all(Array.from({ length: 6 }, () => addAccount(team, credential("user-1", "workspace"), keys)));
+  const results = await Promise.all(Array.from({ length: 6 }, () => addAccount(team, credential("user-1", "workspace"), keys, async () => {})));
   expect(new Set(results.map(result => result.accountId)).size).toBe(1);
   expect(await listAccounts(team)).toHaveLength(1);
 });
@@ -53,9 +53,9 @@ dbTest("adopts a legacy workspace row from its encrypted owner without changing 
   await sql`insert into coderouter_accounts (id,team_id,provider,provider_account_id,label,state,vault_revision) values (${id},${team},'codex','workspace','old-email','active',1)`;
   await sql`insert into coderouter_credentials (account_id,team_id,provider,credential_revision,algorithm,ciphertext,nonce,auth_tag,encrypted_data_key,kms_key_id) values (${id},${team},'codex',1,${encrypted.algorithm},${encrypted.ciphertext},${encrypted.nonce},${encrypted.authTag},${encrypted.encryptedDataKey},${encrypted.kmsKeyId})`;
   await bindSessionAccount(team, "codex", "owner-session", id);
-  const other = await addAccount(team, credential("new-user", "workspace"), keys);
+  const other = await addAccount(team, credential("new-user", "workspace"), keys, async () => {});
   expect(other.accountId).not.toBe(id);
-  const oldAgain = await addAccount(team, credential("original-user", "workspace", "renamed@example.com"), keys);
+  const oldAgain = await addAccount(team, credential("original-user", "workspace", "renamed@example.com"), keys, async () => {});
   expect(oldAgain.accountId).toBe(id);
   expect((await findSessionAccount(team, "codex", "owner-session", []))?.id).toBe(id);
   expect(await listAccounts(team)).toHaveLength(2);

--- a/web/tests/coderouter-signed-owner.test.ts
+++ b/web/tests/coderouter-signed-owner.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { addAccount } from "../services/coderouter/accounts";
+
+test("rejects unsigned owner claims before any account lookup", async () => {
+  const token = `eyJhbGciOiJub25lIn0.${Buffer.from(JSON.stringify({ email: "fake@example.com", "https://api.openai.com/auth": { chatgpt_user_id: "forged-user", chatgpt_account_id: "forged-workspace" } })).toString("base64url")}.signature`;
+  await expect(addAccount("team", {
+    provider: "codex", accessToken: token, idToken: token, refreshToken: "fake",
+    accountId: "forged-workspace", email: "fake@example.com", expiresAt: Date.now()+3600000,
+  })).rejects.toThrow("Codex credential signature is invalid");
+});

--- a/web/tests/coderouter-signed-owner.test.ts
+++ b/web/tests/coderouter-signed-owner.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
 import { addAccount } from "../services/coderouter/accounts";
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
+import { verifyCodexCredential } from "../services/coderouter/codexSignature";
+import { needsCodexOwnerMigration } from "../services/coderouter/codexIdentity";
 
 test("rejects unsigned owner claims before any account lookup", async () => {
   const token = `eyJhbGciOiJub25lIn0.${Buffer.from(JSON.stringify({ email: "fake@example.com", "https://api.openai.com/auth": { chatgpt_user_id: "forged-user", chatgpt_account_id: "forged-workspace" } })).toString("base64url")}.signature`;
@@ -7,4 +10,29 @@ test("rejects unsigned owner claims before any account lookup", async () => {
     provider: "codex", accessToken: token, idToken: token, refreshToken: "fake",
     accountId: "forged-workspace", email: "fake@example.com", expiresAt: Date.now()+3600000,
   })).rejects.toThrow("Codex credential signature is invalid");
+});
+
+test("verifies issuer, audience and signatures for both credentials", async () => {
+  const pair = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(pair.publicKey);
+  const keys = createLocalJWKSet({ keys: [{ ...jwk, kid: "fixture-key", alg: "RS256" }] });
+  const sign = (audience: string, issuer = "https://auth.openai.com") => new SignJWT({ "https://api.openai.com/auth": { chatgpt_user_id: "user", chatgpt_account_id: "workspace" } })
+    .setProtectedHeader({ alg: "RS256", kid: "fixture-key" }).setIssuedAt().setSubject("user").setExpirationTime("5m").setIssuer(issuer).setAudience(audience).sign(pair.privateKey);
+  const idToken = await sign("app_EMoamEEZ73f0CkXaXp7hrann");
+  const accessToken = await sign("https://api.openai.com/v1");
+  const credential = { provider: "codex" as const, idToken, accessToken, accountId: "workspace", email: "fixture@example.com", refreshToken: "synthetic", expiresAt: Date.now()+60_000 };
+  await verifyCodexCredential(credential, keys);
+  await expect(verifyCodexCredential({ ...credential, idToken: await sign("wrong-client") }, keys)).rejects.toThrow("signature is invalid");
+  await expect(verifyCodexCredential({ ...credential, accessToken: await sign("https://api.openai.com/v1", "https://wrong.example.com") }, keys)).rejects.toThrow("signature is invalid");
+  const pieces = accessToken.split(".");
+  pieces[1] = Buffer.from(JSON.stringify({ sub: "forged" })).toString("base64url");
+  await expect(verifyCodexCredential({ ...credential, accessToken: pieces.join(".") }, keys)).rejects.toThrow("signature is invalid");
+});
+
+test("migration planning rejects an existing owner mismatch", () => {
+  const token = `h.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_user_id: "user", chatgpt_account_id: "workspace" } })).toString("base64url")}.s`;
+  const credential = { provider: "codex" as const, idToken: token, accessToken: token, accountId: "workspace", email: "fixture@example.com", refreshToken: "synthetic", expiresAt: Date.now()+60_000 };
+  expect(needsCodexOwnerMigration({ providerAccountId: "workspace" }, credential)).toBe(true);
+  expect(needsCodexOwnerMigration({ providerAccountId: "workspace", providerUserId: "user" }, credential)).toBe(false);
+  expect(() => needsCodexOwnerMigration({ providerAccountId: "workspace", providerUserId: "other" }, credential)).toThrow();
 });


### PR DESCRIPTION
Validate OpenAI credential signatures, issuer and audience before account registration. Reject owner mismatches during migration dry runs and remove the control-character lint error. Follow-up to https://github.com/manaflow-ai/cmux/pull/12446.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791863102&installation_model_id=21920&pr_number=12457&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12457&signature=258a49dbfdc15c402cd3eb3b6ea7ca96d4c30f75be6071360c5d872c0b5a2efb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsigned Codex owner claims before any account lookup, so forged tokens can't create or replace accounts. `addAccount` verifies both tokens' signature, issuer, and audience and returns a 400 `invalid_credential` response on failure. Migration dry runs reject owner mismatches and now use the same database configuration as the deployed application, and the ID validation no longer triggers the control-character lint error.

<sup>Written for commit 265b7386a1d628172508ca29aa7429f327db78c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added verification for Codex credentials, including token signatures and required identity details.
  - Added safeguards to ensure Codex accounts are associated with the correct owner during setup and migration.

- **Bug Fixes**
  - Invalid or expired Codex credentials now return a clear prompt to sign in to Codex again instead of a generic retry error.
  - Improved handling of legacy Codex account ownership checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->