### PR TITLE
Prevent synchronous identity disk I/O during terminal dismissal

### DIFF
--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -128,9 +128,10 @@ final class PhonePushClient {
             configuration: PhonePushConfiguration(defaults: defaults)
         )
     }
-
     func configure(auth: AuthCoordinator) {
         self.auth = auth
+        // Prewarm identity so terminal dismissal never performs disk I/O.
+        _ = MobileHostIdentity.deviceID()
         authLifecycleTask?.cancel()
         cancelInMemoryQueue()
         activeIdentity = nil
@@ -139,7 +140,6 @@ final class PhonePushClient {
             await self.bootstrapQueueAndObserve(auth: auth)
         }
     }
-
     func configuration(
         defaults settingsDefaults: UserDefaults? = nil
     ) -> PhonePushConfiguration {

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -128,9 +128,9 @@ final class PhonePushClient {
             configuration: PhonePushConfiguration(defaults: defaults)
         )
     }
+    /// Starts auth-scoped phone push observation after warming host identity.
     func configure(auth: AuthCoordinator) {
         self.auth = auth
-        // Prewarm identity so terminal dismissal never performs disk I/O.
         _ = MobileHostIdentity.deviceID()
         authLifecycleTask?.cancel()
         cancelInMemoryQueue()

--- a/Sources/Mobile/MobileHostIdentity.swift
+++ b/Sources/Mobile/MobileHostIdentity.swift
@@ -2,23 +2,42 @@ import CMUXMobileCore
 import CmuxSettings
 import Foundation
 
+private final class MobileHostDeviceIDCache: @unchecked Sendable {
+    let lock = NSLock()
+    var value: String?
+}
+
 enum MobileHostIdentity {
     private static let deviceIDKey = "mobileHost.deviceID"
     private static let sharedDeviceIDFileName = "mobile-host-device-id"
     private static let stableBundleIdentifier = "com.cmuxterm.app"
     private static let maximumDisplayNameUTF16Length = 128
     private static let maximumDisplayedBuildTagUTF16Length = 64
+    private static let deviceIDCache = MobileHostDeviceIDCache()
 
     static func deviceID() -> String {
+        deviceIDCache.lock.lock()
+        if let cachedDeviceID = deviceIDCache.value {
+            deviceIDCache.lock.unlock()
+            return cachedDeviceID
+        }
+        deviceIDCache.lock.unlock()
+
         let stableDefaults = Bundle.main.bundleIdentifier == stableBundleIdentifier
             ? nil
             : UserDefaults(suiteName: stableBundleIdentifier)
-        return deviceID(
+        let resolvedDeviceID = deviceID(
             defaults: .standard,
             sharedIDURL: defaultSharedDeviceIDURL(),
             stableDefaults: stableDefaults,
             bundleIdentifier: Bundle.main.bundleIdentifier
         )
+
+        deviceIDCache.lock.lock()
+        deviceIDCache.value = deviceIDCache.value ?? resolvedDeviceID
+        let result = deviceIDCache.value ?? resolvedDeviceID
+        deviceIDCache.lock.unlock()
+        return result
     }
 
     static func deviceID(

--- a/Sources/Mobile/MobileHostIdentity.swift
+++ b/Sources/Mobile/MobileHostIdentity.swift
@@ -2,42 +2,34 @@ import CMUXMobileCore
 import CmuxSettings
 import Foundation
 
-private final class MobileHostDeviceIDCache: @unchecked Sendable {
-    let lock = NSLock()
-    var value: String?
-}
-
 enum MobileHostIdentity {
     private static let deviceIDKey = "mobileHost.deviceID"
     private static let sharedDeviceIDFileName = "mobile-host-device-id"
     private static let stableBundleIdentifier = "com.cmuxterm.app"
     private static let maximumDisplayNameUTF16Length = 128
     private static let maximumDisplayedBuildTagUTF16Length = 64
-    private static let deviceIDCache = MobileHostDeviceIDCache()
 
-    static func deviceID() -> String {
-        deviceIDCache.lock.lock()
-        if let cachedDeviceID = deviceIDCache.value {
-            deviceIDCache.lock.unlock()
-            return cachedDeviceID
-        }
-        deviceIDCache.lock.unlock()
-
+    /// Process-stable host identity used by synchronous transport and terminal paths.
+    ///
+    /// Swift initializes this constant once, so the filesystem-backed migration
+    /// runs at most once per app process. After initialization, ``deviceID()``
+    /// returns the immutable snapshot without locking or disk access. The
+    /// overload below remains the testable resolver for persistence migration.
+    private static let cachedDeviceID: String = {
         let stableDefaults = Bundle.main.bundleIdentifier == stableBundleIdentifier
             ? nil
             : UserDefaults(suiteName: stableBundleIdentifier)
-        let resolvedDeviceID = deviceID(
+        return deviceID(
             defaults: .standard,
             sharedIDURL: defaultSharedDeviceIDURL(),
             stableDefaults: stableDefaults,
             bundleIdentifier: Bundle.main.bundleIdentifier
         )
+    }()
 
-        deviceIDCache.lock.lock()
-        deviceIDCache.value = deviceIDCache.value ?? resolvedDeviceID
-        let result = deviceIDCache.value ?? resolvedDeviceID
-        deviceIDCache.lock.unlock()
-        return result
+    /// Returns the process-stable host identity without repeating filesystem work.
+    static func deviceID() -> String {
+        cachedDeviceID
     }
 
     static func deviceID(


### PR DESCRIPTION
## Summary

- Cache the shared Mac device identity as an immutable, process-stable snapshot and prewarm it during phone-push configuration.
- Terminal notification dismissal remains synchronous for its existing queue semantics, while repeated dismissal interactions no longer rediscover Application Support or stat the identity file.
- The snapshot uses Swift's once-initialized static storage, removing the added lock and unchecked-sendability state. The existing injected resolver overload remains the persistence and migration seam.

## Testing

- `git pull --no-rebase origin main` completed as a clean merge; no conflicts or unmerged paths.
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py`
- `/Users/austinwang/manaflow/cmuxterm-hq/skills/autoreview/scripts/cmux-policy-check --mode branch --base origin/main`
- Canonical `autoreview` run on final HEAD (result recorded in the handoff).
- Incident evidence: `/tmp/cmux-hang-20260912-202043` and Sentry event `CMUXTERM-MACOS-3NSR`.
- No local Xcode build, app-host test, XCUITest, or app launch was run; Swift/macOS execution is routed through the remote fleet by repository policy.

## Demo Video

Code-only performance fix; no UI demo video is applicable. Austin's dogfood build remains the required visual/runtime verification.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (the automatic review ran; no manual review comment was sent)
- [x] All code review bot comments are resolved (latest review reported no actionable comments)
- [x] All human review comments are resolved (none present)
