### PR TITLE
Verify stored Codex ownership before metadata migration

### DIFF
--- a/web/scripts/coderouter/migrate-owner-identities.ts
+++ b/web/scripts/coderouter/migrate-owner-identities.ts
@@ -2,6 +2,7 @@ import { decryptCredential } from "../../services/coderouter/encryption";
 import { needsCodexOwnerMigration, withCodexOwner } from "../../services/coderouter/codexIdentity";
 import { bindCodexOwnerIdentity, listAccounts, listCoderouterTeamIds, listEncryptedCredentials } from "../../services/coderouter/repository";
 import { closeCloudDbForTests } from "../../db/client";
+import { verifyStoredCodexCredential } from "../../services/coderouter/codexSignature";
 import { cloudDbConfig } from "../../db/config";
 import { Signer } from "@aws-sdk/rds-signer";
 import { loadTargetEnv, projects } from "../cloud-vm/projects.mjs";
@@ -46,6 +47,7 @@ try {
       try {
         const credential = await decryptCredential(envelope);
         if (credential.provider !== "codex") throw new Error("provider mismatch");
+        await verifyStoredCodexCredential(credential);
         const identified = withCodexOwner(credential);
         const account = byId.get(envelope.accountId);
         if (!account || account.providerAccountId !== credential.accountId) throw new Error("workspace mismatch");

--- a/web/services/coderouter/accounts.ts
+++ b/web/services/coderouter/accounts.ts
@@ -19,18 +19,19 @@ import {
 import { deleteVaultCredential } from "./vault";
 import { reportCoderouterFailure } from "./observability";
 import { providerIdentityKey, withCodexOwner } from "./codexIdentity";
-import { verifyCodexCredential } from "./codexSignature";
+import { verifyCodexCredential, verifyStoredCodexCredential } from "./codexSignature";
 
 export async function addAccount(
   teamId: string,
   credential: CodeRouterCredential,
   keys?: CredentialKeyService,
   verify: typeof verifyCodexCredential = verifyCodexCredential,
+  verifyStored: typeof verifyStoredCodexCredential = verifyStoredCodexCredential,
 ): Promise<{ accountId: string; alreadyExists: boolean }> {
   if (credential.provider === "codex") {
     await verify(credential);
     credential = withCodexOwner(credential);
-    await upgradeLegacyCodexIdentity(teamId, credential.accountId, keys);
+    await upgradeLegacyCodexIdentity(teamId, credential.accountId, keys, verifyStored);
   }
   const existing = await findAccountByProviderIdentity(
     teamId,
@@ -77,13 +78,14 @@ export async function addAccount(
 }
 
 /** Legacy workspace-only rows are adopted from their own encrypted credentials. */
-export async function upgradeLegacyCodexIdentity(teamId: string, workspaceId: string, keys?: CredentialKeyService): Promise<void> {
+export async function upgradeLegacyCodexIdentity(teamId: string, workspaceId: string, keys?: CredentialKeyService, verify: typeof verifyStoredCodexCredential = verifyStoredCodexCredential): Promise<void> {
   const legacy = await findAccountByProviderIdentity(teamId, "codex", workspaceId);
   if (!legacy) return;
   const encrypted = await encryptedCredentialForAccount(teamId, legacy.id);
   if (!encrypted) throw new Error("legacy Codex credential is unavailable");
   const credential = await decryptCredential(encrypted, keys);
   if (credential.provider !== "codex" || credential.accountId !== workspaceId) throw new Error("legacy Codex identity does not match its record");
+  await verify(credential);
   const migrated = await bindCodexOwnerIdentity({
     teamId, accountId: legacy.id, expectedKey: workspaceId,
     expectedRevision: encrypted.credentialRevision, credential: withCodexOwner(credential),

--- a/web/services/coderouter/codexSignature.ts
+++ b/web/services/coderouter/codexSignature.ts
@@ -1,4 +1,4 @@
-import { compactVerify, createRemoteJWKSet, errors, jwtVerify, type JWTVerifyGetKey } from "jose";
+import { compactVerify, createRemoteJWKSet, errors, jwtVerify, type CompactVerifyGetKey, type JWTVerifyGetKey } from "jose";
 import type { CodexCredential } from "./types";
 
 const ISSUER = "https://auth.openai.com";
@@ -26,7 +26,7 @@ export async function verifyCodexCredential(credential: CodexCredential, key: JW
 }
 
 /** Historical owner proof for encrypted records; this grants no current access. */
-export async function verifyStoredCodexCredential(credential: CodexCredential, key: JWTVerifyGetKey = keys): Promise<void> {
+export async function verifyStoredCodexCredential(credential: CodexCredential, key: CompactVerifyGetKey = keys): Promise<void> {
   for (const [token, audience] of [[credential.idToken, "app_EMoamEEZ73f0CkXaXp7hrann"], [credential.accessToken, "https://api.openai.com/v1"]]) {
     try {
       const { payload } = await compactVerify(token, key, { algorithms: ["RS256"] });

--- a/web/services/coderouter/codexSignature.ts
+++ b/web/services/coderouter/codexSignature.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, errors, jwtVerify, type JWTVerifyGetKey } from "jose";
+import { compactVerify, createRemoteJWKSet, errors, jwtVerify, type JWTVerifyGetKey } from "jose";
 import type { CodexCredential } from "./types";
 
 const ISSUER = "https://auth.openai.com";
@@ -9,18 +9,33 @@ export class CodexSignatureError extends Error {
 }
 
 /** Only a provider-signed, current login may create or replace an account. */
-export async function verifyCodexCredential(credential: CodexCredential, key: JWTVerifyGetKey = keys): Promise<void> {
+export async function verifyCodexCredential(credential: CodexCredential, key: JWTVerifyGetKey = keys, currentDate?: Date): Promise<void> {
   try {
     await jwtVerify(credential.idToken, key, {
       issuer: ISSUER, audience: "app_EMoamEEZ73f0CkXaXp7hrann", algorithms: ["RS256"],
-      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30,
+      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30, currentDate,
     });
     await jwtVerify(credential.accessToken, key, {
       issuer: ISSUER, audience: "https://api.openai.com/v1", algorithms: ["RS256"],
-      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30,
+      requiredClaims: ["exp", "iat", "sub"], clockTolerance: 30, currentDate,
     });
   } catch (error) {
     if (error instanceof errors.JOSEError && error.code !== "ERR_JWKS_TIMEOUT" && error.code !== "ERR_JWKS_INVALID") throw new CodexSignatureError();
     throw error;
+  }
+}
+
+/** Historical owner proof for encrypted records; this grants no current access. */
+export async function verifyStoredCodexCredential(credential: CodexCredential, key: JWTVerifyGetKey = keys): Promise<void> {
+  for (const [token, audience] of [[credential.idToken, "app_EMoamEEZ73f0CkXaXp7hrann"], [credential.accessToken, "https://api.openai.com/v1"]]) {
+    try {
+      const { payload } = await compactVerify(token, key, { algorithms: ["RS256"] });
+      const claims = JSON.parse(new TextDecoder().decode(payload));
+      const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+      if (claims.iss !== ISSUER || !audiences.includes(audience) || typeof claims.sub !== "string" || !claims.sub) throw new CodexSignatureError();
+    } catch (error) {
+      if (error instanceof errors.JOSEError || error instanceof SyntaxError) throw new CodexSignatureError();
+      throw error;
+    }
   }
 }

--- a/web/tests/coderouter-owner-db-behavior.test.ts
+++ b/web/tests/coderouter-owner-db-behavior.test.ts
@@ -29,11 +29,11 @@ function credential(user: string, workspace: string, email = "shared@example.com
 }
 
 dbTest("separates users in one workspace and preserves records when email changes", async () => {
-  const first = await addAccount(team, credential("user-1", "workspace"), keys, async () => {});
-  const second = await addAccount(team, credential("user-2", "workspace"), keys, async () => {});
-  const personal = await addAccount(team, credential("user-1", "personal"), keys, async () => {});
+  const first = await addAccount(team, credential("user-1", "workspace"), keys, async () => {}, async () => {});
+  const second = await addAccount(team, credential("user-2", "workspace"), keys, async () => {}, async () => {});
+  const personal = await addAccount(team, credential("user-1", "personal"), keys, async () => {}, async () => {});
   expect(new Set([first.accountId, second.accountId, personal.accountId]).size).toBe(3);
-  const renamed = await addAccount(team, credential("user-1", "workspace", "renamed@example.com"), keys, async () => {});
+  const renamed = await addAccount(team, credential("user-1", "workspace", "renamed@example.com"), keys, async () => {}, async () => {});
   expect(renamed).toEqual({ accountId: first.accountId, alreadyExists: true });
   const accounts = await listAccounts(team);
   expect(accounts).toHaveLength(3);
@@ -41,7 +41,7 @@ dbTest("separates users in one workspace and preserves records when email change
 });
 
 dbTest("concurrent adds create one record for one owner", async () => {
-  const results = await Promise.all(Array.from({ length: 6 }, () => addAccount(team, credential("user-1", "workspace"), keys, async () => {})));
+  const results = await Promise.all(Array.from({ length: 6 }, () => addAccount(team, credential("user-1", "workspace"), keys, async () => {}, async () => {})));
   expect(new Set(results.map(result => result.accountId)).size).toBe(1);
   expect(await listAccounts(team)).toHaveLength(1);
 });
@@ -53,9 +53,9 @@ dbTest("adopts a legacy workspace row from its encrypted owner without changing 
   await sql`insert into coderouter_accounts (id,team_id,provider,provider_account_id,label,state,vault_revision) values (${id},${team},'codex','workspace','old-email','active',1)`;
   await sql`insert into coderouter_credentials (account_id,team_id,provider,credential_revision,algorithm,ciphertext,nonce,auth_tag,encrypted_data_key,kms_key_id) values (${id},${team},'codex',1,${encrypted.algorithm},${encrypted.ciphertext},${encrypted.nonce},${encrypted.authTag},${encrypted.encryptedDataKey},${encrypted.kmsKeyId})`;
   await bindSessionAccount(team, "codex", "owner-session", id);
-  const other = await addAccount(team, credential("new-user", "workspace"), keys, async () => {});
+  const other = await addAccount(team, credential("new-user", "workspace"), keys, async () => {}, async () => {});
   expect(other.accountId).not.toBe(id);
-  const oldAgain = await addAccount(team, credential("original-user", "workspace", "renamed@example.com"), keys, async () => {});
+  const oldAgain = await addAccount(team, credential("original-user", "workspace", "renamed@example.com"), keys, async () => {}, async () => {});
   expect(oldAgain.accountId).toBe(id);
   expect((await findSessionAccount(team, "codex", "owner-session", []))?.id).toBe(id);
   expect(await listAccounts(team)).toHaveLength(2);

--- a/web/tests/coderouter-signed-owner.test.ts
+++ b/web/tests/coderouter-signed-owner.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { addAccount } from "../services/coderouter/accounts";
 import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
-import { verifyCodexCredential } from "../services/coderouter/codexSignature";
+import { verifyCodexCredential, verifyStoredCodexCredential } from "../services/coderouter/codexSignature";
 import { needsCodexOwnerMigration } from "../services/coderouter/codexIdentity";
 
 test("rejects unsigned owner claims before any account lookup", async () => {
@@ -13,20 +13,25 @@ test("rejects unsigned owner claims before any account lookup", async () => {
 });
 
 test("verifies issuer, audience and signatures for both credentials", async () => {
+  const now = new Date("2026-09-13T00:00:00Z");
+  const issued = Math.floor(now.getTime() / 1000);
   const pair = await generateKeyPair("RS256", { extractable: true });
   const jwk = await exportJWK(pair.publicKey);
   const keys = createLocalJWKSet({ keys: [{ ...jwk, kid: "fixture-key", alg: "RS256" }] });
   const sign = (audience: string, issuer = "https://auth.openai.com") => new SignJWT({ "https://api.openai.com/auth": { chatgpt_user_id: "user", chatgpt_account_id: "workspace" } })
-    .setProtectedHeader({ alg: "RS256", kid: "fixture-key" }).setIssuedAt().setSubject("user").setExpirationTime("5m").setIssuer(issuer).setAudience(audience).sign(pair.privateKey);
+    .setProtectedHeader({ alg: "RS256", kid: "fixture-key" }).setIssuedAt(issued).setSubject("user").setExpirationTime(issued + 300).setIssuer(issuer).setAudience(audience).sign(pair.privateKey);
   const idToken = await sign("app_EMoamEEZ73f0CkXaXp7hrann");
   const accessToken = await sign("https://api.openai.com/v1");
   const credential = { provider: "codex" as const, idToken, accessToken, accountId: "workspace", email: "fixture@example.com", refreshToken: "synthetic", expiresAt: Date.now()+60_000 };
-  await verifyCodexCredential(credential, keys);
-  await expect(verifyCodexCredential({ ...credential, idToken: await sign("wrong-client") }, keys)).rejects.toThrow("signature is invalid");
-  await expect(verifyCodexCredential({ ...credential, accessToken: await sign("https://api.openai.com/v1", "https://wrong.example.com") }, keys)).rejects.toThrow("signature is invalid");
+  await verifyCodexCredential(credential, keys, now);
+  await verifyStoredCodexCredential(credential, keys);
+  await expect(verifyCodexCredential(credential, keys, new Date(now.getTime()+600_000))).rejects.toThrow();
+  await expect(verifyCodexCredential({ ...credential, idToken: await sign("wrong-client") }, keys, now)).rejects.toThrow("signature is invalid");
+  await expect(verifyCodexCredential({ ...credential, accessToken: await sign("https://api.openai.com/v1", "https://wrong.example.com") }, keys, now)).rejects.toThrow("signature is invalid");
   const pieces = accessToken.split(".");
   pieces[1] = Buffer.from(JSON.stringify({ sub: "forged" })).toString("base64url");
-  await expect(verifyCodexCredential({ ...credential, accessToken: pieces.join(".") }, keys)).rejects.toThrow("signature is invalid");
+  await expect(verifyCodexCredential({ ...credential, accessToken: pieces.join(".") }, keys, now)).rejects.toThrow("signature is invalid");
+  await expect(verifyStoredCodexCredential({ ...credential, accessToken: pieces.join(".") }, keys)).rejects.toThrow("signature is invalid");
 });
 
 test("migration planning rejects an existing owner mismatch", () => {


### PR DESCRIPTION
Verify provider signatures, issuer, and audience on stored credentials before legacy-key upgrades. Historical ID tokens can be expired because this operation grants no current access; new account registration still requires current tokens. JWT validity tests now use a fixed clock. Follow-up to https://github.com/manaflow-ai/cmux/pull/12457.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791863884&installation_model_id=21920&pr_number=12460&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12460&signature=52f3f42521027ab379167dc953d78960066cc975911d179ee152f0934a05cd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects forged Codex owner claims before creating accounts or migrating legacy identities. New accounts require a currently valid provider-signed token; stored legacy credentials must pass signature, issuer, and audience checks, expired tokens are still accepted because migration grants no current access, and the migration script now runs this verification without rotating stored credentials.

<sup>Written for commit 735918101d3e0ca52f3c9844f2ecffa59d2d74c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added validation for stored Codex credentials before they are used or associated with an owner identity.
  - Invalid, expired, tampered, or incorrectly issued credentials are now rejected.

- **Bug Fixes**
  - Improved account and identity migration handling to prevent unverified credentials from being processed.

- **Tests**
  - Expanded coverage for credential expiration, issuer and audience validation, token tampering, and legacy account flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->