### PR TITLE
Drop an unreadable claude --settings path instead of failing the launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1611,6 +1611,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_autodiscovery.py
           python3 tests/test_codex_wrapper_resume_hooks.py
           python3 tests/test_claude_wrapper_hooks.py
+          python3 tests/test_claude_wrapper_dead_settings_path.py
           python3 tests/test_codex_wrapper_computer_use_mcp.py
           python3 tests/test_cmux_cua_mcp_smoke.py
           python3 tests/test_cmux_cua_build_cache_safety.py

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -1632,9 +1632,18 @@ unset CMUX_GENERATED_HOOKS_JSON
 # does not rely on the CLI's multi-flag behavior. Requires `node`; if node is
 # missing or the merge fails, preserve the user's original settings and disable
 # cmux hooks for that launch rather than passing an ambiguous pair of flags.
-# A --settings path that is not readable is dropped up front with a warning:
-# Claude would refuse to start on it, so forwarding it (with or without cmux's
-# hooks) can only fail the launch.
+# An unreadable --settings path is dropped up front with a warning ONLY when
+# cmux owns this launch as a restore replay. There the path came from a launch
+# record cmux itself captured, the launcher that created it (for example
+# `sr claude proxy`) has already deleted it, and forwarding it can only fail a
+# restore the user asked for.
+#
+# An ordinary interactive launch keeps failing closed. A settings file can
+# define permission rules and hooks, so silently starting Claude WITHOUT the
+# policy the user named -- because of a typo, a permission change, or an
+# unmounted volume -- would turn an invalid configuration into a quietly
+# less-restricted session. Claude refusing to start is the correct outcome
+# there, and it is the user's own argument to fix.
 unset CMUX_USER_SETTINGS_B64
 CMUX_FILTERED_ARGS=()
 CMUX_USER_SETTINGS=()
@@ -1654,11 +1663,12 @@ for arg in "$@"; do
     fi
     if [[ "$cmux_collect_settings_value" == true ]]; then
         cmux_collect_settings_value=false
-        if cmux_claude_wrapper_settings_value_is_readable "$arg"; then
+        if cmux_claude_wrapper_settings_value_is_readable "$arg" \
+            || [[ "${cmux_claude_app_restore_owned:-0}" != "1" ]]; then
             CMUX_USER_SETTINGS+=("$arg")
             CMUX_PASSTHROUGH_ARGS+=("--settings" "$arg")
         else
-            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "$arg" >&2
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this restore: %s\n' "$arg" >&2
             cmux_dropped_unreadable_settings=true
         fi
         continue
@@ -1678,11 +1688,12 @@ for arg in "$@"; do
         # potentially very large JSON value.
         cmux_collect_settings_value=true
     elif [[ "${arg:0:11}" == "--settings=" ]]; then
-        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}"; then
+        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}" \
+            || [[ "${cmux_claude_app_restore_owned:-0}" != "1" ]]; then
             CMUX_USER_SETTINGS+=("${arg#--settings=}")
             CMUX_PASSTHROUGH_ARGS+=("$arg")
         else
-            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "${arg#--settings=}" >&2
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this restore: %s\n' "${arg#--settings=}" >&2
             cmux_dropped_unreadable_settings=true
         fi
     elif [[ "${arg:0:1}" == "-" ]]; then

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -92,6 +92,27 @@ cmux_claude_wrapper_settings_value_is_managed() {
     grep -Fq 'hooks feed --source claude' "$trimmed" 2>/dev/null
 }
 
+# A user --settings value that names a file must be readable now, or Claude
+# refuses to start ("Settings file not found"). Restore replays can carry a
+# path that a launcher wrote for one session and deleted on exit (for example
+# subrouter's $TMPDIR/subrouter-claude-settings-<rand>/settings.json). Inline
+# JSON and an empty value are left to the merge, which reports them loudly.
+# Mirrors the merge loader: trim, then expand only a leading "~/".
+cmux_claude_wrapper_settings_value_is_readable() {
+    local value="$1"
+    local trimmed="${value#"${value%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    local first="${trimmed:0:1}"
+    if [[ -z "$trimmed" || "$first" == "{" || "$first" == "[" ]]; then
+        return 0
+    fi
+    local path="$trimmed"
+    if [[ "${path:0:2}" == "~/" ]]; then
+        path="${HOME}/${path:2}"
+    fi
+    [[ -f "$path" && -r "$path" ]]
+}
+
 cmux_claude_wrapper_args_have_managed_settings() {
     local collect=false
     local arg
@@ -1611,49 +1632,79 @@ unset CMUX_GENERATED_HOOKS_JSON
 # does not rely on the CLI's multi-flag behavior. Requires `node`; if node is
 # missing or the merge fails, preserve the user's original settings and disable
 # cmux hooks for that launch rather than passing an ambiguous pair of flags.
+# A --settings path that is not readable is dropped up front with a warning:
+# Claude would refuse to start on it, so forwarding it (with or without cmux's
+# hooks) can only fail the launch.
 unset CMUX_USER_SETTINGS_B64
 CMUX_FILTERED_ARGS=()
 CMUX_USER_SETTINGS=()
+# The original argv minus any --settings whose file cannot be read. It replaces
+# "$@" only when such a value was dropped, so the merge-unavailable fallback
+# and the restore capture never forward a path Claude would refuse.
+CMUX_PASSTHROUGH_ARGS=()
+cmux_dropped_unreadable_settings=false
 cmux_collect_settings_value=false
 cmux_pending_option_value=false
 cmux_positional_only=false
 for arg in "$@"; do
     if [[ "$cmux_positional_only" == true ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         continue
     fi
     if [[ "$cmux_collect_settings_value" == true ]]; then
-        CMUX_USER_SETTINGS+=("$arg")
         cmux_collect_settings_value=false
+        if cmux_claude_wrapper_settings_value_is_readable "$arg"; then
+            CMUX_USER_SETTINGS+=("$arg")
+            CMUX_PASSTHROUGH_ARGS+=("--settings" "$arg")
+        else
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "$arg" >&2
+            cmux_dropped_unreadable_settings=true
+        fi
         continue
     fi
     if [[ "$cmux_pending_option_value" == true ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         cmux_pending_option_value=false
         continue
     fi
     if [[ "$arg" == "--" ]]; then
         cmux_positional_only=true
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
     elif [[ "$arg" == "--settings" ]]; then
         # The fixed-width prefix checks above avoid a wildcard match against a
         # potentially very large JSON value.
         cmux_collect_settings_value=true
     elif [[ "${arg:0:11}" == "--settings=" ]]; then
-        CMUX_USER_SETTINGS+=("${arg#--settings=}")
+        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}"; then
+            CMUX_USER_SETTINGS+=("${arg#--settings=}")
+            CMUX_PASSTHROUGH_ARGS+=("$arg")
+        else
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "${arg#--settings=}" >&2
+            cmux_dropped_unreadable_settings=true
+        fi
     elif [[ "${arg:0:1}" == "-" ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         if [[ "${arg%%=*}" == "$arg" ]] && claude_option_consumes_value "$arg"; then
             cmux_pending_option_value=true
         fi
     else
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
     fi
 done
 if [[ "$cmux_collect_settings_value" == true ]]; then
     # Dangling --settings with no value; keep it so the real CLI reports the error.
     CMUX_FILTERED_ARGS+=("--settings")
+    CMUX_PASSTHROUGH_ARGS+=("--settings")
 fi
+if [[ "$cmux_dropped_unreadable_settings" == true ]]; then
+    set -- "${CMUX_PASSTHROUGH_ARGS[@]}"
+fi
+unset CMUX_PASSTHROUGH_ARGS cmux_dropped_unreadable_settings
 
 CMUX_SETTINGS_PATH=""
 CMUX_SETTINGS_BASE_PATH=""

--- a/tests/test_claude_wrapper_dead_settings_path.py
+++ b/tests/test_claude_wrapper_dead_settings_path.py
@@ -75,6 +75,7 @@ def run_wrapper(
     *,
     with_node: bool = True,
     home_files: dict[str, str] | None = None,
+    restore_of: str | None = None,
 ) -> tuple[int, list[str], str, list[str], list[str]]:
     """Run the wrapper against a fake claude.
 
@@ -201,6 +202,11 @@ exit 0
             "NODE_OPTIONS",
         ):
             env.pop(key, None)
+        # cmux only drops an unreadable --settings for a launch it owns as a
+        # restore replay. An ordinary interactive launch must keep failing
+        # closed, so the scenarios opt in explicitly.
+        if restore_of is not None:
+            env["CMUX_AGENT_RESTORE_LAUNCH"] = f"claude:{restore_of}"
 
         try:
             proc = subprocess.run(
@@ -266,7 +272,7 @@ def assert_single_cmux_hook_settings(
 
 def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) -> None:
     code, real_argv, stderr, captured, documents = run_wrapper(
-        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH]
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH], restore_of=SESSION_ID
     )
     assert_single_cmux_hook_settings("restore replay", code, real_argv, stderr, documents, failures)
     expect(
@@ -287,10 +293,16 @@ def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) ->
 
 
 def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
-    code, real_argv, stderr, captured, documents = run_wrapper([f"--settings={DEAD_SETTINGS_PATH}", "hello"])
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, f"--settings={DEAD_SETTINGS_PATH}", "hello"], restore_of=SESSION_ID
+    )
     assert_single_cmux_hook_settings("equals form", code, real_argv, stderr, documents, failures)
     expect(real_argv[-1:] == ["hello"], f"equals form: positional prompt dropped: {real_argv}", failures)
-    expect(DEAD_SETTINGS_PATH not in stderr or "warning" in stderr, f"equals form: {stderr!r}", failures)
+    expect(
+        "warning" in stderr and DEAD_SETTINGS_PATH in stderr,
+        f"equals form: expected a warning naming the dead path, got {stderr!r}",
+        failures,
+    )
     expect(
         not any(DEAD_SETTINGS_PATH in part for part in captured),
         f"equals form: dead path was re-captured: {captured}",
@@ -300,7 +312,8 @@ def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
 
 def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
     code, real_argv, stderr, _, documents = run_wrapper(
-        ["--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"]
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"],
+        restore_of=SESSION_ID,
     )
     settings = assert_single_cmux_hook_settings("mixed settings", code, real_argv, stderr, documents, failures)
     expect(
@@ -312,11 +325,37 @@ def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
 
 
 def test_tilde_dead_path_is_dropped(failures: list[str]) -> None:
-    code, real_argv, stderr, _, _ = run_wrapper(["--settings", "~/missing-settings.json", "hi"])
+    code, real_argv, stderr, _, _ = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", "~/missing-settings.json", "hi"], restore_of=SESSION_ID
+    )
     expect(code == 0, f"tilde dead path: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
     values = settings_values(real_argv)
     expect(len(values) == 1, f"tilde dead path: expected exactly one --settings, got {values}", failures)
     expect("~/missing-settings.json" not in values, f"tilde dead path: still forwarded: {real_argv}", failures)
+
+
+def test_interactive_launch_keeps_failing_closed_on_an_unreadable_settings_file(
+    failures: list[str],
+) -> None:
+    """An ordinary launch must NOT silently start without the policy the user named.
+
+    A settings file can carry permission rules and hooks. Dropping it because of a
+    typo, a permission change, or an unmounted volume would turn an invalid
+    configuration into a quietly less-restricted session, so only a cmux-owned
+    restore replay may drop one.
+    """
+    code, real_argv, stderr, _, _ = run_wrapper(["--settings", DEAD_SETTINGS_PATH, "hi"])
+    values = settings_values(real_argv)
+    expect(
+        DEAD_SETTINGS_PATH in values,
+        f"interactive: unreadable --settings was silently dropped: {real_argv}",
+        failures,
+    )
+    expect(
+        code != 0,
+        f"interactive: claude started anyway without the named settings (stderr: {stderr!r})",
+        failures,
+    )
 
 
 def test_existing_user_settings_file_is_still_merged(failures: list[str]) -> None:
@@ -333,6 +372,7 @@ def test_dead_path_without_node_still_launches_with_cmux_hooks(failures: list[st
     code, real_argv, stderr, captured, documents = run_wrapper(
         ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH],
         with_node=False,
+        restore_of=SESSION_ID,
     )
     assert_single_cmux_hook_settings("no node", code, real_argv, stderr, documents, failures)
     expect(
@@ -351,6 +391,7 @@ def main() -> int:
     test_dead_settings_equals_form_is_dropped(failures)
     test_dead_path_keeps_other_user_settings(failures)
     test_tilde_dead_path_is_dropped(failures)
+    test_interactive_launch_keeps_failing_closed_on_an_unreadable_settings_file(failures)
     test_existing_user_settings_file_is_still_merged(failures)
     test_dead_path_without_node_still_launches_with_cmux_hooks(failures)
     if failures:

--- a/tests/test_claude_wrapper_dead_settings_path.py
+++ b/tests/test_claude_wrapper_dead_settings_path.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Regression checks for a captured `--settings <path>` that no longer exists.
+
+Launchers such as subrouter (`sr claude`) hand Claude an ephemeral settings file
+(`$TMPDIR/subrouter-claude-settings-<rand>/settings.json`) and delete it when
+they exit. cmux captures the launch argv, so `cmux restore claude <id>` replays
+`--settings <that path>` after the file is gone. The wrapper's settings merge
+then fails on ENOENT and the dead path was still forwarded to Claude, which
+hard-errors with `Settings file not found`, so the restored session never
+starts.
+
+The fake `claude` below reproduces that part of the real CLI: a `--settings`
+path that does not exist is a fatal error. Every check asserts that exactly one
+`--settings` reaches Claude and that it is cmux's own (readable) hook settings
+file, so a dead user path degrades to a working launch with a warning instead
+of a failed restore.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+from node_runtime import ensure_node_on_path
+from test_claude_wrapper_hooks import generated_claude_hook_settings
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+SESSION_ID = "3d1d5a5a-6d36-4d3a-9a3c-1d4f0e6c2b7a"
+DEAD_SETTINGS_PATH = "/var/folders/zz/T/subrouter-claude-settings-3294281412/settings.json"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.rstrip("\n") for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def settings_values(argv: list[str]) -> list[str]:
+    values: list[str] = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--settings" and index + 1 < len(argv):
+            values.append(argv[index + 1])
+            index += 2
+            continue
+        if arg.startswith("--settings="):
+            values.append(arg[len("--settings="):])
+        index += 1
+    return values
+
+
+def decode_launch_argv(encoded: str) -> list[str]:
+    if not encoded or encoded == "__UNSET__":
+        return []
+    raw = base64.b64decode(encoded)
+    return [part.decode("utf-8") for part in raw.split(b"\0") if part]
+
+
+def run_wrapper(
+    argv: list[str],
+    *,
+    with_node: bool = True,
+    home_files: dict[str, str] | None = None,
+) -> tuple[int, list[str], str, list[str], list[str]]:
+    """Run the wrapper against a fake claude.
+
+    Returns (exit code, claude argv, stderr, captured launch argv, settings
+    documents as claude read them, in argv order).
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-dead-settings-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "cmux.app" / "Contents" / "Resources" / "bin"
+        real_dir = tmp / "real-bin"
+        bundled_dir = tmp / "bundled cli"
+        home = tmp / "home"
+        for directory in (wrapper_dir, real_dir, bundled_dir, home):
+            directory.mkdir(parents=True, exist_ok=True)
+        for relative, content in (home_files or {}).items():
+            target = home / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+        wrapper = wrapper_dir / "cmux-claude-wrapper"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        real_args_log = tmp / "real-args.log"
+        launch_argv_log = tmp / "launch-argv.log"
+        settings_docs_log = tmp / "settings-docs.log"
+        socket_path = str(tmp / "cmux.sock")
+
+        # Mirrors the real CLI: a --settings path that cannot be read is fatal.
+        make_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+: > "$FAKE_REAL_ARGS_LOG"
+printf '%s\\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-__UNSET__}" > "$FAKE_LAUNCH_ARGV_LOG"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+if [[ "${1:-}" == "--help" ]]; then
+  printf 'Usage: claude [options] [command] [prompt]\\n'
+  exit 0
+fi
+expect_value=0
+for arg in "$@"; do
+  value=""
+  if (( expect_value )); then
+    value="$arg"
+    expect_value=0
+  elif [[ "$arg" == "--settings" ]]; then
+    expect_value=1
+    continue
+  elif [[ "$arg" == --settings=* ]]; then
+    value="${arg#--settings=}"
+  else
+    continue
+  fi
+  trimmed="${value#"${value%%[![:space:]]*}"}"
+  if [[ "$trimmed" == \\{* || "$trimmed" == \\[* ]]; then
+    printf '%s\\n' "$value" >> "$FAKE_SETTINGS_DOCS_LOG"
+  elif [[ -r "$value" ]]; then
+    # Snapshot the document Claude would read now; the wrapper's private
+    # settings file lives under a TMPDIR the harness deletes afterwards.
+    tr -d '\\n' < "$value" >> "$FAKE_SETTINGS_DOCS_LOG"
+    printf '\\n' >> "$FAKE_SETTINGS_DOCS_LOG"
+  else
+    printf 'Error: Settings file not found: %s\\n' "$value" >&2
+    exit 1
+  fi
+done
+exit 0
+""",
+        )
+
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+""",
+        )
+        bundled_cli = bundled_dir / "cmux"
+        make_executable(
+            bundled_cli,
+            """#!/usr/bin/env bash
+if [[ "${1:-}" == "hooks" && "${2:-}" == "claude" && "${3:-}" == "inject-settings" ]]; then
+  printf '%s' "$FAKE_GENERATED_CLAUDE_HOOK_SETTINGS"
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        system_path = "/usr/bin:/bin"
+        if with_node:
+            node = ensure_node_on_path()
+            assert node is not None
+            system_path = f"{Path(node).parent}:{system_path}"
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:{system_path}"
+        env["HOME"] = str(home)
+        env["TMPDIR"] = str(tmp / "tmp")
+        (tmp / "tmp").mkdir(exist_ok=True)
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_SOCKET_PATH"] = socket_path
+        env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli)
+        env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
+        env["FAKE_LAUNCH_ARGV_LOG"] = str(launch_argv_log)
+        env["FAKE_SETTINGS_DOCS_LOG"] = str(settings_docs_log)
+        env["FAKE_GENERATED_CLAUDE_HOOK_SETTINGS"] = generated_claude_hook_settings()
+        for key in (
+            "CMUX_CLAUDE_HOOKS_DISABLED",
+            "CMUX_CLAUDE_HOOK_CMUX_BIN",
+            "CMUX_AGENT_RESTORE_LAUNCH",
+            "CMUX_AGENT_LAUNCH_ARGV_B64",
+            "NODE_OPTIONS",
+        ):
+            env.pop(key, None)
+
+        try:
+            proc = subprocess.run(
+                [str(wrapper), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        finally:
+            test_socket.close()
+
+        launch_argv_lines = read_lines(launch_argv_log)
+        captured = decode_launch_argv(launch_argv_lines[0] if launch_argv_lines else "")
+        return (
+            proc.returncode,
+            read_lines(real_args_log),
+            proc.stderr.strip(),
+            captured,
+            read_lines(settings_docs_log),
+        )
+
+
+def expect(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def assert_single_cmux_hook_settings(
+    label: str,
+    code: int,
+    real_argv: list[str],
+    stderr: str,
+    documents: list[str],
+    failures: list[str],
+) -> dict:
+    expect(code == 0, f"{label}: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
+    values = settings_values(real_argv)
+    expect(len(values) == 1, f"{label}: expected exactly one --settings, got {values} in {real_argv}", failures)
+    expect(
+        DEAD_SETTINGS_PATH not in real_argv and f"--settings={DEAD_SETTINGS_PATH}" not in real_argv,
+        f"{label}: dead settings path still reached claude: {real_argv}",
+        failures,
+    )
+    if len(documents) != 1:
+        failures.append(f"{label}: claude could read {len(documents)} settings documents, expected 1: {values}")
+        return {}
+    try:
+        settings = json.loads(documents[0])
+    except ValueError as exc:
+        failures.append(f"{label}: the surviving --settings is not JSON: {documents[0]!r} ({exc})")
+        return {}
+    hook_text = json.dumps(settings.get("hooks", {}))
+    expect(
+        "hooks" in settings and ("hooks claude" in hook_text or "hooks feed" in hook_text),
+        f"{label}: surviving --settings is not cmux's hook settings: {settings}",
+        failures,
+    )
+    return settings
+
+
+def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH]
+    )
+    assert_single_cmux_hook_settings("restore replay", code, real_argv, stderr, documents, failures)
+    expect(
+        real_argv[:2] == ["--resume", SESSION_ID] or ["--resume", SESSION_ID] == real_argv[-2:],
+        f"restore replay: --resume <id> was not preserved: {real_argv}",
+        failures,
+    )
+    expect(
+        DEAD_SETTINGS_PATH in stderr and "warning" in stderr,
+        f"restore replay: expected a warning naming the dead path, got {stderr!r}",
+        failures,
+    )
+    expect(
+        DEAD_SETTINGS_PATH not in captured,
+        f"restore replay: dead path was re-captured for the next restore: {captured}",
+        failures,
+    )
+
+
+def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper([f"--settings={DEAD_SETTINGS_PATH}", "hello"])
+    assert_single_cmux_hook_settings("equals form", code, real_argv, stderr, documents, failures)
+    expect(real_argv[-1:] == ["hello"], f"equals form: positional prompt dropped: {real_argv}", failures)
+    expect(DEAD_SETTINGS_PATH not in stderr or "warning" in stderr, f"equals form: {stderr!r}", failures)
+    expect(
+        not any(DEAD_SETTINGS_PATH in part for part in captured),
+        f"equals form: dead path was re-captured: {captured}",
+        failures,
+    )
+
+
+def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
+    code, real_argv, stderr, _, documents = run_wrapper(
+        ["--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"]
+    )
+    settings = assert_single_cmux_hook_settings("mixed settings", code, real_argv, stderr, documents, failures)
+    expect(
+        settings.get("effortLevel") == "max",
+        f"mixed settings: the readable user settings were lost with the dead one: {settings}",
+        failures,
+    )
+    expect(real_argv[-1:] == ["hi"], f"mixed settings: positional prompt dropped: {real_argv}", failures)
+
+
+def test_tilde_dead_path_is_dropped(failures: list[str]) -> None:
+    code, real_argv, stderr, _, _ = run_wrapper(["--settings", "~/missing-settings.json", "hi"])
+    expect(code == 0, f"tilde dead path: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
+    values = settings_values(real_argv)
+    expect(len(values) == 1, f"tilde dead path: expected exactly one --settings, got {values}", failures)
+    expect("~/missing-settings.json" not in values, f"tilde dead path: still forwarded: {real_argv}", failures)
+
+
+def test_existing_user_settings_file_is_still_merged(failures: list[str]) -> None:
+    code, real_argv, stderr, _, documents = run_wrapper(
+        ["--settings", "~/present-settings.json", "hi"],
+        home_files={"present-settings.json": '{"ultracode": true}'},
+    )
+    settings = assert_single_cmux_hook_settings("existing file", code, real_argv, stderr, documents, failures)
+    expect(settings.get("ultracode") is True, f"existing file: user settings were not merged: {settings}", failures)
+    expect("warning" not in stderr, f"existing file: unexpected warning for a readable file: {stderr!r}", failures)
+
+
+def test_dead_path_without_node_still_launches_with_cmux_hooks(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH],
+        with_node=False,
+    )
+    assert_single_cmux_hook_settings("no node", code, real_argv, stderr, documents, failures)
+    expect(
+        DEAD_SETTINGS_PATH not in captured,
+        f"no node: dead path was re-captured for the next restore: {captured}",
+        failures,
+    )
+
+
+def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; the wrapper's settings merge needs node")
+        return 0
+    failures: list[str] = []
+    test_restore_replay_with_dead_settings_path_launches(failures)
+    test_dead_settings_equals_form_is_dropped(failures)
+    test_dead_path_keeps_other_user_settings(failures)
+    test_tilde_dead_path_is_dropped(failures)
+    test_existing_user_settings_file_is_still_merged(failures)
+    test_dead_path_without_node_still_launches_with_cmux_hooks(failures)
+    if failures:
+        print("FAIL: a dead --settings path still breaks the cmux claude wrapper launch")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: a dead --settings path is dropped and exactly one cmux hook --settings reaches claude")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`cmux restore claude <id>` can hard-fail with:

```
cmux: --settings merge error: ENOENT: no such file or directory, open '/var/folders/.../T/subrouter-claude-settings-3294281412/settings.json'
cmux: warning: --settings merge failed; your --settings was ignored
Error: Settings file not found: /var/folders/.../subrouter-claude-settings-3294281412/settings.json
```

The warning is not true. The wrapper collects user `--settings` values into `CMUX_USER_SETTINGS` and builds `CMUX_FILTERED_ARGS` with them removed, but it only swaps them in on the **success** path:

- success: `HOOKS_JSON="$CMUX_MERGED_SETTINGS"; set -- "${CMUX_FILTERED_ARGS[@]}"`
- failure: prints the warning and **never runs `set --`**

So `$@` still carries the unreadable path, and the final `exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"` hands Claude **two** `--settings` flags. Claude ≥ 2.1.169 is last-wins (as the wrapper's own comment documents), so the dead path wins and Claude refuses to start.

This is reachable for any launcher that hands Claude a transient settings file. Subrouter's `sr claude proxy` writes one under `$TMPDIR/subrouter-claude-settings-<rand>/` and deletes it when `sr` exits, so every restore of such a session hits it — a reboot is not required.

## Change

`Resources/bin/cmux-claude-wrapper`: an unreadable user `--settings` path is dropped rather than forwarded, so exactly one `--settings` (cmux's hooks) reaches Claude and the warning becomes accurate. A readable settings file is still merged exactly as before.

## Testing

Two-commit regression pattern. `tests/test_claude_wrapper_dead_settings_path.py` (new, wired into `.github/workflows/ci.yml`) drives the real wrapper with a fake `claude` that records its argv, across five scenarios: restore replay, the `--settings=` equals form, a mix of a dead path and valid inline JSON, a tilde path, and the no-Node fallback.

At the test-only commit it **exits 1** and reproduces the literal `Error: Settings file not found`. At the fix commit it **exits 0**. `swift test --package-path Packages/macOS/CMUXAgentLaunch` stays green (399 tests / 55 suites), and the sibling wrapper suites still pass.

Follow-up PR stacks on this one to stop recording dead paths in restore plans at all, and to resume Subrouter-routed Claude sessions through the launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791864272&installation_model_id=21920&pr_number=12463&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12463&signature=72e99d2141389cf49eb4830e7341705417ddcb6b4f7254390cec4d7b5ed30dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux restore claude` hard-failing when a captured `--settings` path no longer exists, so restored sessions launch with cmux hooks instead of Claude refusing to start. An unreadable `--settings` path is now dropped with a warning only for cmux-owned restore replays; readable settings are still merged as before.

**Bug Fixes**
- Unreadable `--settings` paths are dropped only on cmux-owned restore replays; interactive launches still fail closed so an invalid settings file can't silently weaken Claude's policy.
- The regression test drives the real wrapper across seven scenarios, including the interactive fail-closed contract and the no-Node fallback.
- CI now runs the new test.

<sup>Written for commit 43f5d7d4a1772f9b045c08b3f3ccdebccb096b52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude launches no longer forward unreadable or nonexistent settings-file paths.
  * Valid inline settings and readable settings files continue to work.
  * Built-in hook settings, prompts, resume arguments, and other launch options are preserved.
  * Clear warnings are shown when invalid settings paths are skipped.

* **Tests**
  * Added regression coverage for separate and equals-form settings, tilde paths, mixed inputs, and environments without Node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->