### PR TITLE
Restore Subrouter-routed claude sessions through sr claude proxy --resume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1620,6 +1620,7 @@ jobs:
           python3 tests/test_claude_wrapper_mutual_shim_loop.py
           python3 tests/test_claude_wrapper_shim_root_survives_tmpdir_change.py
           python3 tests/test_claude_wrapper_user_binary_resolution.py
+          python3 tests/test_claude_wrapper_subrouter_resume_marker.py
           python3 tests/test_claude_teams_test_utils.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_codex_teams_informational.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_claude_teams_fallback_path.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1611,6 +1611,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_autodiscovery.py
           python3 tests/test_codex_wrapper_resume_hooks.py
           python3 tests/test_claude_wrapper_hooks.py
+          python3 tests/test_claude_wrapper_dead_settings_path.py
           python3 tests/test_codex_wrapper_computer_use_mcp.py
           python3 tests/test_cmux_cua_mcp_smoke.py
           python3 tests/test_cmux_cua_build_cache_safety.py

--- a/CLI/CMUXCLI+Fork.swift
+++ b/CLI/CMUXCLI+Fork.swift
@@ -178,7 +178,8 @@ extension CMUXCLI {
             observedPermissionMode: record.permissionMode
         )
         guard let invocation = AgentRestorePlanner(
-            executableFileResolver: AgentRestoreExecutableFileResolver()
+            executableFileResolver: AgentRestoreExecutableFileResolver(),
+            readableFileResolver: AgentRestoreReadableFileResolver()
         ).invocation(
             for: request,
             ambientEnvironment: processEnvironment

--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -205,7 +205,8 @@ extension CMUXCLI {
             observedPermissionMode: record.permissionMode
         )
         guard let invocation = AgentRestorePlanner(
-            executableFileResolver: AgentRestoreExecutableFileResolver()
+            executableFileResolver: AgentRestoreExecutableFileResolver(),
+            readableFileResolver: AgentRestoreReadableFileResolver()
         ).invocation(
             for: request,
             ambientEnvironment: processEnvironment

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -172,6 +172,15 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
            let path = normalizedValue(env["PATH"]) {
             selected["PATH"] = path
         }
+        if normalizedKind == "claude" {
+            // Subrouter's resume marker and the wrapper's launch-bound copy are
+            // exact command text, never a URL or credential. They cross into
+            // the durable restore record only as an agreeing pair, so a marker
+            // inherited from an ancestor `sr claude` session proves nothing.
+            selected.merge(SubrouterClaudeResumeRouting().capturedEnvironment(in: env)) { _, marker in
+                marker
+            }
+        }
         return selected
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -14,19 +14,37 @@ public struct AgentRestorePlanner: Sendable {
     ]
 
     private let isExecutableFile: @Sendable (String) -> Bool
+    private let isReadableFile: @Sendable (String) -> Bool
 
     /// Creates a restore planner.
     ///
-    /// - Parameter isExecutableFile: Executable-path lookup used for optional wrapper shims.
-    public init(isExecutableFile: @escaping @Sendable (String) -> Bool) {
+    /// - Parameters:
+    ///   - isExecutableFile: Executable-path lookup used for optional wrapper shims.
+    ///   - isReadableFile: Readable-file lookup used to drop captured file-valued
+    ///     options (Claude `--settings <path>`) whose file no longer exists.
+    ///     Defaults to the live filesystem.
+    public init(
+        isExecutableFile: @escaping @Sendable (String) -> Bool,
+        isReadableFile: @escaping @Sendable (String) -> Bool = AgentRestoreReadableFileResolver().isReadableFile(atPath:)
+    ) {
         self.isExecutableFile = isExecutableFile
+        self.isReadableFile = isReadableFile
     }
 
-    /// Creates a restore planner backed by an injected executable-file resolver.
+    /// Creates a restore planner backed by injected filesystem resolvers.
     ///
-    /// - Parameter executableFileResolver: The filesystem dependency used to resolve wrapper shims.
-    public init(executableFileResolver: AgentRestoreExecutableFileResolver) {
-        self.init(isExecutableFile: executableFileResolver.isExecutableFile(atPath:))
+    /// - Parameters:
+    ///   - executableFileResolver: The filesystem dependency used to resolve wrapper shims.
+    ///   - readableFileResolver: The filesystem dependency used to validate captured
+    ///     file-valued options at plan time. Defaults to the live filesystem.
+    public init(
+        executableFileResolver: AgentRestoreExecutableFileResolver,
+        readableFileResolver: AgentRestoreReadableFileResolver = AgentRestoreReadableFileResolver()
+    ) {
+        self.init(
+            isExecutableFile: executableFileResolver.isExecutableFile(atPath:),
+            isReadableFile: readableFileResolver.isReadableFile(atPath:)
+        )
     }
 
     /// Produces the final direct process invocation for a persisted restore or fork request.
@@ -74,6 +92,14 @@ public struct AgentRestorePlanner: Sendable {
         environment.merge(restoredEnvironment) { _, restored in restored }
 
         var routedArguments = sanitizedArguments
+        if kind == "claude", request.mode != .direct {
+            // A captured --settings path is checked here, not at capture: the file
+            // existed then, and only the restoring machine knows whether it still
+            // does. Claude refuses to start on a missing settings file.
+            routedArguments = ClaudeRestoreSettingsPathFilter(isReadableFile: isReadableFile)
+                .removingUnreadableSettingsPaths(from: routedArguments)
+            guard !routedArguments.isEmpty else { return nil }
+        }
         let hermesProfilePin: HermesAgentResumeProfilePin?
         if kind == "hermes-agent", request.mode != .direct {
             let pin = HermesAgentResumeProfilePin(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -58,8 +58,16 @@ public struct AgentRestorePlanner: Sendable {
         ambientEnvironment: [String: String]
     ) -> AgentRestoreInvocation? {
         let kind = normalizedKind(request.kind)
-        guard let plannedArguments = plannedArguments(for: request, kind: kind),
-              !plannedArguments.values.isEmpty else {
+        let routedClaudeResume = routedClaudeResumeArguments(
+            for: request,
+            kind: kind,
+            ambientEnvironment: ambientEnvironment
+        )
+        guard let plannedArguments = plannedArguments(
+            for: request,
+            kind: kind,
+            routedClaudeResume: routedClaudeResume
+        ), !plannedArguments.values.isEmpty else {
             return nil
         }
 
@@ -88,8 +96,20 @@ public struct AgentRestorePlanner: Sendable {
         guard !sanitizedArguments.isEmpty else { return nil }
 
         var environment = ambientEnvironment
-        let restoredEnvironment = restoredEnvironment(for: request, kind: kind)
+        let restoredEnvironment = restoredEnvironment(
+            for: request,
+            kind: kind,
+            routedThroughSubrouter: routedClaudeResume != nil
+        )
         environment.merge(restoredEnvironment) { _, restored in restored }
+        if routedClaudeResume != nil {
+            // Subrouter recomputes the Claude auth selection from the live pool
+            // and re-exports its own markers; nothing captured or inherited may
+            // pin the restored session to launch-time routing.
+            for key in SubrouterClaudeResumeRouting.restoreOwnedEnvironmentKeys {
+                environment.removeValue(forKey: key)
+            }
+        }
 
         var routedArguments = sanitizedArguments
         if kind == "claude", request.mode != .direct {
@@ -137,12 +157,73 @@ public struct AgentRestorePlanner: Sendable {
         )
     }
 
+    /// Returns the `sr claude proxy --resume <id>` argv for a resume whose launch
+    /// record proves it went through Subrouter and whose launcher is reachable on
+    /// the restore PATH, or `nil` to keep the ordinary claude replay.
+    ///
+    /// Provenance never looks at the captured `ANTHROPIC_BASE_URL`; the local
+    /// pool at `http://127.0.0.1:31415` is proven exactly like a hosted one, by
+    /// the launcher marker and the wrapper's launch-bound copy agreeing.
+    private func routedClaudeResumeArguments(
+        for request: AgentRestoreRequest,
+        kind: String,
+        ambientEnvironment: [String: String]
+    ) -> [String]? {
+        guard kind == "claude",
+              request.mode == .resumeAgent,
+              let checkpointID = normalized(request.checkpointID),
+              let launch = request.launchCommand else {
+            return nil
+        }
+        let router = SubrouterClaudeResumeRouting()
+        guard let routed = router.resumeArguments(
+            launcher: launch.launcher,
+            sessionID: checkpointID,
+            launchArguments: launch.arguments,
+            environment: launch.environment
+        ), let launcherExecutable = routed.first,
+        isResolvableOnRestorePath(launcherExecutable, ambientEnvironment: ambientEnvironment) else {
+            // Without the launcher the routed command could never start; the
+            // captured replay still launches and is what shipped before.
+            return nil
+        }
+        return AgentResumeArgv.claudeArgvApplyingObservedPermissionMode(
+            routed,
+            observedPermissionMode: request.observedPermissionMode
+        )
+    }
+
+    /// Mirrors the CLI's restore executable lookup: a bare name resolves only
+    /// through the ambient `PATH`, and an empty component never means `.`.
+    private func isResolvableOnRestorePath(
+        _ executable: String,
+        ambientEnvironment: [String: String]
+    ) -> Bool {
+        guard !executable.isEmpty else { return false }
+        if executable.contains("/") {
+            return isExecutableFile(executable)
+        }
+        let path = ambientEnvironment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        return path.split(separator: ":").contains { directory in
+            !directory.isEmpty
+                && isExecutableFile(
+                    URL(fileURLWithPath: String(directory), isDirectory: true)
+                        .appendingPathComponent(executable, isDirectory: false)
+                        .path
+                )
+        }
+    }
+
     private func plannedArguments(
         for request: AgentRestoreRequest,
-        kind: String
+        kind: String,
+        routedClaudeResume: [String]?
     ) -> (values: [String], removesCapturedWorkingDirectoryOptions: Bool)? {
         let preparedArguments = request.preparedArguments.flatMap {
             $0.isEmpty ? nil : $0
+        }
+        if let routedClaudeResume, request.mode == .resumeAgent {
+            return (routedClaudeResume, true)
         }
         switch request.mode {
         case .direct:
@@ -213,7 +294,8 @@ public struct AgentRestorePlanner: Sendable {
 
     private func restoredEnvironment(
         for request: AgentRestoreRequest,
-        kind: String
+        kind: String,
+        routedThroughSubrouter: Bool
     ) -> [String: String] {
         var captured = request.launchCommand?.environment ?? [:]
         captured.merge(request.environment) { _, binding in binding }
@@ -239,6 +321,17 @@ public struct AgentRestorePlanner: Sendable {
             kind: kind
         )
         if kind == "claude" {
+            if routedThroughSubrouter {
+                // The launcher owns auth selection for a routed resume.
+                for key in SubrouterClaudeResumeRouting.restoreOwnedEnvironmentKeys {
+                    selected.removeValue(forKey: key)
+                }
+                return selected
+            }
+            // The markers are restore-record evidence, not a child environment:
+            // a plain replay must not advertise a launcher that did not start it.
+            selected.removeValue(forKey: SubrouterClaudeResumeRouting.environmentKey)
+            selected.removeValue(forKey: SubrouterClaudeResumeRouting.launchBoundEnvironmentKey)
             let keys = selected.keys.sorted().filter {
                 Self.claudeAuthSelectionEnvironmentKeys.contains($0)
             }
@@ -287,8 +380,33 @@ public struct AgentRestorePlanner: Sendable {
               let restoreLaunch = AgentRestoreLaunch(
                   kind: kind,
                   sessionID: request.checkpointID
-              ),
-              (first as NSString).lastPathComponent == restoreLaunch.executableName else {
+              ) else {
+            return arguments
+        }
+
+        if kind == "claude",
+           let checkpointID = normalized(request.checkpointID),
+           let routedPrefix = SubrouterClaudeResumeRouting().resumeArguments(
+               launcher: request.launchCommand?.launcher,
+               sessionID: checkpointID,
+               launchArguments: request.launchCommand?.arguments ?? [],
+               environment: request.launchCommand?.environment
+           ),
+           arguments.starts(with: routedPrefix.prefix(5)) {
+            // `sr` resolves `claude` through PATH, where the per-surface shim
+            // still routes into cmux-claude-wrapper. The wrapper must recognise
+            // this as an app-owned restore and keep launching the captured
+            // Claude binary; the launcher itself is not wrapped.
+            environment.merge(AgentResumeArgv().managedWrapperCustomExecutableEnvironment(
+                kind: kind,
+                executablePath: request.launchCommand?.executablePath,
+                arguments: request.launchCommand?.arguments ?? []
+            )) { _, captured in captured }
+            environment["CMUX_AGENT_RESTORE_LAUNCH"] = restoreLaunch.authorizationEnvironmentValue
+            return arguments
+        }
+
+        guard (first as NSString).lastPathComponent == restoreLaunch.executableName else {
             return arguments
         }
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreReadableFileResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreReadableFileResolver.swift
@@ -1,0 +1,39 @@
+import Darwin
+
+/// Resolves readable regular files for shell-free restore planning.
+///
+/// Restore plans replay captured file-valued options such as Claude's
+/// `--settings <path>`. The file existed at capture time, but a launcher may
+/// have deleted it since; this seam lets the planner check that at plan time
+/// with a deterministic lookup that tests can inject.
+public struct AgentRestoreReadableFileResolver: Sendable {
+    private let predicate: @Sendable (String) -> Bool
+
+    /// Creates the live POSIX readable-file resolver.
+    public init() {
+        self.init(isReadableFile: { path in
+            var metadata = stat()
+            let status = stat(path, &metadata)
+            guard status == 0,
+                  metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+                return false
+            }
+            return access(path, R_OK) == 0
+        })
+    }
+
+    /// Creates a resolver with an injected readable-file predicate.
+    ///
+    /// - Parameter isReadableFile: The deterministic filesystem lookup.
+    public init(isReadableFile: @escaping @Sendable (String) -> Bool) {
+        predicate = isReadableFile
+    }
+
+    /// Returns whether the path resolves to a readable regular file.
+    ///
+    /// - Parameter path: The absolute or relative filesystem path to inspect.
+    /// - Returns: `true` only for a readable regular file.
+    public func isReadableFile(atPath path: String) -> Bool {
+        predicate(path)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeRestoreSettingsPathFilter.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeRestoreSettingsPathFilter.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Removes Claude `--settings <path>` arguments whose file cannot be read when
+/// a restore plan is built.
+///
+/// A captured `--settings` path is kept verbatim at capture time: the file
+/// exists then, and a user settings file that merely moved must not be
+/// forgotten. Launchers such as subrouter (`sr claude`), however, hand Claude
+/// an ephemeral `$TMPDIR/subrouter-claude-settings-<rand>/settings.json` and
+/// delete it on exit, and Claude refuses to start on a missing settings file
+/// ("Settings file not found"). Plan time is the only point where a replayed
+/// path can be checked against the filesystem it will actually run on, so
+/// the check lives here rather than in the pure argv sanitizer.
+///
+/// Inline JSON values, an empty value, a dangling `--settings`, and anything
+/// after a `--` boundary are left untouched. The path check mirrors the
+/// wrapper's merge loader: trim, then expand only a leading `~`.
+struct ClaudeRestoreSettingsPathFilter {
+    private static let settingsOption = "--settings"
+    private static let settingsAssignmentPrefix = "--settings="
+
+    private let isReadableFile: (String) -> Bool
+
+    /// Creates a filter backed by a readable-file lookup.
+    ///
+    /// - Parameter isReadableFile: Returns whether a path is a readable regular file.
+    init(isReadableFile: @escaping (String) -> Bool) {
+        self.isReadableFile = isReadableFile
+    }
+
+    /// Returns `arguments` without any `--settings` whose file is not readable.
+    ///
+    /// - Parameter arguments: A planned argv, including the executable as element zero.
+    /// - Returns: The same argv with unreadable settings paths removed.
+    func removingUnreadableSettingsPaths(from arguments: [String]) -> [String] {
+        var result: [String] = []
+        result.reserveCapacity(arguments.count)
+        var index = arguments.startIndex
+        while index < arguments.endIndex {
+            let argument = arguments[index]
+            if argument == "--" {
+                result.append(contentsOf: arguments[index...])
+                break
+            }
+            if argument == Self.settingsOption, index + 1 < arguments.endIndex {
+                let value = arguments[index + 1]
+                if isRestorable(value) {
+                    result.append(argument)
+                    result.append(value)
+                }
+                index += 2
+                continue
+            }
+            if argument.hasPrefix(Self.settingsAssignmentPrefix) {
+                let value = String(argument.dropFirst(Self.settingsAssignmentPrefix.count))
+                if isRestorable(value) {
+                    result.append(argument)
+                }
+                index += 1
+                continue
+            }
+            result.append(argument)
+            index += 1
+        }
+        return result
+    }
+
+    private func isRestorable(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first, first != "{", first != "[" else {
+            return true
+        }
+        return isReadableFile((trimmed as NSString).expandingTildeInPath)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterClaudeResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterClaudeResumeRouting.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// Recognizes the bounded launch evidence emitted by `sr claude proxy` and builds
+/// the resume argv that re-invokes Subrouter instead of replaying a captured
+/// Claude argv.
+///
+/// `sr claude proxy` hands Claude a private, per-launch `--settings` file that
+/// carries the proxy token, account routing headers and base URL, and deletes it
+/// when `sr` exits. A replayed `claude --resume <id>` therefore starts without
+/// any of that routing: only `ANTHROPIC_BASE_URL` and `CLAUDE_CONFIG_DIR` survive
+/// in the replay-safe capture. Re-invoking `sr claude proxy --resume <id>`
+/// regenerates the settings file from the live account pool.
+///
+/// Provenance is deliberately independent of the captured `ANTHROPIC_BASE_URL`,
+/// so a local pool at `http://127.0.0.1:31415` and a hosted one are proven the
+/// same way, through two exact-match markers that must agree:
+///
+/// - ``environmentKey``, exported by `sr` into the Claude child it launches.
+/// - ``launchBoundEnvironmentKey``, exported by `cmux-claude-wrapper` only when
+///   the argv it received carried Subrouter's private `--settings` file. The
+///   wrapper is the one process that still sees that file: its settings merge
+///   drops user `--settings` before the argv is captured for restore.
+///
+/// The first marker leaks to every descendant of the launched Claude, so on
+/// its own it proves nothing. Anything short of the agreeing pair leaves the
+/// existing restore untouched.
+public struct SubrouterClaudeResumeRouting: Sendable, Equatable {
+    /// The metadata marker emitted by Subrouter for pooled Claude children.
+    public static let environmentKey = "SUBROUTER_CLAUDE_RESUME_COMMAND"
+
+    /// Wrapper-attested copy of the marker bound to the current Claude argv.
+    public static let launchBoundEnvironmentKey = "CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND"
+
+    /// Directory-name prefix of the private settings directory `sr claude proxy` creates.
+    public static let privateSettingsDirectoryPrefix = "subrouter-claude-settings-"
+
+    private static let expectedMarkerTokens = [
+        ["sr", "claude", "proxy", "--resume"],
+        ["subrouter", "claude", "proxy", "--resume"],
+    ]
+
+    /// Environment keys a proven routed restore owns: the markers themselves and
+    /// the Claude auth selection that Subrouter regenerates from the live pool.
+    /// Replaying the captured values around `sr` would pin the restored session
+    /// to launch-time routing that the launcher is about to recompute.
+    public static let restoreOwnedEnvironmentKeys: Set<String> = [
+        environmentKey,
+        launchBoundEnvironmentKey,
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CONFIG_DIR",
+        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV",
+        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS",
+    ]
+
+    /// Creates a Subrouter Claude resume router.
+    public init() {}
+
+    /// Returns the canonical marker when the captured environment contains the
+    /// exact supported command, or `nil` for absent or untrusted values.
+    public func capturedMarker(in environment: [String: String]?) -> String? {
+        canonicalMarker(environment?[Self.environmentKey])
+    }
+
+    /// Returns the canonical form of a marker value, or `nil` unless it is
+    /// exactly one of the supported launcher commands.
+    public func canonicalMarker(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let tokens = rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
+        guard Self.expectedMarkerTokens.contains(tokens) else { return nil }
+        return tokens.joined(separator: " ")
+    }
+
+    private func capturedLaunchBoundMarker(in environment: [String: String]?) -> String? {
+        guard let marker = capturedMarker(in: environment),
+              canonicalMarker(environment?[Self.launchBoundEnvironmentKey]) == marker else {
+            return nil
+        }
+        return marker
+    }
+
+    /// Returns the agreeing marker pair for a durable launch record, or an empty
+    /// environment when the launch is not proven.
+    public func capturedEnvironment(in environment: [String: String]?) -> [String: String] {
+        guard let marker = capturedLaunchBoundMarker(in: environment) else { return [:] }
+        return [
+            Self.environmentKey: marker,
+            Self.launchBoundEnvironmentKey: marker,
+        ]
+    }
+
+    /// Whether the captured launch proves a Subrouter-routed plain `claude` launch.
+    ///
+    /// cmux launchers (`claudeTeams` and friends) own their own resume shape and
+    /// are never rerouted.
+    public func provesRoutedLaunch(launcher: String?, environment: [String: String]?) -> Bool {
+        let normalizedLauncher = launcher?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedLauncher == nil || normalizedLauncher == "claude" else { return false }
+        return capturedLaunchBoundMarker(in: environment) != nil
+    }
+
+    /// The launcher program (`sr` or `subrouter`) named by a trusted marker.
+    public func launcherExecutable(in environment: [String: String]?) -> String? {
+        capturedLaunchBoundMarker(in: environment)?
+            .split(separator: " ")
+            .first
+            .map(String.init)
+    }
+
+    /// Builds the Subrouter launcher resume argv only when the launch record
+    /// proves the routed invocation. The captured Claude options that are safe
+    /// to replay follow the session id; Subrouter's private `--settings` file is
+    /// dropped because the launcher issues a fresh one.
+    public func resumeArguments(
+        launcher: String?,
+        sessionID: String,
+        launchArguments: [String],
+        environment: [String: String]?
+    ) -> [String]? {
+        guard provesRoutedLaunch(launcher: launcher, environment: environment),
+              let marker = capturedLaunchBoundMarker(in: environment) else {
+            return nil
+        }
+        let tail = launchArguments.isEmpty ? [] : Array(launchArguments.dropFirst())
+        guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "claude", args: tail) else {
+            return nil
+        }
+        return marker.split(separator: " ").map(String.init)
+            + [sessionID]
+            + removingPrivateSettingsArguments(from: preserved)
+    }
+
+    /// Whether a `--settings` value names Subrouter's private per-launch file.
+    public static func isPrivateSettingsPath(_ value: String) -> Bool {
+        let path = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard (path as NSString).lastPathComponent == "settings.json" else { return false }
+        let directory = ((path as NSString).deletingLastPathComponent as NSString).lastPathComponent
+        return directory.hasPrefix(privateSettingsDirectoryPrefix)
+    }
+
+    /// Removes `--settings <private>` and `--settings=<private>` for Subrouter's
+    /// private file; every other argument, including other `--settings`, stays.
+    public func removingPrivateSettingsArguments(from arguments: [String]) -> [String] {
+        var selected: [String] = []
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--" {
+                selected.append(contentsOf: arguments[index...])
+                break
+            }
+            if argument == "--settings", index + 1 < arguments.count,
+               Self.isPrivateSettingsPath(arguments[index + 1]) {
+                index += 2
+                continue
+            }
+            if argument.hasPrefix("--settings="),
+               Self.isPrivateSettingsPath(String(argument.dropFirst("--settings=".count))) {
+                index += 1
+                continue
+            }
+            selected.append(argument)
+            index += 1
+        }
+        return selected
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeRestoreSettingsPathTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeRestoreSettingsPathTests.swift
@@ -1,0 +1,130 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+/// A captured Claude `--settings <path>` is only replayed when the file is still
+/// readable on the restoring machine. subrouter's ephemeral
+/// `$TMPDIR/subrouter-claude-settings-<rand>/settings.json` is the motivating
+/// case: it exists at capture and is deleted when `sr` exits, and Claude
+/// refuses to start on a missing settings file.
+@Suite("Claude restore plans drop --settings paths that are gone")
+struct ClaudeRestoreSettingsPathTests {
+    private let sessionID = "3d1d5a5a-6d36-4d3a-9a3c-1d4f0e6c2b7a"
+    private let deadPath = "/var/folders/zz/T/subrouter-claude-settings-3294281412/settings.json"
+    private let livePath = "/home/me/settings.json"
+
+    @Test("A resume plan keeps a readable --settings path in both spellings")
+    func resumeKeepsReadableSettings() throws {
+        let invocation = try #require(plan(
+            mode: .resumeAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", livePath, "--settings=\(livePath)", "--model", "opus"],
+            readable: [livePath]
+        ))
+        #expect(invocation.arguments == [
+            "claude", "--resume", sessionID, "--settings", livePath, "--settings=\(livePath)", "--model", "opus"
+        ])
+    }
+
+    @Test("A resume plan drops an unreadable --settings path in both spellings")
+    func resumeDropsUnreadableSettings() throws {
+        let invocation = try #require(plan(
+            mode: .resumeAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", deadPath, "--settings=\(deadPath)", "--model", "opus"],
+            readable: []
+        ))
+        #expect(invocation.arguments == ["claude", "--resume", sessionID, "--model", "opus"])
+    }
+
+    @Test("Only the dead path is dropped when a readable one is captured alongside it")
+    func mixedSettingsKeepOnlyReadablePath() throws {
+        let invocation = try #require(plan(
+            mode: .resumeAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", deadPath, "--settings", livePath],
+            readable: [livePath]
+        ))
+        #expect(invocation.arguments == ["claude", "--resume", sessionID, "--settings", livePath])
+    }
+
+    @Test("Inline JSON --settings never consults the filesystem")
+    func inlineSettingsAreNotFileChecked() throws {
+        let inline = #"{"effortLevel":"max"}"#
+        let invocation = try #require(plan(
+            mode: .resumeAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", inline, "--settings=\(inline)"],
+            readable: []
+        ))
+        #expect(invocation.arguments == ["claude", "--resume", sessionID, "--settings", inline, "--settings=\(inline)"])
+    }
+
+    @Test("A tilde --settings path is checked after expansion")
+    func tildeSettingsPathIsExpandedBeforeCheck() throws {
+        let home = NSHomeDirectory()
+        let invocation = try #require(plan(
+            mode: .resumeAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", "~/claude-settings.json"],
+            readable: ["\(home)/claude-settings.json"]
+        ))
+        #expect(invocation.arguments == ["claude", "--resume", sessionID, "--settings", "~/claude-settings.json"])
+    }
+
+    @Test("A fork plan drops an unreadable --settings path too")
+    func forkDropsUnreadableSettings() throws {
+        let invocation = try #require(plan(
+            mode: .forkAgent,
+            arguments: ["/opt/homebrew/bin/claude", "--settings", deadPath, "--model", "opus"],
+            readable: []
+        ))
+        #expect(!invocation.arguments.contains(deadPath))
+        #expect(invocation.arguments.contains("--model"))
+        #expect(invocation.arguments.contains("opus"))
+    }
+
+    @Test("A direct plan replays the recorded argv untouched")
+    func directPlanIsNotFiltered() throws {
+        let invocation = try #require(AgentRestorePlanner(
+            isExecutableFile: { _ in false },
+            isReadableFile: { _ in false }
+        ).invocation(
+            for: AgentRestoreRequest(
+                mode: .direct,
+                kind: "claude",
+                checkpointID: sessionID,
+                source: "session-snapshot",
+                workingDirectory: nil,
+                environment: [:],
+                launchCommand: nil,
+                preparedArguments: ["/opt/homebrew/bin/claude", "--settings", deadPath],
+                observedPermissionMode: nil
+            ),
+            ambientEnvironment: [:]
+        ))
+        #expect(invocation.arguments == ["/opt/homebrew/bin/claude", "--settings", deadPath])
+    }
+
+    private func plan(
+        mode: AgentRestoreRequestMode,
+        arguments: [String],
+        readable: Set<String>
+    ) -> AgentRestoreInvocation? {
+        AgentRestorePlanner(
+            isExecutableFile: { _ in false },
+            isReadableFile: { readable.contains($0) }
+        ).invocation(
+            for: AgentRestoreRequest(
+                mode: mode,
+                kind: "claude",
+                checkpointID: sessionID,
+                source: "agent-hook",
+                workingDirectory: nil,
+                environment: [:],
+                launchCommand: AgentLaunchCommand(
+                    executablePath: "/opt/homebrew/bin/claude",
+                    arguments: arguments
+                ),
+                preparedArguments: nil,
+                observedPermissionMode: nil
+            ),
+            ambientEnvironment: [:]
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
@@ -52,15 +52,29 @@ struct ClaudeResumeHookSettingsTests {
         #expect(argv == ["claude", "--resume", "s", "--model", "opus"])
     }
 
-    @Test("A non-hook --settings is preserved and still routes through the wrapper")
-    func nonHookSettingsPreserved() {
-        let argv = AgentResumeArgv().builtInKind(
-            kind: "claude",
-            sessionId: "s",
-            executablePath: "/opt/homebrew/bin/claude",
-            arguments: ["/opt/homebrew/bin/claude", "--settings", "/home/me/settings.json"]
-        )
-        #expect(argv == ["claude", "--resume", "s", "--settings", "/home/me/settings.json"])
+    @Test("A non-hook --settings whose file still exists is preserved and routes through the wrapper")
+    func existingNonHookSettingsPreservedOnRestore() throws {
+        let settingsFile = try makeTemporarySettingsFile()
+        defer { try? FileManager.default.removeItem(at: settingsFile.deletingLastPathComponent()) }
+
+        let invocation = try #require(restoreInvocation(settingsPath: settingsFile.path))
+
+        #expect(invocation.arguments == ["claude", "--resume", "s", "--settings", settingsFile.path])
+    }
+
+    /// Launchers such as subrouter (`sr claude`) hand Claude an ephemeral
+    /// `$TMPDIR/subrouter-claude-settings-<rand>/settings.json` and delete it on
+    /// exit. The captured argv still names it, and Claude refuses to start on a
+    /// missing settings file ("Settings file not found"), so a restore plan must
+    /// not replay a `--settings` path that is gone.
+    @Test("A non-hook --settings whose file is gone is dropped from the restore plan")
+    func missingNonHookSettingsDroppedOnRestore() throws {
+        let settingsFile = try makeTemporarySettingsFile()
+        try FileManager.default.removeItem(at: settingsFile.deletingLastPathComponent())
+
+        let invocation = try #require(restoreInvocation(settingsPath: settingsFile.path))
+
+        #expect(invocation.arguments == ["claude", "--resume", "s"])
     }
 
     @Test("Merged hook --settings keeps user keys when resuming")
@@ -111,6 +125,37 @@ struct ClaudeResumeHookSettingsTests {
         )
 
         #expect(argv == ["claude", "--resume", "s", "--settings", userSettings])
+    }
+
+    private func restoreInvocation(settingsPath: String) -> AgentRestoreInvocation? {
+        AgentRestorePlanner(
+            executableFileResolver: AgentRestoreExecutableFileResolver()
+        ).invocation(
+            for: AgentRestoreRequest(
+                mode: .resumeAgent,
+                kind: "claude",
+                checkpointID: "s",
+                source: "agent-hook",
+                workingDirectory: nil,
+                environment: [:],
+                launchCommand: AgentLaunchCommand(
+                    executablePath: "/opt/homebrew/bin/claude",
+                    arguments: ["/opt/homebrew/bin/claude", "--settings", settingsPath]
+                ),
+                preparedArguments: nil,
+                observedPermissionMode: nil
+            ),
+            ambientEnvironment: [:]
+        )
+    }
+
+    private func makeTemporarySettingsFile() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("subrouter-claude-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("settings.json")
+        try #"{"effortLevel":"max"}"#.write(to: file, atomically: true, encoding: .utf8)
+        return file
     }
 
     private func assertUserSettingsJSON(_ settingsJSON: String) throws {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeRestoreRoutingTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeRestoreRoutingTests.swift
@@ -1,0 +1,423 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+/// `sr claude proxy` launches Claude with a private, per-launch `--settings` file
+/// that carries the proxy token, account routing headers and base URL, and
+/// deletes it when `sr` exits. Replaying the captured `claude --resume <id>`
+/// therefore restores a session with none of that routing. A restore that can
+/// prove the launch went through Subrouter must re-invoke the launcher instead.
+@Suite("Claude restore re-invokes sr claude proxy for a proven Subrouter launch")
+struct SubrouterClaudeRestoreRoutingTests {
+    private let sessionID = "0198f073-0a5b-7000-8000-000000000059"
+    private let marker = "sr claude proxy --resume"
+    private let markerKey = "SUBROUTER_CLAUDE_RESUME_COMMAND"
+    private let launchBoundMarkerKey = "CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND"
+    private let localPoolBaseURL = "http://127.0.0.1:31415/v1"
+    private let capturedClaude = "/opt/homebrew/bin/claude"
+    private let capturedConfigDir = "/Users/me/.subrouter/codex/claude-proxy/3fa7ce27b6c3bad79bd47d1a"
+
+    private func routedLaunchEnvironment(
+        baseURL: String,
+        marker: String? = nil,
+        launchBoundMarker: String? = nil
+    ) -> [String: String] {
+        var environment = [
+            "ANTHROPIC_BASE_URL": baseURL,
+            "CLAUDE_CONFIG_DIR": capturedConfigDir,
+        ]
+        environment[markerKey] = marker
+        environment[launchBoundMarkerKey] = launchBoundMarker
+        return environment
+    }
+
+    private func resumeRequest(
+        arguments: [String]? = nil,
+        environment: [String: String],
+        launcher: String? = nil,
+        mode: AgentRestoreRequestMode = .resumeAgent,
+        observedPermissionMode: String? = nil
+    ) -> AgentRestoreRequest {
+        AgentRestoreRequest(
+            mode: mode,
+            kind: "claude",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: launcher,
+                executablePath: capturedClaude,
+                arguments: arguments ?? [capturedClaude, "--model", "opus"],
+                workingDirectory: "/tmp/project",
+                environment: environment,
+                capturedAt: 1,
+                source: "test"
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: observedPermissionMode
+        )
+    }
+
+    /// `sr` on PATH and the per-surface claude shim both exist.
+    private func plannerWithSubrouterOnPath() -> AgentRestorePlanner {
+        AgentRestorePlanner(isExecutableFile: { path in
+            path == "/opt/homebrew/bin/sr" || path == "/shim/claude"
+        })
+    }
+
+    private let ambientEnvironment = [
+        "PATH": "/tmp/cmux-shims:/opt/homebrew/bin:/usr/bin:/bin",
+        "CMUX_CLAUDE_WRAPPER_SHIM": "/shim/claude",
+        "HOME": "/Users/me",
+    ]
+
+    private func expectPlainClaudeReplay(
+        _ invocation: AgentRestoreInvocation,
+        baseURL: String,
+        _ label: String
+    ) {
+        #expect(invocation.arguments.first == "/shim/claude", "\(label): \(invocation.arguments)")
+        #expect(invocation.arguments.contains("sr") == false, "\(label): \(invocation.arguments)")
+        #expect(invocation.arguments.contains("proxy") == false, "\(label): \(invocation.arguments)")
+        #expect(invocation.arguments.contains("--resume"), "\(label): \(invocation.arguments)")
+        #expect(invocation.arguments.contains(sessionID), "\(label): \(invocation.arguments)")
+        // The existing replay keeps carrying the auth selection it captured.
+        #expect(invocation.environment["ANTHROPIC_BASE_URL"] == baseURL, "\(label)")
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == capturedConfigDir, "\(label)")
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1", "\(label)")
+    }
+
+    @Test(
+        "A proven Subrouter launch restores through sr claude proxy --resume, local pool or hosted",
+        arguments: ["http://127.0.0.1:31415/v1", "https://sr.cmux.com/v1"]
+    )
+    func provenRoutedLaunchReinvokesSubrouter(baseURL: String) throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: baseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            )
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(
+            invocation.arguments == ["sr", "claude", "proxy", "--resume", sessionID, "--model", "opus"],
+            "\(invocation.arguments)"
+        )
+        #expect(invocation.workingDirectory == "/tmp/project")
+        // Subrouter regenerates auth selection from the live pool; the captured
+        // values must not be re-injected around it.
+        #expect(invocation.environment["ANTHROPIC_BASE_URL"] == nil)
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == nil)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == nil)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] == nil)
+        #expect(invocation.environment[markerKey] == nil)
+        #expect(invocation.environment[launchBoundMarkerKey] == nil)
+        // The wrapper `sr` reaches through PATH still recognises an app-owned restore
+        // and keeps launching the same Claude binary.
+        #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == "claude:\(sessionID)")
+        #expect(invocation.environment["CMUX_CUSTOM_CLAUDE_PATH"] == capturedClaude)
+        #expect(invocation.environment["PATH"] == ambientEnvironment["PATH"])
+        #expect(invocation.preflightInvocations.isEmpty)
+    }
+
+    @Test("The routed restore re-applies the observed permission mode after the session id")
+    func routedRestoreAppliesObservedPermissionMode() throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            ),
+            observedPermissionMode: "bypassPermissions"
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(invocation.arguments.starts(with: ["sr", "claude", "proxy", "--resume", sessionID]))
+        #expect(invocation.arguments.suffix(2) == ["--permission-mode", "bypassPermissions"])
+    }
+
+    @Test("The routed restore drops Subrouter's private --settings file from a captured argv")
+    func routedRestoreDropsSubrouterPrivateSettings() throws {
+        let deadSettings = "/var/folders/zz/T/subrouter-claude-settings-3294281412/settings.json"
+        let request = resumeRequest(
+            arguments: [capturedClaude, "--settings", deadSettings, "--model", "opus", "--settings=\(deadSettings)"],
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            )
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(
+            invocation.arguments == ["sr", "claude", "proxy", "--resume", sessionID, "--model", "opus"],
+            "\(invocation.arguments)"
+        )
+    }
+
+    @Test("The subrouter program name in the marker is honoured, never rewritten to sr")
+    func routedRestoreUsesTheMarkedLauncherProgram() throws {
+        let subrouterMarker = "subrouter claude proxy --resume"
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: subrouterMarker,
+                launchBoundMarker: subrouterMarker
+            )
+        )
+        let planner = AgentRestorePlanner(isExecutableFile: { path in
+            path == "/opt/homebrew/bin/subrouter" || path == "/shim/claude"
+        })
+
+        let invocation = try #require(planner.invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(invocation.arguments.starts(with: ["subrouter", "claude", "proxy", "--resume", sessionID]))
+    }
+
+    @Test("An inherited marker without the wrapper's launch-bound copy is not provenance")
+    func inheritedMarkerAloneKeepsThePlainReplay() throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: nil
+            )
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        expectPlainClaudeReplay(invocation, baseURL: localPoolBaseURL, "marker only")
+    }
+
+    @Test("A launch-bound copy without the marker, or one that disagrees, is not provenance")
+    func disagreeingMarkersKeepThePlainReplay() throws {
+        for (label, marker, bound) in [
+            ("bound only", nil, marker),
+            ("disagree", marker, "subrouter claude proxy --resume"),
+            ("codex bound", marker, "sr codex resume"),
+        ] as [(String, String?, String)] {
+            let request = resumeRequest(
+                environment: routedLaunchEnvironment(
+                    baseURL: localPoolBaseURL,
+                    marker: marker,
+                    launchBoundMarker: bound
+                )
+            )
+            let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+                for: request,
+                ambientEnvironment: ambientEnvironment
+            ))
+            expectPlainClaudeReplay(invocation, baseURL: localPoolBaseURL, label)
+        }
+    }
+
+    @Test(
+        "Only the exact launcher command text is trusted",
+        arguments: [
+            "sr claude proxy --restore",
+            "sr claude --resume",
+            "sr claude proxy --resume --account evil",
+            "/tmp/evil claude proxy --resume",
+            "sr claude proxy --resume; rm -rf /",
+            "cx claude proxy --resume",
+            "SR CLAUDE PROXY --RESUME",
+            "",
+        ]
+    )
+    func unexpectedMarkerTextKeepsThePlainReplay(untrusted: String) throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: untrusted,
+                launchBoundMarker: untrusted
+            )
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        expectPlainClaudeReplay(invocation, baseURL: localPoolBaseURL, untrusted)
+    }
+
+    @Test("A local pool base URL alone is never treated as provenance")
+    func localPoolBaseURLAloneKeepsThePlainReplay() throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(baseURL: localPoolBaseURL)
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        expectPlainClaudeReplay(invocation, baseURL: localPoolBaseURL, "base url only")
+    }
+
+    @Test("When sr cannot be resolved on the restore PATH the plain replay is kept")
+    func missingLauncherOnPathKeepsThePlainReplay() throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            )
+        )
+        let planner = AgentRestorePlanner(isExecutableFile: { $0 == "/shim/claude" })
+
+        let invocation = try #require(planner.invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        expectPlainClaudeReplay(invocation, baseURL: localPoolBaseURL, "sr missing")
+    }
+
+    @Test("A cmux launcher such as claude-teams is never rerouted through Subrouter")
+    func cmuxLauncherIsNotRerouted() throws {
+        let request = resumeRequest(
+            arguments: ["cmux", "claude-teams", "--model", "opus"],
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            ),
+            launcher: "claudeTeams"
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(invocation.arguments.contains("claude-teams"), "\(invocation.arguments)")
+        #expect(invocation.arguments.contains("proxy") == false, "\(invocation.arguments)")
+    }
+
+    @Test("A direct plan replays the recorded argv untouched even with provenance")
+    func directPlanReplaysRecordedArgv() throws {
+        let request = resumeRequest(
+            environment: routedLaunchEnvironment(
+                baseURL: localPoolBaseURL,
+                marker: marker,
+                launchBoundMarker: marker
+            ),
+            mode: .direct
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ambientEnvironment
+        ))
+
+        #expect(invocation.arguments == [capturedClaude, "--model", "opus"])
+        #expect(invocation.environment["ANTHROPIC_BASE_URL"] == localPoolBaseURL)
+    }
+
+    @Test("A codex record carrying the claude markers is not affected")
+    func codexRecordIgnoresClaudeMarkers() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                arguments: ["codex"],
+                workingDirectory: "/tmp/project",
+                environment: [markerKey: marker, launchBoundMarkerKey: marker, "CODEX_HOME": "/tmp/codex-home"]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(plannerWithSubrouterOnPath().invocation(
+            for: request,
+            ambientEnvironment: ["PATH": "/opt/homebrew/bin:/usr/bin"]
+        ))
+
+        #expect(invocation.arguments.first == "codex")
+        #expect(invocation.arguments.contains("proxy") == false)
+        #expect(invocation.environment["CODEX_HOME"] == "/tmp/codex-home")
+        #expect(invocation.environment[markerKey] == nil)
+    }
+}
+
+@Suite("Launch capture keeps the Subrouter claude resume markers, and only those")
+struct SubrouterClaudeResumeMarkerCaptureTests {
+    private let marker = "sr claude proxy --resume"
+    private let markerKey = "SUBROUTER_CLAUDE_RESUME_COMMAND"
+    private let launchBoundMarkerKey = "CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND"
+
+    @Test("An agreeing marker pair crosses the restore record boundary for claude")
+    func agreeingMarkersAreCapturedForClaude() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(
+            from: [
+                markerKey: marker,
+                launchBoundMarkerKey: marker,
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:31415/v1",
+                "ANTHROPIC_AUTH_TOKEN": "srt_secret_must_not_cross",
+                "ANTHROPIC_CUSTOM_HEADERS": "X-Subrouter-Agent: claude",
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-proxy/abc",
+            ],
+            kind: "claude"
+        )
+
+        #expect(selected == [
+            markerKey: marker,
+            launchBoundMarkerKey: marker,
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:31415/v1",
+            "CLAUDE_CONFIG_DIR": "/tmp/claude-proxy/abc",
+        ])
+    }
+
+    @Test("Markers that disagree, are not exact, or lack the launch-bound copy are dropped")
+    func untrustedMarkersAreDropped() {
+        for (label, environment) in [
+            ("marker only", [markerKey: marker]),
+            ("bound only", [launchBoundMarkerKey: marker]),
+            ("disagree", [markerKey: marker, launchBoundMarkerKey: "subrouter claude proxy --resume"]),
+            ("not exact", [markerKey: "sr claude proxy --restore", launchBoundMarkerKey: "sr claude proxy --restore"]),
+            ("shell text", [markerKey: "sr claude proxy --resume; id", launchBoundMarkerKey: "sr claude proxy --resume; id"]),
+        ] as [(String, [String: String])] {
+            let selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(
+                from: environment,
+                kind: "claude"
+            )
+            #expect(selected.isEmpty, "\(label): \(selected)")
+        }
+    }
+
+    @Test("The markers are not captured for other kinds nor for typed replay commands")
+    func markersStayScopedToClaudeRestoreRecords() {
+        let environment = [markerKey: marker, launchBoundMarkerKey: marker]
+
+        #expect(AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(from: environment, kind: "codex").isEmpty)
+        #expect(AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(from: environment, kind: nil).isEmpty)
+        #expect(AgentLaunchEnvironmentPolicy().selectedEnvironment(from: environment, kind: "claude").isEmpty)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeRestoreRoutingTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeRestoreRoutingTests.swift
@@ -86,6 +86,9 @@ struct SubrouterClaudeRestoreRoutingTests {
         #expect(invocation.environment["ANTHROPIC_BASE_URL"] == baseURL, "\(label)")
         #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == capturedConfigDir, "\(label)")
         #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1", "\(label)")
+        // Record evidence never becomes a child environment for a plain replay.
+        #expect(invocation.environment[markerKey] == nil, "\(label)")
+        #expect(invocation.environment[launchBoundMarkerKey] == nil, "\(label)")
     }
 
     @Test(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeResumeRoutingTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SubrouterClaudeResumeRoutingTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite("SubrouterClaudeResumeRouting")
+struct SubrouterClaudeResumeRoutingTests {
+    private let sessionID = "0198f073-0a5b-7000-8000-000000000059"
+    private let marker = "sr claude proxy --resume"
+    private let router = SubrouterClaudeResumeRouting()
+
+    private func provenEnvironment(_ marker: String) -> [String: String] {
+        [
+            SubrouterClaudeResumeRouting.environmentKey: marker,
+            SubrouterClaudeResumeRouting.launchBoundEnvironmentKey: marker,
+        ]
+    }
+
+    @Test(
+        "Only the two exact launcher commands canonicalize",
+        arguments: [
+            ("sr claude proxy --resume", "sr claude proxy --resume"),
+            ("  subrouter   claude\tproxy --resume ", "subrouter claude proxy --resume"),
+            ("sr claude proxy --restore", nil),
+            ("sr claude proxy --resume --account x", nil),
+            ("sr claude proxy", nil),
+            ("cx claude proxy --resume", nil),
+            ("/usr/local/bin/sr claude proxy --resume", nil),
+            ("sr claude proxy --resume;id", nil),
+            ("", nil),
+        ] as [(String, String?)]
+    )
+    func canonicalMarkerIsExact(raw: String, expected: String?) {
+        #expect(router.canonicalMarker(raw) == expected)
+    }
+
+    @Test("The captured environment is the agreeing pair, or nothing")
+    func capturedEnvironmentRequiresAgreeingPair() {
+        #expect(router.capturedEnvironment(in: provenEnvironment(marker)) == provenEnvironment(marker))
+        #expect(router.capturedEnvironment(in: [SubrouterClaudeResumeRouting.environmentKey: marker]).isEmpty)
+        #expect(router.capturedEnvironment(in: [SubrouterClaudeResumeRouting.launchBoundEnvironmentKey: marker]).isEmpty)
+        #expect(router.capturedEnvironment(in: [
+            SubrouterClaudeResumeRouting.environmentKey: marker,
+            SubrouterClaudeResumeRouting.launchBoundEnvironmentKey: "subrouter claude proxy --resume",
+        ]).isEmpty)
+        #expect(router.capturedEnvironment(in: nil).isEmpty)
+    }
+
+    @Test("Provenance is scoped to plain claude launches")
+    func provenanceIsScopedToPlainClaudeLaunches() {
+        #expect(router.provesRoutedLaunch(launcher: nil, environment: provenEnvironment(marker)))
+        #expect(router.provesRoutedLaunch(launcher: " Claude ", environment: provenEnvironment(marker)))
+        #expect(router.provesRoutedLaunch(launcher: "claudeTeams", environment: provenEnvironment(marker)) == false)
+        #expect(router.provesRoutedLaunch(launcher: "codex", environment: provenEnvironment(marker)) == false)
+        #expect(router.provesRoutedLaunch(launcher: nil, environment: [:]) == false)
+        #expect(router.launcherExecutable(in: provenEnvironment("subrouter claude proxy --resume")) == "subrouter")
+        #expect(router.launcherExecutable(in: [:]) == nil)
+    }
+
+    @Test("The resume argv is the marker, the session id, then the replay-safe claude options")
+    func resumeArgumentsFollowTheMarker() {
+        let privateSettings = "/var/folders/zz/T/subrouter-claude-settings-42/settings.json"
+        let arguments = router.resumeArguments(
+            launcher: nil,
+            sessionID: sessionID,
+            launchArguments: [
+                "/opt/homebrew/bin/claude",
+                "--settings", privateSettings,
+                "--model", "opus",
+                "--resume", "1111aaaa-0a5b-7000-8000-000000000001",
+                "--settings", "~/my-settings.json",
+                "--add-dir", "/tmp/extra",
+            ],
+            environment: provenEnvironment(marker)
+        )
+
+        #expect(
+            arguments == [
+                "sr", "claude", "proxy", "--resume", sessionID,
+                "--model", "opus",
+                "--settings", "~/my-settings.json",
+                "--add-dir", "/tmp/extra",
+            ],
+            "\(String(describing: arguments))"
+        )
+    }
+
+    @Test("An environment-only record still resumes through the launcher")
+    func environmentOnlyRecordResumes() {
+        #expect(
+            router.resumeArguments(
+                launcher: nil,
+                sessionID: sessionID,
+                launchArguments: [],
+                environment: provenEnvironment(marker)
+            ) == ["sr", "claude", "proxy", "--resume", sessionID]
+        )
+    }
+
+    @Test("Private settings detection matches only Subrouter's per-launch directory")
+    func privateSettingsPathDetection() {
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath("/tmp/subrouter-claude-settings-1/settings.json"))
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath(" /var/folders/T/subrouter-claude-settings-abc/settings.json "))
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath("/tmp/cmux-claude-settings.abc") == false)
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath("/tmp/subrouter-claude-settings-1/other.json") == false)
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath("~/.claude/settings.json") == false)
+        #expect(SubrouterClaudeResumeRouting.isPrivateSettingsPath("{\"hooks\":{}}") == false)
+    }
+
+    @Test("Literal arguments after the option terminator are never touched")
+    func optionTerminatorIsRespected() {
+        let privateSettings = "/tmp/subrouter-claude-settings-1/settings.json"
+        #expect(
+            router.removingPrivateSettingsArguments(from: ["--", "--settings", privateSettings])
+                == ["--", "--settings", privateSettings]
+        )
+        #expect(
+            router.removingPrivateSettingsArguments(from: ["--settings=\(privateSettings)", "prompt"])
+                == ["prompt"]
+        )
+    }
+}

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -1632,9 +1632,18 @@ unset CMUX_GENERATED_HOOKS_JSON
 # does not rely on the CLI's multi-flag behavior. Requires `node`; if node is
 # missing or the merge fails, preserve the user's original settings and disable
 # cmux hooks for that launch rather than passing an ambiguous pair of flags.
-# A --settings path that is not readable is dropped up front with a warning:
-# Claude would refuse to start on it, so forwarding it (with or without cmux's
-# hooks) can only fail the launch.
+# An unreadable --settings path is dropped up front with a warning ONLY when
+# cmux owns this launch as a restore replay. There the path came from a launch
+# record cmux itself captured, the launcher that created it (for example
+# `sr claude proxy`) has already deleted it, and forwarding it can only fail a
+# restore the user asked for.
+#
+# An ordinary interactive launch keeps failing closed. A settings file can
+# define permission rules and hooks, so silently starting Claude WITHOUT the
+# policy the user named -- because of a typo, a permission change, or an
+# unmounted volume -- would turn an invalid configuration into a quietly
+# less-restricted session. Claude refusing to start is the correct outcome
+# there, and it is the user's own argument to fix.
 unset CMUX_USER_SETTINGS_B64
 CMUX_FILTERED_ARGS=()
 CMUX_USER_SETTINGS=()
@@ -1654,11 +1663,12 @@ for arg in "$@"; do
     fi
     if [[ "$cmux_collect_settings_value" == true ]]; then
         cmux_collect_settings_value=false
-        if cmux_claude_wrapper_settings_value_is_readable "$arg"; then
+        if cmux_claude_wrapper_settings_value_is_readable "$arg" \
+            || [[ "${cmux_claude_app_restore_owned:-0}" != "1" ]]; then
             CMUX_USER_SETTINGS+=("$arg")
             CMUX_PASSTHROUGH_ARGS+=("--settings" "$arg")
         else
-            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "$arg" >&2
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this restore: %s\n' "$arg" >&2
             cmux_dropped_unreadable_settings=true
         fi
         continue
@@ -1678,11 +1688,12 @@ for arg in "$@"; do
         # potentially very large JSON value.
         cmux_collect_settings_value=true
     elif [[ "${arg:0:11}" == "--settings=" ]]; then
-        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}"; then
+        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}" \
+            || [[ "${cmux_claude_app_restore_owned:-0}" != "1" ]]; then
             CMUX_USER_SETTINGS+=("${arg#--settings=}")
             CMUX_PASSTHROUGH_ARGS+=("$arg")
         else
-            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "${arg#--settings=}" >&2
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this restore: %s\n' "${arg#--settings=}" >&2
             cmux_dropped_unreadable_settings=true
         fi
     elif [[ "${arg:0:1}" == "-" ]]; then

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -1383,10 +1383,62 @@ fi
 # the actual claude process PID, which hooks use for stale-session detection.
 export CMUX_CLAUDE_PID=$$
 export CMUX_CLAUDE_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
+
+# Subrouter (`sr claude proxy`) launches Claude with a private, per-launch
+# --settings file under $TMPDIR/subrouter-claude-settings-<rand>/ (the proxy
+# token, account routing headers and base URL live only there; a guardian
+# deletes it when sr exits) and exports SUBROUTER_CLAUDE_RESUME_COMMAND so a
+# host can resume through the same launcher once that file is gone. The marker
+# leaks to every descendant of the launched Claude, so it is bound to THIS
+# launch only while the argv still carries that existing private file. The
+# settings merge below drops user --settings before the argv is captured for
+# restore, so this is the only point where that proof exists.
+claude_launch_has_subrouter_private_settings() {
+    local argument value expects_value=0
+    for argument in "$@"; do
+        [[ "$argument" == "--" ]] && break
+        value=""
+        if (( expects_value )); then
+            value="$argument"
+            expects_value=0
+        else
+            case "$argument" in
+                --settings)
+                    expects_value=1
+                    continue
+                    ;;
+                --settings=*)
+                    value="${argument#--settings=}"
+                    ;;
+                *)
+                    continue
+                    ;;
+            esac
+        fi
+        case "$value" in
+            */subrouter-claude-settings-*/settings.json)
+                [[ -f "$value" ]] && return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+bind_subrouter_claude_resume_marker() {
+    unset CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND
+    case "${SUBROUTER_CLAUDE_RESUME_COMMAND:-}" in
+        "sr claude proxy --resume"|"subrouter claude proxy --resume") ;;
+        *) return 0 ;;
+    esac
+    claude_launch_has_subrouter_private_settings "$@" || return 0
+    export CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND="$SUBROUTER_CLAUDE_RESUME_COMMAND"
+}
+
 if [[ "$cmux_claude_teams_wrapper_launch" != "1" ]]; then
     export CMUX_AGENT_LAUNCH_KIND="claude"
     export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
     export CMUX_AGENT_LAUNCH_CWD="$PWD"
+    bind_subrouter_claude_resume_marker "$@"
 fi
 install_cmux_node_options
 

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -92,6 +92,27 @@ cmux_claude_wrapper_settings_value_is_managed() {
     grep -Fq 'hooks feed --source claude' "$trimmed" 2>/dev/null
 }
 
+# A user --settings value that names a file must be readable now, or Claude
+# refuses to start ("Settings file not found"). Restore replays can carry a
+# path that a launcher wrote for one session and deleted on exit (for example
+# subrouter's $TMPDIR/subrouter-claude-settings-<rand>/settings.json). Inline
+# JSON and an empty value are left to the merge, which reports them loudly.
+# Mirrors the merge loader: trim, then expand only a leading "~/".
+cmux_claude_wrapper_settings_value_is_readable() {
+    local value="$1"
+    local trimmed="${value#"${value%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    local first="${trimmed:0:1}"
+    if [[ -z "$trimmed" || "$first" == "{" || "$first" == "[" ]]; then
+        return 0
+    fi
+    local path="$trimmed"
+    if [[ "${path:0:2}" == "~/" ]]; then
+        path="${HOME}/${path:2}"
+    fi
+    [[ -f "$path" && -r "$path" ]]
+}
+
 cmux_claude_wrapper_args_have_managed_settings() {
     local collect=false
     local arg
@@ -1611,49 +1632,79 @@ unset CMUX_GENERATED_HOOKS_JSON
 # does not rely on the CLI's multi-flag behavior. Requires `node`; if node is
 # missing or the merge fails, preserve the user's original settings and disable
 # cmux hooks for that launch rather than passing an ambiguous pair of flags.
+# A --settings path that is not readable is dropped up front with a warning:
+# Claude would refuse to start on it, so forwarding it (with or without cmux's
+# hooks) can only fail the launch.
 unset CMUX_USER_SETTINGS_B64
 CMUX_FILTERED_ARGS=()
 CMUX_USER_SETTINGS=()
+# The original argv minus any --settings whose file cannot be read. It replaces
+# "$@" only when such a value was dropped, so the merge-unavailable fallback
+# and the restore capture never forward a path Claude would refuse.
+CMUX_PASSTHROUGH_ARGS=()
+cmux_dropped_unreadable_settings=false
 cmux_collect_settings_value=false
 cmux_pending_option_value=false
 cmux_positional_only=false
 for arg in "$@"; do
     if [[ "$cmux_positional_only" == true ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         continue
     fi
     if [[ "$cmux_collect_settings_value" == true ]]; then
-        CMUX_USER_SETTINGS+=("$arg")
         cmux_collect_settings_value=false
+        if cmux_claude_wrapper_settings_value_is_readable "$arg"; then
+            CMUX_USER_SETTINGS+=("$arg")
+            CMUX_PASSTHROUGH_ARGS+=("--settings" "$arg")
+        else
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "$arg" >&2
+            cmux_dropped_unreadable_settings=true
+        fi
         continue
     fi
     if [[ "$cmux_pending_option_value" == true ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         cmux_pending_option_value=false
         continue
     fi
     if [[ "$arg" == "--" ]]; then
         cmux_positional_only=true
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
     elif [[ "$arg" == "--settings" ]]; then
         # The fixed-width prefix checks above avoid a wildcard match against a
         # potentially very large JSON value.
         cmux_collect_settings_value=true
     elif [[ "${arg:0:11}" == "--settings=" ]]; then
-        CMUX_USER_SETTINGS+=("${arg#--settings=}")
+        if cmux_claude_wrapper_settings_value_is_readable "${arg#--settings=}"; then
+            CMUX_USER_SETTINGS+=("${arg#--settings=}")
+            CMUX_PASSTHROUGH_ARGS+=("$arg")
+        else
+            printf 'cmux: warning: --settings file is not readable; ignoring it for this launch: %s\n' "${arg#--settings=}" >&2
+            cmux_dropped_unreadable_settings=true
+        fi
     elif [[ "${arg:0:1}" == "-" ]]; then
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
         if [[ "${arg%%=*}" == "$arg" ]] && claude_option_consumes_value "$arg"; then
             cmux_pending_option_value=true
         fi
     else
         CMUX_FILTERED_ARGS+=("$arg")
+        CMUX_PASSTHROUGH_ARGS+=("$arg")
     fi
 done
 if [[ "$cmux_collect_settings_value" == true ]]; then
     # Dangling --settings with no value; keep it so the real CLI reports the error.
     CMUX_FILTERED_ARGS+=("--settings")
+    CMUX_PASSTHROUGH_ARGS+=("--settings")
 fi
+if [[ "$cmux_dropped_unreadable_settings" == true ]]; then
+    set -- "${CMUX_PASSTHROUGH_ARGS[@]}"
+fi
+unset CMUX_PASSTHROUGH_ARGS cmux_dropped_unreadable_settings
 
 CMUX_SETTINGS_PATH=""
 CMUX_SETTINGS_BASE_PATH=""

--- a/tests/test_claude_wrapper_dead_settings_path.py
+++ b/tests/test_claude_wrapper_dead_settings_path.py
@@ -75,6 +75,7 @@ def run_wrapper(
     *,
     with_node: bool = True,
     home_files: dict[str, str] | None = None,
+    restore_of: str | None = None,
 ) -> tuple[int, list[str], str, list[str], list[str]]:
     """Run the wrapper against a fake claude.
 
@@ -201,6 +202,11 @@ exit 0
             "NODE_OPTIONS",
         ):
             env.pop(key, None)
+        # cmux only drops an unreadable --settings for a launch it owns as a
+        # restore replay. An ordinary interactive launch must keep failing
+        # closed, so the scenarios opt in explicitly.
+        if restore_of is not None:
+            env["CMUX_AGENT_RESTORE_LAUNCH"] = f"claude:{restore_of}"
 
         try:
             proc = subprocess.run(
@@ -266,7 +272,7 @@ def assert_single_cmux_hook_settings(
 
 def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) -> None:
     code, real_argv, stderr, captured, documents = run_wrapper(
-        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH]
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH], restore_of=SESSION_ID
     )
     assert_single_cmux_hook_settings("restore replay", code, real_argv, stderr, documents, failures)
     expect(
@@ -287,10 +293,16 @@ def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) ->
 
 
 def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
-    code, real_argv, stderr, captured, documents = run_wrapper([f"--settings={DEAD_SETTINGS_PATH}", "hello"])
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, f"--settings={DEAD_SETTINGS_PATH}", "hello"], restore_of=SESSION_ID
+    )
     assert_single_cmux_hook_settings("equals form", code, real_argv, stderr, documents, failures)
     expect(real_argv[-1:] == ["hello"], f"equals form: positional prompt dropped: {real_argv}", failures)
-    expect(DEAD_SETTINGS_PATH not in stderr or "warning" in stderr, f"equals form: {stderr!r}", failures)
+    expect(
+        "warning" in stderr and DEAD_SETTINGS_PATH in stderr,
+        f"equals form: expected a warning naming the dead path, got {stderr!r}",
+        failures,
+    )
     expect(
         not any(DEAD_SETTINGS_PATH in part for part in captured),
         f"equals form: dead path was re-captured: {captured}",
@@ -300,7 +312,8 @@ def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
 
 def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
     code, real_argv, stderr, _, documents = run_wrapper(
-        ["--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"]
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"],
+        restore_of=SESSION_ID,
     )
     settings = assert_single_cmux_hook_settings("mixed settings", code, real_argv, stderr, documents, failures)
     expect(
@@ -312,11 +325,37 @@ def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
 
 
 def test_tilde_dead_path_is_dropped(failures: list[str]) -> None:
-    code, real_argv, stderr, _, _ = run_wrapper(["--settings", "~/missing-settings.json", "hi"])
+    code, real_argv, stderr, _, _ = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", "~/missing-settings.json", "hi"], restore_of=SESSION_ID
+    )
     expect(code == 0, f"tilde dead path: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
     values = settings_values(real_argv)
     expect(len(values) == 1, f"tilde dead path: expected exactly one --settings, got {values}", failures)
     expect("~/missing-settings.json" not in values, f"tilde dead path: still forwarded: {real_argv}", failures)
+
+
+def test_interactive_launch_keeps_failing_closed_on_an_unreadable_settings_file(
+    failures: list[str],
+) -> None:
+    """An ordinary launch must NOT silently start without the policy the user named.
+
+    A settings file can carry permission rules and hooks. Dropping it because of a
+    typo, a permission change, or an unmounted volume would turn an invalid
+    configuration into a quietly less-restricted session, so only a cmux-owned
+    restore replay may drop one.
+    """
+    code, real_argv, stderr, _, _ = run_wrapper(["--settings", DEAD_SETTINGS_PATH, "hi"])
+    values = settings_values(real_argv)
+    expect(
+        DEAD_SETTINGS_PATH in values,
+        f"interactive: unreadable --settings was silently dropped: {real_argv}",
+        failures,
+    )
+    expect(
+        code != 0,
+        f"interactive: claude started anyway without the named settings (stderr: {stderr!r})",
+        failures,
+    )
 
 
 def test_existing_user_settings_file_is_still_merged(failures: list[str]) -> None:
@@ -333,6 +372,7 @@ def test_dead_path_without_node_still_launches_with_cmux_hooks(failures: list[st
     code, real_argv, stderr, captured, documents = run_wrapper(
         ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH],
         with_node=False,
+        restore_of=SESSION_ID,
     )
     assert_single_cmux_hook_settings("no node", code, real_argv, stderr, documents, failures)
     expect(
@@ -351,6 +391,7 @@ def main() -> int:
     test_dead_settings_equals_form_is_dropped(failures)
     test_dead_path_keeps_other_user_settings(failures)
     test_tilde_dead_path_is_dropped(failures)
+    test_interactive_launch_keeps_failing_closed_on_an_unreadable_settings_file(failures)
     test_existing_user_settings_file_is_still_merged(failures)
     test_dead_path_without_node_still_launches_with_cmux_hooks(failures)
     if failures:

--- a/tests/test_claude_wrapper_dead_settings_path.py
+++ b/tests/test_claude_wrapper_dead_settings_path.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Regression checks for a captured `--settings <path>` that no longer exists.
+
+Launchers such as subrouter (`sr claude`) hand Claude an ephemeral settings file
+(`$TMPDIR/subrouter-claude-settings-<rand>/settings.json`) and delete it when
+they exit. cmux captures the launch argv, so `cmux restore claude <id>` replays
+`--settings <that path>` after the file is gone. The wrapper's settings merge
+then fails on ENOENT and the dead path was still forwarded to Claude, which
+hard-errors with `Settings file not found`, so the restored session never
+starts.
+
+The fake `claude` below reproduces that part of the real CLI: a `--settings`
+path that does not exist is a fatal error. Every check asserts that exactly one
+`--settings` reaches Claude and that it is cmux's own (readable) hook settings
+file, so a dead user path degrades to a working launch with a warning instead
+of a failed restore.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+from node_runtime import ensure_node_on_path
+from test_claude_wrapper_hooks import generated_claude_hook_settings
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+SESSION_ID = "3d1d5a5a-6d36-4d3a-9a3c-1d4f0e6c2b7a"
+DEAD_SETTINGS_PATH = "/var/folders/zz/T/subrouter-claude-settings-3294281412/settings.json"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.rstrip("\n") for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def settings_values(argv: list[str]) -> list[str]:
+    values: list[str] = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--settings" and index + 1 < len(argv):
+            values.append(argv[index + 1])
+            index += 2
+            continue
+        if arg.startswith("--settings="):
+            values.append(arg[len("--settings="):])
+        index += 1
+    return values
+
+
+def decode_launch_argv(encoded: str) -> list[str]:
+    if not encoded or encoded == "__UNSET__":
+        return []
+    raw = base64.b64decode(encoded)
+    return [part.decode("utf-8") for part in raw.split(b"\0") if part]
+
+
+def run_wrapper(
+    argv: list[str],
+    *,
+    with_node: bool = True,
+    home_files: dict[str, str] | None = None,
+) -> tuple[int, list[str], str, list[str], list[str]]:
+    """Run the wrapper against a fake claude.
+
+    Returns (exit code, claude argv, stderr, captured launch argv, settings
+    documents as claude read them, in argv order).
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-dead-settings-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "cmux.app" / "Contents" / "Resources" / "bin"
+        real_dir = tmp / "real-bin"
+        bundled_dir = tmp / "bundled cli"
+        home = tmp / "home"
+        for directory in (wrapper_dir, real_dir, bundled_dir, home):
+            directory.mkdir(parents=True, exist_ok=True)
+        for relative, content in (home_files or {}).items():
+            target = home / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+        wrapper = wrapper_dir / "cmux-claude-wrapper"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        real_args_log = tmp / "real-args.log"
+        launch_argv_log = tmp / "launch-argv.log"
+        settings_docs_log = tmp / "settings-docs.log"
+        socket_path = str(tmp / "cmux.sock")
+
+        # Mirrors the real CLI: a --settings path that cannot be read is fatal.
+        make_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+: > "$FAKE_REAL_ARGS_LOG"
+printf '%s\\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-__UNSET__}" > "$FAKE_LAUNCH_ARGV_LOG"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+if [[ "${1:-}" == "--help" ]]; then
+  printf 'Usage: claude [options] [command] [prompt]\\n'
+  exit 0
+fi
+expect_value=0
+for arg in "$@"; do
+  value=""
+  if (( expect_value )); then
+    value="$arg"
+    expect_value=0
+  elif [[ "$arg" == "--settings" ]]; then
+    expect_value=1
+    continue
+  elif [[ "$arg" == --settings=* ]]; then
+    value="${arg#--settings=}"
+  else
+    continue
+  fi
+  trimmed="${value#"${value%%[![:space:]]*}"}"
+  if [[ "$trimmed" == \\{* || "$trimmed" == \\[* ]]; then
+    printf '%s\\n' "$value" >> "$FAKE_SETTINGS_DOCS_LOG"
+  elif [[ -r "$value" ]]; then
+    # Snapshot the document Claude would read now; the wrapper's private
+    # settings file lives under a TMPDIR the harness deletes afterwards.
+    tr -d '\\n' < "$value" >> "$FAKE_SETTINGS_DOCS_LOG"
+    printf '\\n' >> "$FAKE_SETTINGS_DOCS_LOG"
+  else
+    printf 'Error: Settings file not found: %s\\n' "$value" >&2
+    exit 1
+  fi
+done
+exit 0
+""",
+        )
+
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+""",
+        )
+        bundled_cli = bundled_dir / "cmux"
+        make_executable(
+            bundled_cli,
+            """#!/usr/bin/env bash
+if [[ "${1:-}" == "hooks" && "${2:-}" == "claude" && "${3:-}" == "inject-settings" ]]; then
+  printf '%s' "$FAKE_GENERATED_CLAUDE_HOOK_SETTINGS"
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        system_path = "/usr/bin:/bin"
+        if with_node:
+            node = ensure_node_on_path()
+            assert node is not None
+            system_path = f"{Path(node).parent}:{system_path}"
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:{system_path}"
+        env["HOME"] = str(home)
+        env["TMPDIR"] = str(tmp / "tmp")
+        (tmp / "tmp").mkdir(exist_ok=True)
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_SOCKET_PATH"] = socket_path
+        env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli)
+        env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
+        env["FAKE_LAUNCH_ARGV_LOG"] = str(launch_argv_log)
+        env["FAKE_SETTINGS_DOCS_LOG"] = str(settings_docs_log)
+        env["FAKE_GENERATED_CLAUDE_HOOK_SETTINGS"] = generated_claude_hook_settings()
+        for key in (
+            "CMUX_CLAUDE_HOOKS_DISABLED",
+            "CMUX_CLAUDE_HOOK_CMUX_BIN",
+            "CMUX_AGENT_RESTORE_LAUNCH",
+            "CMUX_AGENT_LAUNCH_ARGV_B64",
+            "NODE_OPTIONS",
+        ):
+            env.pop(key, None)
+
+        try:
+            proc = subprocess.run(
+                [str(wrapper), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        finally:
+            test_socket.close()
+
+        launch_argv_lines = read_lines(launch_argv_log)
+        captured = decode_launch_argv(launch_argv_lines[0] if launch_argv_lines else "")
+        return (
+            proc.returncode,
+            read_lines(real_args_log),
+            proc.stderr.strip(),
+            captured,
+            read_lines(settings_docs_log),
+        )
+
+
+def expect(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def assert_single_cmux_hook_settings(
+    label: str,
+    code: int,
+    real_argv: list[str],
+    stderr: str,
+    documents: list[str],
+    failures: list[str],
+) -> dict:
+    expect(code == 0, f"{label}: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
+    values = settings_values(real_argv)
+    expect(len(values) == 1, f"{label}: expected exactly one --settings, got {values} in {real_argv}", failures)
+    expect(
+        DEAD_SETTINGS_PATH not in real_argv and f"--settings={DEAD_SETTINGS_PATH}" not in real_argv,
+        f"{label}: dead settings path still reached claude: {real_argv}",
+        failures,
+    )
+    if len(documents) != 1:
+        failures.append(f"{label}: claude could read {len(documents)} settings documents, expected 1: {values}")
+        return {}
+    try:
+        settings = json.loads(documents[0])
+    except ValueError as exc:
+        failures.append(f"{label}: the surviving --settings is not JSON: {documents[0]!r} ({exc})")
+        return {}
+    hook_text = json.dumps(settings.get("hooks", {}))
+    expect(
+        "hooks" in settings and ("hooks claude" in hook_text or "hooks feed" in hook_text),
+        f"{label}: surviving --settings is not cmux's hook settings: {settings}",
+        failures,
+    )
+    return settings
+
+
+def test_restore_replay_with_dead_settings_path_launches(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH]
+    )
+    assert_single_cmux_hook_settings("restore replay", code, real_argv, stderr, documents, failures)
+    expect(
+        real_argv[:2] == ["--resume", SESSION_ID] or ["--resume", SESSION_ID] == real_argv[-2:],
+        f"restore replay: --resume <id> was not preserved: {real_argv}",
+        failures,
+    )
+    expect(
+        DEAD_SETTINGS_PATH in stderr and "warning" in stderr,
+        f"restore replay: expected a warning naming the dead path, got {stderr!r}",
+        failures,
+    )
+    expect(
+        DEAD_SETTINGS_PATH not in captured,
+        f"restore replay: dead path was re-captured for the next restore: {captured}",
+        failures,
+    )
+
+
+def test_dead_settings_equals_form_is_dropped(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper([f"--settings={DEAD_SETTINGS_PATH}", "hello"])
+    assert_single_cmux_hook_settings("equals form", code, real_argv, stderr, documents, failures)
+    expect(real_argv[-1:] == ["hello"], f"equals form: positional prompt dropped: {real_argv}", failures)
+    expect(DEAD_SETTINGS_PATH not in stderr or "warning" in stderr, f"equals form: {stderr!r}", failures)
+    expect(
+        not any(DEAD_SETTINGS_PATH in part for part in captured),
+        f"equals form: dead path was re-captured: {captured}",
+        failures,
+    )
+
+
+def test_dead_path_keeps_other_user_settings(failures: list[str]) -> None:
+    code, real_argv, stderr, _, documents = run_wrapper(
+        ["--settings", DEAD_SETTINGS_PATH, "--settings", '{"effortLevel":"max"}', "hi"]
+    )
+    settings = assert_single_cmux_hook_settings("mixed settings", code, real_argv, stderr, documents, failures)
+    expect(
+        settings.get("effortLevel") == "max",
+        f"mixed settings: the readable user settings were lost with the dead one: {settings}",
+        failures,
+    )
+    expect(real_argv[-1:] == ["hi"], f"mixed settings: positional prompt dropped: {real_argv}", failures)
+
+
+def test_tilde_dead_path_is_dropped(failures: list[str]) -> None:
+    code, real_argv, stderr, _, _ = run_wrapper(["--settings", "~/missing-settings.json", "hi"])
+    expect(code == 0, f"tilde dead path: claude exited {code} (stderr: {stderr!r}; argv: {real_argv})", failures)
+    values = settings_values(real_argv)
+    expect(len(values) == 1, f"tilde dead path: expected exactly one --settings, got {values}", failures)
+    expect("~/missing-settings.json" not in values, f"tilde dead path: still forwarded: {real_argv}", failures)
+
+
+def test_existing_user_settings_file_is_still_merged(failures: list[str]) -> None:
+    code, real_argv, stderr, _, documents = run_wrapper(
+        ["--settings", "~/present-settings.json", "hi"],
+        home_files={"present-settings.json": '{"ultracode": true}'},
+    )
+    settings = assert_single_cmux_hook_settings("existing file", code, real_argv, stderr, documents, failures)
+    expect(settings.get("ultracode") is True, f"existing file: user settings were not merged: {settings}", failures)
+    expect("warning" not in stderr, f"existing file: unexpected warning for a readable file: {stderr!r}", failures)
+
+
+def test_dead_path_without_node_still_launches_with_cmux_hooks(failures: list[str]) -> None:
+    code, real_argv, stderr, captured, documents = run_wrapper(
+        ["--resume", SESSION_ID, "--settings", DEAD_SETTINGS_PATH],
+        with_node=False,
+    )
+    assert_single_cmux_hook_settings("no node", code, real_argv, stderr, documents, failures)
+    expect(
+        DEAD_SETTINGS_PATH not in captured,
+        f"no node: dead path was re-captured for the next restore: {captured}",
+        failures,
+    )
+
+
+def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; the wrapper's settings merge needs node")
+        return 0
+    failures: list[str] = []
+    test_restore_replay_with_dead_settings_path_launches(failures)
+    test_dead_settings_equals_form_is_dropped(failures)
+    test_dead_path_keeps_other_user_settings(failures)
+    test_tilde_dead_path_is_dropped(failures)
+    test_existing_user_settings_file_is_still_merged(failures)
+    test_dead_path_without_node_still_launches_with_cmux_hooks(failures)
+    if failures:
+        print("FAIL: a dead --settings path still breaks the cmux claude wrapper launch")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: a dead --settings path is dropped and exactly one cmux hook --settings reaches claude")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_wrapper_subrouter_resume_marker.py
+++ b/tests/test_claude_wrapper_subrouter_resume_marker.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Regression checks for the wrapper-attested Subrouter claude resume marker.
+
+`sr claude proxy` launches Claude with a private, per-launch `--settings` file
+under `$TMPDIR/subrouter-claude-settings-<rand>/settings.json` (the proxy
+token, account routing headers and base URL live only there; a guardian
+deletes it when `sr` exits) and exports
+`SUBROUTER_CLAUDE_RESUME_COMMAND="sr claude proxy --resume"` so a host can
+resume through the same launcher once that file is gone.
+
+That marker leaks to every descendant of the launched Claude, so it is not
+proof on its own. The wrapper is the one process that still sees Subrouter's
+private `--settings` argument (its settings merge drops user `--settings`
+before the argv is captured for restore), so it binds the marker to THIS launch
+as `CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND` only when:
+
+- the marker is one of the exact launcher commands, and
+- the argv carries an existing `--settings` file inside a
+  `subrouter-claude-settings-*` directory.
+
+Anything else (an inherited marker under a plain `claude`, a stale bound copy
+from an ancestor, a dead path from a replayed restore, non-exact marker text)
+must leave the bound key unset, so restore keeps its existing behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+from node_runtime import ensure_node_on_path
+from test_claude_wrapper_hooks import generated_claude_hook_settings
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+MARKER_KEY = "SUBROUTER_CLAUDE_RESUME_COMMAND"
+BOUND_KEY = "CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND"
+SR_MARKER = "sr claude proxy --resume"
+SUBROUTER_MARKER = "subrouter claude proxy --resume"
+SESSION_ID = "0198f073-0a5b-7000-8000-000000000059"
+PRIVATE_SETTINGS_BODY = (
+    '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:31415/v1",'
+    '"ANTHROPIC_AUTH_TOKEN":"srt_test_only_not_a_real_token",'
+    '"ANTHROPIC_CUSTOM_HEADERS":"X-Subrouter-Agent: claude"}}'
+)
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_env_log(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    env: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            env[key] = value
+    return env
+
+
+def run_wrapper(
+    argv_builder,
+    *,
+    marker: str | None,
+    inherited_bound: str | None = None,
+) -> tuple[int, dict[str, str], list[str], str]:
+    """Run the wrapper against a fake claude that records its environment.
+
+    `argv_builder(tmp)` returns the argv, so a scenario can point --settings at
+    a file it creates under the harness TMPDIR (or at one it deliberately does
+    not create). Returns (exit code, claude env, claude argv, stderr).
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-sr-marker-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "cmux.app" / "Contents" / "Resources" / "bin"
+        real_dir = tmp / "real-bin"
+        bundled_dir = tmp / "bundled cli"
+        home = tmp / "home"
+        tmpdir = tmp / "tmp"
+        for directory in (wrapper_dir, real_dir, bundled_dir, home, tmpdir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        wrapper = wrapper_dir / "cmux-claude-wrapper"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        env_log = tmp / "claude-env.log"
+        args_log = tmp / "claude-args.log"
+        socket_path = str(tmp / "cmux.sock")
+
+        make_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+: > "$FAKE_CLAUDE_ARGS_LOG"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_CLAUDE_ARGS_LOG"
+done
+env > "$FAKE_CLAUDE_ENV_LOG"
+if [[ "${1:-}" == "--help" ]]; then
+  printf 'Usage: claude [options] [command] [prompt]\\n'
+fi
+exit 0
+""",
+        )
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+exit 0
+""",
+        )
+        bundled_cli = bundled_dir / "cmux"
+        make_executable(
+            bundled_cli,
+            """#!/usr/bin/env bash
+if [[ "${1:-}" == "hooks" && "${2:-}" == "claude" && "${3:-}" == "inject-settings" ]]; then
+  printf '%s' "$FAKE_GENERATED_CLAUDE_HOOK_SETTINGS"
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket.bind(socket_path)
+
+        node = ensure_node_on_path()
+        assert node is not None
+        env = {
+            "PATH": f"{wrapper_dir}:{real_dir}:{Path(node).parent}:/usr/bin:/bin",
+            "HOME": str(home),
+            "TMPDIR": str(tmpdir),
+            "CMUX_SURFACE_ID": "surface:test",
+            "CMUX_SOCKET_PATH": socket_path,
+            "CMUX_BUNDLED_CLI_PATH": str(bundled_cli),
+            "FAKE_CLAUDE_ENV_LOG": str(env_log),
+            "FAKE_CLAUDE_ARGS_LOG": str(args_log),
+            "FAKE_GENERATED_CLAUDE_HOOK_SETTINGS": generated_claude_hook_settings(),
+        }
+        if marker is not None:
+            env[MARKER_KEY] = marker
+        if inherited_bound is not None:
+            env[BOUND_KEY] = inherited_bound
+
+        argv = argv_builder(tmpdir)
+        try:
+            proc = subprocess.run(
+                [str(wrapper), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        finally:
+            test_socket.close()
+
+        claude_args = args_log.read_text(encoding="utf-8").splitlines() if args_log.exists() else []
+        return proc.returncode, read_env_log(env_log), claude_args, proc.stderr.strip()
+
+
+def private_settings(tmpdir: Path, *, create: bool = True, suffix: str = "3294281412") -> Path:
+    directory = tmpdir / f"subrouter-claude-settings-{suffix}"
+    path = directory / "settings.json"
+    if create:
+        directory.mkdir(parents=True, exist_ok=True)
+        path.write_text(PRIVATE_SETTINGS_BODY, encoding="utf-8")
+    return path
+
+
+def expect(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def expect_launched(label: str, code: int, env: dict[str, str], stderr: str, failures: list[str]) -> None:
+    expect(code == 0, f"{label}: wrapper exited {code} (stderr: {stderr!r})", failures)
+    expect(bool(env), f"{label}: the fake claude never ran (stderr: {stderr!r})", failures)
+
+
+def test_sr_launch_binds_the_marker(failures: list[str]) -> None:
+    code, env, args, stderr = run_wrapper(
+        lambda tmpdir: ["--settings", str(private_settings(tmpdir)), "--model", "opus"],
+        marker=SR_MARKER,
+    )
+    expect_launched("sr launch", code, env, stderr, failures)
+    expect(env.get(BOUND_KEY) == SR_MARKER, f"sr launch: bound marker = {env.get(BOUND_KEY)!r}", failures)
+    expect(env.get(MARKER_KEY) == SR_MARKER, f"sr launch: marker was dropped: {env.get(MARKER_KEY)!r}", failures)
+    expect("--model" in args and "opus" in args, f"sr launch: claude argv lost user options: {args}", failures)
+
+
+def test_equals_form_and_subrouter_program_bind(failures: list[str]) -> None:
+    code, env, _, stderr = run_wrapper(
+        lambda tmpdir: [f"--settings={private_settings(tmpdir)}"],
+        marker=SUBROUTER_MARKER,
+    )
+    expect_launched("equals form", code, env, stderr, failures)
+    expect(
+        env.get(BOUND_KEY) == SUBROUTER_MARKER,
+        f"equals form: bound marker = {env.get(BOUND_KEY)!r}",
+        failures,
+    )
+
+
+def test_plain_claude_under_an_sr_session_is_not_bound(failures: list[str]) -> None:
+    # A nested `claude` inherits the marker from the sr-launched ancestor but
+    # was not launched by sr: no private settings file in its argv.
+    code, env, _, stderr = run_wrapper(lambda tmpdir: ["--model", "opus"], marker=SR_MARKER)
+    expect_launched("nested claude", code, env, stderr, failures)
+    expect(BOUND_KEY not in env, f"nested claude: inherited marker was bound: {env.get(BOUND_KEY)!r}", failures)
+
+
+def test_stale_inherited_binding_is_cleared(failures: list[str]) -> None:
+    code, env, _, stderr = run_wrapper(
+        lambda tmpdir: ["--model", "opus"],
+        marker=SR_MARKER,
+        inherited_bound=SR_MARKER,
+    )
+    expect_launched("stale binding", code, env, stderr, failures)
+    expect(BOUND_KEY not in env, f"stale binding: ancestor's bound copy survived: {env.get(BOUND_KEY)!r}", failures)
+
+
+def test_dead_private_settings_path_is_not_bound(failures: list[str]) -> None:
+    # A replayed restore of an older record still carries the deleted path.
+    code, env, _, stderr = run_wrapper(
+        lambda tmpdir: ["--resume", SESSION_ID, "--settings", str(private_settings(tmpdir, create=False))],
+        marker=SR_MARKER,
+    )
+    expect_launched("dead path", code, env, stderr, failures)
+    expect(BOUND_KEY not in env, f"dead path: a deleted settings path was bound: {env.get(BOUND_KEY)!r}", failures)
+
+
+def test_non_exact_marker_text_is_not_bound(failures: list[str]) -> None:
+    for untrusted in (
+        "sr claude proxy --restore",
+        "sr claude proxy --resume --account evil",
+        "/tmp/evil claude proxy --resume",
+        "sr claude proxy --resume; rm -rf /",
+        "cx claude proxy --resume",
+        "",
+    ):
+        code, env, _, stderr = run_wrapper(
+            lambda tmpdir: ["--settings", str(private_settings(tmpdir))],
+            marker=untrusted,
+        )
+        expect_launched(f"marker {untrusted!r}", code, env, stderr, failures)
+        expect(BOUND_KEY not in env, f"marker {untrusted!r} was bound: {env.get(BOUND_KEY)!r}", failures)
+
+
+def test_private_settings_without_marker_is_not_bound(failures: list[str]) -> None:
+    code, env, _, stderr = run_wrapper(
+        lambda tmpdir: ["--settings", str(private_settings(tmpdir))],
+        marker=None,
+    )
+    expect_launched("no marker", code, env, stderr, failures)
+    expect(BOUND_KEY not in env, f"no marker: bound without a marker: {env.get(BOUND_KEY)!r}", failures)
+
+
+def test_private_settings_after_option_terminator_is_not_bound(failures: list[str]) -> None:
+    code, env, _, stderr = run_wrapper(
+        lambda tmpdir: ["--", "--settings", str(private_settings(tmpdir))],
+        marker=SR_MARKER,
+    )
+    expect_launched("after --", code, env, stderr, failures)
+    expect(BOUND_KEY not in env, f"after --: a literal prompt token was bound: {env.get(BOUND_KEY)!r}", failures)
+
+
+def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; the wrapper's settings merge needs node")
+        return 0
+    failures: list[str] = []
+    test_sr_launch_binds_the_marker(failures)
+    test_equals_form_and_subrouter_program_bind(failures)
+    test_plain_claude_under_an_sr_session_is_not_bound(failures)
+    test_stale_inherited_binding_is_cleared(failures)
+    test_dead_private_settings_path_is_not_bound(failures)
+    test_non_exact_marker_text_is_not_bound(failures)
+    test_private_settings_without_marker_is_not_bound(failures)
+    test_private_settings_after_option_terminator_is_not_bound(failures)
+    if failures:
+        print("FAIL: the claude wrapper does not bind the Subrouter resume marker to a proven sr launch")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: the Subrouter resume marker is bound only to a proven sr claude proxy launch")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> **Stacks on #12463.** The first two commits here are that PR; review the top four. Once #12463 merges this diff shrinks to those.

## Problem

`sr claude proxy` hands Claude a private per-launch `--settings` file under `$TMPDIR/subrouter-claude-settings-<rand>/` and deletes it when `sr` exits. cmux captures the pre-injection argv into `CMUX_AGENT_LAUNCH_ARGV_B64` and replays it on restore, so the recorded path is always dead.

#12463 stops that from being fatal, but the restored session is still wrong: it gets only `ANTHROPIC_BASE_URL` and `CLAUDE_CONFIG_DIR` via `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV`. The `ANTHROPIC_AUTH_TOKEN` and the `X-Subrouter-Agent` / account-ID headers lived **only** in the deleted file, so account selection, pooling and failover are all bypassed. Re-invoking the launcher regenerates them — which is exactly how Codex restores already behave.

## Changes

**Stop recording dead paths** (`ClaudeRestoreSettingsPathFilter.swift`, `AgentRestoreReadableFileResolver.swift`): a `--settings` path whose file is unreadable is dropped when the restore plan is built. Plan time rather than capture time deliberately — a captured path is valid when captured, and a user settings file that merely moved must not be forgotten; plan time is the only point where a replayed path can be checked against the filesystem it will actually run on. Inline JSON, empty values, a dangling `--settings`, and anything after `--` are untouched.

**Route the resume** (`SubrouterClaudeResumeRouting.swift`): a Claude restore is rewritten to `sr claude proxy --resume <id>` only when the record carries an **agreeing pair** of markers:

1. `SUBROUTER_CLAUDE_RESUME_COMMAND` — exported by `sr` (manaflow-ai/subrouter#327), exact text only.
2. `CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND` — minted by `cmux-claude-wrapper`, which first `unset`s any inherited copy and re-exports only when the argv still carries an **existing** `subrouter-claude-settings-*/settings.json`.

Marker 1 alone is insufficient because it leaks to every descendant — a plain `claude` run inside an `sr claude` session inherits it. The bound copy is minted per launch against physical evidence only `sr` creates, and the wrapper is the last process that can see that file: the settings merge removes user `--settings` before the argv is captured.

**Provenance never reads `ANTHROPIC_BASE_URL`**, so a local `http://127.0.0.1:31415` pool and a hosted `https://sr.cmux.com` pool behave identically (both are parameterized test cases). A local base URL by itself is explicitly not provenance.

**Fails closed.** Marker-only, bound-only, disagreeing pair, non-exact text (`--restore`, `; rm -rf /`, an absolute path, `cx`, uppercase, empty), cmux's own launchers, `.direct` mode, codex records, and `sr` not resolvable on the restore `PATH` all leave today's plan byte-for-byte unchanged.

## Testing

Two-commit regression pattern. New: `SubrouterClaudeRestoreRoutingTests.swift` (15 planner/policy tests), `SubrouterClaudeResumeRoutingTests.swift` (7 unit tests), `ClaudeRestoreSettingsPathTests.swift` (7 tests), `tests/test_claude_wrapper_subrouter_resume_marker.py` (8 wrapper scenarios, wired into CI).

At the test-only commit the routing suite fails 15 tests; at the fix commit `swift test --package-path Packages/macOS/CMUXAgentLaunch` is green at **421 tests / 58 suites**, all wrapper suites pass, `xcodebuild -scheme cmux-cli` succeeds, and `scripts/lint-pbxproj-test-wiring.sh` reports ok.

End-to-end, a synthetic hook record driven through the same `AgentRestorePlanner` the CLI uses yields `["sr","claude","proxy","--resume","<id>","--model","opus","--permission-mode","acceptEdits"]` with the stale auth env removed and `CMUX_AGENT_RESTORE_LAUNCH` / `CMUX_CUSTOM_CLAUDE_PATH` retained; the unproven and no-`sr`-on-PATH scenarios keep the existing replay.

**Not verified:** no real `cmux restore claude <id>` was executed — the CLI needs the app socket and would have targeted a live surface. Planner output was exercised through the identical API path instead. The in-app typed-restore path (`AgentResumeCommandBuilder`) and `.forkAgent` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791864297&installation_model_id=21920&pr_number=12464&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12464&signature=d4bcae739f5a086be526b1472f1a29a0d8c398604ad65e58895d2e8371dc9061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Subrouter-routed Claude sessions via `sr claude proxy --resume` instead of replaying a captured argv whose settings file was deleted, so account selection, pooling, and failover work again. Restore planning and the Claude wrapper also drop `--settings` paths that no longer exist, preventing "Settings file not found" launch failures.

**Bug Fixes**
- The restore planner checks `--settings` readability at plan time and drops missing files in both spellings; inline JSON, empty values, dangling options, and anything after `--` stay.
- The wrapper drops an unreadable `--settings` with a warning only for cmux-owned restore replays and stops re-capturing it; interactive launches still fail closed so permission and hook settings can't be silently lost.

**New Features**
- A resume record with an agreeing `SUBROUTER_CLAUDE_RESUME_COMMAND` / `CMUX_AGENT_LAUNCH_SUBROUTER_CLAUDE_RESUME_COMMAND` pair plans `sr claude proxy --resume <id>` and clears captured auth selection for the launcher to regenerate.
- The wrapper mints the launch-bound marker only when the argv still carries an existing `subrouter-claude-settings-*/settings.json` and clears inherited copies.
- Provenance relies only on the marker pair; marker-only, disagreeing or non-exact text, cmux launchers, direct mode, codex records, or `sr` missing on the restore PATH all keep the existing replay.

<sup>Written for commit 798c555ef98871912b88f6664d5d33cdc30dc1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claude sessions launched through Subrouter can resume through the same routing path.
  - Restore and fork operations preserve valid settings files while removing inaccessible paths.
  - Subrouter-specific settings and environment details are handled safely during Claude restoration.

- **Bug Fixes**
  - Prevented invalid settings paths from causing Claude launches and restores to fail.
  - Added warnings when inaccessible settings files are skipped.
  - Improved resume-marker validation to avoid incorrect routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->