### PR TITLE
fix: restore nightly Release build

### DIFF
--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -502,8 +502,8 @@ struct MachinesPanelView: View {
             nodeActions: nodeActions,
             expansionStore: expansionStore,
             style: CloudTreeStyle.preset(id: cloudTreeStyleID) ?? .defaultStyle,
-            showsCloudVPNWarning: CloudPortsVPNWarning.projection(tunnelState: tunnelStatus.status?.state) != nil,
-            onDragStateChange: { [weak viewModel] dragging in viewModel?.setTreeDragging(dragging) }
+            onDragStateChange: { [weak viewModel] dragging in viewModel?.setTreeDragging(dragging) },
+            showsCloudVPNWarning: CloudPortsVPNWarning.projection(tunnelState: tunnelStatus.status?.state) != nil
         )
         .accessibilityIdentifier("CloudMachinesTree")
     }
@@ -758,7 +758,7 @@ struct MachinesChromeIconButton: View {
 /// see the store. All verbs go through `CloudVMActionLauncher` so this panel,
 /// the ＋ menu, the palette, and the CLI share one mutation path.
 struct MachineRowActions {
-    let setupVPN: @MainActor (NSWindow?) -> Void
+    var setupVPN: @MainActor (NSWindow?) -> Void
     let openShell: @MainActor (String) -> Void
     let openDesktop: @MainActor (String) -> Void
     let runCommand: @MainActor (String, [String]) -> Void

--- a/Sources/CloudTerminalOverlayCoordinator.swift
+++ b/Sources/CloudTerminalOverlayCoordinator.swift
@@ -26,8 +26,13 @@ final class CloudTerminalOverlayCoordinator {
     /// Creates a coordinator backed by the app's signature dismissal store.
     ///
     /// - Parameter dismissalStore: Repository shared by this native surface owner.
-    init(dismissalStore: CloudBannerDismissalStore = CloudBannerDismissalStore(defaults: .standard)) {
+    init(dismissalStore: CloudBannerDismissalStore) {
         self.dismissalStore = dismissalStore
+    }
+
+    /// Creates a coordinator backed by the app's standard user defaults.
+    convenience init() {
+        self.init(dismissalStore: CloudBannerDismissalStore(defaults: .standard))
     }
 
     /// A replaced representable may still emit layout and hide callbacks. Only


### PR DESCRIPTION
Nightly publication was blocked by deterministic Swift Release compile failures in `build-nightly-app` (exit 65), before signing or publishing. The complete direct job log for run 34737818501 showed the first causal errors.

This PR repaired the three errors remaining on current main:

- `CloudTerminalOverlayCoordinator` no longer evaluates a `@MainActor` dismissal-store initializer in a synchronous default-argument context; the standard store is created by an actor-isolated convenience initializer.
- `MachineRowActions.setupVPN` is mutable where `MachinesPanelView` already binds its setup action.
- `CloudTreeOutlineView` arguments are passed in the declared memberwise initializer order.

The older `AppDelegate.swift` `groupPlacement`/`anchorId` diagnostics from run 34737512821 were already fixed on current main by commit 2d723ab71c.

Validation:

- `git diff --check`
- `python3 scripts/swift_file_length_budget.py`
- Main Nightly run [34738640086](https://github.com/manaflow-ai/cmux/actions/runs/34738640086) passed the unsigned universal Release build, all three arm64/x86_64/universal signing and notarization jobs, `publish-nightly`, and `close-nightly-failure-issue`.
- The Nightly tag now points to `d9e50caaed73479d36d3244f751f67a538a81447`; issue #12456 auto-closed at 2026-09-13T05:27:06Z.

A branch `build_only=true` measurement was dispatched but canceled when this PR was merged; the successful main run above is the authoritative full Release and publication proof. Signing, notarization, publication, and security gates were preserved unchanged.
