### PR TITLE
Fix NIGHTLY passive update pill discovery

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/TestSupport/UpdateTestSupport.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/TestSupport/UpdateTestSupport.swift
@@ -26,7 +26,17 @@ public struct UpdateTestSupport {
         if let detectedVersion = env["CMUX_UI_TEST_DETECTED_UPDATE_VERSION"],
            !detectedVersion.isEmpty {
             if let item = Self.makeAppcastItem(displayVersion: detectedVersion) {
-                model.recordDetectedUpdate(item)
+                let delayMilliseconds = Int(env["CMUX_UI_TEST_DETECTED_UPDATE_DELAY_MS"] ?? "") ?? 0
+                if delayMilliseconds > 0 {
+                    let model = self.model
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(delayMilliseconds))
+                        guard !Task.isCancelled else { return }
+                        model.recordDetectedUpdate(item)
+                    }
+                } else {
+                    model.recordDetectedUpdate(item)
+                }
             } else {
                 model.debugSetDetectedVersion(UpdateStateModel.normalizedDetectedUpdateVersion(from: detectedVersion))
             }

--- a/cmuxUITests/UpdatePillUITests.swift
+++ b/cmuxUITests/UpdatePillUITests.swift
@@ -59,6 +59,32 @@ final class UpdatePillUITests: XCTestCase {
         attachScreenshot(name: "background-detected-update-available")
     }
 
+    /// Regression for #12467: a passive Sparkle discovery can arrive after the sidebar has
+    /// mounted. The update pill must observe that in-place model mutation without a foreground
+    /// check or an unrelated sidebar redraw.
+    func testPassiveDetectedUpdateAppearsAfterSidebarMounted() {
+        let systemSettings = XCUIApplication(bundleIdentifier: "com.apple.systempreferences")
+        systemSettings.terminate()
+
+        let app = XCUIApplication.cmuxTestApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DETECTED_UPDATE_VERSION"] = "9.9.9"
+        app.launchEnvironment["CMUX_UI_TEST_DETECTED_UPDATE_DELAY_MS"] = "2500"
+        launchAndActivate(app)
+
+        let sidebar = app.otherElements["Sidebar"]
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 6.0))
+
+        let pill = pillButton(app: app, expectedLabel: "Update Available: 9.9.9")
+        XCTAssertTrue(
+            pill.waitForExistence(timeout: 8.0),
+            "Passive detected update did not reach the mounted sidebar"
+        )
+        XCTAssertEqual(pill.label, "Update Available: 9.9.9")
+        assertVisibleSize(pill)
+        attachScreenshot(name: "passive-detected-update-after-mount")
+    }
+
     func testDetectedBackgroundUpdateFirstClickOpensPopover() {
         let systemSettings = XCUIApplication(bundleIdentifier: "com.apple.systempreferences")
         systemSettings.terminate()


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/12467

The passive Sparkle update probe records availability in `UpdateStateModel`, but the sidebar footer is inside an `Equatable` sidebar subtree that only carries the model reference. In-place passive mutations can therefore be skipped until an unrelated redraw. This PR adds a delayed passive-callback UI regression that runs after the sidebar mounts; the first commit intentionally fails on the current implementation so CI proves the repro.

Validation so far: `git diff --check`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791867533&installation_model_id=21920&pr_number=12473&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12473&signature=6e8a6b325934a83f5e5a414d0adfc82e2b8ec003fa27645b24e3602ee58637ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes passive Sparkle update discovery so a detected update that arrives after the sidebar mounts still shows in the update pill. Adds a regression UI test that simulates a delayed passive update after the sidebar mounts.

<sup>Written for commit 29e1411414eeb88396db154dc7592208e9a18a51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

