### PR TITLE
fix: preserve default Claude authentication when resuming sessions

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -32,8 +32,14 @@ public struct ClaudeConfigDirectoryPath: Sendable {
 
 /// Selects the non-secret launch environment values that are safe to replay when restoring agents.
 public struct AgentLaunchEnvironmentPolicy: Sendable {
+    private let homeDirectory: String
+
     /// Creates a launch environment policy.
-    public init() {}
+    ///
+    /// - Parameter homeDirectory: The home used to identify Claude's default config directory.
+    public init(homeDirectory: String = NSHomeDirectory()) {
+        self.homeDirectory = ((homeDirectory as NSString).expandingTildeInPath as NSString).standardizingPath
+    }
 
     private static let hermesAgentEnvironmentKeys: Set<String> = [
         "CUSTOM_BASE_URL",
@@ -176,11 +182,15 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
     }
 
     /// Returns a replay-safe value for a single environment variable, or `nil` when it should drop.
+    /// Claude's default config directory is omitted because explicitly exporting it changes auth selection.
     public func sanitizedValue(key: String, value: String?) -> String? {
         guard Self.safeEnvironmentKeys.contains(key) else { return nil }
         switch key {
         case "CLAUDE_CONFIG_DIR":
-            return value.map { ClaudeConfigDirectoryPath.preferredPath($0) }
+            guard let value else { return nil }
+            let path = ClaudeConfigDirectoryPath.preferredPath(value, homeDirectory: homeDirectory)
+            let defaultPath = (homeDirectory as NSString).appendingPathComponent(".claude")
+            return path == defaultPath ? nil : path
         case "NODE_OPTIONS":
             return sanitizedNodeOptions(value)
         default:

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeDefaultConfigDirectoryResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeDefaultConfigDirectoryResumeTests.swift
@@ -1,0 +1,67 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite struct ClaudeDefaultConfigDirectoryResumeTests {
+    @Test(arguments: ["~/.claude", NSHomeDirectory() + "/.claude", NSHomeDirectory() + "/.claude/"])
+    func captureOmitsDefaultConfigDirectory(configDirectory: String) {
+        let environment = ["CLAUDE_CONFIG_DIR": configDirectory]
+        let policy = AgentLaunchEnvironmentPolicy()
+
+        #expect(policy.selectedEnvironment(from: environment, kind: "claude").isEmpty)
+        #expect(policy.selectedRestoreEnvironment(from: environment, kind: "claude").isEmpty)
+    }
+
+    @Test(arguments: [AgentRestoreRequestMode.resumeAgent, .forkAgent])
+    func persistedDefaultConfigDirectoryDoesNotChangeRestoredAuth(mode: AgentRestoreRequestMode) throws {
+        let request = AgentRestoreRequest(
+            mode: mode,
+            kind: "claude",
+            checkpointID: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            source: "session-snapshot",
+            workingDirectory: "/tmp",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                arguments: ["claude"],
+                environment: ["CLAUDE_CONFIG_DIR": NSHomeDirectory() + "/.claude"]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+        let invocation = try #require(AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+            for: request,
+            ambientEnvironment: ["PATH": "/usr/bin:/bin"]
+        ))
+
+        #expect(invocation.arguments.contains("--resume"))
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == nil)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == nil)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] == nil)
+    }
+
+    @Test func customConfigDirectoryKeepsItsAuthSelection() throws {
+        let customDirectory = NSHomeDirectory() + "/.claude-work"
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "claude",
+            checkpointID: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            source: "session-snapshot",
+            workingDirectory: "/tmp",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                arguments: ["claude"],
+                environment: ["CLAUDE_CONFIG_DIR": customDirectory]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+        let invocation = try #require(AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+            for: request,
+            ambientEnvironment: [:]
+        ))
+
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == customDirectory)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1")
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] == "CLAUDE_CONFIG_DIR")
+    }
+}

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -364,7 +364,10 @@ struct SessionEntry: Identifiable, Hashable, Sendable {
             if let permissionMode, !permissionMode.isEmpty {
                 parts.append("--permission-mode \(Self.shellQuote(permissionMode))")
             }
-            let environment = configDirectoryForResume.map {
+            let environment = AgentLaunchEnvironmentPolicy().sanitizedValue(
+                key: "CLAUDE_CONFIG_DIR",
+                value: configDirectoryForResume
+            ).map {
                 ["CLAUDE_CONFIG_DIR": $0, "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1", "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR"]
             } ?? [:]
             return AgentResumeArgv.portableClaudeResumeShellCommand(

--- a/cmuxTests/SessionEntryResumeLaunchTests.swift
+++ b/cmuxTests/SessionEntryResumeLaunchTests.swift
@@ -12,6 +12,56 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct SessionEntryResumeLaunchTests {
+    @Test("Vault copy and structured resume omit the default Claude config directory", arguments: [false, true])
+    func claudeResumeConfigDirectoryPreservesAuth(custom: Bool) throws {
+        let configDirectory = NSHomeDirectory() + (custom ? "/.claude-work" : "/.claude")
+        let entry = SessionEntry(
+            id: "claude:default-config-session",
+            agent: .claude,
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            title: "Claude session",
+            cwd: "/tmp",
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: Date(timeIntervalSince1970: 1_800_000_000),
+            fileURL: nil,
+            specifics: .claude(
+                model: "sonnet",
+                permissionMode: "default",
+                configDirectoryForResume: configDirectory
+            )
+        )
+        let command = try #require(entry.copyResumeCommand)
+        #expect(command.contains("CLAUDE_CONFIG_DIR=") == custom)
+        #expect(command.contains("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=") == custom)
+        #expect(command.contains("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=") == custom)
+        #expect(command.contains("--resume \(entry.sessionId)"))
+        #expect(command.contains("--model sonnet"))
+        #expect(command.contains("--permission-mode default"))
+
+        let launch = try #require(entry.resumeLaunch)
+        #expect(launch.strategy == .restoreVerb)
+        let snapshot = try #require(launch.startupRestoreAgent)
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "claude",
+            checkpointID: snapshot.sessionId,
+            source: "vault",
+            workingDirectory: snapshot.workingDirectory,
+            environment: [:],
+            launchCommand: snapshot.launchCommand,
+            preparedArguments: nil,
+            observedPermissionMode: snapshot.permissionMode
+        )
+        let invocation = try #require(AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+            for: request,
+            ambientEnvironment: [:]
+        ))
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == (custom ? configDirectory : nil))
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == (custom ? "1" : nil))
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] == (custom ? "CLAUDE_CONFIG_DIR" : nil))
+    }
+
     @Test("Vault resume plans the short restore verb with structured Codex settings")
     func vaultResumeUsesShortRestoreVerb() throws {
         let entry = SessionEntry(


### PR DESCRIPTION
Fixes #4255

Resuming a Claude session must not export the default `~/.claude` config directory: its presence changes Claude's authentication selection. The shared launch-environment policy now omits that default (including tilde and trailing-slash forms), and copied Vault commands use the same policy. Structured restore/fork also sanitizes older persisted launch environments. Custom account directories retain their environment and wrapper preservation markers.

Reproduced before changing production code on macOS 26.5 with Claude Code 2.1.270:
1. Run `claude auth status --json` with Claude/Anthropic selection overrides unset: exit 0, `loggedIn: true`, `authMethod: claude.ai`.
2. Repeat with only `CLAUDE_CONFIG_DIR="$HOME/.claude"` added: exit 1, `loggedIn: false`, `authMethod: none`.
3. Run `swift test --package-path Packages/macOS/CMUXAgentLaunch --filter ClaudeDefaultConfigDirectoryResumeTests`: capture and persisted resume/fork export the default plus preservation markers; 12 assertions fail. The custom-directory control passes.

Validation:
- Test-only commit `3379a91b5c` precedes fix commit `a5ca82e3eb`.
- All 394 tests in the CMUXAgentLaunch package pass after the fix.
- Compiled the production policy into an auth probe: the filtered restore environment is empty and the real Claude CLI again reports exit 0, `loggedIn: true`, `authMethod: claude.ai`.
- Test wiring and Package.resolved policy checks pass.
- Hosted Vault suite: [before fix](https://github.com/manaflow-ai/cmux/actions/runs/34740861275), [after fix](https://github.com/manaflow-ai/cmux/actions/runs/34740862978).
- Tagged build from pushed commit `a5ca82e3eb`: attempted locally with `./scripts/reload.sh --tag issue-4255` after the hosted build remained queued. Failed in unchanged `Sources/DockSplitStore+PaneFocus.swift:37` with `subscript(_: ) requires that UUID conform to RangeExpression`. That file is identical to base commit `2b09913f2a`; no unrelated fix was added. No runnable dogfood build is available. The redundant queued hosted build was cancelled.

Review focus: default versus custom account selection in both Copy Resume Command and Resume in new tab. GUI dogfood remains for the human; reproduction here used Claude's real auth status and the production launch planner. No fleet manifest is configured on this machine; the before/after Vault suite remains queued on hosted macOS 26 runners. Localization audit: changed output is executable environment syntax; no UI/help strings or catalogs changed.
