### PR TITLE
Fix CLI closed-pipe crashes and disconnect telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1605,7 +1605,6 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_vm_resize.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_layout_focus_contract.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_operation_deadline.py
-          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_broken_pipe_writes.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_simulator_contract.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_browser_profile_cli.py
           python3 tests/test_stress_cli_socket_api.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1605,6 +1605,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_vm_resize.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_layout_focus_contract.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_operation_deadline.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_broken_pipe_writes.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_simulator_contract.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_browser_profile_cli.py
           python3 tests/test_stress_cli_socket_api.py

--- a/.github/workflows/cli-pipe-regressions.yml
+++ b/.github/workflows/cli-pipe-regressions.yml
@@ -1,0 +1,70 @@
+name: CLI pipe regressions
+
+on:
+  pull_request:
+    paths:
+      - 'CLI/**'
+      - 'tests/test_cli_broken_pipe_writes.py'
+      - 'tests/test_cli_socket_operation_deadline.py'
+      - 'cmux.xcodeproj/**'
+      - 'Packages/macOS/CmuxFoundation/**'
+      - '.github/workflows/cli-pipe-regressions.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-pipes-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-pipe-regressions:
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 30
+    env:
+      CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Initialize local Swift package dependency
+        run: git submodule update --init --depth 1 vendor/bonsplit
+
+      - name: Select Xcode
+        run: |
+          if [ -n "${CMUX_CI_XCODE_APP:-}" ]; then
+            sudo xcode-select --switch "$CMUX_CI_XCODE_APP/Contents/Developer"
+          fi
+          xcodebuild -version
+
+      - name: Build the standalone CLI
+        run: |
+          set -euo pipefail
+          CMUX_CLI_TEST_TAG="$(printf '%s' "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" | tr -cs 'A-Za-z0-9._-' '-')"
+          CMUX_CLI_DERIVED="$RUNNER_TEMP/cmux-$CMUX_CLI_TEST_TAG"
+          echo "CMUX_CLI_DERIVED=$CMUX_CLI_DERIVED" >> "$GITHUB_ENV"
+          git rev-parse HEAD > "$RUNNER_TEMP/cli-revision.txt"
+          xcodebuild -project cmux.xcodeproj -scheme cmux-cli \
+            -configuration Debug -destination 'platform=macOS' \
+            -derivedDataPath "$CMUX_CLI_DERIVED" \
+            CODE_SIGNING_ALLOWED=NO build 2>&1 | tee "$RUNNER_TEMP/cli-build.log"
+
+      - name: Exercise closed consumers and socket disconnects
+        run: |
+          set -euo pipefail
+          CMUX_CLI_PRODUCTS="$CMUX_CLI_DERIVED/Build/Products/Debug"
+          export CMUX_CLI_BIN="$CMUX_CLI_PRODUCTS/cmux"
+          export DYLD_FRAMEWORK_PATH="$CMUX_CLI_PRODUCTS/Frameworks:$CMUX_CLI_PRODUCTS"
+          python3 tests/test_cli_broken_pipe_writes.py 2>&1 | tee "$RUNNER_TEMP/cli-pipes.log"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cli-pipe-regressions
+          path: |
+            ${{ runner.temp }}/cli-revision.txt
+            ${{ runner.temp }}/cli-build.log
+            ${{ runner.temp }}/cli-pipes.log
+          retention-days: 7

--- a/.github/workflows/cli-pipe-regressions.yml
+++ b/.github/workflows/cli-pipe-regressions.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -59,7 +59,7 @@ jobs:
           export DYLD_FRAMEWORK_PATH="$CMUX_CLI_PRODUCTS/Frameworks:$CMUX_CLI_PRODUCTS"
           python3 tests/test_cli_broken_pipe_writes.py 2>&1 | tee "$RUNNER_TEMP/cli-pipes.log"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: cli-pipe-regressions

--- a/.github/workflows/cli-pipe-regressions.yml
+++ b/.github/workflows/cli-pipe-regressions.yml
@@ -39,6 +39,25 @@ jobs:
           fi
           xcodebuild -version
 
+      - name: Initialize Ghostty and download its binary framework
+        run: |
+          set -euo pipefail
+          git submodule update --init --depth 1 ghostty
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Install Rust toolchain
+        run: ./scripts/install-rust-ci.sh
+
+      - name: Resolve Swift package dependencies
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$RUNNER_TEMP/cmux-source-packages"
+          mkdir -p "$SOURCE_PACKAGES_DIR"
+          xcodebuild -project cmux.xcodeproj -scheme cmux-cli \
+            -configuration Debug -derivedDataPath "$RUNNER_TEMP/cmux-cli-resolve" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -resolvePackageDependencies
+
       - name: Build the standalone CLI
         run: |
           set -euo pipefail
@@ -49,6 +68,7 @@ jobs:
           xcodebuild -project cmux.xcodeproj -scheme cmux-cli \
             -configuration Debug -destination 'platform=macOS' \
             -derivedDataPath "$CMUX_CLI_DERIVED" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/cmux-source-packages" \
             CODE_SIGNING_ALLOWED=NO build 2>&1 | tee "$RUNNER_TEMP/cli-build.log"
 
       - name: Exercise closed consumers and socket disconnects

--- a/CLI/CLIWriteDescriptor.swift
+++ b/CLI/CLIWriteDescriptor.swift
@@ -5,6 +5,7 @@ struct CLIWriteDescriptor {
     let fileDescriptor: Int32
     private let isSocket: Bool
 
+    /// Creates a writer for an already-open descriptor.
     init(fileDescriptor: Int32) {
         self.fileDescriptor = fileDescriptor
         var status = stat()
@@ -12,6 +13,7 @@ struct CLIWriteDescriptor {
             && status.st_mode & mode_t(S_IFMT) == mode_t(S_IFSOCK)
     }
 
+    /// Enables the descriptor-level pipe guard for non-socket descriptors.
     func setPipeNoSIGPIPE(_ enabled: Bool) {
         guard !isSocket else { return }
         // F_SETNOSIGPIPE on a socket changes its shared SO_NOSIGPIPE option,
@@ -19,6 +21,7 @@ struct CLIWriteDescriptor {
         _ = fcntl(fileDescriptor, F_SETNOSIGPIPE, enabled ? 1 : 0)
     }
 
+    /// Writes bytes while suppressing SIGPIPE on socket descriptors.
     func write(_ buffer: UnsafeRawPointer, count: Int) -> Int {
         // F_SETNOSIGPIPE can fail after a socket disconnects. MSG_NOSIGNAL
         // protects even that first send without affecting any other writer.

--- a/CLI/CLIWriteDescriptor.swift
+++ b/CLI/CLIWriteDescriptor.swift
@@ -1,0 +1,30 @@
+import Darwin
+
+/// Borrows a descriptor for writes without changing a shared socket's signal policy.
+struct CLIWriteDescriptor {
+    let fileDescriptor: Int32
+    private let isSocket: Bool
+
+    init(fileDescriptor: Int32) {
+        self.fileDescriptor = fileDescriptor
+        var status = stat()
+        isSocket = fstat(fileDescriptor, &status) == 0
+            && status.st_mode & mode_t(S_IFMT) == mode_t(S_IFSOCK)
+    }
+
+    func setPipeNoSIGPIPE(_ enabled: Bool) {
+        guard !isSocket else { return }
+        // F_SETNOSIGPIPE on a socket changes its shared SO_NOSIGPIPE option,
+        // which other writers and inherited child descriptors can observe.
+        _ = fcntl(fileDescriptor, F_SETNOSIGPIPE, enabled ? 1 : 0)
+    }
+
+    func write(_ buffer: UnsafeRawPointer, count: Int) -> Int {
+        // F_SETNOSIGPIPE can fail after a socket disconnects. MSG_NOSIGNAL
+        // protects even that first send without affecting any other writer.
+        if isSocket {
+            return Darwin.send(fileDescriptor, buffer, count, MSG_NOSIGNAL)
+        }
+        return Darwin.write(fileDescriptor, buffer, count)
+    }
+}

--- a/CLI/CMUXCLI+CloudDomains.swift
+++ b/CLI/CMUXCLI+CloudDomains.swift
@@ -217,7 +217,7 @@ extension CMUXCLI {
     private static func confirmPublicPublication(_ publication: [String: Any], confirmed: Bool) throws {
         let format = String(localized: "cli.cloud.domains.confirmPublic", defaultValue: "Public access lets anyone open %@ (VM %@, port %@). Continue? [y/N]")
         let warning = String(format: format, publication["hostname"] as? String ?? "?", publication["vmId"] as? String ?? "?", String(Self.intValue(publication["port"]) ?? 0))
-        FileHandle.standardError.write(Data((warning + "\n").utf8))
+        cliWriteStderr(warning + "\n")
         if !confirmed && readLine()?.lowercased() != "y" {
             throw CLIError(message: String(localized: "cli.cloud.domains.publicCancelled", defaultValue: "Public access was not enabled."))
         }

--- a/CLI/CMUXCLI+Coderouter.swift
+++ b/CLI/CMUXCLI+Coderouter.swift
@@ -386,7 +386,7 @@ extension CMUXCLI {
         guard FileManager.default.isExecutableFile(atPath: scriptPath) else {
             return nil
         }
-        FileHandle.standardError.write(Data("Running `claude setup-token`; finish the sign-in in your browser.\n".utf8))
+        cliWriteStderr("Running `claude setup-token`; finish the sign-in in your browser.\n")
 
         let outputPipe = Pipe()
         let process = Process()
@@ -436,7 +436,7 @@ extension CMUXCLI {
     }
 
     private func readHiddenTerminalLine(prompt: String) throws -> String {
-        FileHandle.standardError.write(Data(prompt.utf8))
+        cliWriteStderr(prompt)
         var original = termios()
         let hasTerminal = tcgetattr(STDIN_FILENO, &original) == 0
         if hasTerminal {
@@ -448,7 +448,7 @@ extension CMUXCLI {
             if hasTerminal {
                 _ = tcsetattr(STDIN_FILENO, TCSANOW, &original)
             }
-            FileHandle.standardError.write(Data("\n".utf8))
+            cliWriteStderr("\n")
         }
         guard let line = readLine(strippingNewline: true) else {
             throw CLIError(message: "No input received.")

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -248,7 +248,7 @@ extension CMUXCLI {
             out.append(Data(arg.utf8))
             out.append(0)
         }
-        FileHandle.standardOutput.write(out)
+        cliWriteStdout(out)
     }
 
     /// The cmux-owned directory holding the generated codex hook scripts.

--- a/CLI/CMUXCLI+Process.swift
+++ b/CLI/CMUXCLI+Process.swift
@@ -199,7 +199,7 @@ func cliWrite(_ data: Data, to handle: FileHandle, onBrokenPipe: CLIBrokenPipeDi
                     return false
                 }
                 continue
-            case EPIPE:
+            case EPIPE, EBADF, ECONNRESET:
                 switch onBrokenPipe {
                 case .exit(let code):
                     Darwin._exit(code)

--- a/CLI/CMUXCLI+Process.swift
+++ b/CLI/CMUXCLI+Process.swift
@@ -16,7 +16,7 @@ func currentCLINoSIGPIPEValue(for fd: Int32) -> Int32? {
 }
 
 private func setCLINoSIGPIPE(_ enabled: Bool, for fd: Int32) {
-    _ = fcntl(fd, F_SETNOSIGPIPE, enabled ? 1 : 0)
+    CLIWriteDescriptor(fileDescriptor: fd).setPipeNoSIGPIPE(enabled)
 }
 
 func configureCLIWriteFDNoSIGPIPE(_ fd: Int32) {
@@ -157,9 +157,10 @@ private func cliWriteNeedsStdioDispositionLock(_ fd: Int32) -> Bool {
 func cliWrite(_ data: Data, to handle: FileHandle, onBrokenPipe: CLIBrokenPipeDisposition) -> Bool {
     guard !data.isEmpty else { return true }
     let fd = handle.fileDescriptor
+    let descriptor = CLIWriteDescriptor(fileDescriptor: fd)
     let needsStdioDispositionLock = cliWriteNeedsStdioDispositionLock(fd)
     if !needsStdioDispositionLock {
-        configureCLIWriteFDNoSIGPIPE(fd)
+        descriptor.setPipeNoSIGPIPE(true)
     }
 
     return data.withUnsafeBytes { rawBuffer in
@@ -173,12 +174,12 @@ func cliWrite(_ data: Data, to handle: FileHandle, onBrokenPipe: CLIBrokenPipeDi
             let errorCode: Int32
             if needsStdioDispositionLock {
                 cliStdioDispositionLock.lock()
-                configureCLIWriteFDNoSIGPIPE(fd)
-                written = Darwin.write(fd, baseAddress.advanced(by: offset), rawBuffer.count - offset)
+                descriptor.setPipeNoSIGPIPE(true)
+                written = descriptor.write(baseAddress.advanced(by: offset), count: rawBuffer.count - offset)
                 errorCode = written < 0 ? errno : 0
                 cliStdioDispositionLock.unlock()
             } else {
-                written = Darwin.write(fd, baseAddress.advanced(by: offset), rawBuffer.count - offset)
+                written = descriptor.write(baseAddress.advanced(by: offset), count: rawBuffer.count - offset)
                 errorCode = written < 0 ? errno : 0
             }
 

--- a/CLI/CMUXCLI+RestoreAdmission.swift
+++ b/CLI/CMUXCLI+RestoreAdmission.swift
@@ -57,10 +57,10 @@ extension CMUXCLI {
         let response = try RestoreAdmissionRetryPolicy.response(
             onRetry: { attempt in
                 guard attempt == 0 else { return }
-                FileHandle.standardError.write(Data((String(
+                cliWriteStderr(String(
                     localized: "cli.restore.admission.waiting",
                     defaultValue: "restore: waiting for cmux to verify that this agent session is not already running…"
-                ) + "\n").utf8))
+                ) + "\n")
             }
         ) {
             try client.sendV2(

--- a/CLI/CMUXCLI+Sudo.swift
+++ b/CLI/CMUXCLI+Sudo.swift
@@ -147,7 +147,7 @@ extension CMUXCLI {
     }
 
     private func writeSudoError(_ message: String) {
-        try? FileHandle.standardError.write(contentsOf: Data((message + "\n").utf8))
+        cliWriteStderr(message + "\n")
     }
 
     private struct SudoCLIContext {

--- a/CLI/CMUXCLI+Vault.swift
+++ b/CLI/CMUXCLI+Vault.swift
@@ -202,7 +202,7 @@ extension CMUXCLI {
         }
         if let errors = payload["errors"] as? [String] {
             for message in errors {
-                FileHandle.standardError.write(Data(("warning: " + message + "\n").utf8))
+                cliWriteStderr("warning: " + message + "\n")
             }
         }
         let sessions = payload["sessions"] as? [[String: Any]] ?? []

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3812,9 +3812,12 @@ final class SocketClient {
                     close()
                     throw CLIError(message: timeoutMessage)
                 }
-                // A closed peer wakes poll too. Let the SIGPIPE-protected write
-                // report its errno so telemetry can classify expected disconnects.
-                guard descriptor.revents & Int16(POLLOUT | POLLHUP | POLLERR | POLLNVAL) != 0 else {
+                if descriptor.revents & Int16(POLLNVAL) != 0 {
+                    close()
+                    throw CLIError(message: "\(failureMessage) (\(String(cString: strerror(EBADF))), errno \(EBADF))")
+                }
+                // Let a protected write resolve HUP/ERR to errno for telemetry.
+                guard descriptor.revents & Int16(POLLOUT | POLLHUP | POLLERR) != 0 else {
                     continue
                 }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3814,15 +3814,7 @@ final class SocketClient {
                 }
                 if descriptor.revents & Int16(POLLNVAL) != 0 {
                     close()
-                    let message = String(
-                        format: String(
-                            localized: "cli.socket.error.failedToWriteWithErrno",
-                            defaultValue: "Failed to write to socket (%1$@, errno %2$d)"
-                        ),
-                        String(cString: strerror(EBADF)),
-                        EBADF
-                    )
-                    throw CLIError(message: message)
+                    let message = String(format: String(localized: "cli.socket.error.failedToWriteWithErrno", defaultValue: "Failed to write to socket (%1$@, errno %2$d)"), String(cString: strerror(EBADF)), EBADF); throw CLIError(message: message)
                 }
                 // Let a protected write resolve HUP/ERR to errno for telemetry.
                 guard descriptor.revents & Int16(POLLOUT | POLLHUP | POLLERR) != 0 else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3814,7 +3814,15 @@ final class SocketClient {
                 }
                 if descriptor.revents & Int16(POLLNVAL) != 0 {
                     close()
-                    throw CLIError(message: "\(failureMessage) (\(String(cString: strerror(EBADF))), errno \(EBADF))")
+                    let message = String(
+                        format: String(
+                            localized: "cli.socket.error.failedToWriteWithErrno",
+                            defaultValue: "Failed to write to socket (%1$@, errno %2$d)"
+                        ),
+                        String(cString: strerror(EBADF)),
+                        EBADF
+                    )
+                    throw CLIError(message: message)
                 }
                 // Let a protected write resolve HUP/ERR to errno for telemetry.
                 guard descriptor.revents & Int16(POLLOUT | POLLHUP | POLLERR) != 0 else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3812,12 +3812,9 @@ final class SocketClient {
                     close()
                     throw CLIError(message: timeoutMessage)
                 }
-                let terminalEvents = Int16(POLLHUP | POLLERR | POLLNVAL)
-                if descriptor.revents & terminalEvents != 0 {
-                    close()
-                    throw CLIError(message: failureMessage)
-                }
-                guard descriptor.revents & Int16(POLLOUT) != 0 else {
+                // A closed peer wakes poll too. Let the SIGPIPE-protected write
+                // report its errno so telemetry can classify expected disconnects.
+                guard descriptor.revents & Int16(POLLOUT | POLLHUP | POLLERR | POLLNVAL) != 0 else {
                     continue
                 }
 
@@ -5838,7 +5835,7 @@ struct CMUXCLI {
                     print(prompt)
                 }
                 if let skillPath = response["skill_path"] as? String {
-                    FileHandle.standardError.write(Data("skill: \(skillPath)\n".utf8))
+                    cliWriteStderr("skill: \(skillPath)\n")
                 }
 
             case "stats", "top":
@@ -14205,7 +14202,7 @@ struct CMUXCLI {
                 ),
                 attempt
             )
-            FileHandle.standardError.write(Data("\r\n\(reconnectingLine)\r\n".utf8))
+            cliWriteStderr("\r\n\(reconnectingLine)\r\n")
             Thread.sleep(forTimeInterval: min(pow(2.0, Double(attempt - 1)), 15))
             do {
                 config = try mintVMPtyReconnectConfig(

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -109783,6 +109783,20 @@
         }
       }
     },
+    "cli.socket.error.failedToWriteWithErrno": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Failed to write to socket (%1$@, errno %2$d)"}},
+        "de": {"stringUnit": {"state": "translated", "value": "Schreiben auf den Socket fehlgeschlagen (%1$@, errno %2$d)"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Échec de l’écriture sur le socket (%1$@, errno %2$d)"}},
+        "ar": {"stringUnit": {"state": "translated", "value": "فشلت الكتابة إلى المقبس (%1$@، errno %2$d)"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Error al escribir en el socket (%1$@, errno %2$d)"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法寫入至 Socket（%1$@，errno %2$d）"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "写入套接字失败（%1$@，errno %2$d）"}},
+        "ko": {"stringUnit": {"state": "translated", "value": "소켓 쓰기에 실패했습니다(%1$@, errno %2$d)"}},
+        "ja": {"stringUnit": {"state": "translated", "value": "ソケットへの書き込みに失敗しました（%1$@、errno %2$d）"}}
+      }
+    },
     "cli.socket.error.invalidUTF8Response": {
       "extractionState": "manual",
       "localizations": {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -680,6 +680,7 @@
 		846600000000000000000003 /* CLIWorkspaceGroupSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */; };
 		799100000000000000000001 /* CLIWorkspaceStableIDMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */; };
 		799100000000000000000003 /* CLIWorkspaceStableIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */; };
+		575000010000000000000001 /* CLIWriteDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575000020000000000000001 /* CLIWriteDescriptor.swift */; };
 		C51A73000000000000000101 /* ClosedItemHistory+PanelTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73000000000000000102 /* ClosedItemHistory+PanelTitle.swift */; };
 		C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D51700000000000000001 /* ClosedItemHistory.swift */; };
 		8772A0010000000000000001 /* ClosedItemHistoryCapacityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8772B0010000000000000001 /* ClosedItemHistoryCapacityPolicy.swift */; };
@@ -4402,6 +4403,7 @@
 		846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceGroupSafetyTests.swift; sourceTree = "<group>"; };
 		799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceStableIDMockServer.swift; sourceTree = "<group>"; };
 		799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceStableIDTests.swift; sourceTree = "<group>"; };
+		575000020000000000000001 /* CLIWriteDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWriteDescriptor.swift; sourceTree = "<group>"; };
 		C51A73000000000000000102 /* ClosedItemHistory+PanelTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClosedItemHistory+PanelTitle.swift"; sourceTree = "<group>"; };
 		C10D51700000000000000001 /* ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistory.swift; sourceTree = "<group>"; };
 		8772B0010000000000000001 /* ClosedItemHistoryCapacityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistoryCapacityPolicy.swift; sourceTree = "<group>"; };
@@ -10020,6 +10022,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					B9000065A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */,
 				A106490D0000000000000001 /* CMUXCLI+Automation.swift */,
 				B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */,
+				575000020000000000000001 /* CLIWriteDescriptor.swift */,
 				A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */,
 				A10240070000000000000001 /* CodexTeamsAppServerSupervisor.swift */,
 				A10240090000000000000001 /* CodexTeamsPOSIXSupport.swift */,
@@ -13969,6 +13972,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C11218000000000000000052 /* CLIError.swift in Sources */,
 				B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */,
 				C12985000000000000000002 /* CLISocketSentryTelemetry.swift in Sources */,
+					575000010000000000000001 /* CLIWriteDescriptor.swift in Sources */,
 				B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */,
 				C0DE1A060000000000000001 /* cmux_layout.swift in Sources */,
 				B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */,

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-cli.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-cli.xcscheme
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="2600" version="1.3">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting="YES"
+            buildForRunning="YES"
+            buildForProfiling="YES"
+            buildForArchiving="YES"
+            buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="B9000005A1B2C3D4E5F60719"
+               BuildableName="cmux"
+               BlueprintName="cmux-cli"
+               ReferencedContainer="container:cmux.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+</Scheme>

--- a/tests/test_cli_broken_pipe_writes.py
+++ b/tests/test_cli_broken_pipe_writes.py
@@ -160,7 +160,7 @@ class BrokenPipeWritesTests(unittest.TestCase):
                         process.kill()
                         process.wait()
 
-    def test_socket_peer_closes_during_request_write(self) -> None:
+    def run_socket_disconnect(self) -> subprocess.CompletedProcess:
         def disconnect(conn: socket.socket, _stop: threading.Event) -> None:
             # Read one byte to prove a request has started, then tear down its
             # reader while a request larger than the send buffer is in flight.
@@ -169,15 +169,40 @@ class BrokenPipeWritesTests(unittest.TestCase):
                 conn.shutdown(socket.SHUT_RDWR)
 
         with FakeUnixServer(disconnect) as server:
-            result = self.run_cli(
+            return self.run_cli(
                 "--socket", server.path, "send",
                 "--workspace", "11111111-1111-1111-1111-111111111111",
                 "--surface", "22222222-2222-2222-2222-222222222222",
                 "x" * 196_608,
             )
-            self.assertEqual(result.returncode, 1, result.stderr)
-            self.assertIn(b"Failed to write to socket", result.stderr)
-            self.assertRegex(result.stderr, rb"errno (32|54)")
+
+    def test_socket_peer_closes_during_request_write(self) -> None:
+        result = self.run_socket_disconnect()
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(b"Failed to write to socket", result.stderr)
+        self.assertRegex(result.stderr, rb"errno (32|54)")
+
+    def test_socket_disconnect_is_filtered_before_sentry_capture(self) -> None:
+        # The DEBUG capture probe is downstream of classification, before SDK
+        # startup. An actionable control proves an absent probe is meaningful.
+        self.env.pop("CMUX_CLI_SENTRY_DISABLED")
+        self.env.pop("CMUX_CLAUDE_HOOK_SENTRY_DISABLED")
+        self.env["CMUX_BUNDLE_ID"] = "com.cmuxterm.app.debug.cli-pipe-regressions"
+        probe = Path(self.root.name) / "capture.txt"
+        self.env["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = str(probe)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            port = listener.getsockname()[1]
+        control = self.run_cli("--socket", f"127.0.0.1:{port}", "ping")
+        self.assertEqual(control.returncode, 1, control.stderr)
+        self.assertIn(b"Missing relay auth metadata", control.stderr)
+        self.assertTrue(probe.exists(), "Actionable control did not reach the DEBUG capture probe")
+        probe.unlink()
+
+        result = self.run_socket_disconnect()
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertRegex(result.stderr, rb"errno (32|54)")
+        self.assertFalse(probe.exists(), "Expected disconnect reached Sentry capture")
 
     def test_child_processes_keep_default_sigpipe(self) -> None:
         for mode in ("spawn", "spawn-stderr", "exec"):

--- a/tests/test_cli_broken_pipe_writes.py
+++ b/tests/test_cli_broken_pipe_writes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Exercise real CLI output paths when their pipe consumer disappears (#5750)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import select
+import socket
+import subprocess
+import tempfile
+import threading
+import unittest
+
+from test_cli_socket_operation_deadline import FakeUnixServer
+
+
+class BrokenPipeWritesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cli = os.environ["CMUX_CLI_BIN"]
+        self.root = tempfile.TemporaryDirectory(prefix="cmux-broken-pipe-")
+        self.addCleanup(self.root.cleanup)
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith(("CMUX_", "SENTRY_")) and key != "CODEX_HOME"
+        }
+        self.env.update({
+            "CFFIXED_USER_HOME": self.root.name,
+            "XDG_CONFIG_HOME": self.root.name,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_CLAUDE_HOOK_SENTRY_DISABLED": "1",
+        })
+
+    def run_cli(self, *args: str, closed: str | None = None) -> subprocess.CompletedProcess:
+        outputs = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+        write_fd = None
+        if closed:
+            read_fd, write_fd = os.pipe()
+            os.close(read_fd)
+            outputs[closed] = write_fd
+        try:
+            return subprocess.run(
+                [self.cli, *args], cwd=self.root.name, env=self.env,
+                stdin=subprocess.DEVNULL, timeout=15, **outputs,
+            )
+        finally:
+            if write_fd is not None:
+                os.close(write_fd)
+
+    @staticmethod
+    def responder(method: str, result: dict):
+        def serve(conn: socket.socket, _stop: threading.Event) -> None:
+            conn.settimeout(5)
+            with conn.makefile("rb") as stream:
+                for line in stream:
+                    request = json.loads(line)
+                    response = {"id": request["id"], "ok": True, "result": result}
+                    if request["method"] != method:
+                        response = {
+                            "id": request["id"], "ok": False,
+                            "error": {"code": "internal_error", "message": "Unexpected test RPC"},
+                        }
+                    conn.sendall(json.dumps(response).encode() + b"\n")
+        return serve
+
+    def test_codex_hook_arguments_survive_closed_stdout(self) -> None:
+        args = ("hooks", "codex", "inject-args")
+        normal = self.run_cli(*args)
+        self.assertEqual(normal.returncode, 0, normal.stderr)
+        self.assertTrue(normal.stdout.endswith(b"\0"), normal.stdout)
+        self.assertIn(b"hooks", normal.stdout.split(b"\0"))
+        closed = self.run_cli(*args, closed="stdout")
+        self.assertEqual(closed.returncode, 0, closed.stderr)
+        self.assertEqual(closed.stderr, b"")
+
+    def test_vm_prompt_survives_closed_stderr(self) -> None:
+        with FakeUnixServer(self.responder("vm.cloud_prompt", {
+            "prompt": "test cloud prompt", "skill_path": "/test/skill.md",
+        })) as server:
+            args = ("--socket", server.path, "vm", "prompt")
+            normal = self.run_cli(*args)
+            self.assertEqual(normal.returncode, 0, normal.stderr)
+            self.assertEqual(normal.stdout, b"test cloud prompt\n")
+            self.assertEqual(normal.stderr, b"skill: /test/skill.md\n")
+            closed = self.run_cli(*args, closed="stderr")
+            self.assertEqual(closed.returncode, 0, closed.stdout)
+            self.assertEqual(closed.stdout, normal.stdout)
+
+    def test_vault_warning_survives_closed_stderr(self) -> None:
+        with FakeUnixServer(self.responder("vault.sessions", {
+            "sessions": [], "errors": ["test unavailable session"],
+        })) as server:
+            args = ("--socket", server.path, "vault", "sessions")
+            normal = self.run_cli(*args)
+            self.assertEqual(normal.returncode, 0, normal.stderr)
+            self.assertEqual(normal.stderr, b"warning: test unavailable session\n")
+            closed = self.run_cli(*args, closed="stderr")
+            self.assertEqual(closed.returncode, 0, closed.stdout)
+            self.assertEqual(closed.stdout, normal.stdout)
+
+    def test_closed_stderr_preserves_command_failure(self) -> None:
+        args = ("--socket", str(Path(self.root.name) / "missing.sock"), "ping")
+        normal = self.run_cli(*args)
+        self.assertEqual(normal.returncode, 1, normal.stderr)
+        self.assertIn(b"Socket not found", normal.stderr)
+        closed = self.run_cli(*args, closed="stderr")
+        self.assertEqual(closed.returncode, normal.returncode)
+        self.assertEqual(closed.stdout, normal.stdout)
+
+    def test_consumer_closes_during_large_stdout_write(self) -> None:
+        with FakeUnixServer(self.responder("vm.cloud_prompt", {"prompt": "x" * 1_048_576})) as server:
+            with subprocess.Popen(
+                [self.cli, "--socket", server.path, "vm", "prompt"],
+                cwd=self.root.name, env=self.env, stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            ) as process:
+                try:
+                    ready, _, _ = select.select([process.stdout], [], [], 15)
+                    self.assertTrue(ready, "CLI did not start writing stdout")
+                    self.assertEqual(os.read(process.stdout.fileno(), 16), b"x" * 16)
+                    process.stdout.close()
+                    process.wait(timeout=15)
+                    self.assertEqual(process.returncode, 0, process.stderr.read())
+                finally:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+    def test_socket_peer_closes_during_request_write(self) -> None:
+        def disconnect(conn: socket.socket, _stop: threading.Event) -> None:
+            # Read one byte to prove a request has started, then tear down its
+            # reader while a request larger than the send buffer is in flight.
+            conn.settimeout(5)
+            if conn.recv(1):
+                conn.shutdown(socket.SHUT_RDWR)
+
+        with FakeUnixServer(disconnect) as server:
+            result = self.run_cli(
+                "--socket", server.path, "send",
+                "--workspace", "11111111-1111-1111-1111-111111111111",
+                "--surface", "22222222-2222-2222-2222-222222222222",
+                "x" * 196_608,
+            )
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn(b"Failed to write to socket", result.stderr)
+            self.assertRegex(result.stderr, rb"errno (32|54)")
+
+    def test_child_processes_keep_default_sigpipe(self) -> None:
+        for mode in ("spawn", "spawn-stderr", "exec"):
+            with self.subTest(mode=mode):
+                result = self.run_cli("__sigpipe-probe", mode)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(json.loads(result.stdout), {
+                    "signal": "default", "stdout_nosigpipe": 0, "stderr_nosigpipe": 0,
+                })
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_cli_broken_pipe_writes.py
+++ b/tests/test_cli_broken_pipe_writes.py
@@ -15,6 +15,9 @@ import unittest
 
 from test_cli_socket_operation_deadline import FakeUnixServer
 
+# Darwin exposes this socket option in sys/socket.h, but Python does not.
+DARWIN_SO_NOSIGPIPE = 0x1022
+
 
 class BrokenPipeWritesTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -32,11 +35,17 @@ class BrokenPipeWritesTests(unittest.TestCase):
             "CMUX_CLAUDE_HOOK_SENTRY_DISABLED": "1",
         })
 
-    def run_cli(self, *args: str, closed: str | None = None) -> subprocess.CompletedProcess:
+    def run_cli(
+        self, *args: str, closed: str | None = None, socket_stream: bool = False,
+    ) -> subprocess.CompletedProcess:
         outputs = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
         write_fd = None
         if closed:
-            read_fd, write_fd = os.pipe()
+            if socket_stream:
+                reader, writer = socket.socketpair()
+                read_fd, write_fd = reader.detach(), writer.detach()
+            else:
+                read_fd, write_fd = os.pipe()
             os.close(read_fd)
             outputs[closed] = write_fd
         try:
@@ -107,6 +116,30 @@ class BrokenPipeWritesTests(unittest.TestCase):
         closed = self.run_cli(*args, closed="stderr")
         self.assertEqual(closed.returncode, normal.returncode)
         self.assertEqual(closed.stdout, normal.stdout)
+
+    def test_socket_backed_stdout_does_not_signal(self) -> None:
+        result = self.run_cli("--version", closed="stdout", socket_stream=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, b"")
+
+    def test_socket_backed_stderr_preserves_command_failure(self) -> None:
+        result = self.run_cli(
+            "--socket", str(Path(self.root.name) / "missing.sock"), "ping",
+            closed="stderr", socket_stream=True,
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+
+    def test_stdout_socket_options_are_not_changed_for_other_writers(self) -> None:
+        reader, writer = socket.socketpair()
+        with reader, writer:
+            original = writer.getsockopt(socket.SOL_SOCKET, DARWIN_SO_NOSIGPIPE)
+            result = subprocess.run(
+                [self.cli, "--version"], cwd=self.root.name, env=self.env,
+                stdin=subprocess.DEVNULL, stdout=writer, stderr=subprocess.PIPE, timeout=15,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(writer.getsockopt(socket.SOL_SOCKET, DARWIN_SO_NOSIGPIPE), original)
+            self.assertTrue(reader.recv(4096).startswith(b"cmux "))
 
     def test_consumer_closes_during_large_stdout_write(self) -> None:
         with FakeUnixServer(self.responder("vm.cloud_prompt", {"prompt": "x" * 262_144})) as server:

--- a/tests/test_cli_broken_pipe_writes.py
+++ b/tests/test_cli_broken_pipe_writes.py
@@ -109,7 +109,7 @@ class BrokenPipeWritesTests(unittest.TestCase):
         self.assertEqual(closed.stdout, normal.stdout)
 
     def test_consumer_closes_during_large_stdout_write(self) -> None:
-        with FakeUnixServer(self.responder("vm.cloud_prompt", {"prompt": "x" * 1_048_576})) as server:
+        with FakeUnixServer(self.responder("vm.cloud_prompt", {"prompt": "x" * 262_144})) as server:
             with subprocess.Popen(
                 [self.cli, "--socket", server.path, "vm", "prompt"],
                 cwd=self.root.name, env=self.env, stdin=subprocess.DEVNULL,


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5750. Coordinates the overlapping NSFileHandle crash report https://github.com/manaflow-ai/cmux/issues/2984 (reproduction details posted there).

A CLI consumer closing its pipe can still abort current stable/nightly commands. Socket-backed stdout/stderr can also kill the CLI with SIGPIPE: on Darwin, setting F_SETNOSIGPIPE after the socket disconnects returns EINVAL, which the existing helper ignored. Separately, the Unix-socket request writer discarded the errno when poll reported a closed peer, so the existing Sentry filter could not identify the expected disconnect.

The change establishes one output boundary:
- Route all ten remaining direct standard-stream writes through the existing POSIX output helper, including Codex hook arguments and VM/vault/restore diagnostics.
- Detect sockets once per output operation and use send(MSG_NOSIGNAL). Keep F_SETNOSIGPIPE for pipes/files. Avoid changing an inherited socket's shared SO_NOSIGPIPE option; preserve the existing child-process signal contract.
- Let the already-protected request write obtain the actual disconnect errno after poll wakes. Existing EPIPE/ECONNRESET/EBADF filtering then runs before Sentry capture, without broadening suppression of actionable errors.

Trade-offs: one fstat per output operation, with a 30-line descriptor adapter to keep CMUXCLI+Process.swift below 500 lines. Keep the established policies: closed stdout exits 0; closed stderr preserves command success/failure. A global SIGPIPE ignore would leak into children and would not prevent Foundation exceptions. No process-wide signal changes, retries, or new runtime timing are added.

Release evidence:
- Stable **0.64.22 (102), ddd4a01bc**: `hooks codex inject-args` with closed stdout aborts with NSFileHandleOperationException / signal 6. `--version` or a command-error diagnostic with closed socket-backed stdout/stderr exits with signal 13.
- Nightly **0.64.22-nightly.3473864008601, d9e50ca**: Codex hook stdout, VM prompt stderr, and vault warning stderr each reproduce signal 6; the closed request socket loses its errno.
- Sentry **CMUXTERM-MACOS-1YBG**, event `354c3038962d49588cfa72b94a8ee056`, 2026-09-08: release `com.cmuxterm.app@0.64.22+102`, SIGPIPE in `CMUXCLIOutput.writeStandardError`. Its arm64 UUID `F38EEB50-39BD-3FC9-B03A-98CF1D124203` matches the installed stable binary.
- Latest **S1** event `cc71774e70794721a88b42bd5a3b4e90` (2026-09-12) has the matching NSFileHandle stack but no release identifier. PN/G5 last reported on August 19. Those events alone cannot establish current-main attribution.

Prior work: #6254 supplied the shared writer/socket/filter foundations. #2993 remains unmerged and predates those foundations. #7331's broader structured-errno/other-crash work and #9080's remote child-stdin changes are not duplicated here.

Regression commits: `3560fbf307a` adds command-level closed-pipe tests; `d848894824c` fixes those paths. `4f445425def` adds the newly reproduced inherited-socket tests; `d9deaf5fb6e` fixes that boundary. Tests are wired into the existing macOS CLI regression CI step. Baseline nightly: 4 targeted failures out of 7 cases; baseline stable socket suite: 3 failures, including the shared socket-option mutation. No source-shape tests.

Validation so far:
- `CMUX_CLI_BIN=<stable/nightly binary> python3 tests/test_cli_broken_pipe_writes.py` (baseline failures above; the stable binary lacks the newer VM/vault commands, so only its supported cases establish regression evidence).
- Darwin subprocess experiment: disconnected fcntl => EINVAL + SIGPIPE; per-send MSG_NOSIGNAL => EPIPE and normal process exit.
- `python3 scripts/swift_file_length_budget.py` — passed; neither budget TSV changed.
- `python3 scripts/normalize-pbxproj.py cmux.xcodeproj/project.pbxproj` and `git diff --check` — passed.
- `python3 scripts/localization_catalog.py check` — 6 catalogs, 9 locales, zero parity errors. Output bytes and existing localization keys are preserved; no user-facing strings added.

Dedicated hosted CLI verification is green: CLI build and all 11 closed-pipe/socket/Sentry regression tests passed on macOS 15 in run https://github.com/manaflow-ai/cmux/actions/runs/34744602473. This is a shell-only CLI change; no visual evidence is applicable. The optional Cloud Mac run could not obtain an SSH endpoint before timeout, so no Cloud Mac video is applicable.

The general CI workflow remains blocked by unrelated base failures in `CmuxTuiSurfaceProvider+FileDelivery.swift` (`fallbackTabID` and `waitForScreen` compile errors); no files in that path are changed here. The workflow determinism gate also reported the pre-existing `IrxLiveQUICTests.swift:589` sleep assertion. I am leaving the PR unmerged until the required app-host checks are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI handling when stdout or stderr closes unexpectedly, including socket disconnects.
  * Preserved underlying command failures instead of masking them as broken-pipe errors.
  * Improved interactive VM session handling for invalid or disconnected terminals.
  * Added clearer localized diagnostics for socket write failures.
* **Reliability**
  * CLI output and error reporting are now more resilient during interrupted or large writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->