### PR TITLE
Cloud sidebar: allocate full width for dense rows

### DIFF
--- a/Sources/Cloud/CloudTreeLayoutMetrics.swift
+++ b/Sources/Cloud/CloudTreeLayoutMetrics.swift
@@ -22,6 +22,11 @@ struct CloudTreeLayoutMetrics: Equatable, Sendable {
         max(0, viewportWidth)
     }
 
+    /// Keeps an empty outline scrollable while preserving a taller row document.
+    func documentHeight(viewportHeight: CGFloat, existingHeight: CGFloat) -> CGFloat {
+        max(0, viewportHeight, existingHeight)
+    }
+
     /// Width left for a title after stable trailing controls and both insets.
     /// Titles receive all remaining space and therefore truncate only after
     /// metadata, notification dots, and hover actions have been reserved.

--- a/Sources/Cloud/CloudTreeLayoutMetrics.swift
+++ b/Sources/Cloud/CloudTreeLayoutMetrics.swift
@@ -1,0 +1,35 @@
+import CoreGraphics
+
+/// Geometry shared by the Cloud outline's document and row content.
+///
+/// AppKit owns the outline document width, while SwiftUI owns the contents of
+/// each hosted cell. Keeping the viewport rule here makes both sides agree on
+/// how much width is available without coupling a row to a particular sidebar
+/// size.
+struct CloudTreeLayoutMetrics: Equatable, Sendable {
+    /// The horizontal inset used by the former Cloud setup entry and by row
+    /// accessories at the trailing edge.
+    let referenceInset: CGFloat
+
+    /// Creates Cloud tree geometry for the given content inset.
+    init(referenceInset: CGFloat = 12) {
+        self.referenceInset = max(0, referenceInset)
+    }
+
+    /// The document follows the visible scroll viewport so rows receive the
+    /// full sidebar width and the tree never grows a hidden horizontal gutter.
+    func documentWidth(viewportWidth: CGFloat) -> CGFloat {
+        max(0, viewportWidth)
+    }
+
+    /// Width left for a title after stable trailing controls and both insets.
+    /// Titles receive all remaining space and therefore truncate only after
+    /// metadata, notification dots, and hover actions have been reserved.
+    func titleWidth(
+        rowWidth: CGFloat,
+        leadingContentWidth: CGFloat,
+        trailingContentWidth: CGFloat
+    ) -> CGFloat {
+        max(0, rowWidth - leadingContentWidth - trailingContentWidth - referenceInset)
+    }
+}

--- a/Sources/Cloud/CloudTreeLayoutMetrics.swift
+++ b/Sources/Cloud/CloudTreeLayoutMetrics.swift
@@ -22,9 +22,9 @@ struct CloudTreeLayoutMetrics: Equatable, Sendable {
         max(0, viewportWidth)
     }
 
-    /// Keeps an empty outline scrollable while preserving a taller row document.
-    func documentHeight(viewportHeight: CGFloat, existingHeight: CGFloat) -> CGFloat {
-        max(0, viewportHeight, existingHeight)
+    /// Keeps an empty outline usable while preserving a taller row document.
+    func documentHeight(viewportHeight: CGFloat, contentHeight: CGFloat) -> CGFloat {
+        max(0, viewportHeight, contentHeight)
     }
 
     /// Width left for a title after stable trailing controls and both insets.

--- a/Sources/Cloud/CloudTreeNSOutlineView.swift
+++ b/Sources/Cloud/CloudTreeNSOutlineView.swift
@@ -7,20 +7,11 @@ import CmuxFoundation
 final class CloudTreeNSOutlineView: NSOutlineView {
     static let leadingMargin: CGFloat = 8
 
-    /// Keeps the outline delegate/source graph alive while AppKit owns a
-    /// native surface drag, including reconstruction between writer creation
-    /// and `willBeginAt`.
-    /// Strong coordinator owner for the active Cloud drag. The coordinator
-    /// clears this at the native terminal boundary; the distinct name makes
-    /// its ownership contract explicit (unlike weak File Explorer markers).
     var activeNativeDragCoordinator: AnyObject?
     var activeNativeDragSession: NSDraggingSession?
-    /// Invoked before a new pointer gesture. AppKit cannot deliver this
-    /// boundary while the previous native drag loop is active.
     var onNativeDragPointerBoundary: (() -> Void)?
+    var onDocumentContentChanged: (() -> Void)?
 
-    /// The active visual preset; the coordinator keeps this in step with the
-    /// style it lays rows out with (chevron centering depends on it).
     var treeStyle: CloudTreeStyle = CloudTreeStyleStore.current
 
     /// Per-event context menu, the same presentation path the sidebar rows
@@ -147,6 +138,7 @@ final class CloudTreeNSOutlineView: NSOutlineView {
         NSAnimationContext.current.duration = 0
         super.expandItem(item, expandChildren: expandChildren)
         NSAnimationContext.endGrouping()
+        onDocumentContentChanged?()
     }
 
     override func collapseItem(_ item: Any?, collapseChildren: Bool) {
@@ -154,6 +146,13 @@ final class CloudTreeNSOutlineView: NSOutlineView {
         NSAnimationContext.current.duration = 0
         super.collapseItem(item, collapseChildren: collapseChildren)
         NSAnimationContext.endGrouping()
+        onDocumentContentChanged?()
+    }
+
+    override func reloadData() { super.reloadData(); onDocumentContentChanged?() }
+    override func reloadData(forRowIndexes rowIndexes: IndexSet, columnIndexes: IndexSet) {
+        super.reloadData(forRowIndexes: rowIndexes, columnIndexes: columnIndexes)
+        onDocumentContentChanged?()
     }
 
     /// How far `frameOfCell` moves content past AppKit's default; the cell adds the

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -1116,6 +1116,7 @@ final class CloudTreeContainerView: NSView {
         scrollView.documentView = outlineView
         scrollView.contentInsets = NSEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
         addSubview(scrollView)
+        outlineView.onDocumentContentChanged = { [weak self] in self?.needsLayout = true }
         outlineView.frame = scrollView.contentView.bounds
         outlineView.autoresizingMask = [.width]
         NSLayoutConstraint.activate([
@@ -1131,7 +1132,6 @@ final class CloudTreeContainerView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Recomputes document geometry whenever the container lays out.
     override func layout() {
         super.layout()
         let viewportWidth = scrollView.contentView.bounds.width

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -1131,15 +1131,16 @@ final class CloudTreeContainerView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Width is a pure function of the current bounds, recomputed on every layout
-    /// pass. Rows are correct on first display, on sidebar show, and on any
-    /// programmatic resize — not only after a live divider drag.
+    /// Recomputes document geometry whenever the container lays out.
     override func layout() {
         super.layout()
         let viewportWidth = scrollView.contentView.bounds.width
         let documentWidth = layoutMetrics.documentWidth(viewportWidth: viewportWidth)
+        let contentHeight = outlineView.numberOfRows > 0
+            ? outlineView.rect(ofRow: outlineView.numberOfRows - 1).maxY + scrollView.contentInsets.bottom
+            : 0
         let documentHeight = layoutMetrics.documentHeight(
-            viewportHeight: scrollView.contentView.bounds.height, existingHeight: outlineView.frame.height)
+            viewportHeight: scrollView.contentView.bounds.height, contentHeight: contentHeight)
         if abs(outlineView.frame.width - documentWidth) > 0.5 || abs(outlineView.frame.height - documentHeight) > 0.5 {
             outlineView.setFrameSize(NSSize(width: documentWidth, height: documentHeight))
         }

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -1058,6 +1058,7 @@ final class CloudTreeContainerView: NSView {
     private let scrollView = NSScrollView()
     private let outlineView = CloudTreeNSOutlineView()
     private let coordinator: CloudTreeOutlineView.Coordinator
+    private let layoutMetrics = CloudTreeLayoutMetrics()
 
     init(coordinator: CloudTreeOutlineView.Coordinator) {
         self.coordinator = coordinator
@@ -1067,9 +1068,6 @@ final class CloudTreeContainerView: NSView {
         outlineView.style = .plain
         outlineView.selectionHighlightStyle = .regular
         outlineView.rowSizeStyle = .custom
-        // One slot per level (style-sized): the disclosure chevron lives in the
-        // last slot before a row's content, and leaves keep the slot so glyphs
-        // form a column. `apply(style:)` keeps this in step with the preset.
         outlineView.indentationPerLevel = CloudTreeStyleStore.current.indentPerLevel
         outlineView.allowsMultipleSelection = false
         outlineView.autoresizesOutlineColumn = true
@@ -1083,19 +1081,11 @@ final class CloudTreeContainerView: NSView {
         column.resizingMask = .autoresizingMask
         outlineView.addTableColumn(column)
         outlineView.outlineTableColumn = column
-        // The one column's width is derived from the live bounds on EVERY layout
-        // pass (see `layout()`), never left to resize notifications: a width set
-        // only during live-resize events is exactly the "row content is wrong
-        // until I drag the divider" class of bug.
         outlineView.columnAutoresizingStyle = .firstColumnOnlyAutoresizingStyle
 
         outlineView.dataSource = coordinator
         outlineView.delegate = coordinator
         outlineView.target = coordinator
-        // D9: one click opens, on every row. The single-click handler ignores
-        // the extra clicks of a double-click, so a habitual double-click acts
-        // once and never opens twice. No doubleAction: nothing is double-click
-        // only anymore.
         outlineView.action = #selector(CloudTreeOutlineView.Coordinator.handleSingleClick(_:))
         outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
         outlineView.onOpenSelection = { [weak coordinator] in coordinator?.openSelection() }
@@ -1126,6 +1116,8 @@ final class CloudTreeContainerView: NSView {
         scrollView.documentView = outlineView
         scrollView.contentInsets = NSEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
         addSubview(scrollView)
+        outlineView.frame = scrollView.contentView.bounds
+        outlineView.autoresizingMask = [.width]
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -1144,6 +1136,11 @@ final class CloudTreeContainerView: NSView {
     /// programmatic resize — not only after a live divider drag.
     override func layout() {
         super.layout()
+        let viewportWidth = scrollView.contentView.bounds.width
+        let documentWidth = layoutMetrics.documentWidth(viewportWidth: viewportWidth)
+        if abs(outlineView.frame.width - documentWidth) > 0.5 {
+            outlineView.setFrameSize(NSSize(width: documentWidth, height: outlineView.frame.height))
+        }
         outlineView.sizeLastColumnToFit()
     }
 }

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -1138,8 +1138,10 @@ final class CloudTreeContainerView: NSView {
         super.layout()
         let viewportWidth = scrollView.contentView.bounds.width
         let documentWidth = layoutMetrics.documentWidth(viewportWidth: viewportWidth)
-        if abs(outlineView.frame.width - documentWidth) > 0.5 {
-            outlineView.setFrameSize(NSSize(width: documentWidth, height: outlineView.frame.height))
+        let documentHeight = layoutMetrics.documentHeight(
+            viewportHeight: scrollView.contentView.bounds.height, existingHeight: outlineView.frame.height)
+        if abs(outlineView.frame.width - documentWidth) > 0.5 || abs(outlineView.frame.height - documentHeight) > 0.5 {
+            outlineView.setFrameSize(NSSize(width: documentWidth, height: documentHeight))
         }
         outlineView.sizeLastColumnToFit()
     }

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -13,7 +13,7 @@ enum CloudTreeRowGrid {
     /// Trailing accessories (open marker): gap after the text, a fixed slot, then padding.
     static let trailingGap: CGFloat = 10
     static let trailingSlot: CGFloat = 16
-    static let trailingPadding: CGFloat = 12
+    static let trailingPadding: CGFloat = CloudTreeLayoutMetrics().referenceInset
     static let machineLineSpacing: CGFloat = 1
 }
 

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -13,7 +13,7 @@ enum CloudTreeRowGrid {
     /// Trailing accessories (open marker): gap after the text, a fixed slot, then padding.
     static let trailingGap: CGFloat = 10
     static let trailingSlot: CGFloat = 16
-    static let trailingPadding: CGFloat = 8
+    static let trailingPadding: CGFloat = 12
     static let machineLineSpacing: CGFloat = 1
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -791,6 +791,8 @@
 		C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986A0070000000000000001 /* CloudTreeActiveDrag.swift */; };
 		3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E286761D314959F64AA002 /* CloudTreeCellView.swift */; };
 		46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */; };
+		A12501000000000000000002 /* CloudTreeLayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12501000000000000000001 /* CloudTreeLayoutMetrics.swift */; };
+		A12501000000000000000003 /* CloudTreeLayoutMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12501000000000000000004 /* CloudTreeLayoutMetricsTests.swift */; };
 		B5C68F2FAFD21A103AFF429D /* CloudTreeMachineMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC9BE77DF3A402B8EC51665 /* CloudTreeMachineMenuTests.swift */; };
 		67C1325431BC42F58AC69F1C /* CloudTreeMachineResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4C8CD1419E452C8ACB72E5 /* CloudTreeMachineResourcesTests.swift */; };
 		BE46EFA44C6E4699B64FE62E /* CloudTreeMachineResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF43F26D03DC4827B4AC3E48 /* CloudTreeMachineResourceView.swift */; };
@@ -4503,6 +4505,8 @@
 		C986A0070000000000000001 /* CloudTreeActiveDrag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTreeActiveDrag.swift; sourceTree = "<group>"; };
 		47E286761D314959F64AA002 /* CloudTreeCellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeCellView.swift; sourceTree = "<group>"; };
 		B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeExpansionStore.swift; sourceTree = "<group>"; };
+		A12501000000000000000001 /* CloudTreeLayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeLayoutMetrics.swift; sourceTree = "<group>"; };
+		A12501000000000000000004 /* CloudTreeLayoutMetricsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeLayoutMetricsTests.swift; sourceTree = "<group>"; };
 		ADC9BE77DF3A402B8EC51665 /* CloudTreeMachineMenuTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeMachineMenuTests.swift; sourceTree = "<group>"; };
 		4E4C8CD1419E452C8ACB72E5 /* CloudTreeMachineResourcesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeMachineResourcesTests.swift; sourceTree = "<group>"; };
 		CF43F26D03DC4827B4AC3E48 /* CloudTreeMachineResourceView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeMachineResourceView.swift; sourceTree = "<group>"; };
@@ -7823,6 +7827,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C986A0020000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift */,
 				A4C74749FA907F50D653EF65 /* CloudTreeNSOutlineView.swift */,
 				47E286761D314959F64AA002 /* CloudTreeCellView.swift */,
+				A12501000000000000000001 /* CloudTreeLayoutMetrics.swift */,
 				53075CD5172053B8F994DA2B /* CloudTreeRowContentView.swift */,
 				FB09B103918144A9A420D765 /* CloudTreeMachineRowContent.swift */,
 				CF43F26D03DC4827B4AC3E48 /* CloudTreeMachineResourceView.swift */,
@@ -10537,6 +10542,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */,
 				99BEA5821E46487A94B4E8B8 /* CloudTreeOneMachineManyWorkspacesTests.swift */,
 				A12367000000000000000001 /* CloudTreeWorkspaceTitleLayoutTests.swift */,
+				A12501000000000000000004 /* CloudTreeLayoutMetricsTests.swift */,
 				F739BB5F7AEF47A6A38D6B7C /* CloudWorkspaceMembershipTests.swift */,
 				F11347000000000000000004 /* CloudPortOpenRegressionTests.swift */,
 				F3E5958FB85E4B97957D4F73 /* CloudSidebarSurfaceRegressionTests.swift */,
@@ -12095,6 +12101,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */,
 				3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */,
 				46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */,
+				A12501000000000000000002 /* CloudTreeLayoutMetrics.swift in Sources */,
 				BE46EFA44C6E4699B64FE62E /* CloudTreeMachineResourceView.swift in Sources */,
 				239CDE3EB72D4EFBBBD92783 /* CloudTreeMachineRowContent.swift in Sources */,
 				494BF5E2F1B8BF0369D2DEBC /* CloudTreeNode+ErrorCopy.swift in Sources */,
@@ -14435,6 +14442,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				83EFE46711801D1A82B94FD1 /* CloudTerminalAttachmentRecoveryTests.swift in Sources */,
 				8D00A9B0971047B181BBEDCE /* CloudTerminalCreationCoordinatorTests.swift in Sources */,
 				FA0000000000000000000003 /* CloudTerminalPaneClosureTests.swift in Sources */,
+				A12501000000000000000003 /* CloudTreeLayoutMetricsTests.swift in Sources */,
 				B5C68F2FAFD21A103AFF429D /* CloudTreeMachineMenuTests.swift in Sources */,
 				67C1325431BC42F58AC69F1C /* CloudTreeMachineResourcesTests.swift in Sources */,
 				C986A0030000000000000001 /* CloudTreeNativeDragOwnershipTests.swift in Sources */,

--- a/cmuxTests/CloudTreeLayoutMetricsTests.swift
+++ b/cmuxTests/CloudTreeLayoutMetricsTests.swift
@@ -20,8 +20,8 @@ struct CloudTreeLayoutMetricsTests {
 
     @Test("document height stays usable before rows load")
     func documentHeightTracksViewport() {
-        #expect(metrics.documentHeight(viewportHeight: 300, existingHeight: 0) == 300)
-        #expect(metrics.documentHeight(viewportHeight: 300, existingHeight: 520) == 520)
+        #expect(metrics.documentHeight(viewportHeight: 300, contentHeight: 0) == 300)
+        #expect(metrics.documentHeight(viewportHeight: 300, contentHeight: 520) == 520)
     }
 
     @Test("title width receives space after stable trailing content")

--- a/cmuxTests/CloudTreeLayoutMetricsTests.swift
+++ b/cmuxTests/CloudTreeLayoutMetricsTests.swift
@@ -1,0 +1,32 @@
+import CoreGraphics
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Cloud tree layout metrics")
+struct CloudTreeLayoutMetricsTests {
+    private let metrics = CloudTreeLayoutMetrics()
+
+    @Test("document width fills narrow and wide viewports")
+    func documentWidthTracksViewport() {
+        #expect(metrics.documentWidth(viewportWidth: 180) == 180)
+        #expect(metrics.documentWidth(viewportWidth: 420) == 420)
+        #expect(metrics.documentWidth(viewportWidth: -1) == 0)
+    }
+
+    @Test("title width receives space after stable trailing content")
+    func titleWidthReservesControls() {
+        #expect(metrics.titleWidth(rowWidth: 420, leadingContentWidth: 92, trailingContentWidth: 76) == 240)
+        #expect(metrics.titleWidth(rowWidth: 180, leadingContentWidth: 92, trailingContentWidth: 76) == 0)
+    }
+
+    @Test("the content inset matches the former setup entry")
+    func referenceInsetIsTwelvePoints() {
+        #expect(metrics.referenceInset == 12)
+        #expect(CloudTreeRowGrid.trailingPadding == metrics.referenceInset)
+    }
+}

--- a/cmuxTests/CloudTreeLayoutMetricsTests.swift
+++ b/cmuxTests/CloudTreeLayoutMetricsTests.swift
@@ -18,6 +18,12 @@ struct CloudTreeLayoutMetricsTests {
         #expect(metrics.documentWidth(viewportWidth: -1) == 0)
     }
 
+    @Test("document height stays usable before rows load")
+    func documentHeightTracksViewport() {
+        #expect(metrics.documentHeight(viewportHeight: 300, existingHeight: 0) == 300)
+        #expect(metrics.documentHeight(viewportHeight: 300, existingHeight: 520) == 520)
+    }
+
     @Test("title width receives space after stable trailing content")
     func titleWidthReservesControls() {
         #expect(metrics.titleWidth(rowWidth: 420, leadingContentWidth: 92, trailingContentWidth: 76) == 240)

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -1,5 +1,5 @@
 import AppKit
-import XCTest
+import Testing
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
@@ -7,29 +7,30 @@ import XCTest
 #endif
 
 @MainActor
-final class CloudTreeWorkspaceTitleLayoutTests: XCTestCase {
-    func testDisplayHostUsesVisibleCellWidth() {
+@Suite("Cloud tree workspace title layout")
+struct CloudTreeWorkspaceTitleLayoutTests {
+    @Test("the display host reaches the visible cell trailing edge")
+    func displayHostUsesVisibleCellWidth() {
         let cell = CloudTreeCellView(frame: NSRect(x: 0, y: 0, width: 700, height: 24))
         guard let host = cell.subviews.compactMap({ $0 as? CloudTreePassthroughHostingView }).first else {
-            return XCTFail("Cloud tree cell should host a pass-through display view")
+            Issue.record("Cloud tree cell should host a pass-through display view")
+            return
         }
         guard let trailingConstraint = cell.constraints.first(where: { constraint in
             (constraint.firstItem as? NSView) === host
                 && constraint.firstAttribute == .trailing
                 && (constraint.secondItem as? NSView) === cell
         }) else {
-            return XCTFail("Cloud tree display host should have a trailing constraint")
+            Issue.record("Cloud tree display host should have a trailing constraint")
+            return
         }
 
-        XCTAssertEqual(trailingConstraint.relation, .equal)
-        XCTAssertEqual(
-            trailingConstraint.priority,
-            NSLayoutConstraint.Priority(rawValue: NSLayoutConstraint.Priority.required.rawValue - 1)
-        )
+        #expect(trailingConstraint.relation == .equal)
+        #expect(trailingConstraint.priority == NSLayoutConstraint.Priority(rawValue: NSLayoutConstraint.Priority.required.rawValue - 1))
     }
 
-    @MainActor
-    func testContainerDocumentFillsScrollViewportAtWideAndNarrowSizes() {
+    @Test("the container document fills narrow and wide scroll viewports")
+    func containerDocumentFillsScrollViewportAtWideAndNarrowSizes() {
         let machineActions = MachineRowActions.bound(onDidMutate: {})
         let nodeActions = CloudTreeNodeActions.bound(
             catalog: { SurfaceCatalog.shared }, selectedWorkspaceID: { nil },
@@ -51,9 +52,10 @@ final class CloudTreeWorkspaceTitleLayoutTests: XCTestCase {
             container.layoutSubtreeIfNeeded()
             guard let scroll = container.subviews.compactMap({ $0 as? NSScrollView }).first,
                   let outline = scroll.documentView else {
-                return XCTFail("Cloud tree should install an outline document view")
+                Issue.record("Cloud tree should install an outline document view")
+                return
             }
-            XCTAssertEqual(outline.frame.width, scroll.contentView.bounds.width, accuracy: 0.5)
+            #expect(abs(outline.frame.width - scroll.contentView.bounds.width) <= 0.5)
         }
     }
 }

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -27,4 +27,33 @@ final class CloudTreeWorkspaceTitleLayoutTests: XCTestCase {
             NSLayoutConstraint.Priority(rawValue: NSLayoutConstraint.Priority.required.rawValue - 1)
         )
     }
+
+    @MainActor
+    func testContainerDocumentFillsScrollViewportAtWideAndNarrowSizes() {
+        let machineActions = MachineRowActions.bound(onDidMutate: {})
+        let nodeActions = CloudTreeNodeActions.bound(
+            catalog: { SurfaceCatalog.shared }, selectedWorkspaceID: { nil },
+            selectLocalWorkspace: { _ in }, onWillMutate: { _ in },
+            onDidMutate: {}, onFailure: { _ in }, refresh: {}
+        )
+        let coordinator = CloudTreeOutlineView.Coordinator(
+            machineActions: machineActions,
+            nodeActions: nodeActions,
+            expansionStore: CloudTreeExpansionStore(
+                defaults: UserDefaults(suiteName: "cloud-tree-layout-\(UUID().uuidString)")!
+            ),
+            tabDragTransferRegistry: { nil }
+        )
+        let container = CloudTreeContainerView(coordinator: coordinator)
+
+        for width in [180, 420] {
+            container.frame = NSRect(x: 0, y: 0, width: width, height: 300)
+            container.layoutSubtreeIfNeeded()
+            guard let scroll = container.subviews.compactMap({ $0 as? NSScrollView }).first,
+                  let outline = scroll.documentView else {
+                return XCTFail("Cloud tree should install an outline document view")
+            }
+            XCTAssertEqual(outline.frame.width, scroll.contentView.bounds.width, accuracy: 0.5)
+        }
+    }
 }

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -47,6 +47,8 @@ struct CloudTreeWorkspaceTitleLayoutTests {
         )
         let container = CloudTreeContainerView(coordinator: coordinator)
         let machine = SurfaceMachineID.cloud("layout-test")
+        container.frame = NSRect(x: 0, y: 0, width: 180, height: 300)
+        container.layoutSubtreeIfNeeded()
         coordinator.apply(nodes: (0..<20).map { index in
             CloudTreeNode(
                 id: "layout-placeholder-\(index)",
@@ -56,6 +58,7 @@ struct CloudTreeWorkspaceTitleLayoutTests {
                 )
             )
         })
+        container.layoutSubtreeIfNeeded()
 
         for width in [180, 420] {
             container.frame = NSRect(x: 0, y: 0, width: width, height: 300)

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -46,6 +46,16 @@ struct CloudTreeWorkspaceTitleLayoutTests {
             tabDragTransferRegistry: { nil }
         )
         let container = CloudTreeContainerView(coordinator: coordinator)
+        let machine = SurfaceMachineID.cloud("layout-test")
+        coordinator.apply(nodes: (0..<20).map { index in
+            CloudTreeNode(
+                id: "layout-placeholder-\(index)",
+                kind: .placeholder(
+                    machine: machine,
+                    CloudTreePlaceholder(text: "row \(index)", style: .dimmed)
+                )
+            )
+        })
 
         for width in [180, 420] {
             container.frame = NSRect(x: 0, y: 0, width: width, height: 300)
@@ -57,6 +67,7 @@ struct CloudTreeWorkspaceTitleLayoutTests {
             }
             #expect(abs(outline.frame.width - scroll.contentView.bounds.width) <= 0.5)
             #expect(outline.frame.height >= scroll.contentView.bounds.height - 0.5)
+            #expect(outline.frame.height > scroll.contentView.bounds.height)
         }
     }
 }

--- a/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
+++ b/cmuxTests/CloudTreeWorkspaceTitleLayoutTests.swift
@@ -56,6 +56,7 @@ struct CloudTreeWorkspaceTitleLayoutTests {
                 return
             }
             #expect(abs(outline.frame.width - scroll.contentView.bounds.width) <= 0.5)
+            #expect(outline.frame.height >= scroll.contentView.bounds.height - 0.5)
         }
     }
 }


### PR DESCRIPTION
## Problem
The Cloud Machines right sidebar gave its outline document an intrinsic width narrower than the visible panel, leaving a blank gutter and truncating workspace and terminal rows prematurely.

## Change
- Keep the Cloud outline document tied to the live scroll viewport at every layout pass, including first display and programmatic narrow/wide resizes.
- Keep the document at least as tall as the viewport and grow it from the last realized outline row, preserving scrolling for expanded groups.
- Preserve the existing AppKit disclosure, nested indentation, hover actions, notification dots, accessibility labels, and row ordering while hosted content uses the available width.
- Use the former VPN entry's 12-point inset as the shared trailing row-content reference; the removed top VPN banner is not restored.
- Add runtime AppKit regression coverage for populated rows at 180pt and 420pt widths plus focused geometry tests for width, height, title reservation, and inset behavior.

## Validation
- Passed: `python3 scripts/swift_file_length_budget.py`
- Passed: `python3 scripts/normalize-pbxproj.py --check`
- Passed: `python3 scripts/localization_catalog.py check`
- Passed: canonical autoreview (`/Users/austinwang/manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main`): clean; merge-conflict gate clean; cmux policy clean; no actionable findings.
- Hosted `test-depot.yml` focused suites were dispatched on the final HEAD (`CloudTreeWorkspaceTitleLayoutTests`, `CloudTreeLayoutMetricsTests`), but the existing `origin/main` build fails first in `SurfaceSocketCommands.swift` because `CmuxTuiSurfaceProvider` lacks `sendText`, `readScreen`, and `waitForScreen`. The same unrelated base failure reproduces in the semantic delivery check.
- Hosted Blacksmith tagged build attempted via `reload-cloud.sh --builder blacksmith`; blocked by the same unrelated `SurfaceSocketCommands.swift` compile failure.
- Fleet XCTest/UI evidence attempted; no GUI-capable slot passed preflight and a pinned mini timed out over SSH. No local build, XCUITest, dev-app launch, live VM mutation, or user focus theft was performed.

The regression test is commit `573ae68343`; the implementation is `f84a2a88cc` plus review fixes through `35c61dba49`. The branch merged cleanly with `origin/main` before push.

Fixes #12501
