### PR TITLE
Prevent first-use identity I/O during terminal dismissal

### DIFF
--- a/Sources/Cloud/DefaultPhonePushIdentityProvider.swift
+++ b/Sources/Cloud/DefaultPhonePushIdentityProvider.swift
@@ -1,0 +1,10 @@
+/// Bridges the production host identity snapshot into phone-push ownership.
+struct DefaultPhonePushIdentityProvider: PhonePushIdentityProvider {
+    func deviceIDIfReady() -> String? {
+        MobileHostIdentity.deviceIDIfReady()
+    }
+
+    func prewarm() async {
+        await MobileHostIdentity.prewarm()
+    }
+}

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -147,7 +147,6 @@ final class PhonePushClient {
     ) -> PhonePushConfiguration {
         PhonePushConfiguration(defaults: settingsDefaults ?? defaults)
     }
-
     /// Reconciles state after another owner removes stored overrides (Reset All).
     func reloadConfigurationFromDefaults() {
         let configuration = PhonePushConfiguration(defaults: defaults)
@@ -161,7 +160,6 @@ final class PhonePushClient {
         )
         publishStatusChanged()
     }
-
     /// Sole mutation path for Mac and phone callers. Validation happens before
     /// entry; all three privacy fields publish as one main-actor transaction.
     @discardableResult
@@ -204,7 +202,6 @@ final class PhonePushClient {
         publishStatusChanged()
         return configuration
     }
-
     nonisolated static func shouldForward(
         mode: PhoneForwardingMode,
         presence: MacPresenceMonitor.Decision
@@ -216,7 +213,6 @@ final class PhonePushClient {
             return !presence.isActive
         }
     }
-
     nonisolated static func admission(
         enabled: Bool,
         mode: PhoneForwardingMode,
@@ -227,7 +223,6 @@ final class PhonePushClient {
             ? .queued
             : .presenceSuppressed
     }
-
     func currentAdmission(
         defaults settingsDefaults: UserDefaults? = nil
     ) -> PhonePushAdmission {
@@ -242,7 +237,6 @@ final class PhonePushClient {
             ? .allowed
             : .suppressedMacActive
     }
-
     @discardableResult
     func forward(
         _ notification: TerminalNotification,
@@ -259,7 +253,6 @@ final class PhonePushClient {
         )
         return enqueue(payload)
     }
-
     /// Enqueues a user-requested diagnostic alert through the production path.
     /// The response confirms queue admission only; backend and APNs outcomes
     /// remain asynchronous and are correlated by the envelope UUID.
@@ -290,7 +283,6 @@ final class PhonePushClient {
         )
         return enqueue(payload)
     }
-
     private func forwardingAdmission() -> PhonePushForwardAdmission {
         let mode = PhoneForwardingMode.fromDefaults(defaults)
         let enabled = PhonePushConfiguration.forwardingEnabled(in: defaults)
@@ -303,7 +295,6 @@ final class PhonePushClient {
             presence: presenceCache.decision(from: presenceMonitor)
         )
     }
-
     private func enqueue(
         _ payload: PhonePushPayload
     ) -> PhonePushForwardAdmission {
@@ -343,21 +334,32 @@ final class PhonePushClient {
         }
         return .queued
     }
-    func forwardDismissed(ids: [String], badgeCount: Int) {
-        guard PhonePushConfiguration.forwardingEnabled(in: defaults),
-              !ids.isEmpty,
-              let identity = auth?.authenticatedSessionIdentity,
-              let targetBundleIdentifier = MobileIOSPairingTargetStore()
-                  .pushTargetNamespace?.bundleIdentifier else { return }
+    @discardableResult
+    func forwardDismissed(ids: [String], badgeCount: Int) -> PhonePushForwardAdmission {
+        guard PhonePushConfiguration.forwardingEnabled(in: defaults) else {
+            return .disabled
+        }
+        guard !ids.isEmpty else { return .queued }
+        guard let identity = auth?.authenticatedSessionIdentity else {
+            return .authenticationUnavailable
+        }
+        guard let targetBundleIdentifier = MobileIOSPairingTargetStore()
+            .pushTargetNamespace?.bundleIdentifier else {
+            return .encodingFailed
+        }
         guard let macDeviceID = identityPrewarm.deviceIDIfReady() else {
-            identityPrewarm.appendDismissals(ids: ids, badgeCount: badgeCount)
+            guard identityPrewarm.appendDismissals(ids: ids, badgeCount: badgeCount) else {
+                phonePushLog.error("dismissal prewarm buffer full; dropping batch")
+                return .queueFull
+            }
             startIdentityPrewarmIfNeeded()
-            return
+            return .queued
         }
         deliveryQueue.retainOnly(
             accountID: identity.accountID,
             generation: identity.generation
         )
+        var admission: PhonePushForwardAdmission = .queued
         for start in stride(
             from: 0,
             to: ids.count,
@@ -400,12 +402,14 @@ final class PhonePushClient {
                 continue
             }
             if !deliveryQueue.enqueuePrioritizingDismiss(envelope) {
+                admission = .queueFull
                 logQueueStage(
                     "dismiss_queue_overflow",
                     correlationID: envelope.correlationID
                 )
             }
         }
+        return admission
     }
     /// Cancels in-flight retries and atomically clears credential-free storage.
     func cancelPendingDeliveries() {
@@ -537,7 +541,6 @@ final class PhonePushClient {
             setQueuePersistenceStatus(.clearFailed)
         }
     }
-
     private func setQueuePersistenceStatus(
         _ status: PhonePushQueuePersistenceStatus
     ) {
@@ -548,14 +551,12 @@ final class PhonePushClient {
         )
         publishStatusChanged()
     }
-
     private func publishStatusChanged() {
         MobileHostService.emitEvent(
             topic: "phone_push.status.changed",
             payload: [:]
         )
     }
-
     private func deliver(
         _ envelope: PhonePushRequestEnvelope
     ) async -> PhonePushHTTPResult {
@@ -679,7 +680,6 @@ final class PhonePushClient {
         }
         return .retryExhausted
     }
-
     /// Explicit executor hop for URL loading. Queue ownership remains on the
     /// main actor, while request construction, I/O, and response decoding do
     /// not consume its executor.

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -89,6 +89,7 @@ final class PhonePushClient {
     var presenceMonitor: MacPresenceMonitor = .live()
     private var presenceCache = MacPresenceDecisionCache()
     private var authLifecycleTask: Task<Void, Never>?
+    let identityPrewarm = PhonePushIdentityPrewarm()
     private var activeIdentity: AuthenticatedSessionIdentity?
     private var pendingPersistenceSnapshot: [PhonePushRequestEnvelope]?
     private var persistenceTask: Task<Void, Never>?
@@ -128,13 +129,14 @@ final class PhonePushClient {
             configuration: PhonePushConfiguration(defaults: defaults)
         )
     }
-    /// Starts auth-scoped phone push observation after warming host identity.
+    /// Starts auth-scoped phone push observation and off-main identity warming.
     func configure(auth: AuthCoordinator) {
         self.auth = auth
-        _ = MobileHostIdentity.deviceID()
+        identityPrewarm.reset()
         authLifecycleTask?.cancel()
         cancelInMemoryQueue()
         activeIdentity = nil
+        startIdentityPrewarmIfNeeded()
         authLifecycleTask = Task { [weak self, weak auth] in
             guard let self, let auth else { return }
             await self.bootstrapQueueAndObserve(auth: auth)
@@ -341,13 +343,17 @@ final class PhonePushClient {
         }
         return .queued
     }
-
     func forwardDismissed(ids: [String], badgeCount: Int) {
         guard PhonePushConfiguration.forwardingEnabled(in: defaults),
               !ids.isEmpty,
               let identity = auth?.authenticatedSessionIdentity,
               let targetBundleIdentifier = MobileIOSPairingTargetStore()
                   .pushTargetNamespace?.bundleIdentifier else { return }
+        guard let macDeviceID = identityPrewarm.deviceIDIfReady() else {
+            identityPrewarm.appendDismissals(ids: ids, badgeCount: badgeCount)
+            startIdentityPrewarmIfNeeded()
+            return
+        }
         deliveryQueue.retainOnly(
             accountID: identity.accountID,
             generation: identity.generation
@@ -367,7 +373,7 @@ final class PhonePushClient {
                 workspaceId: nil,
                 surfaceId: nil,
                 retargetsToLiveSurfaceOwner: false,
-                macDeviceId: MobileHostIdentity.deviceID(),
+                macDeviceId: macDeviceID,
                 macInstanceTag: MobileHostIdentity.instanceTag(),
                 notificationId: nil,
                 notificationIds: Array(ids[start..<end]),
@@ -401,14 +407,12 @@ final class PhonePushClient {
             }
         }
     }
-
     /// Cancels in-flight retries and atomically clears credential-free storage.
     func cancelPendingDeliveries() {
         cancelInMemoryQueue()
         pendingPersistenceSnapshot = []
         schedulePersistence([])
     }
-
     private func bootstrapQueueAndObserve(auth: AuthCoordinator) async {
         // This call waits for launch bootstrap. A transient token failure does
         // not erase credential-free queue ownership; the published identity
@@ -427,7 +431,6 @@ final class PhonePushClient {
             await handleAuthTransition(identity, auth: auth)
         }
     }
-
     private func restoreQueueIfAllowed(
         identity: AuthenticatedSessionIdentity?,
         auth: AuthCoordinator
@@ -481,7 +484,6 @@ final class PhonePushClient {
         activeIdentity = identity
         deliveryQueue.start()
     }
-
     private func handleAuthTransition(
         _ identity: AuthenticatedSessionIdentity?,
         auth: AuthCoordinator
@@ -494,7 +496,6 @@ final class PhonePushClient {
         guard self.auth === auth else { return }
         deliveryQueue.start()
     }
-
     private func schedulePersistence(
         _ snapshot: [PhonePushRequestEnvelope]
     ) {
@@ -504,7 +505,6 @@ final class PhonePushClient {
             await self?.drainPersistence()
         }
     }
-
     private func cancelInMemoryQueue() {
         suppressQueuePersistence = true
         deliveryQueue.cancelAll()

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -410,6 +410,7 @@ final class PhonePushClient {
     /// Cancels in-flight retries and atomically clears credential-free storage.
     func cancelPendingDeliveries() {
         cancelInMemoryQueue()
+        identityPrewarm.reset()
         pendingPersistenceSnapshot = []
         schedulePersistence([])
     }
@@ -490,6 +491,7 @@ final class PhonePushClient {
     ) async {
         guard identity != activeIdentity else { return }
         cancelInMemoryQueue()
+        identityPrewarm.reset()
         pendingPersistenceSnapshot = []
         activeIdentity = identity
         await clearPersistedQueue()
@@ -510,7 +512,6 @@ final class PhonePushClient {
         deliveryQueue.cancelAll()
         suppressQueuePersistence = false
     }
-
     private func drainPersistence() async {
         while let snapshot = pendingPersistenceSnapshot {
             pendingPersistenceSnapshot = nil
@@ -528,7 +529,6 @@ final class PhonePushClient {
         }
         persistenceTask = nil
     }
-
     private func clearPersistedQueue() async {
         do {
             try await queueStore.clear()

--- a/Sources/Cloud/PhonePushIdentityPrewarm.swift
+++ b/Sources/Cloud/PhonePushIdentityPrewarm.swift
@@ -1,0 +1,68 @@
+/// Owns the off-main identity warm-up and the bounded dismissal handoff that
+/// can occur while the process-stable snapshot is still being resolved.
+@MainActor
+final class PhonePushIdentityPrewarm {
+    typealias ReadyHandler = @MainActor @Sendable () -> Void
+
+    private static let maximumPendingIDs = 256
+    private let identityProvider: any PhonePushIdentityProvider
+    private var task: Task<Void, Never>?
+    private var pendingIDs: [String] = []
+    private var pendingBadgeCount = 0
+
+    init(identityProvider: any PhonePushIdentityProvider = DefaultPhonePushIdentityProvider()) {
+        self.identityProvider = identityProvider
+    }
+
+    func reset() {
+        task?.cancel()
+        task = nil
+        pendingIDs.removeAll(keepingCapacity: true)
+        pendingBadgeCount = 0
+    }
+
+    func start(onReady: @escaping ReadyHandler) {
+        guard task == nil else { return }
+        task = Task { @MainActor [weak self] in
+            await self?.identityProvider.prewarm()
+            guard let self, !Task.isCancelled else { return }
+            self.task = nil
+            onReady()
+        }
+    }
+
+    func appendDismissals(ids: [String], badgeCount: Int) {
+        pendingIDs.append(contentsOf: ids)
+        let overflow = pendingIDs.count - Self.maximumPendingIDs
+        if overflow > 0 {
+            pendingIDs.removeFirst(overflow)
+        }
+        pendingBadgeCount = badgeCount
+    }
+
+    func takePendingDismissals() -> (ids: [String], badgeCount: Int)? {
+        guard !pendingIDs.isEmpty else { return nil }
+        let result = (pendingIDs, pendingBadgeCount)
+        pendingIDs.removeAll(keepingCapacity: true)
+        pendingBadgeCount = 0
+        return result
+    }
+
+    func deviceIDIfReady() -> String? {
+        identityProvider.deviceIDIfReady()
+    }
+}
+
+extension PhonePushClient {
+    func startIdentityPrewarmIfNeeded() {
+        identityPrewarm.start { [weak self] in
+            self?.flushPendingDismissals()
+        }
+    }
+
+    func flushPendingDismissals() {
+        guard identityPrewarm.deviceIDIfReady() != nil,
+              let pending = identityPrewarm.takePendingDismissals() else { return }
+        forwardDismissed(ids: pending.ids, badgeCount: pending.badgeCount)
+    }
+}

--- a/Sources/Cloud/PhonePushIdentityPrewarm.swift
+++ b/Sources/Cloud/PhonePushIdentityPrewarm.swift
@@ -4,7 +4,8 @@
 final class PhonePushIdentityPrewarm {
     typealias ReadyHandler = @MainActor @Sendable () -> Void
 
-    private static let maximumPendingIDs = 256
+    private static let maximumPendingIDs =
+        PhonePushSerialDeliveryQueue.defaultCapacity * 4
     private let identityProvider: any PhonePushIdentityProvider
     private var task: Task<Void, Never>?
     private var pendingIDs: [String] = []
@@ -23,6 +24,10 @@ final class PhonePushIdentityPrewarm {
 
     func start(onReady: @escaping ReadyHandler) {
         guard task == nil else { return }
+        // The provider's once-initialization is finite and cancellation cannot
+        // interrupt synchronous Foundation file operations. Keep this task
+        // alive until readiness so every accepted dismissal can be flushed;
+        // overflow is reported as queueFull rather than silently evicted.
         task = Task { @MainActor [weak self] in
             await self?.identityProvider.prewarm()
             guard let self, !Task.isCancelled else { return }
@@ -31,13 +36,14 @@ final class PhonePushIdentityPrewarm {
         }
     }
 
-    func appendDismissals(ids: [String], badgeCount: Int) {
-        pendingIDs.append(contentsOf: ids)
-        let overflow = pendingIDs.count - Self.maximumPendingIDs
-        if overflow > 0 {
-            pendingIDs.removeFirst(overflow)
+    @discardableResult
+    func appendDismissals(ids: [String], badgeCount: Int) -> Bool {
+        guard pendingIDs.count + ids.count <= Self.maximumPendingIDs else {
+            return false
         }
+        pendingIDs.append(contentsOf: ids)
         pendingBadgeCount = badgeCount
+        return true
     }
 
     func takePendingDismissals() -> (ids: [String], badgeCount: Int)? {

--- a/Sources/Cloud/PhonePushIdentityProvider.swift
+++ b/Sources/Cloud/PhonePushIdentityProvider.swift
@@ -1,0 +1,5 @@
+/// Supplies the process-stable identity to synchronous phone-push callers.
+protocol PhonePushIdentityProvider: Sendable {
+    func deviceIDIfReady() -> String?
+    func prewarm() async
+}

--- a/Sources/Mobile/MobileHostIdentity.swift
+++ b/Sources/Mobile/MobileHostIdentity.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxFoundation
 import CmuxSettings
 import Foundation
 
@@ -8,6 +9,10 @@ enum MobileHostIdentity {
     private static let stableBundleIdentifier = "com.cmuxterm.app"
     private static let maximumDisplayNameUTF16Length = 128
     private static let maximumDisplayedBuildTagUTF16Length = 64
+    /// Published after the immutable snapshot has been fully initialized.
+    /// Callers on latency-sensitive paths can inspect readiness without
+    /// triggering Swift's once-initialized storage.
+    private static let deviceIDReady = AtomicBooleanGate(false)
 
     /// Process-stable host identity used by synchronous transport and terminal paths.
     ///
@@ -29,7 +34,24 @@ enum MobileHostIdentity {
 
     /// Returns the process-stable host identity without repeating filesystem work.
     static func deviceID() -> String {
-        cachedDeviceID
+        let value = cachedDeviceID
+        deviceIDReady.storeRelease(true)
+        return value
+    }
+
+    /// Returns the process-stable identity only after background prewarming has
+    /// completed. This check never touches the lazy snapshot while it is cold.
+    static func deviceIDIfReady() -> String? {
+        guard deviceIDReady.loadAcquire() else { return nil }
+        return cachedDeviceID
+    }
+
+    /// Resolves the identity on a utility task so migration I/O cannot occupy
+    /// the main actor. Swift still initializes ``cachedDeviceID`` exactly once.
+    static func prewarm() async {
+        await Task.detached(priority: .utility) {
+            _ = deviceID()
+        }.value
     }
 
     static func deviceID(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1407,6 +1407,7 @@
 		DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */; };
 		C0DE31410000000000000103 /* DebugEventLogSerializedAppendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
+		D1F0A0070000000000000001 /* DefaultPhonePushIdentityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0070000000000000002 /* DefaultPhonePushIdentityProvider.swift */; };
 		917300000000000000000001 /* DeferredActionReplacementStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917300000000000000000002 /* DeferredActionReplacementStackTests.swift */; };
 		A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */; };
 		D10786DB0000000000000001 /* DeferredBrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10786DB0000000000000002 /* DeferredBrowserPanel.swift */; };
@@ -1969,6 +1970,7 @@
 		C1A071000000000000000003 /* MobileHostConnectionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A071000000000000000013 /* MobileHostConnectionLifecycleTests.swift */; };
 		C1A070000000000000000008 /* MobileHostConnectionRegistry+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000018 /* MobileHostConnectionRegistry+Debug.swift */; };
 		B8B056D90000000000000001 /* MobileHostIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D90000000000000002 /* MobileHostIdentity.swift */; };
+		B8B056D80000000000000003 /* MobileHostIdentityConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D80000000000000004 /* MobileHostIdentityConcurrencyTests.swift */; };
 		B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D80000000000000002 /* MobileHostIdentityTests.swift */; };
 		C1A071000000000000000001 /* MobileHostIrohAdmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */; };
 		A17070900000000000000002 /* MobileHostIrohApplicationLaneRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */; };
@@ -2177,6 +2179,8 @@
 		D1F0A0030000000000000003 /* PhonePushDeliveryAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0030000000000000004 /* PhonePushDeliveryAuthorization.swift */; };
 		D1F0A0030000000000000005 /* PhonePushForwardAdmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0030000000000000006 /* PhonePushForwardAdmission.swift */; };
 		D1F0A0030000000000000007 /* PhonePushHTTPResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0030000000000000008 /* PhonePushHTTPResult.swift */; };
+		D1F0A0050000000000000001 /* PhonePushIdentityPrewarm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0050000000000000002 /* PhonePushIdentityPrewarm.swift */; };
+		D1F0A0060000000000000001 /* PhonePushIdentityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A0060000000000000002 /* PhonePushIdentityProvider.swift */; };
 		D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A4 /* PhonePushPayload.swift */; };
 		D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */; };
 		D1F0A0030000000000000009 /* PhonePushQueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A003000000000000000A /* PhonePushQueueStore.swift */; };
@@ -4990,6 +4994,7 @@
 		DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolverTests.swift; sourceTree = "<group>"; };
 		C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEventLogSerializedAppendTests.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
+		D1F0A0070000000000000002 /* DefaultPhonePushIdentityProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultPhonePushIdentityProvider.swift; sourceTree = "<group>"; };
 		917300000000000000000002 /* DeferredActionReplacementStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredActionReplacementStackTests.swift; sourceTree = "<group>"; };
 		A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredAgentResumeIndexFallbackTests.swift; sourceTree = "<group>"; };
 		D10786DB0000000000000002 /* DeferredBrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DeferredBrowserPanel.swift; sourceTree = "<group>"; };
@@ -5545,7 +5550,8 @@
 		C1A071000000000000000013 /* MobileHostConnectionLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostConnectionLifecycleTests.swift; sourceTree = "<group>"; };
 		C1A070000000000000000018 /* MobileHostConnectionRegistry+Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Debug/MobileHostConnectionRegistry+Debug.swift"; sourceTree = "<group>"; };
 		B8B056D90000000000000002 /* MobileHostIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentity.swift; sourceTree = "<group>"; };
-B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
+		B8B056D80000000000000004 /* MobileHostIdentityConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityConcurrencyTests.swift; sourceTree = "<group>"; };
+		B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
 		C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAdmissionTests.swift; sourceTree = "<group>"; };
 		A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohApplicationLaneRouter.swift; sourceTree = "<group>"; };
 		C1A070000000000000000012 /* MobileHostIrohAuthObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAuthObserver.swift; sourceTree = "<group>"; };
@@ -5753,6 +5759,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D1F0A0030000000000000004 /* PhonePushDeliveryAuthorization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushDeliveryAuthorization.swift; sourceTree = "<group>"; };
 		D1F0A0030000000000000006 /* PhonePushForwardAdmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushForwardAdmission.swift; sourceTree = "<group>"; };
 		D1F0A0030000000000000008 /* PhonePushHTTPResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushHTTPResult.swift; sourceTree = "<group>"; };
+		D1F0A0050000000000000002 /* PhonePushIdentityPrewarm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushIdentityPrewarm.swift; sourceTree = "<group>"; };
+		D1F0A0060000000000000002 /* PhonePushIdentityProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushIdentityProvider.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A4 /* PhonePushPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushPayload.swift; sourceTree = "<group>"; };
 		D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhonePushPresenceGateTests.swift; sourceTree = "<group>"; };
 		D1F0A003000000000000000A /* PhonePushQueueStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushQueueStore.swift; sourceTree = "<group>"; };
@@ -7703,6 +7711,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A71100000000000000000006 /* SystemTailscaleStatusProviderError.swift */,
 				A71100000000000000000002 /* TailscaleStatusProviding.swift */,
 				D1F0A00100000000000000A2 /* PhonePushClient.swift */,
+				D1F0A0050000000000000002 /* PhonePushIdentityPrewarm.swift */,
+				D1F0A0060000000000000002 /* PhonePushIdentityProvider.swift */,
+				D1F0A0070000000000000002 /* DefaultPhonePushIdentityProvider.swift */,
 				D1F0A0030000000000000002 /* PhonePushClock.swift */,
 				D1F0A0030000000000000004 /* PhonePushDeliveryAuthorization.swift */,
 				D1F0A0030000000000000006 /* PhonePushForwardAdmission.swift */,
@@ -10811,6 +10822,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */,
 				ABMDPARTRES0000000000002 /* MobilePanelArtifactResolutionTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
+				B8B056D80000000000000004 /* MobileHostIdentityConcurrencyTests.swift */,
 				C1B1810000000000000015 /* MobileHostIrxSettingsMappingTests.swift */,
 				A7C0F0010000000000000001 /* MacPairedMacBackupPublisherScopeTests.swift */,
 				5E2701030000000000000002 /* MacSentryStartupPolicyTests.swift */,
@@ -12266,6 +12278,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C57B00090000000000000001 /* CustomSidebarPanelView.swift in Sources */,
 				DEBDADADADADADADAD000001 /* DebugDogfoodCredentialResolver.swift in Sources */,
 				A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */,
+				D1F0A0070000000000000001 /* DefaultPhonePushIdentityProvider.swift in Sources */,
 				D10786DB0000000000000001 /* DeferredBrowserPanel.swift in Sources */,
 				D10786DB0000000000000003 /* DeferredBrowserPanelView.swift in Sources */,
 				F87910140000000000000001 /* DeferredWorkspaceTerminalFontSizeCoordinatorJoin.swift in Sources */,
@@ -12797,6 +12810,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D1F0A0030000000000000003 /* PhonePushDeliveryAuthorization.swift in Sources */,
 				D1F0A0030000000000000005 /* PhonePushForwardAdmission.swift in Sources */,
 				D1F0A0030000000000000007 /* PhonePushHTTPResult.swift in Sources */,
+				D1F0A0050000000000000001 /* PhonePushIdentityPrewarm.swift in Sources */,
+				D1F0A0060000000000000001 /* PhonePushIdentityProvider.swift in Sources */,
 				D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */,
 				D1F0A0030000000000000009 /* PhonePushQueueStore.swift in Sources */,
 				D1F0A003000000000000000D /* PhonePushRetryPolicy.swift in Sources */,
@@ -14580,6 +14595,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				C1A071000000000000000002 /* MobileHostConnectionEventLaneTests.swift in Sources */,
 				C1A071000000000000000003 /* MobileHostConnectionLifecycleTests.swift in Sources */,
+				B8B056D80000000000000003 /* MobileHostIdentityConcurrencyTests.swift in Sources */,
 				B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */,
 				C1A071000000000000000001 /* MobileHostIrohAdmissionTests.swift in Sources */,
 				C1B1810000000000000005 /* MobileHostIrxSettingsMappingTests.swift in Sources */,

--- a/cmuxTests/MobileHostIdentityConcurrencyTests.swift
+++ b/cmuxTests/MobileHostIdentityConcurrencyTests.swift
@@ -35,6 +35,13 @@ struct MobileHostIdentityConcurrencyTests {
         #expect(buffer.takePendingDismissals() == nil)
     }
 
+    @Test func sessionResetDropsBufferedDismissalsBeforeTheyCanFlush() throws {
+        let buffer = PhonePushIdentityPrewarm()
+        buffer.appendDismissals(ids: ["account-a"], badgeCount: 2)
+        buffer.reset()
+        #expect(buffer.takePendingDismissals() == nil)
+    }
+
     @Test func prewarmPublishesOneProcessStableSnapshotForConcurrentCallers() async {
         await MobileHostIdentity.prewarm()
         let expected = MobileHostIdentity.deviceIDIfReady()

--- a/cmuxTests/MobileHostIdentityConcurrencyTests.swift
+++ b/cmuxTests/MobileHostIdentityConcurrencyTests.swift
@@ -23,14 +23,14 @@ struct MobileHostIdentityConcurrencyTests {
     @Test func pendingDismissalsStayBoundedWhileIdentityWarms() throws {
         let buffer = PhonePushIdentityPrewarm()
         buffer.appendDismissals(
-            ids: (0..<300).map(String.init),
+            ids: (0..<2_048).map(String.init),
             badgeCount: 7
         )
-
+        #expect(!buffer.appendDismissals(ids: ["overflow"], badgeCount: 7))
         let pending = try #require(buffer.takePendingDismissals())
-        #expect(pending.ids.count == 256)
-        #expect(pending.ids.first == "44")
-        #expect(pending.ids.last == "299")
+        #expect(pending.ids.count == 2_048)
+        #expect(pending.ids.first == "0")
+        #expect(pending.ids.last == "2047")
         #expect(pending.badgeCount == 7)
         #expect(buffer.takePendingDismissals() == nil)
     }

--- a/cmuxTests/MobileHostIdentityConcurrencyTests.swift
+++ b/cmuxTests/MobileHostIdentityConcurrencyTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct MobileHostIdentityConcurrencyTests {
+    @Test func dismissalWarmupGateDoesNotResolveIdentityOnTheSynchronousPath() throws {
+        let prewarm = PhonePushIdentityPrewarm(
+            identityProvider: NeverReadyPhonePushIdentityProvider()
+        )
+        #expect(prewarm.deviceIDIfReady() == nil)
+        prewarm.appendDismissals(ids: ["dismissal"], badgeCount: 1)
+        let pending = try #require(prewarm.takePendingDismissals())
+        #expect(pending.ids == ["dismissal"])
+        #expect(pending.badgeCount == 1)
+    }
+
+    @Test func pendingDismissalsStayBoundedWhileIdentityWarms() throws {
+        let buffer = PhonePushIdentityPrewarm()
+        buffer.appendDismissals(
+            ids: (0..<300).map(String.init),
+            badgeCount: 7
+        )
+
+        let pending = try #require(buffer.takePendingDismissals())
+        #expect(pending.ids.count == 256)
+        #expect(pending.ids.first == "44")
+        #expect(pending.ids.last == "299")
+        #expect(pending.badgeCount == 7)
+        #expect(buffer.takePendingDismissals() == nil)
+    }
+
+    @Test func prewarmPublishesOneProcessStableSnapshotForConcurrentCallers() async {
+        await MobileHostIdentity.prewarm()
+        let expected = MobileHostIdentity.deviceIDIfReady()
+        #expect(expected != nil)
+
+        let values = await withTaskGroup(of: String.self, returning: [String].self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    MobileHostIdentity.deviceID()
+                }
+            }
+            var values: [String] = []
+            for await value in group {
+                values.append(value)
+            }
+            return values
+        }
+
+        #expect(values.count == 16)
+        #expect(values.allSatisfy { $0 == expected })
+        #expect(MobileHostIdentity.deviceIDIfReady() == expected)
+    }
+}
+
+private struct NeverReadyPhonePushIdentityProvider: PhonePushIdentityProvider {
+    func deviceIDIfReady() -> String? { nil }
+    func prewarm() async {}
+}


### PR DESCRIPTION
## Summary

Follow up on merged PR #12459 for #12475. The merged immutable snapshot removed repeated post-initialization identity stats, but its synchronous `configure(auth:)` prewarm still allowed a first terminal dismissal to race lazy snapshot initialization. This follow-up moves warm-up to a utility task, publishes lock-free readiness, and keeps early dismissals in a bounded handoff until the stable snapshot is ready.

The existing migration, shared identity file, stable identity value, and synchronous queue admission after readiness are preserved. Early dismissals use the existing 512-envelope queue capacity multiplied by the four-ID push batch size (2,048 IDs); overflow returns `.queueFull` and logs an explicit error instead of silently evicting older IDs. Auth transitions and forwarding disable reset the handoff. No sidebar/layout or portal code is changed.

## Objective evidence

The production `PhonePushIdentityPrewarm` helper was compiled into a deterministic harness with an explicitly injected 8,000 ms resolver delay:

| Path | Synchronous dismissal admission | Forwarding |
| --- | ---: | --- |
| Pre-#12459 style synchronous resolver | 8,533.34 ms | Blocks during resolver |
| Follow-up readiness gate | 0.059 ms | 0 before warm-up; 1 after warm-up |

Artifacts and the exact harness source/output are in `/Users/austinwang/manaflow/cmuxterm-hq/out/perf-incident-20260912-identity/`. This is labeled injected latency; ordinary disk latency was not claimed to reproduce the Sentry's 8-second wall-clock stall.

Fresh authenticated Sentry evidence for `CMUXTERM-MACOS-3NSR` / event `ff79a16b6e4348279a991235f5bfc06c` confirms the affected stack: `GhosttyNSView.mouseDown` → `PhonePushClient.forwardDismissed` → `MobileHostIdentity.defaultSharedDeviceIDURL` → Foundation `fileExists` → `stat`, on macOS 26.4.1 release `0.64.22-nightly.3469037774101+3469037774101`.

## Regression coverage

- Injected provider that never becomes ready proves the synchronous path does not fall back to identity resolution.
- Bounded pending dismissal coverage fills the full 2,048-ID handoff and verifies the next batch is rejected rather than evicting accepted IDs.
- Session reset drops buffered dismissals before they can flush across an account transition.
- Concurrent callers after prewarm receive one process-stable snapshot.

## Validation

- `swiftc -frontend -parse` over all changed Swift sources and regression test.
- `python3 scripts/swift_file_length_budget.py` (pass; no TSV changes).
- `git diff --check` (pass).
- `python3 scripts/normalize-pbxproj.py --check` (pass).
- `./scripts/lint-pbxproj-test-wiring.sh` (pass).
- `cmux-policy-check --mode local` (pass).
- Standalone production-helper harness (pass; measurements above).
- Canonical branch autoreview on the final pushed HEAD: merge-conflict gate clean, no accepted/actionable Codex findings, no Aziz policy findings.

A final tagged remote Debug build for `3b37aa4e1cf8df823675a084893185d1142893b5` succeeded on isolated fleet host `cmux-austin-mini-0` (macOS 26.4), after remote-only shims for unrelated main defects (`GHOSTTY_ACTION_OPEN_URL_KIND_OSC8` absent from the checked-in Ghostty header and a `UUID` subscript used where `TabID` is required). The resulting executable SHA-256 is `d51db7ad7204480336fca90813cf92f97965d60ee47980b3c5e2d6fb5de01fd4`. No Ghostty, terminal-link, sidebar, or layout fixes are included here, and no UI was driven on a desktop with personal app contents. The targeted remote XCTest invocation compiled the app but the test target stopped on unrelated current-main defects in `TerminalLinkLocationAndDockTests` and `CloudTreeMachineMenuTests`; no XCTest execution is claimed. The disposable cloud-mac GUI leases were not reachable from local Tailscale and were canceled/expired; no demo video is claimed.

## Related work

- Merged baseline: PR #12459, merge `0fe11944da5ba6fe04dea6f20f4a7e7d554f56e4`, pre-fix first parent `27cd79fb80`.
- Affected issue: #12475.
- Separate layout issue #5752 and portal PR #12414 are intentionally untouched.
