### PR TITLE
Fix cloud workspace sidebar directory and git provenance

### DIFF
--- a/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
+++ b/Sources/Surfaces/CloudWorkspaceRenameService+Directory.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension CloudWorkspaceRenameService {
+    /// Applies accepted cmux-tui terminal cwd values to projected Cloud panels.
+    ///
+    /// - Parameters:
+    ///   - localWorkspaceID: The local workspace whose projected panels are updated.
+    ///   - catalog: The authoritative surface catalog containing projections and resources.
+    @MainActor
+    func updateCloudDirectories(localWorkspaceID: UUID, catalog: SurfaceCatalog) {
+        guard let workspace = environment.workspace(localWorkspaceID) else { return }
+        let snapshot = catalog.snapshot
+        let resourcesByID = Dictionary(
+            snapshot.resources.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for projection in snapshot.projections
+            where projection.workspaceID == localWorkspaceID && !projection.resource.machine.isLocal {
+            guard let resource = resourcesByID[projection.resource] else { continue }
+            if resource.kind == .terminal {
+                workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
+            } else {
+                workspace.clearRemotePanelDirectory(panelId: projection.panelID)
+            }
+        }
+    }
+}

--- a/Sources/Surfaces/CloudWorkspaceRenameService+Reconciliation.swift
+++ b/Sources/Surfaces/CloudWorkspaceRenameService+Reconciliation.swift
@@ -85,9 +85,15 @@ extension CloudWorkspaceRenameService {
         }
         for projection in catalog.projections where projection.resource.machine == machine {
             if let affectedResources, !affectedResources.contains(projection.resource) { continue }
-            guard let resource = catalog.resources[projection.resource], resource.kind == .terminal,
+            guard let resource = catalog.resources[projection.resource],
                   let workspace = environment.workspace(projection.workspaceID),
                   workspace.panels[projection.panelID] != nil else { continue }
+            if resource.kind == .terminal {
+                workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
+            } else {
+                workspace.clearRemotePanelDirectory(panelId: projection.panelID)
+                continue
+            }
             if workspace.panelTitles[projection.panelID] != resource.cloudProcessDisplayTitle {
                 _ = workspace.updatePanelTitle(panelId: projection.panelID, title: resource.cloudProcessDisplayTitle)
             }

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -39,18 +39,19 @@ final class SurfaceCatalog {
 
     private(set) var machines: [SurfaceMachineID: SurfaceMachineInfo] = [:]
     private(set) var resources: [SurfaceResourceID: SurfaceResource] = [:]
-    private(set) var projections: Set<SurfaceProjection> = []
-    /// Resource IDs grouped by machine so providers can answer presence checks
-    /// without sorting the full catalog snapshot on every refresh.
+    private struct CloudProjectionKey: Hashable { let panelID: UUID; let workspaceID: UUID }
+    private var cloudProjectionIndex = Set<CloudProjectionKey>()
+    private var cloudProjectionIndexDirty = true
+    private(set) var projections: Set<SurfaceProjection> = [] { didSet { cloudProjectionIndexDirty = true } }
     private var resourceIDsByMachine: [SurfaceMachineID: Set<SurfaceResourceID>] = [:]
 
     /// The last accepted, revisioned graph for each cloud machine. Resource rows
     /// are derived from this state by the provider; keeping it here makes the
     /// complete state available to socket and agent callers without another cache.
-    private(set) var cloudStates: [SurfaceMachineID: CloudVMState] = [:]
     /// Whether each retained graph was observed on a live link. This is separate
     /// from `CloudVMState` because freshness is local observation metadata, not
     /// part of the daemon document or its cursor.
+    private(set) var cloudStates: [SurfaceMachineID: CloudVMState] = [:]
     private(set) var cloudStateObservations: [SurfaceMachineID: CloudVMStateObservation] = [:]
     private var providers: [SurfaceMachineID: any SurfaceProvider] = [:]
     /// The process-wide ordering owner for remote rename intents. A remote identity can
@@ -59,8 +60,8 @@ final class SurfaceCatalog {
     let cloudWorkspaceProjectionCoordinator: CloudWorkspaceProjectionCoordinator
     /// Resolves local workspace owners for cloud rename write-through. The app installs
     /// its live environment at the composition root; tests keep the no-op environment.
-    private(set) var cloudWorkspaceRenameService: CloudWorkspaceRenameService
     /// Keeps a mirrored local workspace's panes and its machine workspace's tabs in step.
+    private(set) var cloudWorkspaceRenameService: CloudWorkspaceRenameService
     private(set) var cloudPlacementCoordinator: CloudPlacementCoordinator
     /// Materializations are asynchronous, so actor reentrancy can otherwise let two callers
     /// pass the reuse check before either provider has returned a projection.
@@ -186,6 +187,7 @@ final class SurfaceCatalog {
             generatedTitle: generatedTitle
         )
         requestCloudWorkspaceProjection(localWorkspaceID)
+        cloudWorkspaceRenameService.updateCloudDirectories(localWorkspaceID: localWorkspaceID, catalog: self)
     }
 
     // MARK: Providers
@@ -238,6 +240,7 @@ final class SurfaceCatalog {
         let pending = pendingRestoredProjections.keys.filter { $0.resource.machine == machine }
         for record in pending { pendingRestoredProjections[record] = nil }
         cloudWorkspaceProjectionCoordinator.cancel(machine: machine)
+        cloudProjectionIndexDirty = true
         cloudStates[machine] = nil
         cloudStateObservations[machine] = nil
         projections = projections.filter { $0.resource.machine != machine }
@@ -1099,6 +1102,11 @@ final class SurfaceCatalog {
         insertSupersedingLocalPlaceholder(cloudPlacementCoordinator.projectionInCurrentWorkspace(projection))
         reconcileCloudWorkspaceBinding(localWorkspaceID: projection.workspaceID)
         reconcileCloudProjection(projection)
+        if let resource = resources[projection.resource], !resource.machine.isLocal,
+           resource.kind == .terminal,
+           let workspace = cloudWorkspaceRenameService.environment.workspace(projection.workspaceID) {
+            workspace.updateCloudPanelDirectory(panelId: projection.panelID, directory: resource.detail)
+        }
         notifyChange()
     }
 
@@ -1286,6 +1294,20 @@ final class SurfaceCatalog {
         projections.first { $0.panelID == panelID }
     }
 
+    /// Returns whether the panel is backed by a non-local resource projection.
+    func hasCloudProjection(panelID: UUID, workspaceID: UUID) -> Bool {
+        if cloudProjectionIndexDirty {
+            cloudProjectionIndex = Set(projections.filter { !$0.resource.machine.isLocal }.map {
+                CloudProjectionKey(panelID: $0.panelID, workspaceID: $0.workspaceID)
+            })
+            cloudProjectionIndex.formUnion(pendingRestoredProjections.compactMap { record, workspaceID in
+                record.resource.machine.isLocal ? nil : CloudProjectionKey(panelID: record.panelID, workspaceID: workspaceID)
+            })
+            cloudProjectionIndexDirty = false
+        }
+        return cloudProjectionIndex.contains(CloudProjectionKey(panelID: panelID, workspaceID: workspaceID))
+    }
+
     func resource(forPanel panelID: UUID) -> SurfaceResource? {
         projection(forPanel: panelID).flatMap { resources[$0.resource] }
     }
@@ -1312,6 +1334,7 @@ final class SurfaceCatalog {
                 ))
             } else {
                 pendingRestoredProjections[record] = workspaceID
+                cloudProjectionIndexDirty = true
             }
         }
         reconcileCloudWorkspaceBinding(localWorkspaceID: workspaceID)
@@ -1368,6 +1391,7 @@ final class SurfaceCatalog {
                 remoteTabID: record.remoteTabID
             ))
             pendingRestoredProjections[record] = nil
+            cloudProjectionIndexDirty = true
             resolvedWorkspaceIDs.insert(workspaceID)
         }
         for workspaceID in resolvedWorkspaceIDs {

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -107,8 +107,8 @@ final class CloudWorkspaceRenameService {
             machine: target.machine,
             remoteWorkspaceID: target.remoteWorkspaceID
         )
+        updateCloudDirectories(localWorkspaceID: localWorkspaceID, catalog: catalog)
     }
-
     /// The one remote cmux-tui workspace a local workspace stands for. The persisted
     /// binding wins; otherwise the projected cloud resources decide, but only when
     /// every view agrees on a single remote workspace — a local workspace composing

--- a/Sources/TabManager+SidebarGitHosting.swift
+++ b/Sources/TabManager+SidebarGitHosting.swift
@@ -25,7 +25,7 @@ extension TabManager: SidebarGitHosting {
 
     func isRemoteWorkspace(_ workspaceId: UUID) -> Bool? {
         guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return nil }
-        return workspace.isRemoteWorkspace || workspace.isRemoteTmuxMirror
+        return workspace.usesRemoteDirectoryProvenance
     }
 
     func panelIds(in workspaceId: UUID) -> [UUID] {
@@ -42,7 +42,9 @@ extension TabManager: SidebarGitHosting {
     }
 
     func isRemoteTerminalPanel(workspaceId: UUID, panelId: UUID) -> Bool {
-        tabs.first(where: { $0.id == workspaceId })?.isRemoteTerminalSurface(panelId) == true
+        guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return false }
+        return workspace.isRemoteTerminalSurface(panelId) ||
+            workspace.cloudDirectoryProvenanceRequired(panelId: panelId)
     }
 
     func gitProbeDirectory(workspaceId: UUID, panelId: UUID) -> String? {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -854,8 +854,8 @@ class TabManager: ObservableObject {
     }
 
     func gitProbeDirectory(for workspace: Workspace, panelId: UUID) -> String? {
-        // Match the sidebar directory fallback chain so hidden/background panels can
-        // still probe git metadata before OSC 7 has reported a live cwd.
+        // Cloud cwd belongs to another machine and is never a local git/gh probe target.
+        if workspace.cloudDirectoryProvenanceRequired(panelId: panelId) { return nil }
         if let directory = workspace.reportedPanelDirectory(panelId: panelId) { return normalizedWorkingDirectory(directory) }
         guard workspace.allowsLocalDirectoryFallback(panelId: panelId) else { return nil }
         let rawDirectory = workspace.terminalPanel(for: panelId)?.requestedWorkingDirectory ?? (!workspace.usesRemoteDirectoryProvenance && workspace.focusedPanelId == panelId ? workspace.currentDirectory : nil)

--- a/Sources/TerminalController+ControlSidebarContext2.swift
+++ b/Sources/TerminalController+ControlSidebarContext2.swift
@@ -55,6 +55,8 @@ extension TerminalController {
         guard let tab = controlSidebarResolveTabForReport(tabArg: tabArg) else {
             return false
         }
+        if tab.cloudVMBinding != nil { tab.clearSidebarGitMetadata(); return true }
+        if let focusedPanelId = tab.focusedPanelId, tab.cloudDirectoryProvenanceRequired(panelId: focusedPanelId) { tab.clearPanelGitBranch(panelId: focusedPanelId); return true }
         guard SidebarWorkspaceDetailDefaults.gitMetadataActivity(defaults: .standard).acceptsPassiveReports else {
             tab.gitBranch = nil
             return true

--- a/Sources/Workspace+SidebarDirectories.swift
+++ b/Sources/Workspace+SidebarDirectories.swift
@@ -21,7 +21,11 @@ extension Workspace {
                 return nil
             }
         }
-        let activeRemotePanelIds = panels.keys.filter { isRemoteTerminalSurface($0) }
+        let activeRemotePanelIds = panels.keys.filter {
+            isRemoteTerminalSurface($0) ||
+                (cloudVMBinding != nil && terminalPanel(for: $0) != nil) ||
+                cloudProjectedResource(forPanel: $0)?.kind == .terminal
+        }
         guard !activeRemotePanelIds.isEmpty else { return nil }
         let reportedDirectories = activeRemotePanelIds.compactMap { trustedReportedPanelDirectory(panelId: $0) }
         guard reportedDirectories.count == activeRemotePanelIds.count else { return nil }
@@ -37,8 +41,26 @@ extension Workspace {
         reportedRemoteCurrentDirectory(allowLocalFallback: false)
     }
 
+    /// Directory metadata for a cloud-bound or cloud-projected panel is remote
+    /// state, even though its transport is not SSH.
     var usesRemoteDirectoryProvenance: Bool {
-        isRemoteWorkspace || isRemoteTmuxMirror
+        isRemoteWorkspace || isRemoteTmuxMirror || cloudVMBinding != nil ||
+            panels.keys.contains(where: { cloudDirectoryProvenanceRequired(panelId: $0) })
+    }
+
+    /// Returns whether a panel's directory belongs to a Cloud machine rather than this Mac.
+    func cloudDirectoryProvenanceRequired(panelId: UUID) -> Bool {
+        cloudVMBinding != nil || SurfaceCatalog.shared.hasCloudProjection(panelID: panelId, workspaceID: id)
+    }
+
+    /// Applies the cwd carried by a terminal in an accepted cloud snapshot.
+    /// Branch and PR metadata remain absent until the cloud transport reports them.
+    func updateCloudPanelDirectory(panelId: UUID, directory: String?) {
+        guard let directory = normalizedSidebarDirectory(directory) else {
+            clearRemotePanelDirectory(panelId: panelId)
+            return
+        }
+        updateRemotePanelDirectoryWithMetadata(panelId: panelId, directory: directory)
     }
 
     var presentedCurrentDirectory: String? {
@@ -72,6 +94,7 @@ extension Workspace {
 
     func allowsLocalDirectoryFallback(panelId: UUID) -> Bool {
         if !usesRemoteDirectoryProvenance { return true }
+        if cloudDirectoryProvenanceRequired(panelId: panelId) { return false }
         guard !remoteDirectoryTrustRequiredPanelIds.contains(panelId),
               !isRemoteTerminalSurface(panelId),
               !isRemoteTmuxMirror else { return false }
@@ -112,9 +135,10 @@ extension Workspace {
     }
 
     func restoresLegacyRemoteDirectoryWithoutProvenance(_ snapshot: SessionPanelSnapshot) -> Bool {
-        guard remoteConfiguration != nil,
+        guard remoteConfiguration != nil || cloudVMBinding != nil,
               snapshot.directoryIsTrustedRemoteReport == nil,
               snapshot.directoryRequiresRemoteTrust == nil else { return false }
+        if cloudVMBinding != nil { return true }
         if let terminal = snapshot.terminal { return terminal.isRemoteTerminal != false }
         return snapshot.agentSession != nil
     }
@@ -282,11 +306,13 @@ extension Workspace {
     }
 
     var presentedGitBranch: SidebarGitBranchState? {
+        if let focusedPanelId, cloudDirectoryProvenanceRequired(panelId: focusedPanelId) { return nil }
         if usesRemoteDirectoryProvenance, presentedCurrentDirectory == nil { return nil }
         return gitBranch
     }
 
     func reportedPanelGitBranch(panelId: UUID) -> SidebarGitBranchState? {
+        guard !cloudDirectoryProvenanceRequired(panelId: panelId) else { return nil }
         guard let branch = panelGitBranches[panelId] else { return nil }
         if usesRemoteDirectoryProvenance, effectivePanelDirectory(panelId: panelId) == nil { return nil }
         return branch

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -291,7 +291,16 @@ extension Workspace {
         // survive an app restart) inherits it through `newTerminalSurface`.
         workspaceEnvironment = Self.sanitizedWorkspaceEnvironment(snapshot.environment ?? [:])
 
-        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
+        let cloudProjectedPanelIDs = Set(
+            (snapshot.surfaceProjections ?? []).filter { !$0.resource.machine.isLocal }.map(\.panelID)
+        )
+        let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { panel in
+            var panel = panel
+            if cloudProjectedPanelIDs.contains(panel.id), panel.directoryIsTrustedRemoteReport != true {
+                panel.directoryRequiresRemoteTrust = true
+            }
+            return (panel.id, panel)
+        })
         let restorableAgentIndex = restoreAgentIndex(for: snapshot.panels)
         let shouldRestoreSingleDefaultCloudTerminal =
             isDefaultFreestyleSSHDRemoteWorkspace &&
@@ -349,7 +358,10 @@ extension Workspace {
             clearProxyOnlyRemoteSidebarArtifacts()
         }
         progress = snapshot.progress.map { SidebarProgressState(value: $0.value, label: $0.label) }
-        gitBranch = snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty) }
+        let hasCloudProvenance = cloudVMBinding != nil || (snapshot.surfaceProjections ?? []).contains { !$0.resource.machine.isLocal }
+        gitBranch = hasCloudProvenance
+            ? nil
+            : snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty) }
 
         recomputeListeningPorts()
 
@@ -491,6 +503,9 @@ extension Workspace {
             ? (panelCustomTitleSources[panelId] ?? .user)
             : nil
         let directory: String? = {
+            if cloudDirectoryProvenanceRequired(panelId: panelId) {
+                return reportedPanelDirectory(panelId: panelId)
+            }
             if let directory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !directory.isEmpty {
                 return directory
@@ -1553,9 +1568,10 @@ extension Workspace {
             snapshot,
             workspaceId: snapshotWorkspaceId ?? id
         )
-        let restoresUntrustedSavedDirectory = snapshot.directoryIsTrustedRemoteReport != true &&
-            (snapshot.directoryRequiresRemoteTrust == true ||
-                restoresLegacyRemoteDirectoryWithoutProvenance(snapshot))
+        let restoresUntrustedSavedDirectory = cloudVMBinding != nil ||
+            (snapshot.directoryIsTrustedRemoteReport != true &&
+                (snapshot.directoryRequiresRemoteTrust == true ||
+                    restoresLegacyRemoteDirectoryWithoutProvenance(snapshot)))
         switch snapshot.type {
         case .terminal:
             let localTmuxStartCommand = sessionRestorePolicy
@@ -1726,7 +1742,7 @@ extension Workspace {
                 ?? (restoresUntrustedSavedDirectory ? nil : restorableAgent?.workingDirectory)
                 ?? (restoresUntrustedSavedDirectory ? nil : snapshot.directory)
             let workingDirectory = savedWorkingDirectory
-                ?? currentDirectory
+                ?? (restoresUntrustedSavedDirectory ? nil : currentDirectory)
             // A persisted terminal cwd can already be the stray fallback cwd
             // from a prior auto-resume restore; the transient rescue/guard must
             // remember where the resume launcher actually sends the agent.
@@ -2388,7 +2404,8 @@ extension Workspace {
 
         if restoredDirectoryRequiresRemoteTrust {
             clearPanelGitBranch(panelId: panelId)
-        } else if let branch = snapshot.gitBranch {
+        } else if let branch = snapshot.gitBranch,
+                  !cloudDirectoryProvenanceRequired(panelId: panelId) {
             panelGitBranches[panelId] = SidebarGitBranchState(branch: branch.branch, isDirty: branch.isDirty)
         } else {
             panelGitBranches.removeValue(forKey: panelId)
@@ -3077,7 +3094,22 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// not replayed on restore, only the binding is.
     var cloudVMBinding: WorkspaceCloudVMBinding? {
         get { cloudBindingState.binding }
-        set { cloudBindingState.binding = newValue }
+        set {
+            let previous = cloudBindingState.binding
+            cloudBindingState.binding = newValue
+            guard previous != newValue else { return }
+            (owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId: id))?
+                .sidebarGitMetadataService
+                .clearWorkspaceGitProbes(workspaceId: id)
+            clearSidebarGitMetadata()
+            // A binding transition invalidates the previous machine's cwd report.
+            // Local PTY state can be used again only after the binding is removed.
+            panelDirectories.removeAll()
+            panelDirectoryDisplayLabels.removeAll()
+            remoteDirectoryReportPanelIds.removeAll()
+            remoteDirectoryTrustRequiredPanelIds.removeAll()
+            notifyPresentedCurrentDirectoryChanged(from: nil, force: true)
+        }
     }
     @Published var remoteConnectionState: WorkspaceRemoteConnectionState = .disconnected
     @Published var remoteConnectionDetail: String?
@@ -5933,7 +5965,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
         let previousPresentedDirectory = presentedCurrentDirectory
         let isRemoteTerminalReport = isRemoteTerminalSurface(panelId)
-        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) { return false }
+        if source == .liveReport &&
+            (cloudDirectoryProvenanceRequired(panelId: panelId) ||
+                remoteDirectoryTrustRequiredPanelIds.contains(panelId)) {
+            return false
+        }
         let routedRemoteReport = source == .remoteReport && !allowsLocalDirectoryFallback(panelId: panelId)
         let establishesRemoteProvenance = source == .trustedRestoredRemoteSnapshotMetadata ||
             (source.establishesRemoteProvenance &&
@@ -6335,7 +6371,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return panel.isDirty
     }
 
+    /// Applies sidebar Git branch state unless the panel belongs to a Cloud machine.
     func updatePanelGitBranch(panelId: UUID, branch: String, isDirty: Bool) {
+        if cloudDirectoryProvenanceRequired(panelId: panelId) {
+            clearPanelGitBranch(panelId: panelId)
+            return
+        }
         let state = SidebarGitBranchState(branch: branch, isDirty: isDirty)
         let existing = panelGitBranches[panelId]
         let branchChanged = existing?.branch != nil && existing?.branch != branch
@@ -6372,6 +6413,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Applies sidebar pull-request state unless the panel belongs to a Cloud machine.
     func updatePanelPullRequest(
         panelId: UUID,
         number: Int,
@@ -6381,6 +6423,10 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         branch: String? = nil,
         isStale: Bool = false
     ) {
+        if cloudDirectoryProvenanceRequired(panelId: panelId) {
+            clearPanelPullRequest(panelId: panelId)
+            return
+        }
         let existing = panelPullRequests[panelId]
         let normalizedBranch = branch?.normalizedSidebarBranchName
         let currentPanelBranch = panelGitBranches[panelId]?.branch.normalizedSidebarBranchName
@@ -6416,6 +6462,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Removes pull-request metadata for one panel.
     func clearPanelPullRequest(panelId: UUID) {
         if panelPullRequests[panelId] != nil {
             panelPullRequests.removeValue(forKey: panelId)
@@ -6425,6 +6472,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Removes all sidebar pull-request metadata.
     func clearSidebarPullRequestMetadata() {
         if !panelPullRequests.isEmpty {
             panelPullRequests.removeAll()
@@ -6434,6 +6482,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Removes all sidebar Git and pull-request metadata.
     func clearSidebarGitMetadata() {
         if !panelGitBranches.isEmpty {
             panelGitBranches.removeAll()
@@ -6441,6 +6490,18 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         clearSidebarPullRequestMetadata()
         if gitBranch != nil {
             gitBranch = nil
+        }
+    }
+
+    /// Removes remote directory state and any metadata derived from it.
+    func clearRemotePanelDirectory(panelId: UUID) {
+        let previousPresentedDirectory = presentedCurrentDirectory
+        panelDirectories.removeValue(forKey: panelId)
+        panelDirectoryDisplayLabels.removeValue(forKey: panelId)
+        discardRemoteDirectoryTrustState(panelId: panelId)
+        clearPanelGitBranch(panelId: panelId)
+        if usesRemoteDirectoryProvenance {
+            notifyPresentedCurrentDirectoryChanged(from: previousPresentedDirectory, force: true)
         }
     }
 
@@ -6624,6 +6685,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
     func sidebarPullRequestsInDisplayOrder(orderedPanelIds: [UUID]) -> [SidebarPullRequestState] {
         let validPanelPullRequests = panelPullRequests.filter { panelId, state in
+            guard !cloudDirectoryProvenanceRequired(panelId: panelId) else { return false }
             if usesRemoteDirectoryProvenance, effectivePanelDirectory(panelId: panelId) == nil {
                 return false
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -3436,6 +3436,7 @@
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		4F2E42F6D7164832B891F079 /* Workspace+CloudLayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085BB53F552B4C6A8728941E /* Workspace+CloudLayoutProjection.swift */; };
 		C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11323020000000000000001 /* Workspace+CloudManualMirror.swift */; };
+		F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */; };
 		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */; };
 		F1C91A5607ED4F70923F8F91 /* Workspace+CloudTerminalCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380FC55EF1BE4EBC8E8352FC /* Workspace+CloudTerminalCreation.swift */; };
@@ -7035,6 +7036,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		085BB53F552B4C6A8728941E /* Workspace+CloudLayoutProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudLayoutProjection.swift"; sourceTree = "<group>"; };
 		C11323020000000000000001 /* Workspace+CloudManualMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudManualMirror.swift"; sourceTree = "<group>"; };
+		F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceRenameService+Directory.swift"; sourceTree = "<group>"; };
 		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPlacementFailure.swift"; sourceTree = "<group>"; };
 		380FC55EF1BE4EBC8E8352FC /* Workspace+CloudTerminalCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudTerminalCreation.swift"; sourceTree = "<group>"; };
@@ -7701,6 +7703,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D01100800000000000000001 /* SurfaceCatalogQueryService.swift */,
 				278BEFB3583AED9627966DFF /* SurfaceSocketCommands.swift */,
 				47BBA1A8703756FDDFD53CF3 /* Workspace+SurfaceCatalog.swift */,
+				F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */,
 				C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */,
 				380FC55EF1BE4EBC8E8352FC /* Workspace+CloudTerminalCreation.swift */,
 				1EDD243C7C87A2AB78B12BAD /* LocalSurfaceProvider.swift */,
@@ -13795,6 +13798,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				4F2E42F6D7164832B891F079 /* Workspace+CloudLayoutProjection.swift in Sources */,
 				C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */,
+				F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */,
 				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */,
 				F1C91A5607ED4F70923F8F91 /* Workspace+CloudTerminalCreation.swift in Sources */,

--- a/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
+++ b/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
@@ -38,6 +38,29 @@ struct CloudSidebarSurfaceRegressionTests {
         #expect(snapshot.branchDirectoryLines.isEmpty)
         #expect(snapshot.pullRequestRows.isEmpty)
         #expect(snapshot.finderDirectoryPath == nil)
+        let accessibilityLabel = snapshot.accessibilityLabel(index: 0, workspaceCount: 1)
+        #expect(accessibilityLabel.contains("Cloud workspace on cloud-sidebar-vm"))
+        #expect(!accessibilityLabel.contains("local-checkout"))
+        let sidebarDecision = SidebarWorkspaceSnapshotRefreshPolicy().decision(
+            current: nil,
+            next: snapshot,
+            force: false,
+            contextMenuVisible: false
+        )
+        #expect(sidebarDecision.workspaceSnapshotStorage == snapshot)
+        #expect(sidebarDecision.pendingWorkspaceSnapshot == nil)
+
+        let manager = TabManager(
+            initialWorkspaceTitle: "Cloud",
+            initialWorkingDirectory: "/Users/alice/local-checkout",
+            autoWelcomeIfNeeded: false
+        )
+        let managedWorkspace = try #require(manager.selectedWorkspace)
+        let managedPanelID = try #require(managedWorkspace.focusedPanelId)
+        managedWorkspace.cloudVMBinding = WorkspaceCloudVMBinding(
+            vmID: "cloud-sidebar-vm", isBase: false, remoteWorkspaceID: "ws_1"
+        )
+        #expect(manager.gitProbeDirectory(for: managedWorkspace, panelId: managedPanelID) == nil)
 
         let restored = Workspace()
         _ = restored.restoreSessionSnapshot(workspace.sessionSnapshot(includeScrollback: false))
@@ -90,14 +113,30 @@ struct CloudSidebarSurfaceRegressionTests {
         catalog.upsert(resource)
         catalog.record(SurfaceProjection(resource: resource.id, workspaceID: workspace.id, panelID: panelID))
         let state = try #require(CmuxTuiSnapshotParser.state(fromSnapshot: [
-            "workspaces": [], "screens": [], "panes": [], "tabs": [],
+            "workspaces": [["id": "ws_1", "name": "Cloud", "index": 0, "focused": true]],
+            "screens": [], "panes": [], "tabs": [],
             "terminals": [["id": "term_1", "title": "terminal", "cwd": "/home/cloud/project", "lifecycle": "running"]],
             "browsers": [], "agents": []
         ], machine: machine))
+        let info = SurfaceMachineInfo(
+            id: machine,
+            name: machine.rawValue,
+            status: "running",
+            image: nil,
+            hasDesktop: false,
+            memoryMb: nil,
+            diskMb: nil,
+            linkState: .connected,
+            linkError: nil,
+            cpuPercent: nil,
+            memoryUsedMb: nil,
+            diskUsedMb: nil
+        )
+        catalog.replaceCloudState(state, resources: [resource], info: info)
         let service = CloudWorkspaceRenameService(
             environment: CloudWorkspaceRenameEnvironment(workspaces: { [workspace] })
         )
-        service.reconcileRemoteState(machine: machine, state: state, catalog: catalog)
+        service.reconcileRemoteState(machine: machine, state: state, catalog: catalog, observation: .current)
         #expect(workspace.reportedPanelDirectory(panelId: panelID) == "/home/cloud/project")
         #expect(workspace.presentedCurrentDirectory == "/home/cloud/project")
     }

--- a/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
+++ b/cmuxTests/CloudSidebarSurfaceRegressionTests.swift
@@ -10,6 +10,98 @@ import Testing
 struct CloudSidebarSurfaceRegressionTests {
     private let machine = SurfaceMachineID.cloud("sidebar-vm")
 
+    @Test("Cloud-bound workspaces never use local sidebar provenance")
+    @MainActor
+    func cloudBindingRejectsLocalDirectoryAndGitStateIncludingRestore() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        workspace.updatePanelPullRequest(
+            panelId: panelID, number: 4, label: "PR", url: try #require(URL(string: "https://github.com/example/local/pull/4")), status: .open
+        )
+        workspace.cloudVMBinding = WorkspaceCloudVMBinding(
+            vmID: "cloud-sidebar-vm", isBase: false, remoteWorkspaceID: "ws_1"
+        )
+        #expect(workspace.usesRemoteDirectoryProvenance)
+        #expect(!workspace.allowsLocalDirectoryFallback(panelId: panelID))
+        #expect(!workspace.updatePanelDirectory(panelId: panelID, directory: "/Users/alice/local-checkout"))
+        #expect(workspace.effectivePanelDirectory(panelId: panelID) == nil)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        #expect(workspace.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+        #expect(workspace.sidebarPullRequestsInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+        let defaults = try #require(UserDefaults(suiteName: "cloud-sidebar-\(UUID())"))
+        let snapshot = SidebarWorkspaceSnapshotFactory(
+            workspace: workspace, settings: SidebarTabItemSettingsSnapshot(defaults: defaults), showsAgentActivity: false
+        ).makeSnapshot()
+        #expect(snapshot.compactDirectoryCandidates.isEmpty)
+        #expect(snapshot.compactGitBranchSummaryText == nil)
+        #expect(snapshot.branchDirectoryLines.isEmpty)
+        #expect(snapshot.pullRequestRows.isEmpty)
+        #expect(snapshot.finderDirectoryPath == nil)
+
+        let restored = Workspace()
+        _ = restored.restoreSessionSnapshot(workspace.sessionSnapshot(includeScrollback: false))
+        let restoredPanelID = try #require(restored.focusedPanelId)
+        #expect(restored.usesRemoteDirectoryProvenance)
+        #expect(restored.terminalPanel(for: restoredPanelID)?.requestedWorkingDirectory == nil)
+        #expect(restored.effectivePanelDirectory(panelId: restoredPanelID) == nil)
+        #expect(restored.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [restoredPanelID]).isEmpty)
+    }
+
+    @Test("a projected cloud panel cannot reuse local metadata after its remote cwd arrives")
+    @MainActor
+    func projectedPanelRejectsLocalMetadataWithoutWorkspaceBinding() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.updatePanelGitBranch(panelId: panelID, branch: "local-only", isDirty: true)
+        let remoteMachine = SurfaceMachineID.cloud("sidebar-test-\(UUID())")
+        let resource = SurfaceResource(
+            id: SurfaceResourceID(machine: remoteMachine, kind: .terminal, key: "term_1"),
+            title: "terminal", detail: nil, lifecycle: .running,
+            agent: nil, remoteWorkspace: nil, port: nil, url: nil
+        )
+        let catalog = SurfaceCatalog.shared
+        catalog.upsert(resource)
+        catalog.record(SurfaceProjection(resource: resource.id, workspaceID: workspace.id, panelID: panelID))
+        defer {
+            catalog.endProjections(panelID: panelID)
+            catalog.remove(resource.id)
+        }
+        #expect(workspace.cloudVMBinding == nil)
+        #expect(workspace.usesRemoteDirectoryProvenance)
+        #expect(!workspace.allowsLocalDirectoryFallback(panelId: panelID))
+        #expect(workspace.effectivePanelDirectory(panelId: panelID) == nil)
+        workspace.updateRemotePanelDirectory(panelId: panelID, directory: "/home/cloud/project")
+        #expect(workspace.sidebarGitBranchesInDisplayOrder(orderedPanelIds: [panelID]).isEmpty)
+    }
+
+    @Test("daemon cwd enters the trusted remote directory path")
+    @MainActor
+    func daemonCwdIsPresentedForCloudProjection() throws {
+        let workspace = Workspace(workingDirectory: "/Users/alice/local-checkout")
+        let panelID = try #require(workspace.focusedPanelId)
+        workspace.cloudVMBinding = WorkspaceCloudVMBinding(vmID: machine.rawValue, isBase: false, remoteWorkspaceID: "ws_1")
+        let resource = SurfaceResource(
+            id: SurfaceResourceID(machine: machine, kind: .terminal, key: "term_1"),
+            title: "terminal", detail: "/home/cloud/project", lifecycle: .running,
+            agent: nil, remoteWorkspace: nil, port: nil, url: nil
+        )
+        let catalog = SurfaceCatalog()
+        catalog.upsert(resource)
+        catalog.record(SurfaceProjection(resource: resource.id, workspaceID: workspace.id, panelID: panelID))
+        let state = try #require(CmuxTuiSnapshotParser.state(fromSnapshot: [
+            "workspaces": [], "screens": [], "panes": [], "tabs": [],
+            "terminals": [["id": "term_1", "title": "terminal", "cwd": "/home/cloud/project", "lifecycle": "running"]],
+            "browsers": [], "agents": []
+        ], machine: machine))
+        let service = CloudWorkspaceRenameService(
+            environment: CloudWorkspaceRenameEnvironment(workspaces: { [workspace] })
+        )
+        service.reconcileRemoteState(machine: machine, state: state, catalog: catalog)
+        #expect(workspace.reportedPanelDirectory(panelId: panelID) == "/home/cloud/project")
+        #expect(workspace.presentedCurrentDirectory == "/home/cloud/project")
+    }
+
     private func nodes(link: SurfaceLinkState?, desktop: Bool = true) -> [CloudTreeNode] {
         let row = MachineSnapshot(
             id: machine.rawValue, provider: "freestyle", image: "desktop",


### PR DESCRIPTION
Cloud workspace sidebar rows could inherit the Mac launch directory, branch, and pull-request metadata because cmux-tui bindings and projections were outside the existing remote-directory provenance boundary. This change keeps Cloud rows tied to trusted machine state.

The fix:

- Treat `cloudVMBinding` and non-local `cloudProjectedResource` panels as remote directory provenance.
- Reject local cwd fallback and local `git`/`gh` probing for Cloud panels, including passive reports and restore paths.
- Feed cmux-tui terminal `cwd` values from accepted Cloud snapshots through the trusted remote-directory path; clear stale remote directory state when a terminal has no cwd or a non-terminal projection replaces it.
- Keep Cloud branch and PR rows empty until trusted remote metadata exists.
- Preserve the invariant across new bindings, projection reconciliation, and session restore, while retaining existing local and SSH behavior.
- Keep projection membership indexed so provenance checks do not rescan the catalog for every sidebar row.

Fixes #12347.

## Validation

- Regression commit `4742ba78b6` adds the failing Cloud provenance coverage; `edc46c4997` implements the fix.
- Passed `python3 scripts/swift_file_length_budget.py`.
- Passed `./scripts/lint-pbxproj-test-wiring.sh`.
- Passed `python3 scripts/check-workspace-package-groups.py --check` and `python3 scripts/check-package-resolved-policy.py`.
- Tagged fleet build was attempted with `CMUX_DEV_BACKEND_MODE=off` through `reload-cloud.sh`. The build reached Swift compilation but was blocked by three pre-existing `origin/main` errors in `CmuxTuiSurfaceProvider+Environment.swift` (`waitForScreen` missing and an obsolete `fallbackTabID` argument); no error was reported in this issue's changed files.
- No live app was launched or user workspace disturbed.
