### PR TITLE
Fix Cmd+Y Cloud workspace create-and-open

### DIFF
--- a/Sources/AppDelegate+NewCloudWorkspace.swift
+++ b/Sources/AppDelegate+NewCloudWorkspace.swift
@@ -17,7 +17,9 @@ extension AppDelegate {
         let context = preferredWindow.flatMap { contextForMainWindow($0) }
             ?? preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: debugSource)
         let focus = context?.tabManager.selectedTabId != nil
-        return operationController.start {
+        // Cmd+Y is one logical create-and-open intent. Coalesce repeated key
+        // events while the remote receipt is still being discovered/attached.
+        return operationController.start(key: "new-cloud-workspace.default") {
             guard let workspaceID = try await coordinator.createOnDefaultMachine(focus: focus),
                   !Task.isCancelled,
                   coordinator.isAvailable else { return }

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -364,9 +364,10 @@ struct CloudTreeNodeActions {
             refresh: refresh
         )
         actions.refreshMachine = refreshMachine
+        let navigationRun: CloudTreeTerminalNavigationCoordinator.Run = { run($0, $1) }
         let navigation = CloudTreeTerminalNavigationCoordinator(
             machineName: machineName,
-            run: run,
+            run: navigationRun,
             operationController: operationController ?? AppDelegate.shared?.cloudWorkspaceOperationController
         )
         actions.openRemoteTerminal = { navigation.open(machine: $0, group: $1, resource: $2, view: $3, openIn: $4) }
@@ -405,17 +406,18 @@ struct CloudTreeNodeActions {
         name: String?,
         focus: Bool,
         openLocally: Bool = true,
-        existingWorkspace: SurfaceRemoteWorkspace? = nil
+        existingWorkspace: SurfaceRemoteWorkspace? = nil,
+        existingTerminal: SurfaceResource? = nil,
+        onReceipt: @MainActor (SurfaceRemoteWorkspace, SurfaceResource?) -> Void = { _, _ in }
     ) async throws -> (
         workspace: SurfaceRemoteWorkspace,
         terminal: SurfaceResource,
         opened: (workspaceID: UUID, projections: [SurfaceProjection])?
     ) {
-        let workspace: SurfaceRemoteWorkspace
-        if let existingWorkspace { workspace = existingWorkspace }
-        else { workspace = try await provider.createRemoteWorkspace(name: name) }
+        let workspace: SurfaceRemoteWorkspace = if let existingWorkspace { existingWorkspace } else { try await provider.createRemoteWorkspace(name: name) }
+        onReceipt(workspace, nil)
         await provider.refresh()
-        let existing = catalog.snapshot.resources(on: machine).first { resource in
+        let existing = existingTerminal ?? catalog.snapshot.resources(on: machine).first { resource in
             resource.id.kind == .terminal && resource.remoteWorkspaces.contains { $0.id == workspace.id }
         }
         let terminal: SurfaceResource
@@ -424,9 +426,7 @@ struct CloudTreeNodeActions {
         } else {
             terminal = try await provider.createTerminal(command: nil, cwd: nil, name: nil, remoteWorkspaceID: workspace.id)
         }
-        // Headless staging (`cmux vm workspace new --no-open`): the machine workspace and
-        // its starter terminal are created, but nothing local is created or focused. A
-        // later layout apply may target this workspace only when it is still empty.
+        onReceipt(workspace, terminal)
         guard openLocally else { return (workspace, terminal, nil) }
         let placement = SurfaceResourcePlacement(
             resource: terminal.id,
@@ -450,6 +450,7 @@ struct CloudTreeNodeActions {
             remoteWorkspaceID: workspace.id,
             generatedTitle: localWorkspaceTitle(hostName: resolvedMachineName(machine, snapshot: catalog.snapshot), group: group)
         )
+        if focus, let first = opened.projections.first { SurfacePaneFactory.focus(panelID: first.panelID, in: first.workspaceID) }
         return (workspace, terminal, opened)
     }
 

--- a/Sources/Cloud/CloudTreeTerminalNavigationCoordinator.swift
+++ b/Sources/Cloud/CloudTreeTerminalNavigationCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 final class CloudTreeTerminalNavigationCoordinator {
     typealias Run = @MainActor (
         _ label: String,
-        _ operation: @MainActor (SurfaceCatalog) async throws -> Void
+        _ operation: @escaping @MainActor (SurfaceCatalog) async throws -> Void
     ) -> Task<Void, Never>
 
     private let machineName: @MainActor (SurfaceMachineID) -> String

--- a/Sources/Surfaces/Workspace+CloudLayoutProjection.swift
+++ b/Sources/Surfaces/Workspace+CloudLayoutProjection.swift
@@ -45,7 +45,7 @@ extension Workspace {
                                     tabs: [SurfaceResourcePlacement: TabID]) -> Bool {
         switch (layout, live) {
         case (.leaf(let placements), .pane(let pane)):
-            return placements.compactMap { tabs[$0]?.id.uuidString } == pane.tabs.map(\.id)
+            return placements.compactMap { tabs[$0]?.uuid.uuidString } == pane.tabs.map(\.id)
         case (.split(let direction, _, let first, let second), .split(let split)):
             let orientation = direction == .right || direction == .left ? "horizontal" : "vertical"
             return split.orientation == orientation && cloudLayoutMatches(first, live: split.first, tabs: tabs)

--- a/Sources/cmuxApp+CloudWorkspace.swift
+++ b/Sources/cmuxApp+CloudWorkspace.swift
@@ -4,7 +4,11 @@ import Foundation
 extension cmuxApp {
     /// Composes live authentication, authoritative fleet loading, and workspace projection.
     static func makeCloudWorkspaceCoordinator(auth: MacAuthComposition) -> CloudWorkspaceCoordinator {
-        CloudWorkspaceCoordinator(
+        // Keep the authoritative remote receipt across a failed local projection.
+        // A retry must reopen the same workspace/terminal rather than minting a
+        // second remote workspace while the daemon graph catches up.
+        var pendingReceipts: [String: (workspace: SurfaceRemoteWorkspace, terminal: SurfaceResource?)] = [:]
+        return CloudWorkspaceCoordinator(
             defaultMachineStore: DefaultCloudMachineStore(defaults: .standard),
             allowsOperation: { CloudMachinesFeature.isEnabled && auth.accountFlow.isAuthenticated },
             loadMachines: {
@@ -20,10 +24,18 @@ extension cmuxApp {
                 }
                 try Task.checkCancellation()
                 guard CloudMachinesFeature.isEnabled, auth.accountFlow.isAuthenticated else { return nil }
+                let receipt = pendingReceipts[id]
                 let result = try await CloudTreeNodeActions.createWorkspaceAndOpenLocally(
                     machine: .cloud(id), provider: provider, catalog: SurfaceCatalog.shared,
-                    name: nil, focus: focus
+                    name: nil, focus: focus,
+                    existingWorkspace: receipt?.workspace,
+                    existingTerminal: receipt?.terminal,
+                    onReceipt: { workspace, terminal in
+                        let previousTerminal = pendingReceipts[id]?.terminal
+                        pendingReceipts[id] = (workspace, terminal ?? previousTerminal)
+                    }
                 )
+                pendingReceipts[id] = nil
                 return result.opened?.workspaceID
             }
         )

--- a/cmuxTests/NewCloudWorkspaceShortcutTests.swift
+++ b/cmuxTests/NewCloudWorkspaceShortcutTests.swift
@@ -350,6 +350,52 @@ final class NewCloudWorkspaceShortcutTests: XCTestCase {
 #endif
     }
 
+    func testCommandYCoalescesOneCreateAndOpenIntentUntilItFinishes() async throws {
+#if DEBUG
+        let appDelegate = AppDelegate()
+        setCloudMachinesEnabled(true)
+        let presenter = RecordingSheetPresenter()
+        let defaults = UserDefaults(suiteName: "CloudShortcutCoalescingTests.\(UUID().uuidString)")!
+        let store = DefaultCloudMachineStore(defaults: defaults)
+        var createCount = 0
+        var releaseCreate: CheckedContinuation<Void, Never>?
+        appDelegate.cloudWorkspaceCoordinator = CloudWorkspaceCoordinator(
+            defaultMachineStore: store,
+            allowsOperation: { true },
+            loadMachines: { [CloudMachineDescriptor(id: "starred", isDesktop: true)] },
+            createWorkspace: { _, _ in
+                createCount += 1
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    releaseCreate = continuation
+                }
+                return UUID()
+            }
+        )
+        appDelegate.newMachineSheetPresenter = presenter
+        appDelegate.cloudWorkspaceOperationController = CloudWorkspaceOperationController(isAvailable: { true })
+
+        XCTAssertTrue(appDelegate.performNewCloudWorkspaceOnDefaultMachineAction(debugSource: "test.first"))
+        XCTAssertFalse(
+            appDelegate.performNewCloudWorkspaceOnDefaultMachineAction(debugSource: "test.duplicate"),
+            "a second Cmd+Y must not create another remote workspace while the first is attaching"
+        )
+        for _ in 0..<20 where releaseCreate == nil {
+            await Task.yield()
+        }
+        XCTAssertEqual(createCount, 1)
+        guard let releaseCreate else {
+            appDelegate.cloudWorkspaceOperationController?.cancelAll()
+            XCTFail("the first create operation did not reach its receipt gate")
+            return
+        }
+        releaseCreate.resume()
+        await appDelegate.cloudWorkspaceOperationController?.waitForPendingOperations()
+        XCTAssertEqual(presenter.presentCount, 0)
+#else
+        throw XCTSkip("Shortcut routing seam is DEBUG-only")
+#endif
+    }
+
     func testReboundKeyRoutesAndOldKeyDoesNot() async throws {
 #if DEBUG
         let appDelegate = AppDelegate()


### PR DESCRIPTION
## Problem
Cmd+Y could successfully create the remote Cloud workspace while leaving the user in the previous local workspace. A delayed Cloud graph or attachment retry could also lose the creation identity and make a retry create another remote workspace.

## Fix
- Treat Cmd+Y as one keyed create-and-open operation so repeated activations are coalesced while the first request is connecting.
- Retain the authoritative remote workspace and starter-terminal receipts across a failed or delayed local projection, then reuse those identities on retry.
- Explicitly run the canonical Cloud pane focus path after projecting the new local workspace so the new workspace and initial terminal are selected immediately.
- Keep Cloud terminal navigation’s stored operation closure explicitly escaping and update the Cloud layout comparison to Bonsplit’s public `TabID.uuid` API.

## Validation
- Tagged Debug build succeeded with `./scripts/reload.sh --tag issue-12500-cloud-open`.
- `python3 scripts/swift_file_length_budget.py` passed; no budget TSVs changed.
- Standalone `CmuxCloudMachines` Swift Testing suites executed 12 tests successfully. SwiftPM still exits 1 on this host because its xctest loader reports the arm64 bundle as incompatible with the x86_64 loader after the passing test output.
- The `cmux-unit` target reached compilation but was blocked by three unrelated existing test-source errors (`RecordingTerminalLinkContainer` protocol conformance and two UUID/TabID mismatches), so the focused app tests could not execute.

Fixes #12500

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791878785&installation_model_id=21920&pr_number=12516&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12516&signature=221c5e4ee585c897dfd62760a4b659c1789586fbc077a75f4e61aa3966c2703e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+Y so creating a Cloud workspace opens and focuses it in the same operation instead of leaving the user in the previous local workspace. Repeated activations no longer risk creating a second remote workspace while the first is still connecting.

**Changes**
- Cmd+Y is now one create-and-open operation; duplicate key events are ignored until the first connection resolves.
- The remote workspace and starter terminal receipts are retained across failed or delayed local projection, so retries reuse the same identities.
- The new workspace's Cloud pane is explicitly focused after projection.
- Cloud terminal navigation now uses an explicitly escaping closure, and layout comparison uses Bonsplit's public `TabID.uuid` API.

Fixes #12500

<sup>Written for commit a175c13c1d8008b03913fec34880a224b13e711d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated workspace creation commands from creating duplicate cloud workspaces while an operation is still in progress.
  * Improved recovery after local workspace opening fails by retrying the existing cloud workspace and terminal instead of creating new resources.
  * Corrected cloud layout matching to reliably preserve pane and tab arrangements.
  * Improved focus behavior when opening a workspace locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->