### PR TITLE
Fix WebKit WebContent attach crash in browser panes

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -62,6 +62,7 @@ final class BrowserHiddenWebViewDiscardManager {
             isReactGrabActive: Bool,
             isDesignModeActive: Bool = false,
             isVisualAutomationCaptureActive: Bool,
+            isMobileBrowserStreamActive: Bool = false,
             hasPopups: Bool,
             isCapturingMedia: Bool,
             isPlayingMedia: Bool
@@ -83,6 +84,7 @@ final class BrowserHiddenWebViewDiscardManager {
             self.isReactGrabActive = isReactGrabActive
             self.isDesignModeActive = isDesignModeActive
             self.isVisualAutomationCaptureActive = isVisualAutomationCaptureActive
+            self.isMobileBrowserStreamActive = isMobileBrowserStreamActive
             self.hasPopups = hasPopups
             self.isCapturingMedia = isCapturingMedia
             self.isPlayingMedia = isPlayingMedia

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -19,6 +19,8 @@ protocol BrowserHiddenWebViewDiscardManagerDelegate: AnyObject {
 
 @MainActor
 final class BrowserHiddenWebViewDiscardManager {
+    static let systemMemoryPressureReason = "system_memory_pressure"
+
     struct BlockerSnapshot {
         let isClosing: Bool
         let isVisibleInUI: Bool
@@ -28,6 +30,7 @@ final class BrowserHiddenWebViewDiscardManager {
         let isLoading: Bool
         let webViewIsLoading: Bool
         let hasActiveMainFrameProvisionalNavigation: Bool
+        let hasRecoverableWebContentTermination: Bool
         let isDownloading: Bool
         let activeDownloadCount: Int
         let preferredDeveloperToolsVisible: Bool
@@ -40,6 +43,50 @@ final class BrowserHiddenWebViewDiscardManager {
         let hasPopups: Bool
         let isCapturingMedia: Bool
         let isPlayingMedia: Bool
+
+        init(
+            isClosing: Bool,
+            isVisibleInUI: Bool,
+            shouldRenderWebView: Bool,
+            hasPendingRemoteNavigation: Bool,
+            hasCurrentURL: Bool,
+            isLoading: Bool,
+            webViewIsLoading: Bool,
+            hasActiveMainFrameProvisionalNavigation: Bool,
+            hasRecoverableWebContentTermination: Bool = false,
+            isDownloading: Bool,
+            activeDownloadCount: Int,
+            preferredDeveloperToolsVisible: Bool,
+            isDeveloperToolsVisible: Bool,
+            isElementFullscreenActive: Bool,
+            isReactGrabActive: Bool,
+            isDesignModeActive: Bool = false,
+            isVisualAutomationCaptureActive: Bool,
+            hasPopups: Bool,
+            isCapturingMedia: Bool,
+            isPlayingMedia: Bool
+        ) {
+            self.isClosing = isClosing
+            self.isVisibleInUI = isVisibleInUI
+            self.shouldRenderWebView = shouldRenderWebView
+            self.hasPendingRemoteNavigation = hasPendingRemoteNavigation
+            self.hasCurrentURL = hasCurrentURL
+            self.isLoading = isLoading
+            self.webViewIsLoading = webViewIsLoading
+            self.hasActiveMainFrameProvisionalNavigation = hasActiveMainFrameProvisionalNavigation
+            self.hasRecoverableWebContentTermination = hasRecoverableWebContentTermination
+            self.isDownloading = isDownloading
+            self.activeDownloadCount = activeDownloadCount
+            self.preferredDeveloperToolsVisible = preferredDeveloperToolsVisible
+            self.isDeveloperToolsVisible = isDeveloperToolsVisible
+            self.isElementFullscreenActive = isElementFullscreenActive
+            self.isReactGrabActive = isReactGrabActive
+            self.isDesignModeActive = isDesignModeActive
+            self.isVisualAutomationCaptureActive = isVisualAutomationCaptureActive
+            self.hasPopups = hasPopups
+            self.isCapturingMedia = isCapturingMedia
+            self.isPlayingMedia = isPlayingMedia
+        }
     }
 
     weak var delegate: BrowserHiddenWebViewDiscardManagerDelegate?
@@ -74,19 +121,30 @@ final class BrowserHiddenWebViewDiscardManager {
         discardTimer != nil
     }
 
-    func blockers(for snapshot: BlockerSnapshot) -> [String] {
+    func blockers(
+        for snapshot: BlockerSnapshot,
+        now: Date = Date(),
+        allowingRecoverableWebContentTermination: Bool = false
+    ) -> [String] {
         var blockers: [String] = []
         if !BrowserHiddenWebViewDiscardPolicy.isEnabled(defaults: policyDefaults) {
             blockers.append("policy_disabled")
         }
         if isSystemSleeping { blockers.append("system_sleeping") }
+        if snapshot.hasRecoverableWebContentTermination && !allowingRecoverableWebContentTermination {
+            blockers.append("webcontent_recovery")
+        }
         if snapshot.isClosing { blockers.append("closing") }
         if isDiscardedForMemory { blockers.append("already_discarded") }
         if snapshot.isVisibleInUI { blockers.append("visible") }
         if !snapshot.shouldRenderWebView { blockers.append("not_rendered") }
         if snapshot.hasPendingRemoteNavigation { blockers.append("pending_remote_navigation") }
         if !snapshot.hasCurrentURL { blockers.append("no_url") }
-        if snapshot.isLoading || snapshot.webViewIsLoading { blockers.append("loading") }
+        let allowsRecoverableDiscard = snapshot.hasRecoverableWebContentTermination &&
+            allowingRecoverableWebContentTermination
+        if (snapshot.isLoading || snapshot.webViewIsLoading) && !allowsRecoverableDiscard {
+            blockers.append("loading")
+        }
         if snapshot.hasActiveMainFrameProvisionalNavigation { blockers.append("provisional_navigation") }
         if snapshot.isDownloading || snapshot.activeDownloadCount != 0 { blockers.append("download") }
         if snapshot.isCapturingMedia { blockers.append("media_capture") }
@@ -103,13 +161,21 @@ final class BrowserHiddenWebViewDiscardManager {
         return blockers
     }
 
-    func scheduleIfNeeded(reason: String, now: Date = Date()) {
+    func scheduleIfNeeded(
+        reason: String,
+        now: Date = Date(),
+        allowingRecoverableWebContentTermination: Bool = false
+    ) {
         scheduleGeneration &+= 1
         discardTimer?.cancel()
         discardTimer = nil
 
         guard let delegate else { return }
-        guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return }
+        guard blockers(
+            for: delegate.hiddenWebViewDiscardSnapshot,
+            now: now,
+            allowingRecoverableWebContentTermination: allowingRecoverableWebContentTermination
+        ).isEmpty else { return }
 
         let observedWebViewInstanceID = delegate.hiddenWebViewDiscardWebViewInstanceID
         let generation = scheduleGeneration
@@ -148,14 +214,27 @@ final class BrowserHiddenWebViewDiscardManager {
     @discardableResult
     func requestImmediateDiscardIfSafe(reason: String, now: Date = Date()) -> Bool {
         guard let delegate else { return false }
-        guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return false }
+        let allowsRecoverableWebContentTermination = reason == Self.systemMemoryPressureReason
+        guard blockers(
+            for: delegate.hiddenWebViewDiscardSnapshot,
+            now: now,
+            allowingRecoverableWebContentTermination: allowsRecoverableWebContentTermination
+        ).isEmpty else { return false }
         guard delegate.hiddenWebViewDiscardHiddenAt != nil else {
-            scheduleIfNeeded(reason: reason, now: now)
+            scheduleIfNeeded(
+                reason: reason,
+                now: now,
+                allowingRecoverableWebContentTermination: allowsRecoverableWebContentTermination
+            )
             return false
         }
         // Memory pressure bypasses the hidden-duration delay, not the WebKit post-wake crash guard.
         guard !isInPostWakeDiscardDelay(now: now) else {
-            scheduleIfNeeded(reason: reason, now: now)
+            scheduleIfNeeded(
+                reason: reason,
+                now: now,
+                allowingRecoverableWebContentTermination: allowsRecoverableWebContentTermination
+            )
             return false
         }
 

--- a/Sources/Panels/BrowserPanel+MediaPlayback.swift
+++ b/Sources/Panels/BrowserPanel+MediaPlayback.swift
@@ -252,6 +252,15 @@ extension BrowserPanel {
         )
     }
 
+    func tearDownMediaPlaybackMessageHandler(for webView: WKWebView) {
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: mediaPlaybackMessageHandlerName,
+            contentWorld: Self.mediaPlaybackContentWorld
+        )
+        mediaPlaybackMessageHandler = nil
+        resetMediaPlaybackTracking()
+    }
+
     /// Applies a per-frame playback report from the injected hook, aggregating
     /// across the main frame and any iframes. Reports from a superseded webview
     /// generation are dropped.

--- a/Sources/Panels/BrowserPanel+WebContentTermination.swift
+++ b/Sources/Panels/BrowserPanel+WebContentTermination.swift
@@ -1,0 +1,226 @@
+import AppKit
+import Foundation
+import WebKit
+
+extension BrowserPanel {
+    func handleWebContentProcessTermination(for terminatedWebView: WKWebView) {
+        guard terminatedWebView === webView else { return }
+
+        let wasRenderable = shouldRenderWebView
+        let attemptedURL = Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
+            ?? navigationDelegate?.lastAttemptedURL
+        let liveURL = restorableDisplayURLForCurrentErrorPage(liveURL: terminatedWebView.url)
+        let recoveryURL = (isMainFrameProvisionalNavigationActive ? attemptedURL : nil)
+            ?? liveURL
+            ?? attemptedURL
+            ?? resolvedCurrentSessionHistoryURL()
+        let recoveryURLString = recoveryURL?.absoluteString
+        let hasRecoveryTarget = recoveryURLString != nil && recoveryURLString != blankURLString
+
+        loadingGeneration &+= 1
+        loadingEndScheduler.cancel()
+        isMainFrameProvisionalNavigationActive = false
+        isLoading = false
+        estimatedProgress = 0
+        clearBrowserFocusMode(reason: "webContentProcessTerminated")
+        invalidateSearchFocusRequests(reason: "webContentProcessTerminated")
+        if let window = terminatedWebView.window,
+           Self.responderChainContains(window.firstResponder, target: terminatedWebView) {
+            window.makeFirstResponder(nil)
+        }
+        cancelPendingInteractiveBrowserPrompts(reason: "webContentProcessTerminated")
+
+        if wasRenderable, hasRecoveryTarget, let recoveryURL {
+            pendingWebContentRecoveryURL = recoveryURL
+            hasRecoverableWebContentTermination = true
+            closeBackgroundPreloadHost(reason: "webContentRecovery")
+            detachTerminatedWebViewCallbacks(terminatedWebView)
+            hideBrowserPortalView(source: "webContentRecovery")
+        } else {
+            clearWebContentTerminationRecovery()
+        }
+        _ = resetMediaStateAfterWebContentTermination()
+        refreshNavigationAvailability()
+        refreshWebViewLifecycleState()
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webcontent.terminated panel=\(id.uuidString.prefix(5)) " +
+            "renderable=\(wasRenderable ? 1 : 0) recoveryURL=\(recoveryURLString ?? "nil") " +
+            "manualRecovery=\(hasRecoverableWebContentTermination ? 1 : 0)"
+        )
+#endif
+    }
+
+    func detachTerminatedWebViewCallbacks(_ terminatedWebView: WKWebView) {
+        detachWebViewObservers()
+        tearDownReactGrabMessageHandler(for: terminatedWebView, reason: "webContentProcessTerminated")
+        tearDownMediaPlaybackMessageHandler(for: terminatedWebView)
+        webAuthnCoordinator.tearDown(from: terminatedWebView)
+        terminatedWebView.configuration.userContentController.removeScriptMessageHandler(
+            forName: BrowserSSLTrustBypassMessageHandler.name
+        )
+        terminatedWebView.navigationDelegate = nil
+        terminatedWebView.uiDelegate = nil
+        if let terminatedCmuxWebView = terminatedWebView as? CmuxWebView {
+            terminatedCmuxWebView.cmuxDownloadDelegate = nil
+            terminatedCmuxWebView.clearBrowserDownloadCallbacks()
+        }
+    }
+
+    @discardableResult
+    func replaceWebViewPreservingState(
+        from oldWebView: WKWebView,
+        websiteDataStore: WKWebsiteDataStore,
+        reason: String,
+        overrideRestoreURL: URL? = nil,
+        restoreAfterReplacement: Bool = true
+    ) -> Bool {
+        guard oldWebView === webView else { return false }
+
+        let wasRenderable = shouldRenderWebView
+        let attemptedURL = Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
+            ?? navigationDelegate?.lastAttemptedURL
+        let liveURL = restorableDisplayURLForCurrentErrorPage(liveURL: oldWebView.url)
+        let restoreURL = overrideRestoreURL
+            ?? (isMainFrameProvisionalNavigationActive ? attemptedURL : nil)
+            ?? liveURL
+            ?? attemptedURL
+            ?? resolvedCurrentSessionHistoryURL()
+        let restoreURLString = restoreURL?.absoluteString
+        let hasRecoveryTarget = restoreURLString != nil && restoreURLString != blankURLString
+        let shouldRestoreURL = wasRenderable && hasRecoveryTarget
+        let history = sessionNavigationHistorySnapshot()
+        let historyCurrentURL = preferredURLStringForOmnibar()
+        let desiredZoom = max(minPageZoom, min(maxPageZoom, oldWebView.pageZoom))
+        let restoreDevTools = preferredDeveloperToolsVisible
+
+        if oldWebView.configuration.websiteDataStore !== websiteDataStore {
+            navigationDelegate?.clearSSLTrustState()
+        }
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webview.replace.begin panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) " +
+            "renderable=\(wasRenderable ? 1 : 0) restoreURL=\(restoreURLString ?? "nil") " +
+            "restoreHistoryBack=\(history.backHistoryURLStrings.count) " +
+            "restoreHistoryForward=\(history.forwardHistoryURLStrings.count)"
+        )
+#endif
+
+        detachWebViewObservers()
+        clearBrowserFocusMode(reason: reason)
+        faviconTask?.cancel()
+        faviconTask = nil
+        faviconRefreshGeneration &+= 1
+        loadingGeneration &+= 1
+        loadingEndScheduler.cancel()
+        isLoading = false
+        estimatedProgress = 0
+        cancelPendingInteractiveBrowserPrompts(reason: reason)
+        closeBackgroundPreloadHost(reason: reason)
+        BrowserWindowPortalRegistry.detach(webView: oldWebView)
+        webAuthnCoordinator.tearDown(from: oldWebView); oldWebView.stopLoading()
+        isMainFrameProvisionalNavigationActive = false
+        oldWebView.navigationDelegate = nil
+        oldWebView.uiDelegate = nil
+        if let oldCmuxWebView = oldWebView as? CmuxWebView { oldCmuxWebView.clearBrowserDownloadCallbacks() }
+
+        let replacement = makeReplacementWebView(
+            profileID: profileID,
+            websiteDataStore: websiteDataStore
+        )
+        replacement.pageZoom = desiredZoom
+        webViewInstanceID = UUID()
+        hasCommittedDocumentSinceWebViewReplacement = false; userStoppedLoadSinceWebViewReplacement = false
+        resetWebViewLifecycleMetadata(resetVisibility: false)
+        webView = replacement
+        shouldRenderWebView = wasRenderable
+        refreshWebViewLifecycleState()
+
+        bindWebView(replacement)
+        applyBrowserThemeModeIfNeeded()
+
+        if !history.backHistoryURLStrings.isEmpty || !history.forwardHistoryURLStrings.isEmpty {
+            restoreSessionNavigationHistory(
+                backHistoryURLStrings: history.backHistoryURLStrings,
+                forwardHistoryURLStrings: history.forwardHistoryURLStrings,
+                currentURLString: historyCurrentURL
+            )
+        }
+
+        clearWebContentTerminationRecovery()
+        if !restoreAfterReplacement {
+            refreshNavigationAvailability()
+        } else {
+            if shouldRestoreURL, let restoreURL {
+                navigateWithoutInsecureHTTPPrompt(
+                    to: restoreURL,
+                    recordTypedNavigation: false,
+                    preserveRestoredSessionHistory: true
+                )
+            } else {
+                refreshNavigationAvailability()
+            }
+        }
+
+        if restoreDevTools {
+            requestDeveloperToolsRefreshAfterNextAttach(reason: reason)
+        }
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webview.replace.end panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) " +
+            "instance=\(webViewInstanceID.uuidString.prefix(6)) " +
+            "restoreURL=\(restoreURLString ?? "nil") shouldRestore=\(shouldRestoreURL ? 1 : 0)"
+        )
+#endif
+        return true
+    }
+
+    @discardableResult
+    func recoverTerminatedWebContent(
+        reason: String = "manual",
+        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
+    ) -> Bool {
+        guard hasRecoverableWebContentTermination else { return false }
+        let recoveryURL = pendingWebContentRecoveryURL
+        let terminatedWebView = webView
+        guard replaceWebViewPreservingState(
+            from: terminatedWebView,
+            websiteDataStore: websiteDataStore,
+            reason: "webcontent_recovery.\(reason)",
+            overrideRestoreURL: recoveryURL,
+            restoreAfterReplacement: false
+        ) else {
+            clearWebContentTerminationRecovery()
+            refreshNavigationAvailability()
+            return true
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webcontent.recover panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) url=\(recoveryURL?.absoluteString ?? "nil")"
+        )
+#endif
+        guard let recoveryURL else {
+            refreshNavigationAvailability()
+            return true
+        }
+        navigateWithoutInsecureHTTPPrompt(
+            to: recoveryURL,
+            recordTypedNavigation: false,
+            preserveRestoredSessionHistory: true,
+            cachePolicy: cachePolicy
+        )
+        return true
+    }
+
+    func clearWebContentTerminationRecovery() {
+        pendingWebContentRecoveryURL = nil
+        hasRecoverableWebContentTermination = false
+    }
+
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -8410,7 +8410,7 @@ class BrowserDownloadDelegate: NSObject, WKDownloadDelegate {
 // MARK: - UI Delegate
 
 @MainActor
-private final class BrowserUIDelegate: BrowserPDFPreviewActionUIDelegate {
+final class BrowserUIDelegate: BrowserPDFPreviewActionUIDelegate {
     private let externalNavigationHandler: BrowserExternalNavigationHandler
     weak var owner: BrowserPanel?
     var openInNewTab: ((URL) -> Void)?

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2301,7 +2301,7 @@ final class BrowserPanel: Panel, ObservableObject {
         evaluator: BrowserFindWebViewEvaluator(panel: self)
     )
     let portalAnchorView = BrowserPortalAnchorView(frame: .zero)
-    private struct PortalHostLock {
+    struct PortalHostLock {
         let hostId: ObjectIdentifier
         let paneId: UUID
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2027,7 +2027,13 @@ final class BrowserPanel: Panel, ObservableObject {
             }
         }
     }
-    private var pendingWebContentRecoveryURL: URL?
+    var pendingWebContentRecoveryURL: URL?
+    /// Whether the failed WebContent view may be mounted in the portal.
+    /// WebKit can still deliver process-swap IPC after its termination callback,
+    /// so recovery owns the view until an explicit reload creates a fresh page.
+    var shouldAttachWebViewInUI: Bool {
+        shouldRenderWebView && !hasRecoverableWebContentTermination
+    }
 
     /// Prevent the omnibar from auto-focusing for a short window after explicit programmatic focus.
     /// This avoids races where SwiftUI focus state steals first responder back from WebKit.
@@ -2037,7 +2043,7 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Used to keep omnibar text-field focus from being immediately stolen by panel focus.
     private var suppressWebViewFocusUntil: Date?
     private var suppressWebViewFocusForAddressBar: Bool = false
-    private let blankURLString = "about:blank"
+    let blankURLString = "about:blank"
 
     /// Owns the address-bar page-focus capture/restore subsystem.
     ///
@@ -2171,8 +2177,8 @@ final class BrowserPanel: Panel, ObservableObject {
         }
     }
 
-    private var nativeCanGoBack: Bool = false
-    private var nativeCanGoForward: Bool = false
+    var nativeCanGoBack: Bool = false
+    var nativeCanGoForward: Bool = false
 
     /// The replayable back/forward session history this surface restores from a
     /// prior launch. The pure stack state machine lives in `CmuxBrowser`;
@@ -2303,29 +2309,31 @@ final class BrowserPanel: Panel, ObservableObject {
         case attached
         case detached
     }
-    private var activePortalHostLease: PortalHostLease?
-    private var pendingDistinctPortalHostReplacementPaneId: UUID?
-    private var lockedPortalHost: PortalHostLock?
+    var activePortalHostLease: PortalHostLease?
+    var pendingDistinctPortalHostReplacementPaneId: UUID?
+    var lockedPortalHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
     private(set) var navigationDelegate: BrowserNavigationDelegate?
     /// Provenance for an app-owned local document, retained across WebView replacement.
     private var trustedLocalFileURL: URL?
     private var pendingTrustedLocalFileURL: URL?
-    private var uiDelegate: BrowserUIDelegate?
+    var uiDelegate: BrowserUIDelegate?
     var downloadDelegate: BrowserDownloadDelegate?
-    private let webAuthnCoordinator = BrowserWebAuthnCoordinator()
-    private var webViewObservers: [NSKeyValueObservation] = []
+    let webAuthnCoordinator = BrowserWebAuthnCoordinator()
+    var webViewObservers: [NSKeyValueObservation] = []
+    private var webViewObservationGeneration: UInt64 = 0
     private var activeDownloadCount: Int = 0
     // Avoid flickering the loading indicator for very fast navigations.
     private let minLoadingIndicatorDuration: TimeInterval = 0.35
     private var loadingStartedAt: Date?
-    private let loadingEndScheduler = MainActorDeferredActionScheduler()
-    private var loadingGeneration: Int = 0
-    private var faviconTask: Task<Void, Never>?
-    private var faviconRefreshGeneration: Int = 0
+    let loadingEndScheduler = MainActorDeferredActionScheduler()
+    var loadingGeneration: Int = 0
+    private var suppressHiddenWebViewDiscardReevaluation = false
+    var faviconTask: Task<Void, Never>?
+    var faviconRefreshGeneration: Int = 0
     private var lastFaviconURLString: String?
-    private let minPageZoom: CGFloat = CGFloat(BrowserZoomSettings.minimumLevel)
-    private let maxPageZoom: CGFloat = CGFloat(BrowserZoomSettings.maximumLevel)
+    let minPageZoom: CGFloat = CGFloat(BrowserZoomSettings.minimumLevel)
+    let maxPageZoom: CGFloat = CGFloat(BrowserZoomSettings.maximumLevel)
     private let pageZoomStep: CGFloat = CGFloat(BrowserZoomSettings.step)
     private var insecureHTTPBypassHostOnce: String?
     var activeInteractiveBrowserPromptIDs: Set<UUID> = []
@@ -2435,6 +2443,29 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func refreshAudioMediaActivity(reason: String) { setMediaActivity(isPlayingAudio: !audibleMediaFrameIDs.isEmpty && !isMuted, reason: reason) }
+
+    /// Clears page-owned media state before a terminated WebView is detached.
+    /// WebKit can publish stale capture/playback callbacks while it is tearing
+    /// down the process; the recovery state must be the only lifecycle owner.
+    @discardableResult
+    func resetMediaStateAfterWebContentTermination() -> Bool {
+        suppressHiddenWebViewDiscardReevaluation = true
+        defer { suppressHiddenWebViewDiscardReevaluation = false }
+
+        let changed = !playingMediaFrameIDs.isEmpty ||
+            !audibleMediaFrameIDs.isEmpty ||
+            isPlayingMedia ||
+            mediaActivity != BrowserMediaActivity()
+        (playingMediaFrameIDs, audibleMediaFrameIDs) = ([], [])
+        isPlayingMedia = false
+        setMediaActivity(
+            isPlayingAudio: false,
+            isUsingMicrophone: false,
+            isUsingCamera: false,
+            reason: "webContentProcessTerminated"
+        )
+        return changed
+    }
     var pendingReactGrabReturnTargetPanelId: UUID?
     var pendingReactGrabRoundTripToken: String?
     let reactGrabBridgeSessionUpdaterName = "__cmuxReactGrabBridgeSync_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
@@ -2601,7 +2632,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewLifecycleState = nextState
     }
 
-    private func resetWebViewLifecycleMetadata(resetVisibility: Bool = true) {
+    func resetWebViewLifecycleMetadata(resetVisibility: Bool = true) {
         cancelHiddenWebViewDiscard()
         webViewLifecycleState = .newTab; pendingDiscardRestoreNavigation = nil; currentDiscardRestoreAttemptID = nil
         if resetVisibility {
@@ -2619,6 +2650,15 @@ final class BrowserPanel: Panel, ObservableObject {
         hiddenWebViewDiscardManager.blockers(for: hiddenWebViewDiscardSnapshot)
     }
 
+    private func hiddenWebViewDiscardBlockers(
+        allowingRecoverableWebContentTermination: Bool
+    ) -> [String] {
+        hiddenWebViewDiscardManager.blockers(
+            for: hiddenWebViewDiscardSnapshot,
+            allowingRecoverableWebContentTermination: allowingRecoverableWebContentTermination
+        )
+    }
+
     private func scheduleHiddenWebViewDiscardIfNeeded(reason: String, now: Date = Date()) {
         hiddenWebViewDiscardManager.scheduleIfNeeded(reason: reason, now: now)
     }
@@ -2628,6 +2668,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func reevaluateHiddenWebViewDiscardScheduling(reason: String) {
+        guard !suppressHiddenWebViewDiscardReevaluation else { return }
         if isWebViewVisibleInUI {
             cancelHiddenWebViewDiscard()
         } else {
@@ -2642,15 +2683,23 @@ final class BrowserPanel: Panel, ObservableObject {
 
     @discardableResult
     func discardHiddenWebViewForMemory(reason: String, now: Date = Date()) -> Bool {
-        let blockers = hiddenWebViewDiscardBlockers()
+        let allowsRecoverableWebContentTermination =
+            reason == BrowserHiddenWebViewDiscardManager.systemMemoryPressureReason
+        let blockers = hiddenWebViewDiscardBlockers(
+            allowingRecoverableWebContentTermination: allowsRecoverableWebContentTermination
+        )
         guard blockers.isEmpty else { return false }
 
         cancelHiddenWebViewDiscard()
 
         let oldWebView = webView
-        let restoreURL = restorableDisplayURLForCurrentErrorPage(liveURL: oldWebView.url)
+        let pendingRecoveryURL = pendingWebContentRecoveryURL
+        let restoreURL = pendingRecoveryURL
+            ?? restorableDisplayURLForCurrentErrorPage(liveURL: oldWebView.url)
         let history = sessionNavigationHistorySnapshot()
-        let historyCurrentURL = preferredURLStringForOmnibar() ?? restoreURL?.absoluteString
+        let historyCurrentURL = pendingRecoveryURL?.absoluteString
+            ?? preferredURLStringForOmnibar()
+            ?? restoreURL?.absoluteString
         let desiredZoom = max(minPageZoom, min(maxPageZoom, oldWebView.pageZoom))
 
         clearBrowserFocusMode(reason: "webViewDiscard")
@@ -2682,6 +2731,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webView = replacement
         hiddenWebViewDiscardManager.markDiscarded(reason: reason, now: now)
         currentURL = restoreURL
+        clearWebContentTerminationRecovery()
         shouldRenderWebView = false
         nativeCanGoBack = false
         nativeCanGoForward = false
@@ -2706,7 +2756,10 @@ final class BrowserPanel: Panel, ObservableObject {
 
     @discardableResult
     func discardHiddenWebViewForSystemMemoryPressure(now: Date = Date()) -> Bool {
-        hiddenWebViewDiscardManager.requestImmediateDiscardIfSafe(reason: "system_memory_pressure", now: now)
+        hiddenWebViewDiscardManager.requestImmediateDiscardIfSafe(
+            reason: BrowserHiddenWebViewDiscardManager.systemMemoryPressureReason,
+            now: now
+        )
     }
 
     var hasPendingRemoteNavigation: Bool { pendingRemoteNavigation != nil }
@@ -3018,6 +3071,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func bindWebView(_ webView: CmuxWebView) {
+        webViewObservationGeneration &+= 1
         browserViewportHostRestorationTask?.cancel()
         browserViewportHostRestorationTask = nil
         browserViewportHostRestorationPending = false
@@ -3338,6 +3392,15 @@ final class BrowserPanel: Panel, ObservableObject {
         return instanceID == webViewInstanceID
     }
 
+    private func isCurrentObservedWebView(
+        _ candidate: WKWebView,
+        instanceID: UUID,
+        observationGeneration: UInt64
+    ) -> Bool {
+        isCurrentWebView(candidate, instanceID: instanceID) &&
+            observationGeneration == webViewObservationGeneration
+    }
+
     /// Tracks whether the process-once browser defaults bootstrap has run.
     private static var hasBootstrappedBrowserDefaults = false
 
@@ -3598,7 +3661,7 @@ final class BrowserPanel: Panel, ObservableObject {
             self.refreshBackgroundAppearance()
         }
         navDelegate.didTerminateWebContentProcess = { [weak self] webView in
-            self?.replaceWebViewAfterContentProcessTermination(for: webView)
+            self?.handleWebContentProcessTermination(for: webView)
         }
         // Set up download delegate for navigation-based downloads.
         // Downloads save to a temp file synchronously (no UI during WebKit
@@ -3950,7 +4013,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
     }
 
-    private func cancelPendingInteractiveBrowserPrompts(reason: String, cancelAuthenticationPrompts: Bool = true) {
+    func cancelPendingInteractiveBrowserPrompts(reason: String, cancelAuthenticationPrompts: Bool = true) {
         if cancelAuthenticationPrompts { navigationDelegate?.cancelPendingAuthenticationPrompts(allowFuturePrompts: true) }
         guard !pendingInteractiveBrowserPrompts.isEmpty else { return }
         let prompts = pendingInteractiveBrowserPrompts
@@ -3975,7 +4038,7 @@ final class BrowserPanel: Panel, ObservableObject {
         drainPendingInteractiveBrowserPromptsIfPossible(reason: reason)
     }
 
-    private func closeBackgroundPreloadHost(reason: String) {
+    func closeBackgroundPreloadHost(reason: String) {
         guard let preloadWindow = backgroundPreloadWindow else { return }
         backgroundPreloadWindow = nil
         preloadWindow.contentView = nil
@@ -4486,6 +4549,7 @@ final class BrowserPanel: Panel, ObservableObject {
     /// speaker/mic/camera glyph; the next `setupObservers` re-seeds the flags
     /// from the fresh web view.
     private func detachWebViewObservers() {
+        webViewObservationGeneration &+= 1
         webViewObservers.removeAll()
         webView.configuration.userContentController.removeScriptMessageHandler(
             forName: BrowserSameDocumentNavigationMessageHandler.name,
@@ -4499,12 +4563,20 @@ final class BrowserPanel: Panel, ObservableObject {
 
     private func setupObservers(for webView: WKWebView) {
         let observedWebViewInstanceID = webViewInstanceID
+        let observedWebViewObservationGeneration = webViewObservationGeneration
+        func isCurrentObservedWebView(_ panel: BrowserPanel, _ candidate: WKWebView) -> Bool {
+            panel.isCurrentObservedWebView(
+                candidate,
+                instanceID: observedWebViewInstanceID,
+                observationGeneration: observedWebViewObservationGeneration
+            )
+        }
 
         // URL changes
         let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] webView, change in
             let observedURL = change.newValue ?? webView.url
             MainActor.assumeIsolated {
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 guard !self.isMainFrameProvisionalNavigationActive else { return }
                 self.designModeController.webViewURLDidChange(to: observedURL)
                 self.currentURL = Self.remoteProxyDisplayURL(for: observedURL) ?? observedURL
@@ -4517,7 +4589,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Title changes
         let titleObserver = webView.observe(\.title, options: [.new]) { [weak self] webView, _ in
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 // Keep showing the last non-empty title while the new navigation is loading.
                 // WebKit often clears title to nil/"" during reload/navigation, which causes
                 // a distracting tab-title flash (e.g. to host/URL). Only accept non-empty titles.
@@ -4538,7 +4610,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let loadingObserver = webView.observe(\.isLoading, options: [.new]) { [weak self] webView, change in
             let newValue = change.newValue ?? webView.isLoading
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.handleWebViewLoadingChanged(newValue)
             }
         }
@@ -4547,7 +4619,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Can go back
         let backObserver = webView.observe(\.canGoBack, options: [.new]) { [weak self] webView, _ in
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.nativeCanGoBack = webView.canGoBack
                 self.refreshNavigationAvailability()
             }
@@ -4557,7 +4629,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Can go forward
         let forwardObserver = webView.observe(\.canGoForward, options: [.new]) { [weak self] webView, _ in
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.nativeCanGoForward = webView.canGoForward
                 self.refreshNavigationAvailability()
             }
@@ -4567,7 +4639,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Progress
         let progressObserver = webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.estimatedProgress = webView.estimatedProgress
             }
         }
@@ -4577,7 +4649,7 @@ final class BrowserPanel: Panel, ObservableObject {
             let isElementFullscreenActive = webView.cmuxIsElementFullscreenActiveOrTransitioning
             let fullscreenState = webView.fullscreenState
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 let didChangeFullscreenBlocker = self.isElementFullscreenActive != isElementFullscreenActive
                 self.isElementFullscreenActive = isElementFullscreenActive
                 let didChangeViewportOwnership = self.reconcileAutomationViewportForElementFullscreen(
@@ -4607,7 +4679,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let cameraCaptureObserver = webView.observe(\.cameraCaptureState, options: [.new]) { [weak self] webView, _ in
             let isUsingCamera = webView.cameraCaptureState != .none
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.setMediaActivity(isUsingCamera: isUsingCamera, reason: "media_capture_changed")
             }
         }
@@ -4616,7 +4688,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let microphoneCaptureObserver = webView.observe(\.microphoneCaptureState, options: [.new]) { [weak self] webView, _ in
             let isUsingMicrophone = webView.microphoneCaptureState != .none
             Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
+                guard let self, isCurrentObservedWebView(self, webView) else { return }
                 self.setMediaActivity(isUsingMicrophone: isUsingMicrophone, reason: "media_capture_changed")
             }
         }
@@ -4732,170 +4804,13 @@ final class BrowserPanel: Panel, ObservableObject {
         )
     }
 
-    private func restorableDisplayURLForCurrentErrorPage(liveURL: URL?) -> URL? {
+    func restorableDisplayURLForCurrentErrorPage(liveURL: URL?) -> URL? {
         Self.restorableDisplayURL(
             liveURL: liveURL,
             currentURL: currentURL,
             activeErrorPageDisplayURL: navigationDelegate?.activeErrorPageDisplayURL
         )
     }
-
-    private func replaceWebViewAfterContentProcessTermination(for terminatedWebView: WKWebView) {
-        replaceWebViewPreservingState(
-            from: terminatedWebView,
-            websiteDataStore: websiteDataStore,
-            reason: "webcontent_process_terminated",
-            waitForManualRecovery: true
-        )
-    }
-    func replaceWebViewPreservingState(
-        from oldWebView: WKWebView,
-        websiteDataStore: WKWebsiteDataStore,
-        reason: String,
-        waitForManualRecovery: Bool = false
-    ) {
-        guard oldWebView === webView else { return }
-
-        let wasRenderable = shouldRenderWebView
-        let attemptedURL = Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
-            ?? navigationDelegate?.lastAttemptedURL
-        let liveURL = restorableDisplayURLForCurrentErrorPage(liveURL: oldWebView.url)
-        let restoreURL = (isMainFrameProvisionalNavigationActive ? attemptedURL : nil)
-            ?? liveURL
-            ?? attemptedURL
-            ?? resolvedCurrentSessionHistoryURL()
-        let restoreURLString = restoreURL?.absoluteString
-        let hasRecoveryTarget = restoreURLString != nil && restoreURLString != blankURLString
-        let shouldRestoreURL = wasRenderable && hasRecoveryTarget
-        let shouldShowManualRecovery = waitForManualRecovery && wasRenderable && hasRecoveryTarget
-        let history = sessionNavigationHistorySnapshot()
-        let historyCurrentURL = preferredURLStringForOmnibar()
-        let desiredZoom = max(minPageZoom, min(maxPageZoom, oldWebView.pageZoom))
-        let restoreDevTools = preferredDeveloperToolsVisible
-
-        if oldWebView.configuration.websiteDataStore !== websiteDataStore {
-            navigationDelegate?.clearSSLTrustState()
-        }
-
-#if DEBUG
-        cmuxDebugLog(
-            "browser.webview.replace.begin panel=\(id.uuidString.prefix(5)) " +
-            "reason=\(reason) " +
-            "renderable=\(wasRenderable ? 1 : 0) restoreURL=\(restoreURLString ?? "nil") " +
-            "restoreHistoryBack=\(history.backHistoryURLStrings.count) " +
-            "restoreHistoryForward=\(history.forwardHistoryURLStrings.count)"
-        )
-#endif
-
-        detachWebViewObservers()
-        clearBrowserFocusMode(reason: reason)
-        faviconTask?.cancel()
-        faviconTask = nil
-        faviconRefreshGeneration &+= 1
-        loadingGeneration &+= 1
-        loadingEndScheduler.cancel()
-        isLoading = false
-        estimatedProgress = 0
-        cancelPendingInteractiveBrowserPrompts(reason: reason)
-        closeBackgroundPreloadHost(reason: reason)
-        BrowserWindowPortalRegistry.detach(webView: oldWebView)
-        webAuthnCoordinator.tearDown(from: oldWebView); oldWebView.stopLoading()
-        isMainFrameProvisionalNavigationActive = false
-        oldWebView.navigationDelegate = nil
-        oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView { oldCmuxWebView.clearBrowserDownloadCallbacks() }
-
-        let replacement = makeReplacementWebView(
-            profileID: profileID,
-            websiteDataStore: websiteDataStore
-        )
-        replacement.pageZoom = desiredZoom
-        webViewInstanceID = UUID()
-        hasCommittedDocumentSinceWebViewReplacement = false; userStoppedLoadSinceWebViewReplacement = false
-        resetWebViewLifecycleMetadata(resetVisibility: false)
-        webView = replacement
-        shouldRenderWebView = wasRenderable
-        refreshWebViewLifecycleState()
-
-        bindWebView(replacement)
-        applyBrowserThemeModeIfNeeded()
-
-        if !history.backHistoryURLStrings.isEmpty || !history.forwardHistoryURLStrings.isEmpty {
-            restoreSessionNavigationHistory(
-                backHistoryURLStrings: history.backHistoryURLStrings,
-                forwardHistoryURLStrings: history.forwardHistoryURLStrings,
-                currentURLString: historyCurrentURL
-            )
-        }
-
-        if shouldShowManualRecovery, let restoreURL {
-            pendingWebContentRecoveryURL = restoreURL
-            hasRecoverableWebContentTermination = true
-            refreshNavigationAvailability()
-        } else {
-            clearWebContentTerminationRecovery()
-            if shouldRestoreURL, let restoreURL {
-                navigateWithoutInsecureHTTPPrompt(
-                    to: restoreURL,
-                    recordTypedNavigation: false,
-                    preserveRestoredSessionHistory: true
-                )
-            } else {
-                refreshNavigationAvailability()
-            }
-        }
-
-        if restoreDevTools {
-            requestDeveloperToolsRefreshAfterNextAttach(reason: reason)
-        }
-
-#if DEBUG
-        cmuxDebugLog(
-            "browser.webview.replace.end panel=\(id.uuidString.prefix(5)) " +
-            "reason=\(reason) " +
-            "instance=\(webViewInstanceID.uuidString.prefix(6)) " +
-            "restoreURL=\(restoreURLString ?? "nil") shouldRestore=\(shouldRestoreURL ? 1 : 0)"
-        )
-#endif
-    }
-
-    @discardableResult
-    func recoverTerminatedWebContent(
-        reason: String = "manual",
-        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
-    ) -> Bool {
-        guard hasRecoverableWebContentTermination else { return false }
-        let recoveryURL = pendingWebContentRecoveryURL
-        clearWebContentTerminationRecovery()
-#if DEBUG
-        cmuxDebugLog(
-            "browser.webcontent.recover panel=\(id.uuidString.prefix(5)) " +
-            "reason=\(reason) url=\(recoveryURL?.absoluteString ?? "nil")"
-        )
-#endif
-        guard let recoveryURL else {
-            refreshNavigationAvailability()
-            return true
-        }
-        navigateWithoutInsecureHTTPPrompt(
-            to: recoveryURL,
-            recordTypedNavigation: false,
-            preserveRestoredSessionHistory: true,
-            cachePolicy: cachePolicy
-        )
-        return true
-    }
-
-    private func clearWebContentTerminationRecovery() {
-        pendingWebContentRecoveryURL = nil
-        hasRecoverableWebContentTermination = false
-    }
-
-#if DEBUG
-    func debugSimulateWebContentProcessTermination() {
-        replaceWebViewAfterContentProcessTermination(for: webView)
-    }
-#endif
 
     // MARK: - Panel Protocol
 
@@ -5568,7 +5483,17 @@ final class BrowserPanel: Panel, ObservableObject {
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         cancelHiddenWebViewDiscard()
-        clearWebContentTerminationRecovery()
+        if hasRecoverableWebContentTermination {
+            _ = replaceWebViewPreservingState(
+                from: webView,
+                websiteDataStore: websiteDataStore,
+                reason: "webcontent_recovery.navigation",
+                overrideRestoreURL: originalURL,
+                restoreAfterReplacement: false
+            )
+        } else {
+            clearWebContentTerminationRecovery()
+        }
         if !preserveRestoredSessionHistory {
             abandonRestoredSessionHistoryIfNeeded()
         }
@@ -5914,10 +5839,15 @@ extension BrowserPanel: BrowserHiddenWebViewDiscardManagerDelegate {
             isVisibleInUI: isWebViewVisibleInUI,
             shouldRenderWebView: shouldRenderWebView,
             hasPendingRemoteNavigation: pendingRemoteNavigation != nil,
-            hasCurrentURL: (currentURL ?? Self.remoteProxyDisplayURL(for: webView.url)) != nil,
+            hasCurrentURL: (
+                currentURL
+                    ?? pendingWebContentRecoveryURL
+                    ?? Self.remoteProxyDisplayURL(for: webView.url)
+            ) != nil,
             isLoading: isLoading,
             webViewIsLoading: webView.isLoading,
             hasActiveMainFrameProvisionalNavigation: isMainFrameProvisionalNavigationActive,
+            hasRecoverableWebContentTermination: hasRecoverableWebContentTermination,
             isDownloading: isDownloading,
             activeDownloadCount: activeDownloadCount,
             preferredDeveloperToolsVisible: preferredDeveloperToolsVisible,
@@ -7827,7 +7757,7 @@ extension BrowserPanel {
         return searchFocusRequestGeneration
     }
 
-    private func invalidateSearchFocusRequests(reason: String) {
+    func invalidateSearchFocusRequests(reason: String) {
         searchFocusRequestGeneration &+= 1
 #if DEBUG
         cmuxDebugLog(
@@ -7906,6 +7836,11 @@ extension BrowserPanel {
     }
 
     func refreshNavigationAvailability() {
+        if hasRecoverableWebContentTermination {
+            if canGoBack { canGoBack = false }
+            if canGoForward { canGoForward = false }
+            return
+        }
         let availability = restoredSessionHistory.availability(
             nativeCanGoBack: nativeCanGoBack,
             nativeCanGoForward: nativeCanGoForward
@@ -7949,7 +7884,7 @@ extension BrowserPanel {
 }
 
 extension BrowserPanel {
-    private func applyBrowserThemeModeIfNeeded() {
+    func applyBrowserThemeModeIfNeeded() {
         BrowserThemeSettings.apply(browserThemeMode, to: webView)
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -496,7 +496,7 @@ struct BrowserPanelView: View {
 
     private var shouldRenderOmnibarSuggestionsInPortal: Bool {
         hasVisibleOmnibarSuggestions &&
-            panel.shouldRenderWebView
+            panel.shouldAttachWebViewInUI
     }
 
     private var shouldRenderOmnibarSuggestionsInSwiftUI: Bool {
@@ -1836,7 +1836,7 @@ struct BrowserPanelView: View {
         let useLocalInlineDeveloperToolsHosting = canvasInlineBrowserHosting
 
         return Group {
-            if panel.shouldRenderWebView {
+            if panel.shouldAttachWebViewInUI {
                 WebViewRepresentable(
                     panel: panel,
                     paneId: paneId,

--- a/Sources/Panels/ReactGrab.swift
+++ b/Sources/Panels/ReactGrab.swift
@@ -226,6 +226,12 @@ extension BrowserPanel {
         webView.configuration.userContentController.add(handler, name: reactGrabMessageHandlerName)
     }
 
+    func tearDownReactGrabMessageHandler(for webView: WKWebView, reason: String = "unspecified") {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: reactGrabMessageHandlerName)
+        reactGrabMessageHandler = nil
+        resetReactGrabState(reason: reason)
+    }
+
     func armReactGrabRoundTrip(returnTo panelId: UUID) {
         let token = UUID().uuidString
 #if DEBUG

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */; };
 		C67540060000000000000001 /* BrowserPanel+PDFDocumentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540060000000000000002 /* BrowserPanel+PDFDocumentActions.swift */; };
 		B424PWAD000000000000PW01 /* BrowserPanel+PrewarmedWebViewAdoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PWAD000000000000PW02 /* BrowserPanel+PrewarmedWebViewAdoption.swift */; };
+		C0DE47010000000000000001 /* BrowserPanel+WebContentTermination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE47010000000000000002 /* BrowserPanel+WebContentTermination.swift */; };
 		A5001402 /* BrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001412 /* BrowserPanel.swift */; };
 		B1F0C0090000000000000001 /* BrowserPanelDeveloperToolsLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0090000000000000002 /* BrowserPanelDeveloperToolsLifecycle.swift */; };
 		C62530010000000000000001 /* BrowserPanelReloadMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62530010000000000000002 /* BrowserPanelReloadMode.swift */; };
@@ -4244,6 +4245,7 @@
 		D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		C67540060000000000000002 /* BrowserPanel+PDFDocumentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+PDFDocumentActions.swift"; sourceTree = "<group>"; };
 		B424PWAD000000000000PW02 /* BrowserPanel+PrewarmedWebViewAdoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+PrewarmedWebViewAdoption.swift"; sourceTree = "<group>"; };
+		C0DE47010000000000000002 /* BrowserPanel+WebContentTermination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+WebContentTermination.swift"; sourceTree = "<group>"; };
 		A5001412 /* BrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanel.swift; sourceTree = "<group>"; };
 		B1F0C0090000000000000002 /* BrowserPanelDeveloperToolsLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelDeveloperToolsLifecycle.swift; sourceTree = "<group>"; };
 		C62530010000000000000002 /* BrowserPanelReloadMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelReloadMode.swift; sourceTree = "<group>"; };
@@ -9327,6 +9329,7 @@
 				805600000000000000000006 /* TerminalController+BrowserViewport.swift */,
 				A12451000000000000000003 /* TerminalController+BrowserDownloadHistory.swift */,
 				8054A0020000000000000002 /* BrowserPanel+AutomationRecovery.swift */,
+				C0DE47010000000000000002 /* BrowserPanel+WebContentTermination.swift */,
 				8054B0020000000000000002 /* BrowserWebViewLifecycleState.swift */,
 				B1F0C0090000000000000002 /* BrowserPanelDeveloperToolsLifecycle.swift */,
 				C2035A010000000000000002 /* BrowserErrorPage.swift */,
@@ -12077,6 +12080,7 @@
 				D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */,
 				C67540060000000000000001 /* BrowserPanel+PDFDocumentActions.swift in Sources */,
 				B424PWAD000000000000PW01 /* BrowserPanel+PrewarmedWebViewAdoption.swift in Sources */,
+				C0DE47010000000000000001 /* BrowserPanel+WebContentTermination.swift in Sources */,
 				A5001402 /* BrowserPanel.swift in Sources */,
 				B1F0C0090000000000000001 /* BrowserPanelDeveloperToolsLifecycle.swift in Sources */,
 				C62530010000000000000001 /* BrowserPanelReloadMode.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 		A50100000000000000000020 /* BrowserWebAuthnTransportSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */; };
 		A50100000000000000000022 /* BrowserWebAuthnUserDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */; };
 		C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */; };
+		C0DE49870000000000000003 /* BrowserWebContentTerminationLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49870000000000000004 /* BrowserWebContentTerminationLifecycleTests.swift */; };
 		C0DE58990000000000000003 /* BrowserWebKitKeyDownDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */; };
 		8054B0010000000000000001 /* BrowserWebViewLifecycleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8054B0020000000000000002 /* BrowserWebViewLifecycleState.swift */; };
 		A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
@@ -933,6 +934,7 @@
 		D59CC3EA15344B47915B3779 /* CloudWorkspaceProjectionEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFE35D27805468DBA885560 /* CloudWorkspaceProjectionEnvironment.swift */; };
 		CD3F805069CA4CE1B3987C05 /* CloudWorkspaceProjectionPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1660E446B91349C08725BFFF /* CloudWorkspaceProjectionPlan.swift */; };
 		2E5A89D8BBDB410B8BC59557 /* CloudWorkspaceProjectionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5D0FC63C854C90B2974F39 /* CloudWorkspaceProjectionTask.swift */; };
+		F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */; };
 		ED654029AEB34F08A9420402 /* CloudWorkspaceRenameService+Reconciliation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEB2668D80B41349D7CA539 /* CloudWorkspaceRenameService+Reconciliation.swift */; };
 		B12438010000000000000001 /* CloudWorkspaceRestoreNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12438010000000000000002 /* CloudWorkspaceRestoreNamesTests.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
@@ -3470,7 +3472,6 @@
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		4F2E42F6D7164832B891F079 /* Workspace+CloudLayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085BB53F552B4C6A8728941E /* Workspace+CloudLayoutProjection.swift */; };
 		C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11323020000000000000001 /* Workspace+CloudManualMirror.swift */; };
-		F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */; };
 		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */; };
 		05944A51F29C4C628EA7107B /* Workspace+CloudRenameFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4321A9DE80444085D19939 /* Workspace+CloudRenameFailure.swift */; };
@@ -4332,6 +4333,7 @@
 		A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnTransportSummary.swift; sourceTree = "<group>"; };
 		A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnUserDescriptor.swift; sourceTree = "<group>"; };
 		C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWebContentProcessTests.swift; sourceTree = "<group>"; };
+		C0DE49870000000000000004 /* BrowserWebContentTerminationLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWebContentTerminationLifecycleTests.swift; sourceTree = "<group>"; };
 		C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebKitKeyDownDispatch.swift; sourceTree = "<group>"; };
 		8054B0020000000000000002 /* BrowserWebViewLifecycleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebViewLifecycleState.swift; sourceTree = "<group>"; };
 		A5001533 /* BrowserWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortal.swift; sourceTree = "<group>"; };
@@ -4691,6 +4693,7 @@
 		0DFE35D27805468DBA885560 /* CloudWorkspaceProjectionEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceProjectionEnvironment.swift"; sourceTree = "<group>"; };
 		1660E446B91349C08725BFFF /* CloudWorkspaceProjectionPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceProjectionPlan.swift"; sourceTree = "<group>"; };
 		1A5D0FC63C854C90B2974F39 /* CloudWorkspaceProjectionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceProjectionTask.swift"; sourceTree = "<group>"; };
+		F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceRenameService+Directory.swift"; sourceTree = "<group>"; };
 		BFEB2668D80B41349D7CA539 /* CloudWorkspaceRenameService+Reconciliation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceRenameService+Reconciliation.swift"; sourceTree = "<group>"; };
 		B12438010000000000000002 /* CloudWorkspaceRestoreNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudWorkspaceRestoreNamesTests.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7107,7 +7110,6 @@
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		085BB53F552B4C6A8728941E /* Workspace+CloudLayoutProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudLayoutProjection.swift"; sourceTree = "<group>"; };
 		C11323020000000000000001 /* Workspace+CloudManualMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudManualMirror.swift"; sourceTree = "<group>"; };
-		F3C1A7B40000000000000006 /* CloudWorkspaceRenameService+Directory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudWorkspaceRenameService+Directory.swift"; sourceTree = "<group>"; };
 		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		2B46AEF9309B83E909710517 /* Workspace+CloudPlacementFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPlacementFailure.swift"; sourceTree = "<group>"; };
 		FA4321A9DE80444085D19939 /* Workspace+CloudRenameFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudRenameFailure.swift"; sourceTree = "<group>"; };
@@ -10427,6 +10429,7 @@
 				C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */,
 				C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
+				C0DE49870000000000000004 /* BrowserWebContentTerminationLifecycleTests.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
 				D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */,
@@ -12351,6 +12354,7 @@
 				D59CC3EA15344B47915B3779 /* CloudWorkspaceProjectionEnvironment.swift in Sources */,
 				CD3F805069CA4CE1B3987C05 /* CloudWorkspaceProjectionPlan.swift in Sources */,
 				2E5A89D8BBDB410B8BC59557 /* CloudWorkspaceProjectionTask.swift in Sources */,
+				F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */,
 				ED654029AEB34F08A9420402 /* CloudWorkspaceRenameService+Reconciliation.swift in Sources */,
 				A5001654 /* CmuxActionTrust.swift in Sources */,
 				C0DE43000000000000000001 /* CmuxAgentChatConfig.swift in Sources */,
@@ -13936,7 +13940,6 @@
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				4F2E42F6D7164832B891F079 /* Workspace+CloudLayoutProjection.swift in Sources */,
 				C11323010000000000000001 /* Workspace+CloudManualMirror.swift in Sources */,
-				F3C1A7B40000000000000005 /* CloudWorkspaceRenameService+Directory.swift in Sources */,
 				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				74ED9CE6230A97ED8BBCAB0C /* Workspace+CloudPlacementFailure.swift in Sources */,
 				05944A51F29C4C628EA7107B /* Workspace+CloudRenameFailure.swift in Sources */,
@@ -14506,6 +14509,7 @@
 				D8072A02D8072A02D8072A02 /* BrowserViewportRuntimeLoadDelegate.swift in Sources */,
 				D8072A04D8072A04D8072A04 /* BrowserViewportRuntimeTests.swift in Sources */,
 				C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */,
+				C0DE49870000000000000003 /* BrowserWebContentTerminationLifecycleTests.swift in Sources */,
 				C0DE62600000000000000001 /* BrowserWindowPortalRegistryNotificationTests.swift in Sources */,
 				C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */,
 				CAFE00000000000000000006 /* CaffeineControllerTests.swift in Sources */,

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2940,29 +2940,12 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         )
     }
 
-    func testWebViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {
-        let panel = BrowserPanel(
-            workspaceId: UUID(),
-            initialURL: URL(string: "https://example.com")
-        )
-        defer { panel.close() }
-        let oldWebView = panel.webView
-        let oldInstanceID = panel.webViewInstanceID
-
-        panel.debugSimulateWebContentProcessTermination()
-
-        XCTAssertFalse(panel.webView === oldWebView)
-        XCTAssertNotEqual(panel.webViewInstanceID, oldInstanceID)
-        XCTAssertNotNil(panel.webView.navigationDelegate)
-        XCTAssertNotNil(panel.webView.uiDelegate)
-    }
-
     func testWebViewReplacementPreservesEmptyNewTabRenderState() {
         let panel = BrowserPanel(workspaceId: UUID())
         defer { panel.close() }
         XCTAssertFalse(panel.shouldRenderWebView)
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
 
         XCTAssertFalse(panel.shouldRenderWebView)
     }

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -1073,7 +1073,7 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
-    func webViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {
+    func webContentProcessTerminationDefersReplacementUntilExplicitRecovery() {
         let panel = BrowserPanel(
             workspaceId: UUID(),
             initialURL: recoveryURL
@@ -1086,57 +1086,22 @@ struct BrowserWebContentProcessTests {
         #expect(oldWebView.superview == nil)
         #expect(oldWebView.cmuxBrowserViewportHostView === viewportHost)
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
 
+        #expect(panel.webView === oldWebView)
+        #expect(panel.webViewInstanceID == oldInstanceID)
+        #expect(panel.hasRecoverableWebContentTermination)
+        #expect(oldWebView.navigationDelegate == nil)
+        #expect(oldWebView.uiDelegate == nil)
+
+        #expect(panel.recoverTerminatedWebContent(reason: "test"))
         #expect(!(panel.webView === oldWebView))
         #expect(panel.webViewInstanceID != oldInstanceID)
-        #expect(panel.hasRecoverableWebContentTermination)
         #expect(panel.webView.navigationDelegate != nil)
         #expect(panel.webView.uiDelegate != nil)
         #expect(panel.webView.superview == nil)
         #expect(panel.webView.cmuxBrowserViewportHostView === viewportHost)
         #expect(oldWebView.cmuxBrowserViewportHostView == nil)
-    }
-
-    @Test
-    func webViewReplacementPreservesActiveEmulatedViewportHost() throws {
-        let panel = BrowserPanel(
-            workspaceId: UUID(),
-            initialURL: recoveryURL
-        )
-        defer { panel.close() }
-        let oldWebView = panel.webView
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 610))
-        container.addSubview(oldWebView)
-        let viewport = try #require(BrowserViewport(width: 1_280, height: 720))
-        _ = try panel.setAutomationViewport(viewport).get()
-
-        #expect(oldWebView.superview === panel.viewportHostView)
-
-        panel.debugSimulateWebContentProcessTermination()
-
-        #expect(!(panel.webView === oldWebView))
-        #expect(panel.webView.superview === panel.viewportHostView)
-        #expect(panel.webView.cmuxBrowserViewportPresentationView === panel.viewportHostView)
-        #expect(panel.webView.cmuxBrowserViewportHostView === panel.viewportHostView)
-        #expect(oldWebView.cmuxBrowserViewportHostView == nil)
-    }
-
-    @Test
-    func remoteWorkspaceWebsiteDataStoreSurvivesWebViewReplacement() {
-        let storeIdentifier = UUID()
-        let panel = BrowserPanel(
-            workspaceId: UUID(),
-            initialURL: recoveryURL,
-            isRemoteWorkspace: true,
-            remoteWebsiteDataStoreIdentifier: storeIdentifier
-        )
-        defer { panel.close() }
-        let originalStore = panel.webView.configuration.websiteDataStore
-
-        panel.debugSimulateWebContentProcessTermination()
-
-        #expect(panel.webView.configuration.websiteDataStore === originalStore)
     }
 
     @Test
@@ -1147,7 +1112,7 @@ struct BrowserWebContentProcessTests {
         )
         defer { panel.close() }
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
         #expect(panel.hasRecoverableWebContentTermination)
 
         panel.reload()
@@ -1164,7 +1129,7 @@ struct BrowserWebContentProcessTests {
         )
         defer { panel.close() }
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
         #expect(panel.hasRecoverableWebContentTermination)
 
         panel.resetForWorkspaceContextChange(reason: "test")
@@ -1188,7 +1153,7 @@ struct BrowserWebContentProcessTests {
         )
         defer { panel.close() }
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
         #expect(panel.hasRecoverableWebContentTermination)
 
         #expect(panel.switchToProfile(profile.id))
@@ -1202,7 +1167,7 @@ struct BrowserWebContentProcessTests {
         defer { panel.close() }
         #expect(!panel.shouldRenderWebView)
 
-        panel.debugSimulateWebContentProcessTermination()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
 
         #expect(!panel.shouldRenderWebView)
         #expect(!panel.hasRecoverableWebContentTermination)

--- a/cmuxTests/BrowserWebContentTerminationLifecycleTests.swift
+++ b/cmuxTests/BrowserWebContentTerminationLifecycleTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the WebKit process termination callback boundary.
+@MainActor
+@Suite(.serialized)
+struct BrowserWebContentTerminationLifecycleTests {
+    @Test
+    func terminationCallbackDoesNotReplaceWebViewInsideWebKitCallback() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.com/recovery")!
+        )
+        defer { panel.close() }
+
+        let originalWebView = panel.webView
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(originalWebView)
+
+        #expect(panel.webView === originalWebView)
+        #expect(originalWebView.navigationDelegate == nil)
+    }
+}

--- a/cmuxTests/BrowserWebContentTerminationLifecycleTests.swift
+++ b/cmuxTests/BrowserWebContentTerminationLifecycleTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 import WebKit
@@ -25,5 +26,80 @@ struct BrowserWebContentTerminationLifecycleTests {
 
         #expect(panel.webView === originalWebView)
         #expect(originalWebView.navigationDelegate == nil)
+    }
+
+    @Test
+    func recoverableTerminationBlocksHiddenDiscardUntilRecovery() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.com/recovery")!
+        )
+        defer { panel.close() }
+
+        panel.noteWebViewVisibility(false, reason: "test.hidden")
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
+
+        #expect(panel.hasRecoverableWebContentTermination)
+        #expect(panel.webViewLifecycleTopPayload()["discard_blockers"] as? [String] == ["webcontent_recovery"])
+        #expect(!panel.discardHiddenWebViewForMemory(reason: "test.hidden_timer"))
+    }
+
+    @Test
+    func systemMemoryPressureCanReclaimRecoverableHiddenWebView() {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.com/recovery")!
+        )
+        defer { panel.close() }
+
+        panel.noteWebViewVisibility(false, reason: "test.hidden")
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(panel.webView)
+
+        #expect(panel.hasRecoverableWebContentTermination)
+        #expect(panel.discardHiddenWebViewForSystemMemoryPressure(now: Date(timeIntervalSince1970: 10_000)))
+        #expect(!panel.hasRecoverableWebContentTermination)
+        #expect(!panel.shouldRenderWebView)
+    }
+
+    @Test
+    func recoveryPreservesActiveEmulatedViewportHost() throws {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.com/recovery")!
+        )
+        defer { panel.close() }
+
+        let oldWebView = panel.webView
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 610))
+        container.addSubview(oldWebView)
+        let viewport = try #require(BrowserViewport(width: 1_280, height: 720))
+        _ = try panel.setAutomationViewport(viewport).get()
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(oldWebView)
+
+        #expect(panel.webView === oldWebView)
+        #expect(panel.recoverTerminatedWebContent(reason: "test"))
+        #expect(panel.webView.superview === panel.viewportHostView)
+        #expect(panel.webView.cmuxBrowserViewportPresentationView === panel.viewportHostView)
+        #expect(panel.webView.cmuxBrowserViewportHostView === panel.viewportHostView)
+        #expect(oldWebView.cmuxBrowserViewportHostView == nil)
+    }
+
+    @Test
+    func recoveryPreservesRemoteWorkspaceWebsiteDataStore() {
+        let storeIdentifier = UUID()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: URL(string: "https://example.com/recovery")!,
+            isRemoteWorkspace: true,
+            remoteWebsiteDataStoreIdentifier: storeIdentifier
+        )
+        defer { panel.close() }
+
+        let originalStore = panel.webView.configuration.websiteDataStore
+        let oldWebView = panel.webView
+        panel.webView.navigationDelegate?.webViewWebContentProcessDidTerminate?(oldWebView)
+        #expect(panel.webView === oldWebView)
+        #expect(panel.recoverTerminatedWebContent(reason: "test"))
+        #expect(panel.webView.configuration.websiteDataStore === originalStore)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/4701.

## Summary
When WebKit reports that a browser WebContent process terminated, cmux used to tear down and replace the `WKWebView` synchronously from that WebKit callback. On macOS 26, that can overlap WebKit's provisional-page attach path (`finishAttachingToWebProcess` → `updateActivityState`) and take down the entire app.

The browser panel now owns an explicit recoverable-termination state. The callback records the recovery URL, clears stale page activity, detaches the terminated view's callbacks, and withholds portal mounting. A replacement is created only through explicit reload/navigation recovery, while hidden WebView discard is blocked during recovery (system memory pressure may still reclaim it while preserving the URL). Observer generations reject stale KVO deliveries.

The lifecycle implementation is extracted into `BrowserPanel+WebContentTermination.swift` to stay within the Swift file-length budget. No user-facing strings or keyboard shortcuts changed.

## Reproduction
The original report says: “Not reproduced deterministically.” I followed the documented family repro from the related reports: open a browser pane, switch workspaces to hide it, kill its attributed WebContent process, then reveal/reload it. On macOS 26.5 (`cmux-austin-mini-1`) the app survived the kill/reveal/reload cycle on 0.64.17; the native SIGSEGV itself did not reproduce. The app-side hazard was the synchronous replacement path, which this change removes.

## Investigation
Sentry shows this exact WebKit `updateActivityState` attach signature in 0.64.9 (19 events), with the largest volume in 0.64.17 (1,923 events in the attach-family query). The current 0.64.22 release still has related WebKit attach events, so this is not treated as a release-specific duplicate.

Open reports #6911 and #7270 reproduce the same Apple WebKit stack on 0.64.17 after the earlier sleep/wake mitigation. Their timing and lifecycle triggers overlap this report, but the reports do not prove a single WebKit or cmux root cause; this PR addresses the shared cmux-side invariant: a WebView whose WebContent process has terminated must not be synchronously replaced or mounted while WebKit can still deliver provisional-page attach IPC. Upstream WebKit commit `314838@main` fixes a related null `PageClient` dereference, which confirms that the final null safety belongs upstream as well; cmux can only avoid provoking the unsafe lifecycle window.

## Validation
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- `swiftc -parse` on all changed Swift files
- Tagged cloud build from pushed HEAD `bc6d2e002f` attempted with `CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-4701-webkit-crash --launch --no-dev-backend`; the browser lifecycle files compiled, while the build stopped on seven unrelated invalid redeclarations in `CmuxTuiSurfaceProvider+TerminalIO.swift` and `CmuxTuiSurfaceProviders.swift`, which are present in the merged `origin/main` baseline.
- Hosted focused lifecycle run `34761155914` on the browser fix tree compiled through the browser target and explicit `CmuxBrowser` import, then stopped before selected tests on the unrelated pre-existing recursive Swift Testing `#require` macro in `cmuxTests/CmuxTuiSurfaceProviderTests.swift`. No local Xcode build or test was run.
- On macOS 26.5, the released baseline followed the report's exact statement “Not reproduced deterministically.” and the related family sequence: open a browser pane to `https://example.org`, hide it in another workspace, kill its WebContent PID, reveal it, and reload. The app stayed alive and the browser surface remained present after the kill/reveal; the native SIGSEGV did not reproduce. Evidence is retained in the cloud recording and lifecycle logs.
- No user-facing strings, localization entries, or keyboard shortcuts changed; the existing localized reload UI is reused and the localization audit found no new strings.

The regression test and fix remain split in history: `8d41c775fe` is the failing-test commit, followed by the fix commits through `bc6d2e002f`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791893072&installation_model_id=21920&pr_number=12519&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12519&signature=f28317fd1009e0623016071611350998e61f22c4ba7319f1bc88241d12321ba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4701 by deferring WebKit WebContent termination recovery until an explicit reload or navigation. The termination callback no longer replaces the `WKWebView`; it detaches the terminated view's callbacks, clears stale page and media state, and withholds portal mounting until explicit recovery.

**Notes**
- Records the recovery URL when one exists; panes without a URL still enter the recoverable state.
- Explicit recovery creates a fresh `WKWebView` and preserves session history, zoom, developer tools state, and the current website data store.
- Hidden-WebView discard is blocked during recovery; system memory pressure can still reclaim the view while preserving the recovery URL.
- Stale KVO and ReactGrab deliveries from the terminated WebView are rejected via observer generations and view identity checks.
- Lifecycle logic moved to `BrowserPanel+WebContentTermination.swift`; no user-facing strings or keyboard shortcuts changed.
- Adds regression tests for termination-callback behavior, recovery, memory-pressure discard, and revealed history restoration.

<sup>Written for commit 819f3e74a020c432a2dac4e31453c8fa3c4a4a83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after unexpected web content process termination.
  * Added reliable manual page recovery after a web content failure.
  * Preserves navigation, zoom, developer tools, and relevant browser state when restoring a page.
  * Prevents premature hidden-tab cleanup while recovery is available, while still allowing cleanup during system memory pressure.
  * Improved media playback and interactive web tool handling when replacing a terminated page.
  * Maintains correct empty-tab and placeholder displays while a page is recovering.
  * Prevents outdated web view callbacks from affecting the active page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




