### PR TITLE
Preserve Subrouter Codex restore routing on current main

### DIFF
--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -8,7 +8,8 @@ extension CMUXCLI {
             var selected: [String: Any] = [:]
             for (key, value) in dictionary
                 where !key.hasPrefix("SUBROUTER_CODEX_")
-                    && key != SubrouterCodexResumeRouting.launchBoundEnvironmentKey {
+                    && key != SubrouterCodexResumeRouting.launchBoundEnvironmentKey
+                    && key != "CMUX_CUSTOM_CODEX_PATH" {
                 selected[key] = publicSurfaceResumePayload(value)
             }
             return selected
@@ -18,7 +19,7 @@ extension CMUXCLI {
             where value.contains("SUBROUTER_CODEX_")
                 || value.contains("model_provider=subrouter")
                 || value.contains("model_providers.subrouter."):
-            return "[private routing metadata]"
+            return NSNull()
         default:
             return object
         }

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -11,6 +11,10 @@ extension CMUXCLI {
             return selected
         case let array as [Any]:
             return array.map(publicSurfaceResumePayload)
+        case let value as String
+            where value.contains("SUBROUTER_CODEX_")
+                || value.contains("model_providers.subrouter."):
+            return "[private routing metadata]"
         default:
             return object
         }

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -1,6 +1,21 @@
 import Foundation
 
 extension CMUXCLI {
+    func publicSurfaceResumePayload(_ object: Any) -> Any {
+        switch object {
+        case let dictionary as [String: Any]:
+            var selected: [String: Any] = [:]
+            for (key, value) in dictionary where !key.hasPrefix("SUBROUTER_CODEX_") {
+                selected[key] = publicSurfaceResumePayload(value)
+            }
+            return selected
+        case let array as [Any]:
+            return array.map(publicSurfaceResumePayload)
+        default:
+            return object
+        }
+    }
+
     func jsonString(_ object: Any) -> String {
         var options: JSONSerialization.WritingOptions = [.prettyPrinted]
         options.insert(.sortedKeys)

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -6,32 +6,32 @@ extension CMUXCLI {
         switch object {
         case let dictionary as [String: Any]:
             var selected: [String: Any] = [:]
+            let commandContainsPrivateEnvironment = (dictionary["environment"] as? [String: Any])?
+                .keys
+                .contains(where: isPrivateSubrouterRoutingKey) == true
             for (key, value) in dictionary
-                where !key.hasPrefix("SUBROUTER_CODEX_")
-                    && key != SubrouterCodexResumeRouting.launchBoundEnvironmentKey
-                    && key != "CMUX_CUSTOM_CODEX_PATH" {
-                selected[key] = publicSurfaceResumePayload(value)
+                where !isPrivateSubrouterRoutingKey(key) {
+                if key == "command", commandContainsPrivateEnvironment {
+                    selected[key] = NSNull()
+                } else if key == "arguments", let arguments = value as? [String] {
+                    selected[key] = SubrouterCodexResumeRouting()
+                        .removingPrivateRoutingArguments(from: arguments)
+                } else {
+                    selected[key] = publicSurfaceResumePayload(value)
+                }
             }
             return selected
         case let array as [Any]:
             return array.map(publicSurfaceResumePayload)
-        case let value as String where containsPrivateSubrouterRoutingMetadata(value):
-            return NSNull()
         default:
             return object
         }
     }
 
-    private func containsPrivateSubrouterRoutingMetadata(_ value: String) -> Bool {
-        if value.contains("SUBROUTER_CODEX_") || value.contains("model_providers.subrouter.") {
-            return true
-        }
-        let normalized = value.filter {
-            !$0.isWhitespace && $0 != "\"" && $0 != "'"
-        }
-        // `sr`/`subrouter`/`cx` are user-facing launcher names and remain public;
-        // only captured routing inputs and internal provider configuration are private.
-        return normalized.contains("model_provider=subrouter")
+    private func isPrivateSubrouterRoutingKey(_ key: String) -> Bool {
+        key.hasPrefix("SUBROUTER_CODEX_")
+            || key == SubrouterCodexResumeRouting.launchBoundEnvironmentKey
+            || key == "CMUX_CUSTOM_CODEX_PATH"
     }
 
     func jsonString(_ object: Any) -> String {

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -6,12 +6,18 @@ extension CMUXCLI {
         switch object {
         case let dictionary as [String: Any]:
             var selected: [String: Any] = [:]
-            let commandContainsPrivateEnvironment = (dictionary["environment"] as? [String: Any])?
-                .keys
-                .contains(where: isPrivateSubrouterRoutingKey) == true
+            let commandContainsPrivateEnvironment = containsPrivateSubrouterRoutingKey(
+                in: dictionary["environment"]
+            )
+            let legacyCommandContainsPrivateEnvironment = commandContainsPrivateEnvironment
+                || containsPrivateSubrouterRoutingKey(
+                    in: (dictionary["launch_command"] as? [String: Any])?["environment"]
+                )
             for (key, value) in dictionary
                 where !isPrivateSubrouterRoutingKey(key) {
                 if key == "command", commandContainsPrivateEnvironment {
+                    selected[key] = NSNull()
+                } else if key == "legacy_command", legacyCommandContainsPrivateEnvironment {
                     selected[key] = NSNull()
                 } else if key == "arguments", let arguments = value as? [String] {
                     selected[key] = SubrouterCodexResumeRouting()
@@ -26,6 +32,12 @@ extension CMUXCLI {
         default:
             return object
         }
+    }
+
+    private func containsPrivateSubrouterRoutingKey(in value: Any?) -> Bool {
+        (value as? [String: Any])?
+            .keys
+            .contains(where: isPrivateSubrouterRoutingKey) == true
     }
 
     private func isPrivateSubrouterRoutingKey(_ key: String) -> Bool {

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -6,22 +6,31 @@ extension CMUXCLI {
         switch object {
         case let dictionary as [String: Any]:
             var selected: [String: Any] = [:]
+            let directPrivateEnvironment = dictionary["environment"]
+            let nestedLaunchEnvironment = (dictionary["launch_command"] as? [String: Any])?["environment"]
             let commandContainsPrivateEnvironment = containsPrivateSubrouterRoutingKey(
-                in: dictionary["environment"]
+                in: directPrivateEnvironment
             )
             let legacyCommandContainsPrivateEnvironment = commandContainsPrivateEnvironment
                 || containsPrivateSubrouterRoutingKey(
-                    in: (dictionary["launch_command"] as? [String: Any])?["environment"]
+                    in: nestedLaunchEnvironment
                 )
+            let privateRoutingValues = privateSubrouterRoutingValues(in: directPrivateEnvironment)
+                .union(privateSubrouterRoutingValues(in: nestedLaunchEnvironment))
             for (key, value) in dictionary
                 where !isPrivateSubrouterRoutingKey(key) {
                 if key == "command", commandContainsPrivateEnvironment {
                     selected[key] = NSNull()
                 } else if key == "legacy_command", legacyCommandContainsPrivateEnvironment {
                     selected[key] = NSNull()
-                } else if key == "arguments", let arguments = value as? [String] {
-                    selected[key] = SubrouterCodexResumeRouting()
-                        .removingPrivateRoutingArguments(from: arguments)
+                } else if (key == "arguments" || key == "prepared_arguments"),
+                          let arguments = value as? [String] {
+                    selected[key] = publicRoutingArguments(
+                        arguments,
+                        privateValues: privateRoutingValues
+                    )
+                } else if let value = value as? String, privateRoutingValues.contains(value) {
+                    selected[key] = NSNull()
                 } else {
                     selected[key] = publicSurfaceResumePayload(value)
                 }
@@ -38,6 +47,27 @@ extension CMUXCLI {
         (value as? [String: Any])?
             .keys
             .contains(where: isPrivateSubrouterRoutingKey) == true
+    }
+
+    private func privateSubrouterRoutingValues(in value: Any?) -> Set<String> {
+        guard let environment = value as? [String: Any] else { return [] }
+        return Set(environment.compactMap { key, value in
+            guard isPrivateSubrouterRoutingKey(key), let value = value as? String else {
+                return nil
+            }
+            return value
+        })
+    }
+
+    private func publicRoutingArguments(
+        _ arguments: [String],
+        privateValues: Set<String>
+    ) -> [Any] {
+        SubrouterCodexResumeRouting()
+            .removingPrivateRoutingArguments(from: arguments)
+            .map { argument -> Any in
+                privateValues.contains(argument) ? NSNull() : argument
+            }
     }
 
     private func isPrivateSubrouterRoutingKey(_ key: String) -> Bool {

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
@@ -5,7 +6,9 @@ extension CMUXCLI {
         switch object {
         case let dictionary as [String: Any]:
             var selected: [String: Any] = [:]
-            for (key, value) in dictionary where !key.hasPrefix("SUBROUTER_CODEX_") {
+            for (key, value) in dictionary
+                where !key.hasPrefix("SUBROUTER_CODEX_")
+                    && key != SubrouterCodexResumeRouting.launchBoundEnvironmentKey {
                 selected[key] = publicSurfaceResumePayload(value)
             }
             return selected
@@ -13,6 +16,7 @@ extension CMUXCLI {
             return array.map(publicSurfaceResumePayload)
         case let value as String
             where value.contains("SUBROUTER_CODEX_")
+                || value.contains("model_provider=subrouter")
                 || value.contains("model_providers.subrouter."):
             return "[private routing metadata]"
         default:

--- a/CLI/CMUXCLI+JSONOutput.swift
+++ b/CLI/CMUXCLI+JSONOutput.swift
@@ -15,14 +15,23 @@ extension CMUXCLI {
             return selected
         case let array as [Any]:
             return array.map(publicSurfaceResumePayload)
-        case let value as String
-            where value.contains("SUBROUTER_CODEX_")
-                || value.contains("model_provider=subrouter")
-                || value.contains("model_providers.subrouter."):
+        case let value as String where containsPrivateSubrouterRoutingMetadata(value):
             return NSNull()
         default:
             return object
         }
+    }
+
+    private func containsPrivateSubrouterRoutingMetadata(_ value: String) -> Bool {
+        if value.contains("SUBROUTER_CODEX_") || value.contains("model_providers.subrouter.") {
+            return true
+        }
+        let normalized = value.filter {
+            !$0.isWhitespace && $0 != "\"" && $0 != "'"
+        }
+        // `sr`/`subrouter`/`cx` are user-facing launcher names and remain public;
+        // only captured routing inputs and internal provider configuration are private.
+        return normalized.contains("model_provider=subrouter")
     }
 
     func jsonString(_ object: Any) -> String {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31134,9 +31134,8 @@ struct CMUXCLI {
             ?? normalizedHookValue(env["PWD"])
         var environment = selectedAgentLaunchEnvironment(from: env, kind: launcher)
         let subrouterRouting = SubrouterCodexResumeRouting()
-        if fallbackKind == "codex",
-           let marker = subrouterRouting.capturedMarker(in: env) {
-            environment[SubrouterCodexResumeRouting.environmentKey] = marker
+        if fallbackKind == "codex" {
+            environment.merge(subrouterRouting.capturedEnvironment(in: env)) { _, captured in captured }
         }
         // HOME is intentionally not part of the replay environment: changing
         // it for every restored agent can redirect unrelated config and caches.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9152,7 +9152,8 @@ struct CMUXCLI {
             } else if let binding = payload["resume_binding"] as? [String: Any],
                       let command = binding["command"] as? String,
                       !command.isEmpty {
-                if let publicCommand = publicSurfaceResumePayload(command) as? String {
+                let publicBinding = publicSurfaceResumePayload(binding) as? [String: Any]
+                if let publicCommand = publicBinding?["command"] as? String {
                     print(publicCommand)
                 } else {
                     print("null")

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31186,12 +31186,20 @@ struct CMUXCLI {
             // replace it with an env-only fallback.
             return AgentHookLaunchCommandRecord(launcher: launcher, executablePath: executablePath, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "rejected")
         }
+        let replayArguments = fallbackKind == "codex"
+            ? subrouterRouting.retainingRoutingProof(
+                in: sanitizedArguments,
+                from: arguments,
+                launcher: launcher,
+                environment: env
+            )
+            : sanitizedArguments
         let source = envArguments == nil ? "process" : "environment"
 
         return AgentHookLaunchCommandRecord(
             launcher: launcher,
             executablePath: executablePath,
-            arguments: sanitizedArguments,
+            arguments: replayArguments,
             workingDirectory: workingDirectory,
             environment: environment.isEmpty ? nil : environment,
             verificationHome: verificationHome,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7109,7 +7109,7 @@ struct CMUXCLI {
             if let wsId { params["workspace_id"] = wsId }
             let payload = try client.sendV2(method: "surface.list", params: params)
             if jsonOutput {
-                print(jsonString(formatIDs(payload, mode: idFormat)))
+                print(jsonString(formatIDs(publicSurfaceResumePayload(payload), mode: idFormat)))
             } else {
                 let surfaces = payload["surfaces"] as? [[String: Any]] ?? []
                 if surfaces.isEmpty {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31132,7 +31132,12 @@ struct CMUXCLI {
         let workingDirectory = (envCaptureIsTrusted ? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"]) : nil)
             ?? normalizedHookValue(cwd)
             ?? normalizedHookValue(env["PWD"])
-        let environment = selectedAgentLaunchEnvironment(from: env, kind: launcher)
+        var environment = selectedAgentLaunchEnvironment(from: env, kind: launcher)
+        let subrouterRouting = SubrouterCodexResumeRouting()
+        if fallbackKind == "codex",
+           let marker = subrouterRouting.capturedMarker(in: env) {
+            environment[SubrouterCodexResumeRouting.environmentKey] = marker
+        }
         // HOME is intentionally not part of the replay environment: changing
         // it for every restored agent can redirect unrelated config and caches.
         // Codex verification still needs the launch account's state root when
@@ -31415,7 +31420,8 @@ struct CMUXCLI {
             launcher: launchCommand?.launcher,
             sessionId: normalizedSessionId,
             executablePath: launchCommand?.executablePath,
-            arguments: launchCommand?.arguments ?? []
+            arguments: launchCommand?.arguments ?? [],
+            environment: launchCommand?.environment
         ) {
         case .resolved(let resolved):
             // Wrapper launchers include the claude-teams orphan-respawn path,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9152,7 +9152,11 @@ struct CMUXCLI {
             } else if let binding = payload["resume_binding"] as? [String: Any],
                       let command = binding["command"] as? String,
                       !command.isEmpty {
-                print(command)
+                if let publicCommand = publicSurfaceResumePayload(command) as? String {
+                    print(publicCommand)
+                } else {
+                    print("null")
+                }
             } else {
                 print("No resume binding")
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31135,7 +31135,10 @@ struct CMUXCLI {
         var environment = selectedAgentLaunchEnvironment(from: env, kind: launcher)
         let subrouterRouting = SubrouterCodexResumeRouting()
         if fallbackKind == "codex" {
-            environment.merge(subrouterRouting.capturedEnvironment(in: env)) { _, captured in captured }
+            var launchBoundEnvironment = env
+            launchBoundEnvironment[SubrouterCodexResumeRouting.environmentKey] =
+                env[SubrouterCodexResumeRouting.launchBoundEnvironmentKey]
+            environment.merge(subrouterRouting.capturedEnvironment(in: launchBoundEnvironment)) { _, captured in captured }
         }
         // HOME is intentionally not part of the replay environment: changing
         // it for every restored agent can redirect unrelated config and caches.
@@ -31191,7 +31194,7 @@ struct CMUXCLI {
                 in: sanitizedArguments,
                 from: arguments,
                 launcher: launcher,
-                environment: env
+                environment: environment
             )
             : sanitizedArguments
         let source = envArguments == nil ? "process" : "environment"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9148,7 +9148,7 @@ struct CMUXCLI {
             let params = try surfaceResumeTarget(rest, client: client, windowOverride: windowOverride).params
             let payload = try client.sendV2(method: "surface.resume.get", params: params)
             if jsonOutput {
-                print(jsonString(formatIDs(payload, mode: idFormat)))
+                print(jsonString(formatIDs(publicSurfaceResumePayload(payload), mode: idFormat)))
             } else if let binding = payload["resume_binding"] as? [String: Any],
                       let command = binding["command"] as? String,
                       !command.isEmpty {
@@ -31360,7 +31360,7 @@ struct CMUXCLI {
         if let resumeWorkingDirectory {
             params["cwd"] = resumeWorkingDirectory
         }
-        if let resumeEnvironment, !resumeEnvironment.isEmpty {
+        if !resumeEnvironment.isEmpty {
             params["environment"] = resumeEnvironment
         }
         if let launchCommand {
@@ -31569,16 +31569,15 @@ struct CMUXCLI {
     private func agentSurfaceResumeEnvironment(
         kind: String,
         launchCommand: AgentHookLaunchCommandRecord?
-    ) -> [String: String]? {
-        let environment = launchCommand?.environment
-        guard let environment else { return nil }
+    ) -> [String: String] {
+        let environment = launchCommand?.environment ?? [:]
         let selected = AgentLaunchEnvironmentPolicy().selectedReplayEnvironment(
             from: environment,
             kind: kind,
             launcher: launchCommand?.launcher,
             arguments: launchCommand?.arguments ?? []
         )
-        guard !selected.isEmpty else { return nil }
+        guard !selected.isEmpty else { return [:] }
 
         let claudeAuthKeys: Set<String> = [
             "ANTHROPIC_API_KEY",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31313,7 +31313,7 @@ struct CMUXCLI {
             )
             return
         }
-        let resumeEnvironment = agentSurfaceResumeEnvironment(kind: kind, environment: launchCommand?.environment)
+        let resumeEnvironment = agentSurfaceResumeEnvironment(kind: kind, launchCommand: launchCommand)
         // Pin to the launch directory, not drift-prone runtime cwd.
         let resumeWorkingDirectory = AgentResumeWorkingDirectory().resolve(
             kind: kind,
@@ -31568,10 +31568,16 @@ struct CMUXCLI {
 
     private func agentSurfaceResumeEnvironment(
         kind: String,
-        environment: [String: String]?
+        launchCommand: AgentHookLaunchCommandRecord?
     ) -> [String: String]? {
+        let environment = launchCommand?.environment
         guard let environment else { return nil }
-        let selected = selectedAgentLaunchEnvironment(from: environment, kind: kind)
+        let selected = AgentLaunchEnvironmentPolicy().selectedReplayEnvironment(
+            from: environment,
+            kind: kind,
+            launcher: launchCommand?.launcher,
+            arguments: launchCommand?.arguments ?? []
+        )
         guard !selected.isEmpty else { return nil }
 
         let claudeAuthKeys: Set<String> = [

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -207,6 +207,25 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         return selected
     }
 
+    /// Returns replay-safe environment values for a rendered resume command.
+    /// Routed Codex resumes retain their bounded account/server inputs after
+    /// the metadata-only launcher marker has selected the explicit `sr` argv.
+    public func selectedReplayEnvironment(
+        from env: [String: String],
+        kind: String?,
+        launcher: String?,
+        arguments: [String]
+    ) -> [String: String] {
+        var selected = selectedRestoreRecordEnvironment(
+            from: env,
+            kind: kind,
+            launcher: launcher,
+            arguments: arguments
+        )
+        selected.removeValue(forKey: SubrouterCodexResumeRouting.environmentKey)
+        return selected
+    }
+
     /// Returns a replay-safe value for a single environment variable, or `nil` when it should drop.
     public func sanitizedValue(key: String, value: String?) -> String? {
         guard Self.safeEnvironmentKeys.contains(key) else { return nil }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -72,6 +72,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         // so restoring it keeps a restored agent on the account it launched with.
         "CLAUDE_SECURESTORAGE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",
+        "CMUX_CUSTOM_CODEX_PATH",
         "CMUX_ROVODEV_SESSIONS_DIR",
         "CODEX_HOME",
         "CODEBUDDY_BASE_URL",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -200,6 +200,9 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         let marker = router.capturedMarker(in: env) else {
             return selected
         }
+        selected.merge(router.capturedRoutingEnvironment(in: env)) { _, routingValue in
+            routingValue
+        }
         selected[SubrouterCodexResumeRouting.environmentKey] = marker
         return selected
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -174,6 +174,36 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         return selected
     }
 
+    /// Returns the bounded environment metadata that may cross the structured
+    /// restore-record boundary. Subrouter's Codex resume marker is retained
+    /// only when the captured argv independently proves routed execution; the
+    /// ordinary restore policy still removes it before process replay.
+    public func selectedRestoreRecordEnvironment(
+        from env: [String: String],
+        kind: String?,
+        launcher: String?,
+        arguments: [String]
+    ) -> [String: String] {
+        var selected = selectedRestoreEnvironment(from: env, kind: kind)
+        let normalizedKind = kind?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedKind == "codex" else { return selected }
+
+        let router = SubrouterCodexResumeRouting()
+        guard router.resumeArguments(
+            launcher: launcher,
+            sessionID: "restore-record-validation",
+            launchArguments: arguments,
+            environment: env
+        ) != nil,
+        let marker = router.capturedMarker(in: env) else {
+            return selected
+        }
+        selected[SubrouterCodexResumeRouting.environmentKey] = marker
+        return selected
+    }
+
     /// Returns a replay-safe value for a single environment variable, or `nil` when it should drop.
     public func sanitizedValue(key: String, value: String?) -> String? {
         guard Self.safeEnvironmentKeys.contains(key) else { return nil }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -205,6 +205,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
             routingValue
         }
         selected[SubrouterCodexResumeRouting.environmentKey] = marker
+        selected[SubrouterCodexResumeRouting.launchBoundEnvironmentKey] = marker
         return selected
     }
 
@@ -224,6 +225,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
             arguments: arguments
         )
         selected.removeValue(forKey: SubrouterCodexResumeRouting.environmentKey)
+        selected.removeValue(forKey: SubrouterCodexResumeRouting.launchBoundEnvironmentKey)
         return selected
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -143,6 +143,9 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
                 result.removeValue(forKey: key)
             }
         }
+        if normalizedKind != "codex" {
+            result.removeValue(forKey: "CMUX_CUSTOM_CODEX_PATH")
+        }
         if normalizedKind == "campfire" {
             for key in Self.campfireManagedEnvironmentKeys {
                 result.removeValue(forKey: key)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -140,7 +140,8 @@ public struct AgentRestorePlanner: Sendable {
                 launcher: launch?.launcher,
                 sessionId: checkpointID,
                 executablePath: launch?.executablePath,
-                arguments: launch?.arguments ?? []
+                arguments: launch?.arguments ?? [],
+                environment: launch?.environment
             ) {
             case .resolved(let arguments):
                 if let arguments {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -71,6 +71,11 @@ public struct AgentRestorePlanner: Sendable {
 
         var environment = ambientEnvironment
         let restoredEnvironment = restoredEnvironment(for: request, kind: kind)
+        if hasProvenRoutedCodexLaunch(request, kind: kind) {
+            for key in SubrouterCodexResumeRouting.restoreOwnedEnvironmentKeys {
+                environment.removeValue(forKey: key)
+            }
+        }
         environment.merge(restoredEnvironment) { _, restored in restored }
 
         var routedArguments = sanitizedArguments
@@ -201,10 +206,19 @@ public struct AgentRestorePlanner: Sendable {
                 environment: launchEnvironment
             ) != nil {
                 // Only the launch record can prove routed resume. Request environment
-                // remains authoritative for ordinary replay values, but cannot replace
-                // the bounded routing values captured with that proof.
+                // remains authoritative for ordinary replay values, but presence and
+                // absence of restore-owned routing values come only from that proof.
+                for key in SubrouterCodexResumeRouting.restoreOwnedEnvironmentKeys {
+                    selected.removeValue(forKey: key)
+                }
                 selected.merge(router.capturedRoutingEnvironment(in: launchEnvironment)) { _, routingValue in
                     routingValue
+                }
+                if let customCodexPath = environmentPolicy.sanitizedValue(
+                    key: "CMUX_CUSTOM_CODEX_PATH",
+                    value: launchEnvironment["CMUX_CUSTOM_CODEX_PATH"]
+                ) {
+                    selected["CMUX_CUSTOM_CODEX_PATH"] = customCodexPath
                 }
             }
         }
@@ -218,6 +232,16 @@ public struct AgentRestorePlanner: Sendable {
             }
         }
         return selected
+    }
+
+    private func hasProvenRoutedCodexLaunch(_ request: AgentRestoreRequest, kind: String) -> Bool {
+        guard kind == "codex", request.mode != .direct else { return false }
+        return SubrouterCodexResumeRouting().resumeArguments(
+            launcher: request.launchCommand?.launcher,
+            sessionID: "restore-environment-validation",
+            launchArguments: request.launchCommand?.arguments ?? [],
+            environment: request.launchCommand?.environment
+        ) != nil
     }
 
     private func retargetPreparedWorkingDirectory(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -167,7 +167,8 @@ public struct AgentRestorePlanner: Sendable {
         for request: AgentRestoreRequest,
         kind: String
     ) -> [String: String] {
-        var captured = request.launchCommand?.environment ?? [:]
+        let launchEnvironment = request.launchCommand?.environment ?? [:]
+        var captured = launchEnvironment
         captured.merge(request.environment) { _, binding in binding }
         if kind == "codex",
            let rawCodexHome = normalized(captured["CODEX_HOME"]),
@@ -197,9 +198,12 @@ public struct AgentRestorePlanner: Sendable {
                 launcher: request.launchCommand?.launcher,
                 sessionID: "restore-environment-validation",
                 launchArguments: request.launchCommand?.arguments ?? [],
-                environment: captured
+                environment: launchEnvironment
             ) != nil {
-                selected.merge(router.capturedRoutingEnvironment(in: captured)) { _, routingValue in
+                // Only the launch record can prove routed resume. Request environment
+                // remains authoritative for ordinary replay values, but cannot replace
+                // the bounded routing values captured with that proof.
+                selected.merge(router.capturedRoutingEnvironment(in: launchEnvironment)) { _, routingValue in
                     routingValue
                 }
             }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -253,11 +253,34 @@ public struct AgentRestorePlanner: Sendable {
         kind: String,
         environment: inout [String: String]
     ) -> [String] {
+        guard let restoreLaunch = AgentRestoreLaunch(
+            kind: kind,
+            sessionID: request.checkpointID
+        ) else {
+            return arguments
+        }
+
+        if kind == "codex",
+           let checkpointID = normalized(request.checkpointID),
+           let routedPrefix = SubrouterCodexResumeRouting().resumeArguments(
+               launcher: request.launchCommand?.launcher,
+               sessionID: checkpointID,
+               launchArguments: request.launchCommand?.arguments ?? [],
+               environment: request.launchCommand?.environment
+           ),
+           arguments.starts(with: routedPrefix),
+           let wrapperShim = normalized(environment[restoreLaunch.wrapperShimEnvironmentKey]),
+           isExecutableFile(wrapperShim) {
+            if let capturedExecutable = normalized(environment["SUBROUTER_CODEX_BIN"]),
+               capturedExecutable != wrapperShim {
+                environment[restoreLaunch.customExecutablePathEnvironmentKey] = capturedExecutable
+            }
+            environment["SUBROUTER_CODEX_BIN"] = wrapperShim
+            environment["CMUX_AGENT_RESTORE_LAUNCH"] = restoreLaunch.authorizationEnvironmentValue
+            return arguments
+        }
+
         guard let first = arguments.first,
-              let restoreLaunch = AgentRestoreLaunch(
-                  kind: kind,
-                  sessionID: request.checkpointID
-              ),
               (first as NSString).lastPathComponent == restoreLaunch.executableName else {
             return arguments
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -186,10 +186,24 @@ public struct AgentRestorePlanner: Sendable {
         if request.mode == .direct {
             return captured
         }
-        var selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(
+        let environmentPolicy = AgentLaunchEnvironmentPolicy()
+        var selected = environmentPolicy.selectedRestoreEnvironment(
             from: captured,
             kind: kind
         )
+        if kind == "codex" {
+            let router = SubrouterCodexResumeRouting()
+            if router.resumeArguments(
+                launcher: request.launchCommand?.launcher,
+                sessionID: "restore-environment-validation",
+                launchArguments: request.launchCommand?.arguments ?? [],
+                environment: captured
+            ) != nil {
+                selected.merge(router.capturedRoutingEnvironment(in: captured)) { _, routingValue in
+                    routingValue
+                }
+            }
+        }
         if kind == "claude" {
             let keys = selected.keys.sorted().filter {
                 Self.claudeAuthSelectionEnvironmentKeys.contains($0)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -271,8 +271,11 @@ public struct AgentRestorePlanner: Sendable {
            arguments.starts(with: routedPrefix),
            let wrapperShim = normalized(environment[restoreLaunch.wrapperShimEnvironmentKey]),
            isExecutableFile(wrapperShim) {
-            if let capturedExecutable = normalized(environment["SUBROUTER_CODEX_BIN"]),
-               capturedExecutable != wrapperShim {
+            if let capturedExecutable = SubrouterCodexResumeRouting().preferredCustomCodexExecutable(
+                in: request.launchCommand?.environment,
+                fallbackExecutable: request.launchCommand?.executablePath,
+                wrapperShim: wrapperShim
+            ) {
                 environment[restoreLaunch.customExecutablePathEnvironmentKey] = capturedExecutable
             }
             environment["SUBROUTER_CODEX_BIN"] = wrapperShim

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -284,7 +284,18 @@ public struct AgentResumeArgv: Sendable, Equatable {
             launchArguments: arguments,
             environment: environment
         ) {
-            return .resolved(routed)
+            let parts = commandParts(
+                executablePath: executablePath,
+                arguments: arguments,
+                fallbackExecutable: "codex"
+            )
+            guard let captured = preservedCodexForkArguments(
+                args: parts.tail,
+                preservePromptTags: false,
+                stripCmuxHooks: parts.executable == "codex"
+            ) else { return .resolved(nil) }
+            let preserved = SubrouterCodexResumeRouting().removingRoutingArguments(from: captured)
+            return .resolved(routed + codexResumeConfigOverrides(preserved: preserved) + preserved)
         }
         switch launcher {
         case "claudeTeams":

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -78,6 +78,16 @@ public struct AgentResumeArgv: Sendable, Equatable {
     public static let codexWrapperShellExecutableToken =
         "\"$([ -x \"${CMUX_CODEX_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CODEX_WRAPPER_SHIM\" || printf codex)\""
 
+    /// The managed Codex wrapper token with a captured executable as its fallback.
+    ///
+    /// Remote restore shells can lack the `bash` required by `cmux-codex-wrapper`,
+    /// or a previously installed shim can disappear. In those cases a routed
+    /// restore must retain the captured Codex executable instead of assuming a
+    /// separate `codex` is available on `PATH`.
+    public static func codexWrapperShellExecutableToken(fallbackExecutable: String) -> String {
+        "\"$([ -x \"${CMUX_CODEX_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CODEX_WRAPPER_SHIM\" || printf '%s' \(posixSingleQuoted(fallbackExecutable)))\""
+    }
+
     /// The shell token that resolves cmux's Hermes wrapper at restore time.
     ///
     /// Restored Hermes sessions must pass through the per-surface wrapper so its

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -228,23 +228,28 @@ public struct AgentResumeArgv: Sendable, Equatable {
     }
 
     /// Renders shell command `parts` to quoted tokens, substituting
-    /// ``codexWrapperShellExecutableToken`` for the first bare `codex` executable token.
+    /// ``codexWrapperShellExecutableToken`` only when `codex` is the executable token.
     ///
-    /// Mirror of ``renderingClaudeWrapperExecutable(parts:quote:)`` for codex: only
-    /// the first element equal to `codex` — a logical wrapper executable emitted
-    /// by the codex resume builder — is replaced; every other token is quoted normally.
+    /// Mirror of ``renderingClaudeWrapperExecutable(parts:quote:)`` for codex: the
+    /// executable position is the first token, or the first non-assignment after an
+    /// `env` prefix. A nested `codex` subcommand such as `sr codex resume` is left alone.
     /// Call only for the codex kind. https://github.com/manaflow-ai/cmux/issues/5639
     public static func renderingCodexWrapperExecutable(
         parts: [String],
         quote: (String) -> String
     ) -> [String] {
-        var replaced = false
-        return parts.map { part in
-            if !replaced, part == "codex" {
-                replaced = true
-                return codexWrapperShellExecutableToken
+        var executableIndex = 0
+        if parts.first == "env" {
+            executableIndex = 1
+            while executableIndex < parts.count,
+                  parts[executableIndex].contains("=") {
+                executableIndex += 1
             }
-            return quote(part)
+        }
+        return parts.enumerated().map { index, part in
+            index == executableIndex && part == "codex"
+                ? codexWrapperShellExecutableToken
+                : quote(part)
         }
     }
 
@@ -270,8 +275,17 @@ public struct AgentResumeArgv: Sendable, Equatable {
         launcher: String?,
         sessionId: String,
         executablePath: String?,
-        arguments: [String]
+        arguments: [String],
+        environment: [String: String]? = nil
     ) -> LauncherResolution {
+        if let routed = SubrouterCodexResumeRouting().resumeArguments(
+            launcher: launcher,
+            sessionID: sessionId,
+            launchArguments: arguments,
+            environment: environment
+        ) {
+            return .resolved(routed)
+        }
         switch launcher {
         case "claudeTeams":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "cmux")

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -15,6 +15,7 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     private static let routingEnvironmentLimits = [
         "SUBROUTER_CODEX_ACCOUNT_ID": 256,
         "SUBROUTER_CODEX_BASE_URL": 2048,
+        "SUBROUTER_CODEX_BIN": 4096,
         "SUBROUTER_CODEX_SERVER": 256,
         "SUBROUTER_CODEX_USER_EMAIL": 320,
     ]
@@ -75,6 +76,30 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return marker.split(separator: " ").map(String.init) + [sessionID]
     }
 
+    func removingRoutingArguments(from arguments: [String]) -> [String] {
+        var selected: [String] = []
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if (argument == "-c" || argument == "--config"), index + 1 < arguments.count {
+                if isSubrouterRoutingAssignment(arguments[index + 1]) {
+                    index += 2
+                    continue
+                }
+            }
+            if ["-c=", "--config="].contains(where: { prefix in
+                argument.hasPrefix(prefix)
+                    && isSubrouterRoutingAssignment(String(argument.dropFirst(prefix.count)))
+            }) {
+                index += 1
+                continue
+            }
+            selected.append(argument)
+            index += 1
+        }
+        return selected
+    }
+
     private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {
         for (index, argument) in arguments.enumerated() {
             if (argument == "-c" || argument == "--config"),
@@ -108,6 +133,13 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return value == "subrouter"
     }
 
+    private func isSubrouterRoutingAssignment(_ rawValue: String) -> Bool {
+        let parts = rawValue.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        return key == "model_provider" || key.hasPrefix("model_providers.subrouter.")
+    }
+
     private func sanitizedRoutingValue(key: String, value: String?) -> String? {
         guard let maximumByteCount = Self.routingEnvironmentLimits[key],
               let value else {
@@ -128,7 +160,9 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
               components.user == nil,
               components.password == nil,
               components.query == nil,
-              components.fragment == nil else {
+              components.fragment == nil,
+              !components.path.lowercased().hasPrefix("/t/"),
+              !components.percentEncodedPath.lowercased().hasPrefix("/t/") else {
             return nil
         }
         return trimmed

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -51,6 +51,22 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return selected
     }
 
+    /// Returns the real Codex executable retained behind the managed wrapper.
+    /// An already captured custom path takes precedence over Subrouter's child
+    /// binary, which may itself be the wrapper after an earlier restore.
+    public func preferredCustomCodexExecutable(
+        in environment: [String: String]?,
+        fallbackExecutable: String?,
+        wrapperShim: String
+    ) -> String? {
+        let candidates = [
+            sanitizedPathValue(environment?["CMUX_CUSTOM_CODEX_PATH"]),
+            sanitizedPathValue(environment?["SUBROUTER_CODEX_BIN"]),
+            sanitizedPathValue(fallbackExecutable),
+        ]
+        return candidates.compactMap { $0 }.first { $0 != wrapperShim }
+    }
+
     /// Returns the trusted marker and its bounded routing inputs for durable
     /// hook capture, or an empty environment when the marker is absent.
     public func capturedEnvironment(in environment: [String: String]?) -> [String: String] {
@@ -205,6 +221,17 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
               components.fragment == nil,
               !components.path.lowercased().hasPrefix("/t/"),
               !components.percentEncodedPath.lowercased().hasPrefix("/t/") else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private func sanitizedPathValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.utf8.count <= 4096,
+              !trimmed.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) else {
             return nil
         }
         return trimmed

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -23,6 +23,15 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         "SUBROUTER_CODEX_USER_EMAIL": 320,
     ]
 
+    /// Environment keys whose presence and absence are owned by a proven
+    /// routed launch record during restore.
+    public static let restoreOwnedEnvironmentKeys: Set<String> = Set(routingEnvironmentLimits.keys)
+        .union([
+            environmentKey,
+            launchBoundEnvironmentKey,
+            "CMUX_CUSTOM_CODEX_PATH",
+        ])
+
     /// Creates a Subrouter Codex resume router.
     public init() {}
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -47,6 +47,15 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return selected
     }
 
+    /// Returns the trusted marker and its bounded routing inputs for durable
+    /// hook capture, or an empty environment when the marker is absent.
+    public func capturedEnvironment(in environment: [String: String]?) -> [String: String] {
+        guard let marker = capturedMarker(in: environment) else { return [:] }
+        var selected = capturedRoutingEnvironment(in: environment)
+        selected[Self.environmentKey] = marker
+        return selected
+    }
+
     /// Builds the captured Subrouter launcher resume argv only when both the
     /// trusted marker and Codex routing config prove the routed invocation.
     public func resumeArguments(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -81,6 +81,10 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         var index = 0
         while index < arguments.count {
             let argument = arguments[index]
+            if argument == "--" {
+                selected.append(contentsOf: arguments[index...])
+                break
+            }
             if (argument == "-c" || argument == "--config"), index + 1 < arguments.count {
                 if isSubrouterRoutingAssignment(arguments[index + 1]) {
                     index += 2
@@ -102,17 +106,25 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
 
     private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {
         var effectiveProvider: String?
-        for (index, argument) in arguments.enumerated() {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--" {
+                break
+            }
             if (argument == "-c" || argument == "--config"),
                index + 1 < arguments.count,
                let provider = modelProviderAssignment(in: arguments[index + 1]) {
                 effectiveProvider = provider
+                index += 2
+                continue
             }
             for prefix in ["-c=", "--config="] where argument.hasPrefix(prefix) {
                 if let provider = modelProviderAssignment(in: String(argument.dropFirst(prefix.count))) {
                     effectiveProvider = provider
                 }
             }
+            index += 1
         }
         return effectiveProvider == "subrouter"
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -12,6 +12,13 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         ["cx", "codex", "resume"],
     ]
 
+    private static let routingEnvironmentLimits = [
+        "SUBROUTER_CODEX_ACCOUNT_ID": 256,
+        "SUBROUTER_CODEX_BASE_URL": 2048,
+        "SUBROUTER_CODEX_SERVER": 256,
+        "SUBROUTER_CODEX_USER_EMAIL": 320,
+    ]
+
     /// Creates a Subrouter Codex resume router.
     public init() {}
 
@@ -24,6 +31,20 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         let tokens = rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
         guard Self.expectedMarkerTokens.contains(tokens) else { return nil }
         return tokens.joined(separator: " ")
+    }
+
+    /// Returns bounded, non-secret Subrouter routing inputs that may accompany
+    /// a trusted resume marker through structured restore metadata.
+    public func capturedRoutingEnvironment(in environment: [String: String]?) -> [String: String] {
+        guard let environment else { return [:] }
+        var selected: [String: String] = [:]
+        for key in Self.routingEnvironmentLimits.keys.sorted() {
+            guard let value = sanitizedRoutingValue(key: key, value: environment[key]) else {
+                continue
+            }
+            selected[key] = value
+        }
+        return selected
     }
 
     /// Builds the captured Subrouter launcher resume argv only when both the
@@ -76,5 +97,31 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
             value.removeLast()
         }
         return value == "subrouter"
+    }
+
+    private func sanitizedRoutingValue(key: String, value: String?) -> String? {
+        guard let maximumByteCount = Self.routingEnvironmentLimits[key],
+              let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.utf8.count <= maximumByteCount,
+              !trimmed.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) else {
+            return nil
+        }
+        guard key == "SUBROUTER_CODEX_BASE_URL" else { return trimmed }
+
+        guard let components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host != nil,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil else {
+            return nil
+        }
+        return trimmed
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -29,9 +29,19 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     /// Returns the canonical marker when the captured environment contains the
     /// exact supported command, or `nil` for absent or untrusted values.
     public func capturedMarker(in environment: [String: String]?) -> String? {
-        guard let rawValue = environment?[Self.environmentKey] else {
+        canonicalMarker(environment?[Self.environmentKey])
+    }
+
+    private func capturedLaunchBoundMarker(in environment: [String: String]?) -> String? {
+        guard let marker = capturedMarker(in: environment),
+              canonicalMarker(environment?[Self.launchBoundEnvironmentKey]) == marker else {
             return nil
         }
+        return marker
+    }
+
+    private func canonicalMarker(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
         let tokens = rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
         guard Self.expectedMarkerTokens.contains(tokens) else { return nil }
         return tokens.joined(separator: " ")
@@ -70,9 +80,10 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     /// Returns the trusted marker and its bounded routing inputs for durable
     /// hook capture, or an empty environment when the marker is absent.
     public func capturedEnvironment(in environment: [String: String]?) -> [String: String] {
-        guard let marker = capturedMarker(in: environment) else { return [:] }
+        guard let marker = capturedLaunchBoundMarker(in: environment) else { return [:] }
         var selected = capturedRoutingEnvironment(in: environment)
         selected[Self.environmentKey] = marker
+        selected[Self.launchBoundEnvironmentKey] = marker
         return selected
     }
 
@@ -88,7 +99,7 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard normalizedLauncher == nil || normalizedLauncher == "codex",
-              let marker = capturedMarker(in: environment),
+              let marker = capturedLaunchBoundMarker(in: environment),
               launchArgumentsContainSubrouterProvider(launchArguments) else {
             return nil
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -6,6 +6,9 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     /// The metadata marker emitted by Subrouter for routed Codex children.
     public static let environmentKey = "SUBROUTER_CODEX_RESUME_COMMAND"
 
+    /// Wrapper-attested copy of the marker bound to the current Codex argv.
+    public static let launchBoundEnvironmentKey = "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND"
+
     private static let expectedMarkerTokens = [
         ["sr", "codex", "resume"],
         ["subrouter", "codex", "resume"],

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -160,6 +160,36 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return selected
     }
 
+    /// Removes only actual pre-terminator Subrouter configuration options from
+    /// an argv intended for a public status surface. Prompt text and the literal
+    /// `--` suffix remain byte-for-byte intact.
+    public func removingPrivateRoutingArguments(from arguments: [String]) -> [String] {
+        var selected: [String] = []
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--" {
+                selected.append(contentsOf: arguments[index...])
+                break
+            }
+            if (argument == "-c" || argument == "--config"), index + 1 < arguments.count,
+               isPrivateSubrouterRoutingAssignment(arguments[index + 1]) {
+                index += 2
+                continue
+            }
+            if ["-c=", "--config="].contains(where: { prefix in
+                argument.hasPrefix(prefix)
+                    && isPrivateSubrouterRoutingAssignment(String(argument.dropFirst(prefix.count)))
+            }) {
+                index += 1
+                continue
+            }
+            selected.append(argument)
+            index += 1
+        }
+        return selected
+    }
+
     private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {
         var effectiveProvider: String?
         var index = 0
@@ -207,6 +237,17 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         guard parts.count == 2 else { return false }
         let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
         return key == "model_provider" || key.hasPrefix("model_providers.subrouter.")
+    }
+
+    private func isPrivateSubrouterRoutingAssignment(_ rawValue: String) -> Bool {
+        if modelProviderAssignment(in: rawValue) == "subrouter" {
+            return true
+        }
+        let parts = rawValue.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        return parts[0]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .hasPrefix("model_providers.subrouter.")
     }
 
     private func sanitizedRoutingValue(key: String, value: String?) -> String? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -76,6 +76,32 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
         return marker.split(separator: " ").map(String.init) + [sessionID]
     }
 
+    /// Retains a canonical, non-secret routing proof when prompt sanitization
+    /// removes Subrouter's trailing injected config block from captured argv.
+    public func retainingRoutingProof(
+        in sanitizedArguments: [String],
+        from capturedArguments: [String],
+        launcher: String?,
+        environment: [String: String]?
+    ) -> [String] {
+        guard resumeArguments(
+            launcher: launcher,
+            sessionID: "capture-routing-validation",
+            launchArguments: capturedArguments,
+            environment: environment
+        ) != nil else {
+            return sanitizedArguments
+        }
+        if launchArgumentsContainSubrouterProvider(sanitizedArguments) {
+            return sanitizedArguments
+        }
+
+        var retained = sanitizedArguments
+        let insertionIndex = retained.firstIndex(of: "--") ?? retained.endIndex
+        retained.insert(contentsOf: ["-c", "model_provider=subrouter"], at: insertionIndex)
+        return retained
+    }
+
     func removingRoutingArguments(from arguments: [String]) -> [String] {
         var selected: [String] = []
         var index = 0

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -6,7 +6,11 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     /// The metadata marker emitted by Subrouter for routed Codex children.
     public static let environmentKey = "SUBROUTER_CODEX_RESUME_COMMAND"
 
-    private static let expectedMarkerTokens = ["sr", "codex", "resume"]
+    private static let expectedMarkerTokens = [
+        ["sr", "codex", "resume"],
+        ["subrouter", "codex", "resume"],
+        ["cx", "codex", "resume"],
+    ]
 
     /// Creates a Subrouter Codex resume router.
     public init() {}
@@ -14,16 +18,16 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     /// Returns the canonical marker when the captured environment contains the
     /// exact supported command, or `nil` for absent or untrusted values.
     public func capturedMarker(in environment: [String: String]?) -> String? {
-        guard let rawValue = environment?[Self.environmentKey],
-              rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
-                == Self.expectedMarkerTokens else {
+        guard let rawValue = environment?[Self.environmentKey] else {
             return nil
         }
-        return Self.expectedMarkerTokens.joined(separator: " ")
+        let tokens = rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
+        guard Self.expectedMarkerTokens.contains(tokens) else { return nil }
+        return tokens.joined(separator: " ")
     }
 
-    /// Builds `sr codex resume <id>` only when both the trusted marker and the
-    /// captured Codex routing config prove this process came through Subrouter.
+    /// Builds the captured Subrouter launcher resume argv only when both the
+    /// trusted marker and Codex routing config prove the routed invocation.
     public func resumeArguments(
         launcher: String?,
         sessionID: String,
@@ -34,11 +38,11 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard normalizedLauncher == nil || normalizedLauncher == "codex",
-              capturedMarker(in: environment) != nil,
+              let marker = capturedMarker(in: environment),
               launchArgumentsContainSubrouterProvider(launchArguments) else {
             return nil
         }
-        return Self.expectedMarkerTokens + [sessionID]
+        return marker.split(separator: " ").map(String.init) + [sessionID]
     }
 
     private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Recognizes the bounded launch evidence emitted by `sr codex` and builds its
+/// explicit resume argv without trusting environment-provided shell text.
+public struct SubrouterCodexResumeRouting: Sendable, Equatable {
+    /// The metadata marker emitted by Subrouter for routed Codex children.
+    public static let environmentKey = "SUBROUTER_CODEX_RESUME_COMMAND"
+
+    private static let expectedMarkerTokens = ["sr", "codex", "resume"]
+
+    /// Creates a Subrouter Codex resume router.
+    public init() {}
+
+    /// Returns the canonical marker when the captured environment contains the
+    /// exact supported command, or `nil` for absent or untrusted values.
+    public func capturedMarker(in environment: [String: String]?) -> String? {
+        guard let rawValue = environment?[Self.environmentKey],
+              rawValue.split(whereSeparator: \Character.isWhitespace).map(String.init)
+                == Self.expectedMarkerTokens else {
+            return nil
+        }
+        return Self.expectedMarkerTokens.joined(separator: " ")
+    }
+
+    /// Builds `sr codex resume <id>` only when both the trusted marker and the
+    /// captured Codex routing config prove this process came through Subrouter.
+    public func resumeArguments(
+        launcher: String?,
+        sessionID: String,
+        launchArguments: [String],
+        environment: [String: String]?
+    ) -> [String]? {
+        let normalizedLauncher = launcher?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedLauncher == nil || normalizedLauncher == "codex",
+              capturedMarker(in: environment) != nil,
+              launchArgumentsContainSubrouterProvider(launchArguments) else {
+            return nil
+        }
+        return Self.expectedMarkerTokens + [sessionID]
+    }
+
+    private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {
+        for (index, argument) in arguments.enumerated() {
+            if (argument == "-c" || argument == "--config"),
+               index + 1 < arguments.count,
+               isSubrouterProviderAssignment(arguments[index + 1]) {
+                return true
+            }
+            for prefix in ["-c=", "--config="] where argument.hasPrefix(prefix) {
+                if isSubrouterProviderAssignment(String(argument.dropFirst(prefix.count))) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private func isSubrouterProviderAssignment(_ rawValue: String) -> Bool {
+        let parts = rawValue.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              parts[0].trimmingCharacters(in: .whitespacesAndNewlines) == "model_provider" else {
+            return false
+        }
+        var value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.count >= 2,
+           let first = value.first,
+           let last = value.last,
+           (first == "\"" && last == "\"") || (first == "'" && last == "'") {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value == "subrouter"
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -71,8 +71,8 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     ) -> String? {
         let candidates = [
             sanitizedPathValue(environment?["CMUX_CUSTOM_CODEX_PATH"]),
-            sanitizedPathValue(environment?["SUBROUTER_CODEX_BIN"]),
             sanitizedPathValue(fallbackExecutable),
+            sanitizedPathValue(environment?["SUBROUTER_CODEX_BIN"]),
         ]
         return candidates.compactMap { $0 }.first { $0 != wrapperShim }
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SubrouterCodexResumeRouting.swift
@@ -101,26 +101,27 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
     }
 
     private func launchArgumentsContainSubrouterProvider(_ arguments: [String]) -> Bool {
+        var effectiveProvider: String?
         for (index, argument) in arguments.enumerated() {
             if (argument == "-c" || argument == "--config"),
                index + 1 < arguments.count,
-               isSubrouterProviderAssignment(arguments[index + 1]) {
-                return true
+               let provider = modelProviderAssignment(in: arguments[index + 1]) {
+                effectiveProvider = provider
             }
             for prefix in ["-c=", "--config="] where argument.hasPrefix(prefix) {
-                if isSubrouterProviderAssignment(String(argument.dropFirst(prefix.count))) {
-                    return true
+                if let provider = modelProviderAssignment(in: String(argument.dropFirst(prefix.count))) {
+                    effectiveProvider = provider
                 }
             }
         }
-        return false
+        return effectiveProvider == "subrouter"
     }
 
-    private func isSubrouterProviderAssignment(_ rawValue: String) -> Bool {
+    private func modelProviderAssignment(in rawValue: String) -> String? {
         let parts = rawValue.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
         guard parts.count == 2,
               parts[0].trimmingCharacters(in: .whitespacesAndNewlines) == "model_provider" else {
-            return false
+            return nil
         }
         var value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
         if value.count >= 2,
@@ -130,7 +131,7 @@ public struct SubrouterCodexResumeRouting: Sendable, Equatable {
             value.removeFirst()
             value.removeLast()
         }
-        return value == "subrouter"
+        return value
     }
 
     private func isSubrouterRoutingAssignment(_ rawValue: String) -> Bool {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -51,6 +51,7 @@ struct AgentLaunchEnvironmentPolicyTests {
                 "OPENAI_API_KEY": "secret-should-not-cross-socket",
                 "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
                 "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
                 "SUBROUTER_CODEX_SERVER": "team",
                 "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -63,6 +64,7 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected == [
             "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -94,11 +96,31 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test("Restore records do not persist tenant credentials embedded in URLs")
+    func restoreRecordsRejectTenantCredentialURLs() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedRestoreRecordEnvironment(
+            from: [
+                "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/t/srt_secret/v1",
+                "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "SUBROUTER_CODEX_SERVER": "team",
+            ],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        )
+
+        #expect(selected == [
+            "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "SUBROUTER_CODEX_SERVER": "team",
+        ])
+    }
+
     @Test("Hook capture retains safe Subrouter routing metadata with its marker")
     func hookCaptureRetainsSafeSubrouterRoutingMetadataWithMarker() {
         let captured = SubrouterCodexResumeRouting().capturedEnvironment(in: [
             "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -107,6 +129,7 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(captured == [
             "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -120,6 +143,7 @@ struct AgentLaunchEnvironmentPolicyTests {
                 "OPENAI_API_KEY": "secret-should-not-replay",
                 "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
                 "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 "SUBROUTER_CODEX_SERVER": "team",
                 "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -132,6 +156,7 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected == [
             "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
         ])

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -53,6 +53,7 @@ struct AgentLaunchEnvironmentPolicyTests {
                 "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
                 "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+                "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
                 "SUBROUTER_CODEX_SERVER": "team",
                 "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
             ],
@@ -66,6 +67,7 @@ struct AgentLaunchEnvironmentPolicyTests {
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
             "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
         ])
@@ -83,6 +85,7 @@ struct AgentLaunchEnvironmentPolicyTests {
                 "SUBROUTER_CODEX_ACCOUNT_ID": "team\ncodex",
                 "SUBROUTER_CODEX_BASE_URL": "https://user:secret@router.example.test/v1",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 "SUBROUTER_CODEX_SERVER": "team\nstaging",
                 "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test\nX-Injected: yes",
             ],
@@ -93,6 +96,7 @@ struct AgentLaunchEnvironmentPolicyTests {
 
         #expect(selected == [
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
         ])
     }
 
@@ -102,6 +106,7 @@ struct AgentLaunchEnvironmentPolicyTests {
             from: [
                 "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/t/srt_secret/v1",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 "SUBROUTER_CODEX_SERVER": "team",
             ],
             kind: "codex",
@@ -111,6 +116,7 @@ struct AgentLaunchEnvironmentPolicyTests {
 
         #expect(selected == [
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
         ])
     }
@@ -122,6 +128,7 @@ struct AgentLaunchEnvironmentPolicyTests {
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
             "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
         ])
@@ -131,6 +138,7 @@ struct AgentLaunchEnvironmentPolicyTests {
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
             "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_SERVER": "team",
             "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
         ])
@@ -145,6 +153,7 @@ struct AgentLaunchEnvironmentPolicyTests {
                 "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
                 "SUBROUTER_CODEX_BIN": "/opt/codex/bin/codex",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 "SUBROUTER_CODEX_SERVER": "team",
                 "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
             ],

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -49,7 +49,11 @@ struct AgentLaunchEnvironmentPolicyTests {
         let selected = policy.selectedRestoreRecordEnvironment(
             from: [
                 "OPENAI_API_KEY": "secret-should-not-cross-socket",
+                "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+                "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
                 "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+                "SUBROUTER_CODEX_SERVER": "team",
+                "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
             ],
             kind: "codex",
             launcher: "codex",
@@ -57,13 +61,37 @@ struct AgentLaunchEnvironmentPolicyTests {
         )
 
         #expect(selected == [
+            "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+            "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
             "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+            "SUBROUTER_CODEX_SERVER": "team",
+            "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
         ])
         #expect(
             policy.selectedRestoreEnvironment(from: selected, kind: "codex")[
                 "SUBROUTER_CODEX_RESUME_COMMAND"
             ] == nil
         )
+    }
+
+    @Test("Restore records reject unsafe Subrouter routing metadata")
+    func restoreRecordsRejectUnsafeSubrouterRoutingMetadata() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedRestoreRecordEnvironment(
+            from: [
+                "SUBROUTER_CODEX_ACCOUNT_ID": "team\ncodex",
+                "SUBROUTER_CODEX_BASE_URL": "https://user:secret@router.example.test/v1",
+                "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "SUBROUTER_CODEX_SERVER": "team\nstaging",
+                "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test\nX-Injected: yes",
+            ],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        )
+
+        #expect(selected == [
+            "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+        ])
     }
 
     @Test("Restore records reject unproved or noncanonical Subrouter metadata")

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -3,6 +3,17 @@ import Testing
 
 @Suite("AgentLaunchEnvironmentPolicy")
 struct AgentLaunchEnvironmentPolicyTests {
+    @Test("Custom Codex executable remains scoped to Codex restores")
+    func customCodexExecutableRemainsScopedToCodexRestores() {
+        let policy = AgentLaunchEnvironmentPolicy()
+        let environment = ["CMUX_CUSTOM_CODEX_PATH": "/opt/custom/codex"]
+
+        #expect(policy.selectedEnvironment(from: environment, kind: "codex") == environment)
+        #expect(policy.selectedEnvironment(from: environment, kind: "claude").isEmpty)
+        #expect(policy.selectedEnvironment(from: environment, kind: "pi").isEmpty)
+        #expect(policy.selectedEnvironment(from: environment, kind: nil).isEmpty)
+    }
+
     @Test("Preserves OMP config roots without persisting secrets")
     func preservesOmpConfigRootsWithoutPersistingSecrets() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -40,6 +40,50 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test(
+        "Restore records retain only trusted Subrouter Codex routing metadata",
+        arguments: ["sr", "subrouter", "cx"]
+    )
+    func restoreRecordsRetainTrustedSubrouterCodexMetadata(command: String) {
+        let policy = AgentLaunchEnvironmentPolicy()
+        let selected = policy.selectedRestoreRecordEnvironment(
+            from: [
+                "OPENAI_API_KEY": "secret-should-not-cross-socket",
+                "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+            ],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        )
+
+        #expect(selected == [
+            "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+        ])
+        #expect(
+            policy.selectedRestoreEnvironment(from: selected, kind: "codex")[
+                "SUBROUTER_CODEX_RESUME_COMMAND"
+            ] == nil
+        )
+    }
+
+    @Test("Restore records reject unproved or noncanonical Subrouter metadata")
+    func restoreRecordsRejectUntrustedSubrouterMetadata() {
+        let policy = AgentLaunchEnvironmentPolicy()
+
+        #expect(policy.selectedRestoreRecordEnvironment(
+            from: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex"]
+        ).isEmpty)
+        #expect(policy.selectedRestoreRecordEnvironment(
+            from: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume; echo unsafe"],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        ).isEmpty)
+    }
+
     @Test("Preserves Campfire config roots and drops Pi-managed env")
     func preservesCampfireConfigRootsAndDropsManagedPackageDir() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -170,6 +170,12 @@ struct AgentLaunchEnvironmentPolicyTests {
             from: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"],
             kind: "codex",
             launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        ).isEmpty)
+        #expect(policy.selectedRestoreRecordEnvironment(
+            from: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"],
+            kind: "codex",
+            launcher: "codex",
             arguments: ["codex"]
         ).isEmpty)
         #expect(policy.selectedRestoreRecordEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -94,6 +94,25 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test("Hook capture retains safe Subrouter routing metadata with its marker")
+    func hookCaptureRetainsSafeSubrouterRoutingMetadataWithMarker() {
+        let captured = SubrouterCodexResumeRouting().capturedEnvironment(in: [
+            "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+            "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "SUBROUTER_CODEX_SERVER": "team",
+            "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+        ])
+
+        #expect(captured == [
+            "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+            "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "SUBROUTER_CODEX_SERVER": "team",
+            "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+        ])
+    }
+
     @Test("Restore records reject unproved or noncanonical Subrouter metadata")
     func restoreRecordsRejectUntrustedSubrouterMetadata() {
         let policy = AgentLaunchEnvironmentPolicy()

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -113,6 +113,30 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test("Shell replay retains routed Subrouter inputs without replaying its marker")
+    func shellReplayRetainsRoutedSubrouterInputsWithoutMarker() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedReplayEnvironment(
+            from: [
+                "OPENAI_API_KEY": "secret-should-not-replay",
+                "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+                "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                "SUBROUTER_CODEX_SERVER": "team",
+                "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+            ],
+            kind: "codex",
+            launcher: "codex",
+            arguments: ["codex", "-c", "model_provider=subrouter"]
+        )
+
+        #expect(selected == [
+            "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+            "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_SERVER": "team",
+            "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+        ])
+    }
+
     @Test("Restore records reject unproved or noncanonical Subrouter metadata")
     func restoreRecordsRejectUntrustedSubrouterMetadata() {
         let policy = AgentLaunchEnvironmentPolicy()

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -247,6 +247,43 @@ import Testing
         #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == "codex:\(sessionID)")
     }
 
+    @Test func repeatedStructuredSubrouterRestoreKeepsTheCapturedRealCodexExecutable() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "/opt/custom/codex",
+                arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "CMUX_CUSTOM_CODEX_PATH": "/opt/custom/codex",
+                    "SUBROUTER_CODEX_BIN": "/shim/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { $0 == "/shim/codex" }).invocation(
+                for: request,
+                ambientEnvironment: [
+                    "PATH": "/usr/bin:/bin",
+                    "CMUX_CODEX_WRAPPER_SHIM": "/shim/codex",
+                ]
+            )
+        )
+
+        #expect(invocation.environment["SUBROUTER_CODEX_BIN"] == "/shim/codex")
+        #expect(invocation.environment["CMUX_CUSTOM_CODEX_PATH"] == "/opt/custom/codex")
+    }
+
     @Test func structuredSubrouterRestoreKeepsProvedLaunchRoutingInputsAuthoritative() throws {
         let request = AgentRestoreRequest(
             mode: .resumeAgent,

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -145,7 +145,13 @@ import Testing
                     "model_provider=subrouter",
                 ],
                 workingDirectory: "/tmp/project",
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+                environment: [
+                    "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+                    "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                    "SUBROUTER_CODEX_SERVER": "team",
+                    "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+                ]
             ),
             preparedArguments: nil,
             observedPermissionMode: nil
@@ -159,7 +165,11 @@ import Testing
         )
 
         #expect(invocation.arguments == ["sr", "codex", "resume", sessionID])
+        #expect(invocation.environment["SUBROUTER_CODEX_ACCOUNT_ID"] == "team-codex-1")
+        #expect(invocation.environment["SUBROUTER_CODEX_BASE_URL"] == "https://router.example.test/v1")
         #expect(invocation.environment["SUBROUTER_CODEX_RESUME_COMMAND"] == nil)
+        #expect(invocation.environment["SUBROUTER_CODEX_SERVER"] == "team")
+        #expect(invocation.environment["SUBROUTER_CODEX_USER_EMAIL"] == "operator@example.test")
         #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == nil)
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -209,6 +209,55 @@ import Testing
         ])
     }
 
+    @Test func structuredSubrouterRestoreKeepsProvedLaunchRoutingInputsAuthoritative() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [
+                "SUBROUTER_CODEX_ACCOUNT_ID": "replacement-account",
+                "SUBROUTER_CODEX_BASE_URL": "https://replacement.example.test/v1",
+                "SUBROUTER_CODEX_BIN": "/tmp/replacement-codex",
+                "SUBROUTER_CODEX_RESUME_COMMAND": "cx codex resume",
+                "SUBROUTER_CODEX_SERVER": "replacement-server",
+                "SUBROUTER_CODEX_USER_EMAIL": "replacement@example.test",
+            ],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "SUBROUTER_CODEX_ACCOUNT_ID": "captured-account",
+                    "SUBROUTER_CODEX_BASE_URL": "https://captured.example.test/v1",
+                    "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                    "SUBROUTER_CODEX_SERVER": "captured-server",
+                    "SUBROUTER_CODEX_USER_EMAIL": "captured@example.test",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: ["PATH": "/usr/bin:/bin"]
+            )
+        )
+
+        #expect(invocation.arguments.prefix(4) == ["sr", "codex", "resume", sessionID])
+        #expect(invocation.environment["SUBROUTER_CODEX_ACCOUNT_ID"] == "captured-account")
+        #expect(invocation.environment["SUBROUTER_CODEX_BASE_URL"] == "https://captured.example.test/v1")
+        #expect(invocation.environment["SUBROUTER_CODEX_BIN"] == "/opt/bin/codex")
+        #expect(invocation.environment["SUBROUTER_CODEX_RESUME_COMMAND"] == nil)
+        #expect(invocation.environment["SUBROUTER_CODEX_SERVER"] == "captured-server")
+        #expect(invocation.environment["SUBROUTER_CODEX_USER_EMAIL"] == "captured@example.test")
+    }
+
     @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {
         let launchDirectory = "/tmp/codex-launch-root/repository"
         let restoredDirectory = "/tmp/codex-launch-root/repository/worktree"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -128,6 +128,41 @@ import Testing
         #expect(invocation.arguments.contains("-lc") == false)
     }
 
+    @Test func structuredSubrouterCodexRestoreUsesExplicitSrResumeCommand() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "/opt/bin/codex",
+                arguments: [
+                    "/opt/bin/codex",
+                    "-c",
+                    "model_provider=subrouter",
+                ],
+                workingDirectory: "/tmp/project",
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: ["PATH": "/usr/bin:/bin"]
+            )
+        )
+
+        #expect(invocation.arguments == ["sr", "codex", "resume", sessionID])
+        #expect(invocation.environment["SUBROUTER_CODEX_RESUME_COMMAND"] == nil)
+        #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == nil)
+    }
+
     @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {
         let launchDirectory = "/tmp/codex-launch-root/repository"
         let restoredDirectory = "/tmp/codex-launch-root/repository/worktree"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -209,6 +209,44 @@ import Testing
         ])
     }
 
+    @Test func structuredSubrouterRestoreRoutesItsChildThroughTheManagedCodexWrapper() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { $0 == "/shim/codex" }).invocation(
+                for: request,
+                ambientEnvironment: [
+                    "PATH": "/usr/bin:/bin",
+                    "CMUX_CODEX_WRAPPER_SHIM": "/shim/codex",
+                ]
+            )
+        )
+
+        #expect(invocation.arguments.prefix(4) == ["sr", "codex", "resume", sessionID])
+        #expect(invocation.environment["SUBROUTER_CODEX_BIN"] == "/shim/codex")
+        #expect(invocation.environment["CMUX_CUSTOM_CODEX_PATH"] == "/opt/bin/codex")
+        #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == "codex:\(sessionID)")
+    }
+
     @Test func structuredSubrouterRestoreKeepsProvedLaunchRoutingInputsAuthoritative() throws {
         let request = AgentRestoreRequest(
             mode: .resumeAgent,

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -148,6 +148,7 @@ import Testing
                 environment: [
                     "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
                     "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_SERVER": "team",
                     "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
@@ -190,7 +191,10 @@ import Testing
                 executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/tmp/project",
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume"]
+                environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume",
+                ]
             ),
             preparedArguments: nil,
             observedPermissionMode: nil
@@ -223,6 +227,7 @@ import Testing
                 arguments: ["/opt/bin/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/tmp/project",
                 environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 ]
@@ -261,6 +266,7 @@ import Testing
                 arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/tmp/project",
                 environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "CMUX_CUSTOM_CODEX_PATH": "/opt/custom/codex",
                     "SUBROUTER_CODEX_BIN": "/shim/codex",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
@@ -308,6 +314,7 @@ import Testing
                     "SUBROUTER_CODEX_ACCOUNT_ID": "captured-account",
                     "SUBROUTER_CODEX_BASE_URL": "https://captured.example.test/v1",
                     "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_SERVER": "captured-server",
                     "SUBROUTER_CODEX_USER_EMAIL": "captured@example.test",

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -163,6 +163,36 @@ import Testing
         #expect(invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"] == nil)
     }
 
+    @Test("Structured Subrouter restore preserves the captured launcher alias", arguments: ["subrouter", "cx"])
+    func structuredSubrouterCodexRestorePreservesLauncherAlias(command: String) throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume"]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: ["PATH": "/usr/bin:/bin"]
+            )
+        )
+
+        #expect(invocation.arguments == [command, "codex", "resume", sessionID])
+    }
+
     @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {
         let launchDirectory = "/tmp/codex-launch-root/repository"
         let restoredDirectory = "/tmp/codex-launch-root/repository/worktree"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -340,6 +340,52 @@ import Testing
         #expect(invocation.environment["SUBROUTER_CODEX_USER_EMAIL"] == "captured@example.test")
     }
 
+    @Test func structuredSubrouterRestoreTreatsAbsentLaunchRoutingInputsAsAuthoritative() throws {
+        let inheritedRouting = [
+            "CMUX_CUSTOM_CODEX_PATH": "/ambient/custom-codex",
+            "SUBROUTER_CODEX_ACCOUNT_ID": "ambient-account",
+            "SUBROUTER_CODEX_BASE_URL": "https://ambient.example.test/v1",
+            "SUBROUTER_CODEX_BIN": "/ambient/codex",
+            "SUBROUTER_CODEX_RESUME_COMMAND": "cx codex resume",
+            "SUBROUTER_CODEX_SERVER": "ambient-server",
+            "SUBROUTER_CODEX_USER_EMAIL": "ambient@example.test",
+        ]
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/project",
+            environment: inheritedRouting,
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                executablePath: "codex",
+                arguments: ["codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        var ambientEnvironment = inheritedRouting
+        ambientEnvironment["PATH"] = "/usr/bin:/bin"
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: ambientEnvironment
+            )
+        )
+
+        #expect(invocation.arguments.prefix(4) == ["sr", "codex", "resume", sessionID])
+        for key in inheritedRouting.keys {
+            #expect(invocation.environment[key] == nil, "\(key) leaked into routed restore")
+        }
+    }
+
     @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {
         let launchDirectory = "/tmp/codex-launch-root/repository"
         let restoredDirectory = "/tmp/codex-launch-root/repository/worktree"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -164,7 +164,10 @@ import Testing
             )
         )
 
-        #expect(invocation.arguments == ["sr", "codex", "resume", sessionID])
+        #expect(invocation.arguments == [
+            "sr", "codex", "resume", sessionID,
+            "-c", "check_for_update_on_startup=false",
+        ])
         #expect(invocation.environment["SUBROUTER_CODEX_ACCOUNT_ID"] == "team-codex-1")
         #expect(invocation.environment["SUBROUTER_CODEX_BASE_URL"] == "https://router.example.test/v1")
         #expect(invocation.environment["SUBROUTER_CODEX_RESUME_COMMAND"] == nil)
@@ -200,7 +203,10 @@ import Testing
             )
         )
 
-        #expect(invocation.arguments == [command, "codex", "resume", sessionID])
+        #expect(invocation.arguments == [
+            command, "codex", "resume", sessionID,
+            "-c", "check_for_update_on_startup=false",
+        ])
     }
 
     @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -304,7 +304,10 @@ struct AgentResumeArgvTests {
                 executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex", "--config=model_provider=\"subrouter\""],
                 environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "  sr   codex resume  "]
-            ) == .resolved(["sr", "codex", "resume", "SID"])
+            ) == .resolved([
+                "sr", "codex", "resume", "SID",
+                "-c", "check_for_update_on_startup=false",
+            ])
         )
 
         #expect(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -382,6 +382,45 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Subrouter routing proof and filtering stop at the option terminator")
+    func subrouterRoutingStopsAtOptionTerminator() {
+        let marker = ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: [
+                    "/opt/bin/codex",
+                    "-c", "model_provider=subrouter",
+                    "--",
+                    "-c", "model_provider=openai",
+                ],
+                environment: marker
+            ) == .resolved([
+                "sr", "codex", "resume", "SID",
+                "-c", "check_for_update_on_startup=false",
+                "--",
+                "-c", "model_provider=openai",
+            ])
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: [
+                    "/opt/bin/codex",
+                    "--",
+                    "--config=model_provider=subrouter",
+                ],
+                environment: marker
+            ) == .passthrough
+        )
+    }
+
     @Test("Codex wrapper rendering does not rewrite sr's codex subcommand")
     func renderedSubrouterResumeKeepsExplicitLauncher() {
         let quote: (String) -> String = { "'" + $0 + "'" }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -325,6 +325,37 @@ struct AgentResumeArgvTests {
                 launcher: "codex",
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
+                arguments: [
+                    "/opt/bin/codex",
+                    "-c", "model_provider=subrouter",
+                    "-c", "model_provider=openai",
+                ],
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ) == .passthrough
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: [
+                    "/opt/bin/codex",
+                    "-c", "model_provider=openai",
+                    "--config=model_provider='subrouter'",
+                ],
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ) == .resolved([
+                "sr", "codex", "resume", "SID",
+                "-c", "check_for_update_on_startup=false",
+            ])
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex"],
                 environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
             ) == .passthrough

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -419,6 +419,26 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Subrouter routing proof survives prompt sanitization")
+    func subrouterRoutingProofSurvivesPromptSanitization() {
+        let router = SubrouterCodexResumeRouting()
+        let marker = ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+
+        #expect(router.retainingRoutingProof(
+            in: ["codex"],
+            from: ["codex", "fix this", "-c", "model_provider=subrouter"],
+            launcher: "codex",
+            environment: marker
+        ) == ["codex", "-c", "model_provider=subrouter"])
+
+        #expect(router.retainingRoutingProof(
+            in: ["codex", "--"],
+            from: ["codex", "fix this", "--", "-c", "model_provider=subrouter"],
+            launcher: "codex",
+            environment: marker
+        ) == ["codex", "--"])
+    }
+
     @Test("Codex wrapper rendering does not rewrite sr's codex subcommand")
     func renderedSubrouterResumeKeepsExplicitLauncher() {
         let quote: (String) -> String = { "'" + $0 + "'" }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -257,10 +257,22 @@ struct AgentResumeArgvTests {
     func subrouterCodexResumeUsesCapturedExplicitLauncher() {
         let routedArguments = [
             "/opt/bin/codex",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--model",
+            "gpt-test",
             "-c",
             "model_provider=subrouter",
             "-c",
             "model_providers.subrouter.base_url=\"http://router.example/v1\"",
+            "-c",
+            "model_reasoning_effort=high",
+        ]
+
+        let preserved = [
+            "-c", "check_for_update_on_startup=false",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--model", "gpt-test",
+            "-c", "model_reasoning_effort=high",
         ]
 
         #expect(
@@ -270,7 +282,7 @@ struct AgentResumeArgvTests {
                 executablePath: "/opt/bin/codex",
                 arguments: routedArguments,
                 environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
-            ) == .resolved(["sr", "codex", "resume", "SID"])
+            ) == .resolved(["sr", "codex", "resume", "SID"] + preserved)
         )
 
         for command in ["subrouter", "cx"] {
@@ -281,7 +293,7 @@ struct AgentResumeArgvTests {
                     executablePath: "/opt/bin/codex",
                     arguments: routedArguments,
                     environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume"]
-                ) == .resolved([command, "codex", "resume", "SID"])
+                ) == .resolved([command, "codex", "resume", "SID"] + preserved)
             )
         }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -246,6 +246,7 @@ struct AgentResumeArgvTests {
                 launcher: "claude", sessionId: "SID", executablePath: nil, arguments: ["claude"]
             ) == .passthrough
         )
+
         #expect(
             AgentResumeArgv().launcherResolution(
                 launcher: nil, sessionId: "SID", executablePath: nil, arguments: []
@@ -274,6 +275,17 @@ struct AgentResumeArgvTests {
             "--model", "gpt-test",
             "-c", "model_reasoning_effort=high",
         ]
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: routedArguments,
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ) == .passthrough,
+            "An inherited raw marker without wrapper-bound proof must not reroute a direct Codex restore"
+        )
 
         #expect(
             AgentResumeArgv().launcherResolution(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -253,8 +253,8 @@ struct AgentResumeArgvTests {
         )
     }
 
-    @Test("Subrouter-routed Codex resumes through the explicit sr launcher")
-    func subrouterCodexResumeUsesExplicitLauncher() {
+    @Test("Subrouter-routed Codex resumes through the captured explicit launcher")
+    func subrouterCodexResumeUsesCapturedExplicitLauncher() {
         let routedArguments = [
             "/opt/bin/codex",
             "-c",
@@ -272,6 +272,18 @@ struct AgentResumeArgvTests {
                 environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
             ) == .resolved(["sr", "codex", "resume", "SID"])
         )
+
+        for command in ["subrouter", "cx"] {
+            #expect(
+                AgentResumeArgv().launcherResolution(
+                    launcher: "codex",
+                    sessionId: "SID",
+                    executablePath: "/opt/bin/codex",
+                    arguments: routedArguments,
+                    environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume"]
+                ) == .resolved([command, "codex", "resume", "SID"])
+            )
+        }
 
         #expect(
             AgentResumeArgv().launcherResolution(
@@ -310,6 +322,16 @@ struct AgentResumeArgvTests {
                 executablePath: "/opt/bin/codex",
                 arguments: routedArguments,
                 environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume; echo unsafe"]
+            ) == .passthrough
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: routedArguments,
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "router codex resume"]
             ) == .passthrough
         )
     }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -455,6 +455,15 @@ struct AgentResumeArgvTests {
         ])
     }
 
+    @Test("Captured executable fallback outranks a stale Subrouter child path")
+    func capturedExecutableFallbackOutranksStaleSubrouterPath() {
+        #expect(SubrouterCodexResumeRouting().preferredCustomCodexExecutable(
+            in: ["SUBROUTER_CODEX_BIN": "/stale/cmux-codex-wrapper"],
+            fallbackExecutable: "/opt/bin/codex",
+            wrapperShim: "/managed/cmux-codex-wrapper"
+        ) == "/opt/bin/codex")
+    }
+
     @Test("Subrouter routing proof survives prompt sanitization")
     func subrouterRoutingProofSurvivesPromptSanitization() {
         let router = SubrouterCodexResumeRouting()

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -401,8 +401,6 @@ struct AgentResumeArgvTests {
             ) == .resolved([
                 "sr", "codex", "resume", "SID",
                 "-c", "check_for_update_on_startup=false",
-                "--",
-                "-c", "model_provider=openai",
             ])
         )
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -3,6 +3,13 @@ import Testing
 
 @Suite("AgentResumeArgv")
 struct AgentResumeArgvTests {
+    private func boundSubrouterMarker(_ command: String = "sr codex resume") -> [String: String] {
+        [
+            SubrouterCodexResumeRouting.environmentKey: command,
+            SubrouterCodexResumeRouting.launchBoundEnvironmentKey: command,
+        ]
+    }
+
     @Test("Built-in --option style kinds", arguments: [
         ("claude", "claude", ["claude", "--resume", "SID"]),
         ("grok", "grok", ["grok", "-r", "SID"]),
@@ -293,7 +300,7 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: routedArguments,
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+                environment: boundSubrouterMarker()
             ) == .resolved(["sr", "codex", "resume", "SID"] + preserved)
         )
 
@@ -304,7 +311,7 @@ struct AgentResumeArgvTests {
                     sessionId: "SID",
                     executablePath: "/opt/bin/codex",
                     arguments: routedArguments,
-                    environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "\(command) codex resume"]
+                    environment: boundSubrouterMarker("\(command) codex resume")
                 ) == .resolved([command, "codex", "resume", "SID"] + preserved)
             )
         }
@@ -315,7 +322,7 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex", "--config=model_provider=\"subrouter\""],
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "  sr   codex resume  "]
+                environment: boundSubrouterMarker("  sr   codex resume  ")
             ) == .resolved([
                 "sr", "codex", "resume", "SID",
                 "-c", "check_for_update_on_startup=false",
@@ -342,7 +349,7 @@ struct AgentResumeArgvTests {
                     "-c", "model_provider=subrouter",
                     "-c", "model_provider=openai",
                 ],
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+                environment: boundSubrouterMarker()
             ) == .passthrough
         )
 
@@ -356,7 +363,7 @@ struct AgentResumeArgvTests {
                     "-c", "model_provider=openai",
                     "--config=model_provider='subrouter'",
                 ],
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+                environment: boundSubrouterMarker()
             ) == .resolved([
                 "sr", "codex", "resume", "SID",
                 "-c", "check_for_update_on_startup=false",
@@ -369,7 +376,7 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex"],
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+                environment: boundSubrouterMarker()
             ) == .passthrough
         )
 
@@ -379,7 +386,7 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: routedArguments,
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume; echo unsafe"]
+                environment: boundSubrouterMarker("sr codex resume; echo unsafe")
             ) == .passthrough
         )
 
@@ -389,14 +396,14 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: routedArguments,
-                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "router codex resume"]
+                environment: boundSubrouterMarker("router codex resume")
             ) == .passthrough
         )
     }
 
     @Test("Subrouter routing proof and filtering stop at the option terminator")
     func subrouterRoutingStopsAtOptionTerminator() {
-        let marker = ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+        let marker = boundSubrouterMarker()
 
         #expect(
             AgentResumeArgv().launcherResolution(
@@ -434,7 +441,7 @@ struct AgentResumeArgvTests {
     @Test("Subrouter routing proof survives prompt sanitization")
     func subrouterRoutingProofSurvivesPromptSanitization() {
         let router = SubrouterCodexResumeRouting()
-        let marker = ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+        let marker = boundSubrouterMarker()
 
         #expect(router.retainingRoutingProof(
             in: ["codex"],
@@ -499,11 +506,15 @@ struct AgentResumeArgvTests {
         )
     }
 
-    @Test("Codex wrapper token resolves CMUX_CODEX_WRAPPER_SHIM, degrading to bare codex")
+    @Test("Codex wrapper token resolves CMUX_CODEX_WRAPPER_SHIM with an explicit fallback")
     func codexWrapperShellExecutableToken() {
         #expect(
             AgentResumeArgv.codexWrapperShellExecutableToken
                 == "\"$([ -x \"${CMUX_CODEX_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CODEX_WRAPPER_SHIM\" || printf codex)\""
+        )
+        #expect(
+            AgentResumeArgv.codexWrapperShellExecutableToken(fallbackExecutable: "/opt/team's codex")
+                == "\"$([ -x \"${CMUX_CODEX_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CODEX_WRAPPER_SHIM\" || printf '%s' '/opt/team'\\''s codex')\""
         )
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -438,6 +438,23 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Public Subrouter arguments redact config without nulling prompt text")
+    func publicSubrouterArgumentsAreStructurallyRedacted() {
+        #expect(SubrouterCodexResumeRouting().removingPrivateRoutingArguments(from: [
+            "codex",
+            "discuss SUBROUTER_CODEX_USER_EMAIL and model_provider=subrouter",
+            "-c", "model_provider=\"subrouter\"",
+            "--config=model_providers.subrouter.base_url=https://router.example.test/v1",
+            "--",
+            "--config=model_provider=subrouter",
+        ]) == [
+            "codex",
+            "discuss SUBROUTER_CODEX_USER_EMAIL and model_provider=subrouter",
+            "--",
+            "--config=model_provider=subrouter",
+        ])
+    }
+
     @Test("Subrouter routing proof survives prompt sanitization")
     func subrouterRoutingProofSurvivesPromptSanitization() {
         let router = SubrouterCodexResumeRouting()

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -253,6 +253,79 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Subrouter-routed Codex resumes through the explicit sr launcher")
+    func subrouterCodexResumeUsesExplicitLauncher() {
+        let routedArguments = [
+            "/opt/bin/codex",
+            "-c",
+            "model_provider=subrouter",
+            "-c",
+            "model_providers.subrouter.base_url=\"http://router.example/v1\"",
+        ]
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: routedArguments,
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ) == .resolved(["sr", "codex", "resume", "SID"])
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex", "--config=model_provider=\"subrouter\""],
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "  sr   codex resume  "]
+            ) == .resolved(["sr", "codex", "resume", "SID"])
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: routedArguments,
+                environment: [:]
+            ) == .passthrough
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex"],
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume"]
+            ) == .passthrough
+        )
+
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codex",
+                sessionId: "SID",
+                executablePath: "/opt/bin/codex",
+                arguments: routedArguments,
+                environment: ["SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume; echo unsafe"]
+            ) == .passthrough
+        )
+    }
+
+    @Test("Codex wrapper rendering does not rewrite sr's codex subcommand")
+    func renderedSubrouterResumeKeepsExplicitLauncher() {
+        let quote: (String) -> String = { "'" + $0 + "'" }
+
+        #expect(
+            AgentResumeArgv.renderedPortableCodexResumeShellCommand(
+                parts: ["sr", "codex", "resume", "SID"],
+                quote: quote
+            ) == "'sr' 'codex' 'resume' 'SID'"
+        )
+    }
+
     @Test("Portable claude resume command wraps the POSIX rendering for any login shell")
     func portableClaudeResumeShellCommand() {
         #expect(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+RelayProvisioning.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+RelayProvisioning.swift
@@ -185,9 +185,26 @@ extension RemoteSessionCoordinator {
         """
     }
 
-    static func remoteCLIWrapperInstallScript(daemonRemotePath: String) -> String {
+    static func remoteCLIWrapperInstallScript(
+        daemonRemotePath: String,
+        codexWrapperScript: String? = nil
+    ) -> String {
         let trimmedRemotePath = daemonRemotePath.trimmingCharacters(in: .whitespacesAndNewlines)
         let daemonPathExpression = remoteDaemonPathShellExpression(trimmedRemotePath)
+        let codexWrapperInstall: String
+        if let codexWrapperScript,
+           !codexWrapperScript.components(separatedBy: .newlines).contains("CMUXREMOTE_CODEX_WRAPPER") {
+            codexWrapperInstall = """
+            codex_wrapper_tmp="$HOME/.cmux/bin/.codex-wrapper.tmp.$$"
+            cat > "$codex_wrapper_tmp" <<'CMUXREMOTE_CODEX_WRAPPER'
+            \(codexWrapperScript)
+            CMUXREMOTE_CODEX_WRAPPER
+            chmod 755 "$codex_wrapper_tmp"
+            mv -f "$codex_wrapper_tmp" "$HOME/.cmux/bin/cmux-codex-wrapper"
+            """
+        } else {
+            codexWrapperInstall = ""
+        }
         return """
         mkdir -p "$HOME/.cmux/bin" "$HOME/.cmux/relay"
         ln -sf \(daemonPathExpression) "$HOME/.cmux/bin/cmuxd-remote-current"
@@ -197,6 +214,7 @@ extension RemoteSessionCoordinator {
         CMUXWRAPPER
         chmod 755 "$wrapper_tmp"
         mv -f "$wrapper_tmp" "$HOME/.cmux/bin/cmux"
+        \(codexWrapperInstall)
         """
     }
 
@@ -205,7 +223,8 @@ extension RemoteSessionCoordinator {
         relayPort: Int,
         relayID: String,
         relayToken: String,
-        persistentDaemonSlot: String? = nil
+        persistentDaemonSlot: String? = nil,
+        codexWrapperScript: String? = nil
     ) -> String {
         let trimmedRemotePath = daemonRemotePath.trimmingCharacters(in: .whitespacesAndNewlines)
         let daemonPathExpression = remoteDaemonPathShellExpression(trimmedRemotePath)
@@ -222,7 +241,10 @@ extension RemoteSessionCoordinator {
         umask 077
         mkdir -p "$HOME/.cmux" "$HOME/.cmux/relay"
         chmod 700 "$HOME/.cmux/relay"
-        \(remoteCLIWrapperInstallScript(daemonRemotePath: trimmedRemotePath))
+        \(remoteCLIWrapperInstallScript(
+            daemonRemotePath: trimmedRemotePath,
+            codexWrapperScript: codexWrapperScript
+        ))
         printf '%s' \(daemonPathExpression) > "$HOME/.cmux/relay/\(relayPort).daemon_path"
         \(slotMetadataLine)
         cat > "$HOME/.cmux/relay/\(relayPort).auth" <<'CMUXRELAYAUTH'

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+RelayProvisioning.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+RelayProvisioning.swift
@@ -196,11 +196,15 @@ extension RemoteSessionCoordinator {
            !codexWrapperScript.components(separatedBy: .newlines).contains("CMUXREMOTE_CODEX_WRAPPER") {
             codexWrapperInstall = """
             codex_wrapper_tmp="$HOME/.cmux/bin/.codex-wrapper.tmp.$$"
-            cat > "$codex_wrapper_tmp" <<'CMUXREMOTE_CODEX_WRAPPER'
+            if ! cat > "$codex_wrapper_tmp" <<'CMUXREMOTE_CODEX_WRAPPER'
             \(codexWrapperScript)
             CMUXREMOTE_CODEX_WRAPPER
-            chmod 755 "$codex_wrapper_tmp"
-            mv -f "$codex_wrapper_tmp" "$HOME/.cmux/bin/cmux-codex-wrapper"
+            then
+              rm -f "$codex_wrapper_tmp"
+              exit 1
+            fi
+            chmod 755 "$codex_wrapper_tmp" || { rm -f "$codex_wrapper_tmp"; exit 1; }
+            mv -f "$codex_wrapper_tmp" "$HOME/.cmux/bin/cmux-codex-wrapper" || { rm -f "$codex_wrapper_tmp"; exit 1; }
             """
         } else {
             codexWrapperInstall = ""

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
@@ -362,7 +362,8 @@ extension RemoteSessionCoordinator {
             relayPort: relayPort,
             relayID: relayID,
             relayToken: relayToken,
-            persistentDaemonSlot: configuration.persistentDaemonSlot
+            persistentDaemonSlot: configuration.persistentDaemonSlot,
+            codexWrapperScript: codexWrapperScript
         )
         let command = "sh -c \(script.shellSingleQuoted)"
         let result = try sshExec(arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command], timeout: 8)

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -62,6 +62,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     let reachabilityProbe: any RemoteHostReachabilityProbing
     let relayCommandRewriter: any RemoteRelayCommandRewriting
     let buildInfo: any RemoteSessionBuildInfoProviding
+    let codexWrapperScript: String?
     let daemonStrings: RemoteDaemonStrings
     let strings: RemoteSessionStrings
     /// Sleep seam for every legacy `asyncAfter` delay (reconnect backoff,
@@ -177,6 +178,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         reachabilityProbe: any RemoteHostReachabilityProbing,
         relayCommandRewriter: any RemoteRelayCommandRewriting,
         buildInfo: any RemoteSessionBuildInfoProviding,
+        codexWrapperScript: String? = nil,
         daemonStrings: RemoteDaemonStrings,
         strings: RemoteSessionStrings,
         clock: any RemoteProxyRetryClock = SystemRemoteProxyRetryClock()
@@ -191,6 +193,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         self.reachabilityProbe = reachabilityProbe
         self.relayCommandRewriter = relayCommandRewriter
         self.buildInfo = buildInfo
+        self.codexWrapperScript = codexWrapperScript
         self.daemonStrings = daemonStrings
         self.strings = strings
         self.clock = clock

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
@@ -50,4 +50,46 @@ struct RemoteCodexWrapperProvisioningTests {
         #expect(String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
             == "remote-codex-wrapper\n")
     }
+
+    @Test("relay metadata fails and removes the temporary Codex wrapper when chmod fails")
+    func codexWrapperInstallFailureIsAtomic() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-remote-codex-wrapper-failure-\(UUID().uuidString)", isDirectory: true)
+        let fakeBin = root.appendingPathComponent("fake-bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: fakeBin, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let chmod = fakeBin.appendingPathComponent("chmod")
+        try """
+        #!/bin/sh
+        count_file="$HOME/chmod-count"
+        count=0
+        [ ! -r "$count_file" ] || count="$(cat "$count_file")"
+        count=$((count + 1))
+        printf '%s' "$count" > "$count_file"
+        [ "$count" -ne 2 ] || exit 23
+        exec /bin/chmod "$@"
+        """.write(to: chmod, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: chmod.path)
+
+        let script = RemoteSessionCoordinator.remoteRelayMetadataInstallScript(
+            daemonRemotePath: "/bin/true",
+            relayPort: 64_044,
+            relayID: "relay-test",
+            relayToken: String(repeating: "a", count: 64),
+            codexWrapperScript: "#!/bin/sh\nexit 0"
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        process.environment = ["HOME": root.path, "PATH": fakeBin.path + ":/usr/bin:/bin"]
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus != 0)
+        let bin = root.appendingPathComponent(".cmux/bin")
+        let remaining = try FileManager.default.contentsOfDirectory(atPath: bin.path)
+        #expect(!remaining.contains(where: { $0.hasPrefix(".codex-wrapper.tmp.") }))
+        #expect(!remaining.contains("cmux-codex-wrapper"))
+    }
 }

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
@@ -30,8 +30,24 @@ struct RemoteCodexWrapperProvisioningTests {
         process.waitUntilExit()
         #expect(process.terminationStatus == 0)
 
-        let installed = root.appendingPathComponent(".cmux/bin/codex")
+        let installed = root.appendingPathComponent(".cmux/bin/cmux-codex-wrapper")
         #expect(try String(contentsOf: installed, encoding: .utf8) == wrapper + "\n")
         #expect(FileManager.default.isExecutableFile(atPath: installed.path))
+
+        let launch = Process()
+        let output = Pipe()
+        launch.executableURL = URL(fileURLWithPath: "/bin/sh")
+        launch.arguments = ["-c", "\"$CMUX_CODEX_WRAPPER_SHIM\""]
+        launch.environment = [
+            "CMUX_CODEX_WRAPPER_SHIM": installed.path,
+            "HOME": root.path,
+            "PATH": root.appendingPathComponent(".cmux/bin").path + ":/usr/bin:/bin",
+        ]
+        launch.standardOutput = output
+        try launch.run()
+        launch.waitUntilExit()
+        #expect(launch.terminationStatus == 0)
+        #expect(String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            == "remote-codex-wrapper\n")
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import CmuxRemoteSession
+
+@Suite("Remote Codex wrapper provisioning")
+struct RemoteCodexWrapperProvisioningTests {
+    @Test("relay metadata installs the bundled Codex wrapper on the remote PATH")
+    func installsBundledCodexWrapper() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-remote-codex-wrapper-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let wrapper = """
+        #!/bin/sh
+        printf '%s\\n' remote-codex-wrapper
+        """
+        let script = RemoteSessionCoordinator.remoteRelayMetadataInstallScript(
+            daemonRemotePath: "/bin/true",
+            relayPort: 64_044,
+            relayID: "relay-test",
+            relayToken: String(repeating: "a", count: 64),
+            codexWrapperScript: wrapper
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        process.environment = ["HOME": root.path, "PATH": "/usr/bin:/bin"]
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+
+        let installed = root.appendingPathComponent(".cmux/bin/codex")
+        #expect(try String(contentsOf: installed, encoding: .utf8) == wrapper + "\n")
+        #expect(FileManager.default.isExecutableFile(atPath: installed.path))
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteCodexWrapperProvisioningTests.swift
@@ -62,12 +62,9 @@ struct RemoteCodexWrapperProvisioningTests {
         let chmod = fakeBin.appendingPathComponent("chmod")
         try """
         #!/bin/sh
-        count_file="$HOME/chmod-count"
-        count=0
-        [ ! -r "$count_file" ] || count="$(cat "$count_file")"
-        count=$((count + 1))
-        printf '%s' "$count" > "$count_file"
-        [ "$count" -ne 2 ] || exit 23
+        case "$*" in
+          *".codex-wrapper.tmp."*) exit 23 ;;
+        esac
         exec /bin/chmod "$@"
         """.write(to: chmod, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: chmod.path)

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -46,6 +46,42 @@ cmux_codex_wrapper_is_self_or_shim() {
     return 1
 }
 
+codex_launch_has_subrouter_provider() {
+    local argument assignment compact provider=""
+    local expects_config_value=0
+    for argument in "$@"; do
+        [[ "$argument" == "--" ]] && break
+        assignment=""
+        if (( expects_config_value )); then
+            assignment="$argument"
+            expects_config_value=0
+        else
+            case "$argument" in
+                -c|--config)
+                    expects_config_value=1
+                    continue
+                    ;;
+                -c=*|--config=*)
+                    assignment="${argument#*=}"
+                    ;;
+                *)
+                    continue
+                    ;;
+            esac
+        fi
+        compact="${assignment//[[:space:]]/}"
+        case "$compact" in
+            model_provider=subrouter|model_provider=\"subrouter\"|model_provider=\'subrouter\')
+                provider="subrouter"
+                ;;
+            model_provider=*)
+                provider="other"
+                ;;
+        esac
+    done
+    [[ "$provider" == "subrouter" ]]
+}
+
 # Find the real codex binary, skipping this wrapper and cmux's shell shims.
 find_real_codex() {
     local custom="${CMUX_CUSTOM_CODEX_PATH:-}"
@@ -255,6 +291,14 @@ export CMUX_CODEX_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
 export CMUX_AGENT_LAUNCH_KIND="codex"
 export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CODEX"
 export CMUX_AGENT_LAUNCH_CWD="$PWD"
+unset CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND
+if codex_launch_has_subrouter_provider "$@"; then
+    case "${SUBROUTER_CODEX_RESUME_COMMAND:-}" in
+        "sr codex resume"|"subrouter codex resume"|"cx codex resume")
+            export CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND="$SUBROUTER_CODEX_RESUME_COMMAND"
+            ;;
+    esac
+fi
 {
     cmux_codex_argv_b64="$(
         {

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -499,9 +499,11 @@ extension TerminalController {
     ) -> ControlAgentLaunchCommand {
         let environment = kind.flatMap { kind in
             command.environment.map {
-                AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(
+                AgentLaunchEnvironmentPolicy().selectedRestoreRecordEnvironment(
                     from: $0,
-                    kind: kind
+                    kind: kind,
+                    launcher: command.launcher,
+                    arguments: command.arguments
                 )
             }
         } ?? command.environment

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -1,32 +1,6 @@
 import CmuxFoundation
 import Foundation
 
-struct RemoteSessionBundledResourceLoader {
-    let resourceURL: URL?
-    let fileManager: FileManager
-
-    init(
-        resourceURL: URL? = Bundle.main.resourceURL,
-        fileManager: FileManager = .default
-    ) {
-        self.resourceURL = resourceURL
-        self.fileManager = fileManager
-    }
-
-    func codexWrapperScript() -> String? {
-        guard let resourceURL else { return nil }
-        let url = resourceURL
-            .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
-        guard fileManager.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url),
-              let contents = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return contents
-    }
-}
-
 enum RemoteInteractiveShellBootstrapBuilder {
     static func script(
         remoteRelayPort: Int,

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -264,7 +264,7 @@ enum RemoteInteractiveShellBootstrapBuilder {
         lines.append(contentsOf: shellExportLines(shellFeatures: shellFeatures))
         lines.append("export PATH=\"$HOME/.cmux/bin:$PATH\"")
         lines.append("export CMUX_BUNDLED_CLI_PATH=\"$HOME/.cmux/bin/cmux\"")
-        lines.append("if [ -x \"$HOME/.cmux/bin/cmux-codex-wrapper\" ] && command -v bash >/dev/null 2>&1; then export CMUX_CODEX_WRAPPER_SHIM=\"$HOME/.cmux/bin/cmux-codex-wrapper\"; fi")
+        lines.append("unset CMUX_CODEX_WRAPPER_SHIM; if [ -x \"$HOME/.cmux/bin/cmux-codex-wrapper\" ] && command -v bash >/dev/null 2>&1; then export CMUX_CODEX_WRAPPER_SHIM=\"$HOME/.cmux/bin/cmux-codex-wrapper\"; fi")
         lines.append(
             "export CMUX_PERSISTENT_PTY_EXEC_HELPER=\"${CMUX_PERSISTENT_PTY_EXEC_HELPER:-$CMUX_BUNDLED_CLI_PATH}\""
         )

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -236,6 +236,22 @@ enum RemoteInteractiveShellBootstrapBuilder {
         return contents
     }
 
+    static func bundledCodexWrapperScript(
+        bundleResourceURL: URL? = Bundle.main.resourceURL,
+        fileManager: FileManager = .default
+    ) -> String? {
+        guard let bundleResourceURL else { return nil }
+        let url = bundleResourceURL
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let contents = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return contents
+    }
+
     private static func commonShellLines(
         remoteRelayPort: Int,
         shellStateDir: String,
@@ -248,6 +264,7 @@ enum RemoteInteractiveShellBootstrapBuilder {
         lines.append(contentsOf: shellExportLines(shellFeatures: shellFeatures))
         lines.append("export PATH=\"$HOME/.cmux/bin:$PATH\"")
         lines.append("export CMUX_BUNDLED_CLI_PATH=\"$HOME/.cmux/bin/cmux\"")
+        lines.append("if [ -x \"$HOME/.cmux/bin/cmux-codex-wrapper\" ] && command -v bash >/dev/null 2>&1; then export CMUX_CODEX_WRAPPER_SHIM=\"$HOME/.cmux/bin/cmux-codex-wrapper\"; fi")
         lines.append(
             "export CMUX_PERSISTENT_PTY_EXEC_HELPER=\"${CMUX_PERSISTENT_PTY_EXEC_HELPER:-$CMUX_BUNDLED_CLI_PATH}\""
         )

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -1,6 +1,32 @@
 import CmuxFoundation
 import Foundation
 
+struct RemoteSessionBundledResourceLoader {
+    let resourceURL: URL?
+    let fileManager: FileManager
+
+    init(
+        resourceURL: URL? = Bundle.main.resourceURL,
+        fileManager: FileManager = .default
+    ) {
+        self.resourceURL = resourceURL
+        self.fileManager = fileManager
+    }
+
+    func codexWrapperScript() -> String? {
+        guard let resourceURL else { return nil }
+        let url = resourceURL
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let contents = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return contents
+    }
+}
+
 enum RemoteInteractiveShellBootstrapBuilder {
     static func script(
         remoteRelayPort: Int,
@@ -228,22 +254,6 @@ enum RemoteInteractiveShellBootstrapBuilder {
         let url = bundleResourceURL
             .appendingPathComponent("shell-integration", isDirectory: true)
             .appendingPathComponent(fileName, isDirectory: false)
-        guard fileManager.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url),
-              let contents = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return contents
-    }
-
-    static func bundledCodexWrapperScript(
-        bundleResourceURL: URL? = Bundle.main.resourceURL,
-        fileManager: FileManager = .default
-    ) -> String? {
-        guard let bundleResourceURL else { return nil }
-        let url = bundleResourceURL
-            .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
         guard fileManager.fileExists(atPath: url.path),
               let data = try? Data(contentsOf: url),
               let contents = String(data: data, encoding: .utf8) else {

--- a/Sources/RemoteSessionBundledResourceLoader.swift
+++ b/Sources/RemoteSessionBundledResourceLoader.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct RemoteSessionBundledResourceLoader {
+    let resourceURL: URL?
+    let fileManager: FileManager
+
+    init(
+        resourceURL: URL? = Bundle.main.resourceURL,
+        fileManager: FileManager = .default
+    ) {
+        self.resourceURL = resourceURL
+        self.fileManager = fileManager
+    }
+
+    func codexWrapperScript() -> String? {
+        guard let resourceURL else { return nil }
+        let url = resourceURL
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let contents = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return contents
+    }
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -457,7 +457,7 @@ enum AgentResumeCommandBuilder {
         includeWorkingDirectoryPrefix: Bool
     ) -> String {
         var commandParts: [String] = []
-        let environmentParts = launchEnvironmentParts(kind: kind, environment: launchCommand?.environment)
+        let environmentParts = launchEnvironmentParts(kind: kind, launchCommand: launchCommand)
         if !environmentParts.isEmpty {
             commandParts.append("env")
             commandParts.append(contentsOf: environmentParts)
@@ -537,15 +537,21 @@ enum AgentResumeCommandBuilder {
 
     private static func launchEnvironmentParts(
         kind: RestorableAgentKind,
-        environment: [String: String]?
+        launchCommand: AgentLaunchCommandSnapshot?
     ) -> [String] {
+        let environment = launchCommand?.environment
         guard let environment, !environment.isEmpty else {
             return []
         }
 
         var environmentParts: [String] = []
         var preservedClaudeAuthSelectionEnvironmentKeys: [String] = []
-        var selectedEnvironment = AgentLaunchEnvironmentPolicy().selectedEnvironment(from: environment, kind: kind.rawValue)
+        var selectedEnvironment = AgentLaunchEnvironmentPolicy().selectedReplayEnvironment(
+            from: environment,
+            kind: kind.rawValue,
+            launcher: launchCommand?.launcher,
+            arguments: launchCommand?.arguments ?? []
+        )
         let piFamilyUsesCapturedPath = kind == .pi
             || kind.customAgentID == "pi"
             || kind.customAgentID == "omp"

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -888,7 +888,11 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             restoringWorkingDirectory: effectiveWorkingDirectory
         ).map { command in
             AgentRestoreLaunch(kind: kind.rawValue, sessionID: sessionId)?
-                .applying(toStoredCommand: command) ?? command
+                .applying(
+                    toStoredCommand: command,
+                    routedLaunchCommand: launchCommand,
+                    checkpointID: sessionId
+                ) ?? command
         }
         return restoreCommand.map { $0 + "\n" }
     }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -584,7 +584,8 @@ enum AgentResumeCommandBuilder {
             launcher: launchCommand?.launcher,
             sessionId: sessionId,
             executablePath: launchCommand?.executablePath,
-            arguments: launchCommand?.arguments ?? []
+            arguments: launchCommand?.arguments ?? [],
+            environment: launchCommand?.environment
         ) {
         case .resolved(let argv):
             return argv

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -190,16 +190,20 @@ extension AgentRestoreLaunch {
 
         let executableStart = words[executableIndex].range.lowerBound
         var assignments: [String] = []
-        if let capturedExecutable = SubrouterCodexResumeRouting().preferredCustomCodexExecutable(
+        let capturedExecutable = SubrouterCodexResumeRouting().preferredCustomCodexExecutable(
             in: launchCommand.environment,
             fallbackExecutable: launchCommand.executablePath,
             wrapperShim: wrapperShellExecutableToken
-        ) {
+        )
+        if let capturedExecutable {
             assignments.append(
                 TerminalStartupShellQuoting.singleQuoted("CMUX_CUSTOM_CODEX_PATH=\(capturedExecutable)")
             )
         }
-        assignments.append("SUBROUTER_CODEX_BIN=\(wrapperShellExecutableToken)")
+        let routedExecutableToken = capturedExecutable.map {
+            AgentResumeArgv.codexWrapperShellExecutableToken(fallbackExecutable: $0)
+        } ?? wrapperShellExecutableToken
+        assignments.append("SUBROUTER_CODEX_BIN=\(routedExecutableToken)")
         let routedCommand = "/usr/bin/env " + assignments.joined(separator: " ") + " "
             + String(command[executableStart...])
         return authorizing(

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -110,17 +110,34 @@ extension SurfaceResumeBindingSnapshot {
             repaired = suppressed
         }
         guard let restoreLaunch = AgentRestoreLaunch(kind: kind, sessionID: checkpointId) else { return repaired }
-        return restoreLaunch.applying(toStoredCommand: repaired)
+        return restoreLaunch.applying(
+            toStoredCommand: repaired,
+            routedLaunchCommand: launchCommand,
+            checkpointID: checkpointId
+        )
     }
 }
 
 extension AgentRestoreLaunch {
-    func applying(toStoredCommand command: String) -> String {
+    func applying(
+        toStoredCommand command: String,
+        routedLaunchCommand launchCommand: AgentLaunchCommandSnapshot? = nil,
+        checkpointID: String? = nil
+    ) -> String {
         let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
         guard let executableIndex = SurfaceResumeCommandCanonicalizer.commandExecutableWordIndex(
             in: words,
             command: command
         ) else { return command }
+        if let routed = applyingSubrouterCodexChildWrapper(
+            to: command,
+            words: words,
+            executableIndex: executableIndex,
+            launchCommand: launchCommand,
+            checkpointID: checkpointID
+        ) {
+            return routed
+        }
         let wrapperToken = wrapperShellExecutableToken
         let executable = words[executableIndex].value
         guard command.contains(wrapperToken) || (executable as NSString).lastPathComponent == executableName else {
@@ -146,6 +163,45 @@ extension AgentRestoreLaunch {
         return authorizing(
             leadingShell: String(routed[..<executableStart]),
             routedCommand: String(routed[executableStart...])
+        )
+    }
+
+    private func applyingSubrouterCodexChildWrapper(
+        to command: String,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
+        executableIndex: Int,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        checkpointID: String?
+    ) -> String? {
+        guard executableName == "codex",
+              let launchCommand,
+              let checkpointID,
+              let routedPrefix = SubrouterCodexResumeRouting().resumeArguments(
+                  launcher: launchCommand.launcher,
+                  sessionID: checkpointID,
+                  launchArguments: launchCommand.arguments,
+                  environment: launchCommand.environment
+              ),
+              words.count >= executableIndex + routedPrefix.count,
+              Array(words[executableIndex..<(executableIndex + routedPrefix.count)]).map(\.value)
+                  == routedPrefix else {
+            return nil
+        }
+
+        let executableStart = words[executableIndex].range.lowerBound
+        var assignments: [String] = []
+        if let capturedExecutable = SubrouterCodexResumeRouting()
+            .capturedRoutingEnvironment(in: launchCommand.environment)["SUBROUTER_CODEX_BIN"] {
+            assignments.append(
+                TerminalStartupShellQuoting.singleQuoted("CMUX_CUSTOM_CODEX_PATH=\(capturedExecutable)")
+            )
+        }
+        assignments.append("SUBROUTER_CODEX_BIN=\(wrapperShellExecutableToken)")
+        let routedCommand = "/usr/bin/env " + assignments.joined(separator: " ") + " "
+            + String(command[executableStart...])
+        return authorizing(
+            leadingShell: String(command[..<executableStart]),
+            routedCommand: routedCommand
         )
     }
 }

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -201,7 +201,7 @@ extension AgentRestoreLaunch {
             + String(command[executableStart...])
         return authorizing(
             leadingShell: String(command[..<executableStart]),
-            routedCommand: routedCommand
+            routedCommand: portableWrapperShellCommand(posixCommand: routedCommand)
         )
     }
 }

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -190,8 +190,11 @@ extension AgentRestoreLaunch {
 
         let executableStart = words[executableIndex].range.lowerBound
         var assignments: [String] = []
-        if let capturedExecutable = SubrouterCodexResumeRouting()
-            .capturedRoutingEnvironment(in: launchCommand.environment)["SUBROUTER_CODEX_BIN"] {
+        if let capturedExecutable = SubrouterCodexResumeRouting().preferredCustomCodexExecutable(
+            in: launchCommand.environment,
+            fallbackExecutable: launchCommand.executablePath,
+            wrapperShim: wrapperShellExecutableToken
+        ) {
             assignments.append(
                 TerminalStartupShellQuoting.singleQuoted("CMUX_CUSTOM_CODEX_PATH=\(capturedExecutable)")
             )

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -122,7 +122,7 @@ extension Workspace {
                 remoteRelayTokenHex: configuration.relayToken ?? ""
             ),
             buildInfo: WorkspaceRemoteSessionBuildInfo(),
-            codexWrapperScript: RemoteInteractiveShellBootstrapBuilder.bundledCodexWrapperScript(),
+            codexWrapperScript: RemoteSessionBundledResourceLoader().codexWrapperScript(),
             daemonStrings: RemoteDaemonStrings.appLocalized,
             strings: RemoteSessionStrings.appLocalized
         )

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -122,6 +122,7 @@ extension Workspace {
                 remoteRelayTokenHex: configuration.relayToken ?? ""
             ),
             buildInfo: WorkspaceRemoteSessionBuildInfo(),
+            codexWrapperScript: RemoteInteractiveShellBootstrapBuilder.bundledCodexWrapperScript(),
             daemonStrings: RemoteDaemonStrings.appLocalized,
             strings: RemoteSessionStrings.appLocalized
         )

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1745,6 +1745,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		REE0CA0000000000000000A2 /* RemotesClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = REE0CA0000000000000000A1 /* RemotesClient.swift */; };
 		C1A070000000000000000007 /* RemotesClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000017 /* RemotesClientError.swift */; };
 		REE0CA0000000000000000B2 /* RemotesClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = REE0CA0000000000000000B1 /* RemotesClientTests.swift */; };
+		A5001645 /* RemoteSessionBundledResourceLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001644 /* RemoteSessionBundledResourceLoader.swift */; };
+		B9000029A1B2C3D4E5F60719 /* RemoteSessionBundledResourceLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001644 /* RemoteSessionBundledResourceLoader.swift */; };
 		806100020000000000000001 /* RemoteSessionCleanupLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806100020000000000000002 /* RemoteSessionCleanupLifecycleTests.swift */; };
 		797800020000000000000001 /* RemoteSessionPowerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800020000000000000002 /* RemoteSessionPowerObserver.swift */; };
 		EE30D6000000000000000006 /* RemoteSessionStrings+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */; };
@@ -4641,6 +4643,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		REE0CA0000000000000000A1 /* RemotesClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemotesClient.swift; sourceTree = "<group>"; };
 		C1A070000000000000000017 /* RemotesClientError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemotesClientError.swift; sourceTree = "<group>"; };
 		REE0CA0000000000000000B1 /* RemotesClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotesClientTests.swift; sourceTree = "<group>"; };
+		A5001644 /* RemoteSessionBundledResourceLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionBundledResourceLoader.swift; sourceTree = "<group>"; };
 		806100020000000000000002 /* RemoteSessionCleanupLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionCleanupLifecycleTests.swift; sourceTree = "<group>"; };
 		797800020000000000000002 /* RemoteSessionPowerObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RemoteSessionPowerObserver.swift; sourceTree = "<group>"; };
 		EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSessionStrings+App.swift"; sourceTree = "<group>"; };
@@ -7771,6 +7774,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DEF0C20000000000000002 /* SemanticVersion.swift */,
 				835000000000000000000003 /* RemoteInitialCommandBootstrap.swift */,
 				A5001642 /* RemoteInteractiveShellBootstrapBuilder.swift */,
+				A5001644 /* RemoteSessionBundledResourceLoader.swift */,
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
 				C0DE43000000000000000002 /* CmuxAgentChatConfig.swift */,
 				A5001651 /* CmuxConfig.swift */,
@@ -10383,6 +10387,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				REE0CA0000000000000000D2 /* RemoteRouteSpec.swift in Sources */,
 				REE0CA0000000000000000A2 /* RemotesClient.swift in Sources */,
 				C1A070000000000000000007 /* RemotesClientError.swift in Sources */,
+				A5001645 /* RemoteSessionBundledResourceLoader.swift in Sources */,
 				797800020000000000000001 /* RemoteSessionPowerObserver.swift in Sources */,
 				EE30D6000000000000000006 /* RemoteSessionStrings+App.swift in Sources */,
 				E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */,
@@ -11359,6 +11364,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				835000000000000000000002 /* RemoteInitialCommandBootstrap.swift in Sources */,
 				B9000028A1B2C3D4E5F60719 /* RemoteInteractiveShellBootstrapBuilder.swift in Sources */,
 				B9000027A1B2C3D4E5F60719 /* RemoteRelayZshBootstrap.swift in Sources */,
+				B9000029A1B2C3D4E5F60719 /* RemoteSessionBundledResourceLoader.swift in Sources */,
 				A10052000000000000000002 /* SocketClient+StartupWait.swift in Sources */,
 				C510C1E00000000000000002 /* SocketOperationTelemetry.swift in Sources */,
 				B816E948EC5E42AF967648AC /* SSHPTYAttachReconnectInputFilter.swift in Sources */,

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -282,6 +282,18 @@ import Testing
         let launchCommand = try #require(record["launch_command"] as? [String: Any])
         let launchEnvironment = try #require(launchCommand["environment"] as? [String: Any])
         #expect(launchEnvironment["PATH"] as? String == "/usr/bin:/bin")
+
+        let plainResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["surface", "resume", "show"],
+            environment: environment,
+            timeout: 5
+        )
+        #expect(!plainResult.timedOut, Comment(rawValue: plainResult.diagnostics))
+        #expect(plainResult.status == 0, Comment(rawValue: plainResult.diagnostics))
+        #expect(plainResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "null")
+        #expect(plainResult.stdout.contains("private@example.test") == false)
+        #expect(plainResult.stdout.contains("router.example.test") == false)
     }
 
     @Test func testIOSContextFromTerminalFallsBackToWorkspaceSimulator() throws {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -232,7 +232,7 @@ import Testing
                 "kind": "codex",
                 "launch_command": [
                     "arguments": [
-                        "codex", "-c", "model_provider=subrouter",
+                        "codex", "-c", "model_provider=\"subrouter\"",
                         "-c", "model_providers.subrouter.base_url=https://router.example.test/v1",
                     ],
                     "environment": [
@@ -272,7 +272,7 @@ import Testing
         #expect(result.stdout.contains("CMUX_CUSTOM_CODEX_PATH") == false)
         #expect(result.stdout.contains("/private/custom/codex") == false)
         #expect(result.stdout.contains("[private routing metadata]") == false)
-        #expect(result.stdout.contains("model_provider=subrouter") == false)
+        #expect(result.stdout.contains("model_provider") == false)
         #expect(result.stdout.contains("private@example.test") == false)
         #expect(result.stdout.contains("router.example.test") == false)
         let payload = try #require(

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -220,6 +220,26 @@ import Testing
     @Test func testSurfaceResumeJSONDoesNotExposePrivateSubrouterRoutingMetadata() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = "/tmp/cmux-resume-private-\(UUID().uuidString.prefix(8)).sock"
+        let privateRestoreRecord: [String: Any] = [
+            "kind": "codex",
+            "launch_command": [
+                "arguments": [
+                    "codex", "-c", "model_provider=\"subrouter\"",
+                    "-c", "model_providers.subrouter.base_url=https://router.example.test/v1",
+                ],
+                "environment": [
+                    "PATH": "/usr/bin:/bin",
+                    "SUBROUTER_CODEX_ACCOUNT_ID": "private-account",
+                    "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                    "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                    "CMUX_CUSTOM_CODEX_PATH": "/private/custom/codex",
+                    "SUBROUTER_CODEX_SERVER": "private-server",
+                    "SUBROUTER_CODEX_USER_EMAIL": "private@example.test",
+                ],
+            ],
+        ]
         let response = try jsonResponse(result: [
             "resume_binding": [
                 "command": "env 'SUBROUTER_CODEX_USER_EMAIL=private@example.test' sr codex resume session-id",
@@ -228,26 +248,15 @@ import Testing
                     "SUBROUTER_CODEX_SERVER": "private-server",
                 ],
             ],
-            "restore_record": [
-                "kind": "codex",
-                "launch_command": [
-                    "arguments": [
-                        "codex", "-c", "model_provider=\"subrouter\"",
-                        "-c", "model_providers.subrouter.base_url=https://router.example.test/v1",
-                    ],
-                    "environment": [
-                        "PATH": "/usr/bin:/bin",
-                        "SUBROUTER_CODEX_ACCOUNT_ID": "private-account",
-                        "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
-                        "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
-                        "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
-                        "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
-                        "CMUX_CUSTOM_CODEX_PATH": "/private/custom/codex",
-                        "SUBROUTER_CODEX_SERVER": "private-server",
-                        "SUBROUTER_CODEX_USER_EMAIL": "private@example.test",
-                    ],
-                ],
-            ],
+            "restore_record": privateRestoreRecord,
+        ])
+        let listResponse = try jsonResponse(result: [
+            "surfaces": [[
+                "id": UUID().uuidString.lowercased(),
+                "ref": "surface:1",
+                "type": "terminal",
+                "restore_record": privateRestoreRecord,
+            ]],
         ])
         let directCommand = "codex resume direct-session -- 'discuss SUBROUTER_CODEX_USER_EMAIL and model_provider=subrouter'"
         let directResponse = try jsonResponse(result: [
@@ -258,7 +267,7 @@ import Testing
         ])
         let responder = try UnixSocketResponder(
             path: socketPath,
-            responses: [response, response, directResponse]
+            responses: [response, response, listResponse, directResponse]
         )
         defer { responder.stop() }
 
@@ -278,19 +287,20 @@ import Testing
 
         #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
         #expect(result.status == 0, Comment(rawValue: result.diagnostics))
-        #expect(result.stdout.contains("SUBROUTER_CODEX_") == false)
-        #expect(result.stdout.contains("CMUX_CUSTOM_CODEX_PATH") == false)
-        #expect(result.stdout.contains("/private/custom/codex") == false)
-        #expect(result.stdout.contains("[private routing metadata]") == false)
-        #expect(result.stdout.contains("model_provider") == false)
-        #expect(result.stdout.contains("private@example.test") == false)
-        #expect(result.stdout.contains("router.example.test") == false)
+        #expect(result.combinedOutput.contains("SUBROUTER_CODEX_") == false)
+        #expect(result.combinedOutput.contains("CMUX_CUSTOM_CODEX_PATH") == false)
+        #expect(result.combinedOutput.contains("/private/custom/codex") == false)
+        #expect(result.combinedOutput.contains("[private routing metadata]") == false)
+        #expect(result.combinedOutput.contains("model_provider") == false)
+        #expect(result.combinedOutput.contains("private@example.test") == false)
+        #expect(result.combinedOutput.contains("router.example.test") == false)
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
         )
         let record = try #require(payload["restore_record"] as? [String: Any])
         let launchCommand = try #require(record["launch_command"] as? [String: Any])
         let launchEnvironment = try #require(launchCommand["environment"] as? [String: Any])
+        #expect(Set(launchEnvironment.keys) == Set(["PATH"]))
         #expect(launchEnvironment["PATH"] as? String == "/usr/bin:/bin")
 
         let plainResult = runProcess(
@@ -302,8 +312,28 @@ import Testing
         #expect(!plainResult.timedOut, Comment(rawValue: plainResult.diagnostics))
         #expect(plainResult.status == 0, Comment(rawValue: plainResult.diagnostics))
         #expect(plainResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "null")
-        #expect(plainResult.stdout.contains("private@example.test") == false)
-        #expect(plainResult.stdout.contains("router.example.test") == false)
+        #expect(plainResult.combinedOutput.contains("SUBROUTER_CODEX_") == false)
+        #expect(plainResult.combinedOutput.contains("CMUX_CUSTOM_CODEX_PATH") == false)
+        #expect(plainResult.combinedOutput.contains("/private/custom/codex") == false)
+        #expect(plainResult.combinedOutput.contains("[private routing metadata]") == false)
+        #expect(plainResult.combinedOutput.contains("model_provider") == false)
+        #expect(plainResult.combinedOutput.contains("private@example.test") == false)
+        #expect(plainResult.combinedOutput.contains("router.example.test") == false)
+
+        let listResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["list-panels", "--json"],
+            environment: environment,
+            timeout: 5
+        )
+        #expect(!listResult.timedOut, Comment(rawValue: listResult.diagnostics))
+        #expect(listResult.status == 0, Comment(rawValue: listResult.diagnostics))
+        #expect(listResult.combinedOutput.contains("SUBROUTER_CODEX_") == false)
+        #expect(listResult.combinedOutput.contains("CMUX_CUSTOM_CODEX_PATH") == false)
+        #expect(listResult.combinedOutput.contains("/private/custom/codex") == false)
+        #expect(listResult.combinedOutput.contains("model_provider") == false)
+        #expect(listResult.combinedOutput.contains("private@example.test") == false)
+        #expect(listResult.combinedOutput.contains("router.example.test") == false)
 
         let directResult = runProcess(
             executablePath: cliPath,

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -223,11 +223,17 @@ import Testing
         let privateRestoreRecord: [String: Any] = [
             "kind": "codex",
             "legacy_command": "env 'SUBROUTER_CODEX_USER_EMAIL=legacy-private@example.test' sr codex resume session-id",
+            "prepared_arguments": [
+                "/private/custom/codex",
+                "-c", "model_provider=subrouter",
+                "--config=model_providers.subrouter.base_url=https://prepared-router.example.test/v1",
+            ],
             "launch_command": [
                 "arguments": [
-                    "codex", "-c", "model_provider=\"subrouter\"",
+                    "/private/custom/codex", "-c", "model_provider=\"subrouter\"",
                     "-c", "model_providers.subrouter.base_url=https://router.example.test/v1",
                 ],
+                "executable_path": "/private/custom/codex",
                 "environment": [
                     "PATH": "/usr/bin:/bin",
                     "SUBROUTER_CODEX_ACCOUNT_ID": "private-account",
@@ -301,7 +307,14 @@ import Testing
         )
         let record = try #require(payload["restore_record"] as? [String: Any])
         #expect(record["legacy_command"] is NSNull)
+        let preparedArguments = try #require(record["prepared_arguments"] as? [Any])
+        #expect(preparedArguments.first is NSNull)
+        #expect(preparedArguments.count == 1)
         let launchCommand = try #require(record["launch_command"] as? [String: Any])
+        #expect(launchCommand["executable_path"] is NSNull)
+        let launchArguments = try #require(launchCommand["arguments"] as? [Any])
+        #expect(launchArguments.first is NSNull)
+        #expect(launchArguments.count == 1)
         let launchEnvironment = try #require(launchCommand["environment"] as? [String: Any])
         #expect(Set(launchEnvironment.keys) == Set(["PATH"]))
         #expect(launchEnvironment["PATH"] as? String == "/usr/bin:/bin")

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -241,6 +241,7 @@ import Testing
                         "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
                         "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
                         "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                        "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                         "SUBROUTER_CODEX_SERVER": "private-server",
                         "SUBROUTER_CODEX_USER_EMAIL": "private@example.test",
                     ],

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -242,6 +242,7 @@ import Testing
                         "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
                         "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                         "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                        "CMUX_CUSTOM_CODEX_PATH": "/private/custom/codex",
                         "SUBROUTER_CODEX_SERVER": "private-server",
                         "SUBROUTER_CODEX_USER_EMAIL": "private@example.test",
                     ],
@@ -268,6 +269,9 @@ import Testing
         #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
         #expect(result.status == 0, Comment(rawValue: result.diagnostics))
         #expect(result.stdout.contains("SUBROUTER_CODEX_") == false)
+        #expect(result.stdout.contains("CMUX_CUSTOM_CODEX_PATH") == false)
+        #expect(result.stdout.contains("/private/custom/codex") == false)
+        #expect(result.stdout.contains("[private routing metadata]") == false)
         #expect(result.stdout.contains("model_provider=subrouter") == false)
         #expect(result.stdout.contains("private@example.test") == false)
         #expect(result.stdout.contains("router.example.test") == false)

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -222,6 +222,7 @@ import Testing
         let socketPath = "/tmp/cmux-resume-private-\(UUID().uuidString.prefix(8)).sock"
         let privateRestoreRecord: [String: Any] = [
             "kind": "codex",
+            "legacy_command": "env 'SUBROUTER_CODEX_USER_EMAIL=legacy-private@example.test' sr codex resume session-id",
             "launch_command": [
                 "arguments": [
                     "codex", "-c", "model_provider=\"subrouter\"",
@@ -293,11 +294,13 @@ import Testing
         #expect(result.combinedOutput.contains("[private routing metadata]") == false)
         #expect(result.combinedOutput.contains("model_provider") == false)
         #expect(result.combinedOutput.contains("private@example.test") == false)
+        #expect(result.combinedOutput.contains("legacy-private@example.test") == false)
         #expect(result.combinedOutput.contains("router.example.test") == false)
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
         )
         let record = try #require(payload["restore_record"] as? [String: Any])
+        #expect(record["legacy_command"] is NSNull)
         let launchCommand = try #require(record["launch_command"] as? [String: Any])
         let launchEnvironment = try #require(launchCommand["environment"] as? [String: Any])
         #expect(Set(launchEnvironment.keys) == Set(["PATH"]))
@@ -318,6 +321,7 @@ import Testing
         #expect(plainResult.combinedOutput.contains("[private routing metadata]") == false)
         #expect(plainResult.combinedOutput.contains("model_provider") == false)
         #expect(plainResult.combinedOutput.contains("private@example.test") == false)
+        #expect(plainResult.combinedOutput.contains("legacy-private@example.test") == false)
         #expect(plainResult.combinedOutput.contains("router.example.test") == false)
 
         let listResult = runProcess(
@@ -333,6 +337,7 @@ import Testing
         #expect(listResult.combinedOutput.contains("/private/custom/codex") == false)
         #expect(listResult.combinedOutput.contains("model_provider") == false)
         #expect(listResult.combinedOutput.contains("private@example.test") == false)
+        #expect(listResult.combinedOutput.contains("legacy-private@example.test") == false)
         #expect(listResult.combinedOutput.contains("router.example.test") == false)
 
         let directResult = runProcess(

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -268,6 +268,7 @@ import Testing
         #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
         #expect(result.status == 0, Comment(rawValue: result.diagnostics))
         #expect(result.stdout.contains("SUBROUTER_CODEX_") == false)
+        #expect(result.stdout.contains("model_provider=subrouter") == false)
         #expect(result.stdout.contains("private@example.test") == false)
         #expect(result.stdout.contains("router.example.test") == false)
         let payload = try #require(

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -222,7 +222,7 @@ import Testing
         let socketPath = "/tmp/cmux-resume-private-\(UUID().uuidString.prefix(8)).sock"
         let response = try jsonResponse(result: [
             "resume_binding": [
-                "command": "sr codex resume session-id",
+                "command": "env 'SUBROUTER_CODEX_USER_EMAIL=private@example.test' sr codex resume session-id",
                 "environment": [
                     "PATH": "/usr/bin:/bin",
                     "SUBROUTER_CODEX_SERVER": "private-server",
@@ -231,7 +231,10 @@ import Testing
             "restore_record": [
                 "kind": "codex",
                 "launch_command": [
-                    "arguments": ["codex", "-c", "model_provider=subrouter"],
+                    "arguments": [
+                        "codex", "-c", "model_provider=subrouter",
+                        "-c", "model_providers.subrouter.base_url=https://router.example.test/v1",
+                    ],
                     "environment": [
                         "PATH": "/usr/bin:/bin",
                         "SUBROUTER_CODEX_ACCOUNT_ID": "private-account",
@@ -264,6 +267,8 @@ import Testing
         #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
         #expect(result.status == 0, Comment(rawValue: result.diagnostics))
         #expect(result.stdout.contains("SUBROUTER_CODEX_") == false)
+        #expect(result.stdout.contains("private@example.test") == false)
+        #expect(result.stdout.contains("router.example.test") == false)
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
         )

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -249,7 +249,17 @@ import Testing
                 ],
             ],
         ])
-        let responder = try UnixSocketResponder(path: socketPath, response: response)
+        let directCommand = "codex resume direct-session -- 'discuss SUBROUTER_CODEX_USER_EMAIL and model_provider=subrouter'"
+        let directResponse = try jsonResponse(result: [
+            "resume_binding": [
+                "command": directCommand,
+                "environment": ["PATH": "/usr/bin:/bin"],
+            ],
+        ])
+        let responder = try UnixSocketResponder(
+            path: socketPath,
+            responses: [response, response, directResponse]
+        )
         defer { responder.stop() }
 
         var environment = ProcessInfo.processInfo.environment
@@ -294,6 +304,16 @@ import Testing
         #expect(plainResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "null")
         #expect(plainResult.stdout.contains("private@example.test") == false)
         #expect(plainResult.stdout.contains("router.example.test") == false)
+
+        let directResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["surface", "resume", "show"],
+            environment: environment,
+            timeout: 5
+        )
+        #expect(!directResult.timedOut, Comment(rawValue: directResult.diagnostics))
+        #expect(directResult.status == 0, Comment(rawValue: directResult.diagnostics))
+        #expect(directResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == directCommand)
     }
 
     @Test func testIOSContextFromTerminalFallsBackToWorkspaceSimulator() throws {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -217,6 +217,62 @@ import Testing
         )
     }
 
+    @Test func testSurfaceResumeJSONDoesNotExposePrivateSubrouterRoutingMetadata() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = "/tmp/cmux-resume-private-\(UUID().uuidString.prefix(8)).sock"
+        let response = try jsonResponse(result: [
+            "resume_binding": [
+                "command": "sr codex resume session-id",
+                "environment": [
+                    "PATH": "/usr/bin:/bin",
+                    "SUBROUTER_CODEX_SERVER": "private-server",
+                ],
+            ],
+            "restore_record": [
+                "kind": "codex",
+                "launch_command": [
+                    "arguments": ["codex", "-c", "model_provider=subrouter"],
+                    "environment": [
+                        "PATH": "/usr/bin:/bin",
+                        "SUBROUTER_CODEX_ACCOUNT_ID": "private-account",
+                        "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+                        "SUBROUTER_CODEX_BIN": "/opt/bin/codex",
+                        "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                        "SUBROUTER_CODEX_SERVER": "private-server",
+                        "SUBROUTER_CODEX_USER_EMAIL": "private@example.test",
+                    ],
+                ],
+            ],
+        ])
+        let responder = try UnixSocketResponder(path: socketPath, response: response)
+        defer { responder.stop() }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["surface", "resume", "show", "--json"],
+            environment: environment,
+            timeout: 5
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
+        #expect(result.status == 0, Comment(rawValue: result.diagnostics))
+        #expect(result.stdout.contains("SUBROUTER_CODEX_") == false)
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+        let record = try #require(payload["restore_record"] as? [String: Any])
+        let launchCommand = try #require(record["launch_command"] as? [String: Any])
+        let launchEnvironment = try #require(launchCommand["environment"] as? [String: Any])
+        #expect(launchEnvironment["PATH"] as? String == "/usr/bin:/bin")
+    }
+
     @Test func testIOSContextFromTerminalFallsBackToWorkspaceSimulator() throws {
         let cliPath = try bundledCLIPath()
         let workspaceID = UUID().uuidString.lowercased()

--- a/cmuxTests/CodexResumeBindingVerificationRegressionTests.swift
+++ b/cmuxTests/CodexResumeBindingVerificationRegressionTests.swift
@@ -182,6 +182,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
 
         let routingEnvironment = [
+            "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
             "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
             "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
             "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
@@ -201,10 +202,13 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let binding = try XCTUnwrap(fixture.binding.snapshot())
         XCTAssertTrue((binding["command"] as? String)?.contains("'sr' 'codex' 'resume' '\(sessionID)'") == true)
         let publishedEnvironment = try XCTUnwrap(binding["environment"] as? [String: String])
-        for (key, value) in routingEnvironment where key != "SUBROUTER_CODEX_RESUME_COMMAND" {
+        for (key, value) in routingEnvironment
+            where key != "SUBROUTER_CODEX_RESUME_COMMAND"
+                && key != "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND" {
             XCTAssertEqual(publishedEnvironment[key], value, key)
         }
         XCTAssertNil(publishedEnvironment["SUBROUTER_CODEX_RESUME_COMMAND"])
+        XCTAssertNil(publishedEnvironment["CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND"])
     }
 
     func testCodexTUISessionCanRebindAnOlderVerifiedTUICheckpoint() throws {

--- a/cmuxTests/CodexResumeBindingVerificationRegressionTests.swift
+++ b/cmuxTests/CodexResumeBindingVerificationRegressionTests.swift
@@ -170,6 +170,43 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    func testSubrouterCodexBindingPublishesCapturedRoutingEnvironment() throws {
+        let sessionID = "019ff9c1-d827-7831-960d-fd9bdf7d54e2"
+        let fixture = try makeCodexBindingFixture(name: "subrouter-routing", existingCheckpoint: nil)
+        defer { fixture.cleanup() }
+        try writeCodexRollout(
+            fixture: fixture,
+            sessionID: sessionID,
+            source: "cli",
+            originator: "codex-tui"
+        )
+
+        let routingEnvironment = [
+            "SUBROUTER_CODEX_ACCOUNT_ID": "team-codex-1",
+            "SUBROUTER_CODEX_BASE_URL": "https://router.example.test/v1",
+            "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+            "SUBROUTER_CODEX_SERVER": "team",
+            "SUBROUTER_CODEX_USER_EMAIL": "operator@example.test",
+        ]
+        let result = runCodexBindingHook(
+            fixture: fixture,
+            sessionID: sessionID,
+            inputEvent: "SessionStart",
+            launchArguments: ["/usr/local/bin/codex", "-c", "model_provider=subrouter"],
+            additionalEnvironment: routingEnvironment
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let binding = try XCTUnwrap(fixture.binding.snapshot())
+        XCTAssertTrue((binding["command"] as? String)?.contains("'sr' 'codex' 'resume' '\(sessionID)'") == true)
+        let publishedEnvironment = try XCTUnwrap(binding["environment"] as? [String: String])
+        for (key, value) in routingEnvironment where key != "SUBROUTER_CODEX_RESUME_COMMAND" {
+            XCTAssertEqual(publishedEnvironment[key], value, key)
+        }
+        XCTAssertNil(publishedEnvironment["SUBROUTER_CODEX_RESUME_COMMAND"])
+    }
+
     func testCodexTUISessionCanRebindAnOlderVerifiedTUICheckpoint() throws {
         let oldSessionID = "019ff98a-d827-7831-960d-fd9bdf7d54e2"
         let newSessionID = "019ff9c0-d827-7831-960d-fd9bdf7d54e2"
@@ -415,7 +452,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
         fixture: CodexBindingFixture,
         sessionID: String,
         inputEvent: String,
-        includeCodexHome: Bool = true
+        includeCodexHome: Bool = true,
+        launchArguments: [String] = ["/usr/local/bin/codex"],
+        additionalEnvironment: [String: String] = [:]
     ) -> ProcessRunResult {
         let state = fixture.state
         let serverHandled = startMockServer(listenerFD: fixture.listenerFD, state: state) { [self] line in
@@ -478,8 +517,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
         environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = "/usr/local/bin/codex"
-        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(["/usr/local/bin/codex"])
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(launchArguments)
         environment["CMUX_AGENT_LAUNCH_CWD"] = fixture.root.path
+        for (key, value) in additionalEnvironment {
+            environment[key] = value
+        }
 
         let result = runProcess(
             executablePath: fixture.cliPath,

--- a/cmuxTests/RemoteShellPromptRelayTests.swift
+++ b/cmuxTests/RemoteShellPromptRelayTests.swift
@@ -24,7 +24,7 @@ struct RemoteShellPromptRelayTests {
         )
 
         #expect(script.contains(
-            "export CMUX_CODEX_WRAPPER_SHIM=\"$HOME/.cmux/bin/cmux-codex-wrapper\""
+            "unset CMUX_CODEX_WRAPPER_SHIM; if [ -x \"$HOME/.cmux/bin/cmux-codex-wrapper\" ]"
         ))
         #expect(script.contains("command -v bash"))
     }

--- a/cmuxTests/RemoteShellPromptRelayTests.swift
+++ b/cmuxTests/RemoteShellPromptRelayTests.swift
@@ -16,6 +16,19 @@ private let remoteShellPromptFishExecutablePath = [
 ].first { FileManager.default.isExecutableFile(atPath: $0) }
 
 struct RemoteShellPromptRelayTests {
+    @Test("remote shell re-exports the provisioned Codex wrapper shim")
+    func remoteShellExportsCodexWrapperShim() {
+        let script = RemoteInteractiveShellBootstrapBuilder.script(
+            remoteRelayPort: 64_044,
+            shellFeatures: "ssh-env,ssh-terminfo"
+        )
+
+        #expect(script.contains(
+            "export CMUX_CODEX_WRAPPER_SHIM=\"$HOME/.cmux/bin/cmux-codex-wrapper\""
+        ))
+        #expect(script.contains("command -v bash"))
+    }
+
     @Test("remote zsh prompt reports Git metadata through the relay")
     func remoteZshPromptReportsGitMetadataThroughRelay() throws {
         let output = try runPrompt(

--- a/cmuxTests/RemoteShellPromptRelayTests.swift
+++ b/cmuxTests/RemoteShellPromptRelayTests.swift
@@ -16,6 +16,26 @@ private let remoteShellPromptFishExecutablePath = [
 ].first { FileManager.default.isExecutableFile(atPath: $0) }
 
 struct RemoteShellPromptRelayTests {
+    @Test("remote session resource loader owns a dedicated source file")
+    func remoteSessionResourceLoaderOwnsDedicatedSourceFile() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let loaderSource = try String(
+            contentsOf: repositoryRoot
+                .appendingPathComponent("Sources/RemoteSessionBundledResourceLoader.swift"),
+            encoding: .utf8
+        )
+        let bootstrapSource = try String(
+            contentsOf: repositoryRoot
+                .appendingPathComponent("Sources/RemoteInteractiveShellBootstrapBuilder.swift"),
+            encoding: .utf8
+        )
+
+        #expect(loaderSource.contains("struct RemoteSessionBundledResourceLoader"))
+        #expect(!bootstrapSource.contains("struct RemoteSessionBundledResourceLoader"))
+    }
+
     @Test("remote session resource loader reads the bundled Codex wrapper")
     func remoteSessionResourceLoaderReadsBundledCodexWrapper() throws {
         let directory = FileManager.default.temporaryDirectory

--- a/cmuxTests/RemoteShellPromptRelayTests.swift
+++ b/cmuxTests/RemoteShellPromptRelayTests.swift
@@ -16,6 +16,24 @@ private let remoteShellPromptFishExecutablePath = [
 ].first { FileManager.default.isExecutableFile(atPath: $0) }
 
 struct RemoteShellPromptRelayTests {
+    @Test("remote session resource loader reads the bundled Codex wrapper")
+    func remoteSessionResourceLoaderReadsBundledCodexWrapper() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-wrapper-resource-\(UUID().uuidString)", isDirectory: true)
+        let binDirectory = directory.appendingPathComponent("bin", isDirectory: true)
+        let wrapperURL = binDirectory.appendingPathComponent("cmux-codex-wrapper", isDirectory: false)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try "#!/usr/bin/env bash\nexit 0\n".write(to: wrapperURL, atomically: true, encoding: .utf8)
+
+        let loader = RemoteSessionBundledResourceLoader(
+            resourceURL: directory,
+            fileManager: .default
+        )
+
+        #expect(loader.codexWrapperScript() == "#!/usr/bin/env bash\nexit 0\n")
+    }
+
     @Test("remote shell re-exports the provisioned Codex wrapper shim")
     func remoteShellExportsCodexWrapperShim() {
         let script = RemoteInteractiveShellBootstrapBuilder.script(

--- a/cmuxTests/ResumeLauncherCwdConsistencyTests.swift
+++ b/cmuxTests/ResumeLauncherCwdConsistencyTests.swift
@@ -159,6 +159,7 @@ struct ResumeLauncherCwdConsistencyTests {
                 arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/home/dev/repo",
                 environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_BIN": "/opt/custom/codex",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 ],

--- a/cmuxTests/ResumeLauncherCwdConsistencyTests.swift
+++ b/cmuxTests/ResumeLauncherCwdConsistencyTests.swift
@@ -146,6 +146,35 @@ struct ResumeLauncherCwdConsistencyTests {
         #expect(!input.contains(savedDirectory))
     }
 
+    @Test("remote inline Subrouter resume routes its Codex child through the managed wrapper")
+    func remoteInlineSubrouterResumeKeepsCodexHooks() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: sessionId,
+            workingDirectory: "/home/dev/repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/opt/custom/codex",
+                arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/home/dev/repo",
+                environment: [
+                    "SUBROUTER_CODEX_BIN": "/opt/custom/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ],
+                capturedAt: 123,
+                source: "remote"
+            )
+        )
+
+        let input = try #require(snapshot.resumeStartupInput(useLocalRestoreVerb: false))
+
+        #expect(input.contains("CMUX_AGENT_RESTORE_LAUNCH=codex:\(sessionId)"), "\(input)")
+        #expect(input.contains("SUBROUTER_CODEX_BIN="), "\(input)")
+        #expect(input.contains("CMUX_CODEX_WRAPPER_SHIM"), "\(input)")
+        #expect(input.contains("CMUX_CUSTOM_CODEX_PATH=/opt/custom/codex"), "\(input)")
+    }
+
     @Test("restored terminal command wrapper sources login files once")
     func restoredTerminalCommandWrapperAvoidsNestedLoginStartup() throws {
         let fileManager = FileManager.default

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -159,6 +159,7 @@ import Testing
                 arguments: ["/opt/company/bin/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/tmp/project",
                 environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "SUBROUTER_CODEX_BIN": "/opt/company/bin/codex",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                 ],
@@ -190,6 +191,7 @@ import Testing
                 arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
                 workingDirectory: "/tmp/project",
                 environment: [
+                    "CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
                     "CMUX_CUSTOM_CODEX_PATH": "/opt/custom/codex",
                     "SUBROUTER_CODEX_BIN": "${CMUX_CODEX_WRAPPER_SHIM:-codex}",
                     "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -206,7 +206,7 @@ import Testing
 
         #expect(startupInput.contains("CMUX_CUSTOM_CODEX_PATH=/opt/custom/codex"), "\(startupInput)")
         #expect(
-            startupInput.contains("CMUX_CUSTOM_CODEX_PATH=${CMUX_CODEX_WRAPPER_SHIM:-codex}") == false,
+            !startupInput.contains("${CMUX_CODEX_WRAPPER_SHIM:-codex}"),
             "\(startupInput)"
         )
     }

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -174,6 +174,7 @@ import Testing
         #expect(startupInput.contains("SUBROUTER_CODEX_BIN="), "\(startupInput)")
         #expect(startupInput.contains("CMUX_CODEX_WRAPPER_SHIM"), "\(startupInput)")
         #expect(startupInput.contains("CMUX_CUSTOM_CODEX_PATH=/opt/company/bin/codex"), "\(startupInput)")
+        #expect(startupInput.contains("/bin/sh -c"), "\(startupInput)")
     }
 
     @Test func restoreBindingAuthorizationRejectsUnownedOrUnboundCommands() throws {

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -145,6 +145,37 @@ import Testing
         #expect(startupInput.contains("CMUX_CUSTOM_\(kind.uppercased())_PATH="), "\(startupInput)")
     }
 
+    @Test func routedCodexBindingRoutesSubrouterChildThroughManagedWrapper() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "'sr' 'codex' 'resume' '\(sessionId)'",
+            checkpointId: sessionId,
+            source: "agent-hook",
+            environment: ["SUBROUTER_CODEX_BIN": "/opt/company/bin/codex"],
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/opt/company/bin/codex",
+                arguments: ["/opt/company/bin/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "SUBROUTER_CODEX_BIN": "/opt/company/bin/codex",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ],
+                capturedAt: 1,
+                source: "environment"
+            ),
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.inlineStartupInput)
+
+        #expect(startupInput.contains("CMUX_AGENT_RESTORE_LAUNCH=codex:\(sessionId)"), "\(startupInput)")
+        #expect(startupInput.contains("SUBROUTER_CODEX_BIN="), "\(startupInput)")
+        #expect(startupInput.contains("CMUX_CODEX_WRAPPER_SHIM"), "\(startupInput)")
+        #expect(startupInput.contains("CMUX_CUSTOM_CODEX_PATH=/opt/company/bin/codex"), "\(startupInput)")
+    }
+
     @Test func restoreBindingAuthorizationRejectsUnownedOrUnboundCommands() throws {
         let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
         let nonHook = SurfaceResumeBindingSnapshot(

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -177,6 +177,38 @@ import Testing
         #expect(startupInput.contains("/bin/sh -c"), "\(startupInput)")
     }
 
+    @Test func repeatedRoutedCodexBindingKeepsTheCapturedRealCodexExecutable() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "'sr' 'codex' 'resume' '\(sessionId)'",
+            checkpointId: sessionId,
+            source: "agent-hook",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/opt/custom/codex",
+                arguments: ["/opt/custom/codex", "-c", "model_provider=subrouter"],
+                workingDirectory: "/tmp/project",
+                environment: [
+                    "CMUX_CUSTOM_CODEX_PATH": "/opt/custom/codex",
+                    "SUBROUTER_CODEX_BIN": "${CMUX_CODEX_WRAPPER_SHIM:-codex}",
+                    "SUBROUTER_CODEX_RESUME_COMMAND": "sr codex resume",
+                ],
+                capturedAt: 1,
+                source: "environment"
+            ),
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.inlineStartupInput)
+
+        #expect(startupInput.contains("CMUX_CUSTOM_CODEX_PATH=/opt/custom/codex"), "\(startupInput)")
+        #expect(
+            startupInput.contains("CMUX_CUSTOM_CODEX_PATH=${CMUX_CODEX_WRAPPER_SHIM:-codex}") == false,
+            "\(startupInput)"
+        )
+    }
+
     @Test func restoreBindingAuthorizationRejectsUnownedOrUnboundCommands() throws {
         let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
         let nonHook = SurfaceResumeBindingSnapshot(

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -34,6 +34,7 @@ def run_wrapper(
     hooks_disabled: bool = False,
     restore_token: str | None = None,
     inject_args_available: bool = True,
+    subrouter_marker: str | None = None,
 ) -> tuple[int, list[str], list[str], dict[str, str], str]:
     with tempfile.TemporaryDirectory(prefix="cmux-codex-wrapper-test-") as td:
         tmp = Path(td)
@@ -67,6 +68,7 @@ done
   printf 'CMUX_AGENT_LAUNCH_KIND=%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}"
   printf 'CMUX_AGENT_RESUME_LAUNCH=%s\\n' "${CMUX_AGENT_RESUME_LAUNCH-__UNSET__}"
   printf 'CMUX_AGENT_RESTORE_LAUNCH=%s\\n' "${CMUX_AGENT_RESTORE_LAUNCH-__UNSET__}"
+  printf 'CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND=%s\\n' "${CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND-__UNSET__}"
   printf 'CMUX_WORKSPACE_ID=%s\\n' "${CMUX_WORKSPACE_ID-__UNSET__}"
   printf 'CMUX_SURFACE_ID=%s\\n' "${CMUX_SURFACE_ID-__UNSET__}"
 } > "$FAKE_REAL_ENV_LOG"
@@ -131,6 +133,12 @@ exit 1
             env["CMUX_AGENT_RESTORE_LAUNCH"] = restore_token
         else:
             env.pop("CMUX_AGENT_RESTORE_LAUNCH", None)
+        if subrouter_marker is not None:
+            env["SUBROUTER_CODEX_RESUME_COMMAND"] = subrouter_marker
+            env["CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND"] = "inherited ancestor marker"
+        else:
+            env.pop("SUBROUTER_CODEX_RESUME_COMMAND", None)
+            env.pop("CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND", None)
 
         try:
             proc = subprocess.run(
@@ -291,6 +299,31 @@ def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
     expect(cmux_log == [], f"help: expected no cmux calls, got {cmux_log}", failures)
 
 
+def test_subrouter_marker_is_bound_to_current_launch_argv(failures: list[str]) -> None:
+    marker = "sr codex resume"
+    _, _, _, routed_env, _ = run_wrapper(
+        socket_state="stale",
+        argv=["fix this", "-c", 'model_provider="subrouter"'],
+        subrouter_marker=marker,
+    )
+    expect(
+        routed_env.get("CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND") == marker,
+        f"routed launch did not bind its marker: {routed_env}",
+        failures,
+    )
+
+    _, _, _, direct_env, _ = run_wrapper(
+        socket_state="stale",
+        argv=["fix this"],
+        subrouter_marker=marker,
+    )
+    expect(
+        direct_env.get("CMUX_AGENT_LAUNCH_SUBROUTER_CODEX_RESUME_COMMAND") == "__UNSET__",
+        f"direct nested launch retained an inherited marker: {direct_env}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_every_resume_route_is_instrumented(failures)
@@ -300,6 +333,7 @@ def main() -> int:
     test_restore_tokens_do_not_gate_instrumentation(failures)
     test_injection_failure_preserves_cmux_context(failures)
     test_non_session_command_still_bypasses_hooks(failures)
+    test_subrouter_marker_is_bound_to_current_launch_argv(failures)
     if failures:
         print("FAIL: Codex session-entrypoint wrapper reliability checks failed")
         for failure in failures:


### PR DESCRIPTION
Preserve Subrouter-routed Codex resumes across local restore records and remote wrapper provisioning. Captured routing requires matching launcher-bound metadata; public JSON redacts private routing data. Remote wrapper installation fails if publication fails.

Integrates Daniel Raffel’s https://github.com/manaflow-ai/cmux/pull/11081 with current main. Conflict resolution retains the general managed-wrapper renderer, custom-agent environment support, compact JSON option, and moved surface-resume binding code.

Validation: Codex wrapper entrypoint regression passes. Swift package, app-host, and tagged-build verification are required before merge. No new relay permissions are granted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12961?ref=codesmith_pr_footer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1792365822&installation_model_id=21920&pr_number=12961&ref=codesmith_pr_footer&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12961&signature=79e5a274e08087537bb4a2de974f00a63743112247fc8231c139ae7479f2c94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Subrouter-routed Codex resume routing across local restore records and remote wrapper provisioning after integrating [`manaflow-ai/cmux`](https://github.com/manaflow-ai/cmux/pull/11081) with current main.

- Public surface listings and resume output (JSON and plain text) now redact private Subrouter routing metadata.
- Remote restore shells install the bundled `cmux-codex-wrapper` and route Subrouter Codex children through it when `bash` is available; installation is skipped if the wrapper script cannot be published, and restores fall back to the captured Codex executable when the shim is unavailable.
- `CMUX_CUSTOM_CODEX_PATH` is scoped to Codex restores only.

**Migration**

- Swift package, app-host, and tagged-build verification are required before merge; the Codex wrapper entrypoint regression already passes.
- Archive identity fixtures now read `CMUX_APP_BUNDLE_IDENTIFIER` and provide the notification extension provisioning profile.

<sup>Written for commit 3cdb3427677f79cf986499ef8ed3b0f627ad75c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved restoration of Codex sessions routed through supported providers, preserving the correct executable and launch settings.
  - Remote sessions can now install and use the bundled Codex wrapper automatically.
  - Resume and surface-binding outputs now retain only the information needed for future restoration.

- **Bug Fixes**
  - Private routing data and sensitive environment details are now excluded from CLI and JSON output.
  - Codex resume commands are more reliably matched to their original launch configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->